### PR TITLE
Per-type icons + US cameras with live HLS video

### DIFF
--- a/app/api/camera/[id]/route.ts
+++ b/app/api/camera/[id]/route.ts
@@ -1,4 +1,5 @@
 import { getCameraById, nearestTo } from "@/lib/sources/registry";
+import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
 
 export const dynamic = "force-dynamic";
 
@@ -13,5 +14,10 @@ export async function GET(
     .filter((n) => n.camera.id !== camera.id)
     .slice(0, 6)
     .map((n) => ({ id: n.camera.id, name: n.camera.name, km: Number(n.km.toFixed(2)) }));
-  return Response.json({ camera, nearby });
+  // Never hand the raw upstream stream URL to the client — video is fetched
+  // exclusively through the closed /api/hls proxy. `live` tells the UI to use
+  // the video player; mediaType is kept for display.
+  const safe = { ...camera, live: isLiveStreamUrl(camera.streamUrl) };
+  delete (safe as { streamUrl?: string }).streamUrl;
+  return Response.json({ camera: safe, nearby });
 }

--- a/app/api/cameras/route.ts
+++ b/app/api/cameras/route.ts
@@ -1,14 +1,16 @@
 import { getRegistry } from "@/lib/sources/registry";
+import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   const cams = await getRegistry();
-  // source + mediaType let the client pick the right camera icon (shape = feed,
-  // colour = region); country is carried for the US-cameras work.
+  // source + live let the client pick the right camera icon (shape = feed,
+  // colour = region). `live` = has a stream our /api/hls proxy can play, so the
+  // video icon means genuinely-playable live video (not just any mediaType).
   const cameras = cams.map((c) => ({
     id: c.id, name: c.name, lat: c.lat, lon: c.lon, available: c.available,
-    source: c.source, country: c.country, mediaType: c.mediaType,
+    source: c.source, country: c.country, live: isLiveStreamUrl(c.streamUrl),
   }));
   return Response.json({ count: cameras.length, cameras });
 }

--- a/app/api/cameras/route.ts
+++ b/app/api/cameras/route.ts
@@ -4,8 +4,11 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   const cams = await getRegistry();
+  // source + mediaType let the client pick the right camera icon (shape = feed,
+  // colour = region); country is carried for the US-cameras work.
   const cameras = cams.map((c) => ({
     id: c.id, name: c.name, lat: c.lat, lon: c.lon, available: c.available,
+    source: c.source, country: c.country, mediaType: c.mediaType,
   }));
   return Response.json({ count: cameras.length, cameras });
 }

--- a/app/api/hls/route.ts
+++ b/app/api/hls/route.ts
@@ -1,0 +1,66 @@
+import type { NextRequest } from "next/server";
+import { getCameraById } from "@/lib/sources/registry";
+import { isHlsAllowed } from "@/lib/proxy/hls-allowlist";
+import { rewritePlaylist } from "@/lib/proxy/hls-rewrite";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const idParam = req.nextUrl.searchParams.get("id");
+  const uParam = req.nextUrl.searchParams.get("u");
+
+  let upstream: string | null = null;
+  if (uParam) {
+    upstream = uParam;
+  } else if (idParam) {
+    const cam = await getCameraById(idParam);
+    if (!cam?.streamUrl) return new Response("camera or stream not found", { status: 404 });
+    upstream = cam.streamUrl;
+  }
+  if (!upstream) return new Response("missing id or u", { status: 400 });
+
+  let target: URL;
+  try { target = new URL(upstream); } catch { return new Response("bad url", { status: 400 }); }
+
+  const verdict = isHlsAllowed(target);
+  if (!verdict.ok) return new Response("forbidden host", { status: 403 });
+
+  const range = req.headers.get("range");
+  let res: Response;
+  try {
+    res = await fetch(target.toString(), {
+      headers: {
+        Referer: verdict.referer ?? "",
+        "User-Agent": "TrafficNerd/2.0 (+https://github.com/011-sam-110/TrafficNerd-V2)",
+        Accept: "*/*",
+        ...(range ? { Range: range } : {}),
+      },
+      cache: "no-store",
+      redirect: "error",
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    return new Response("upstream fetch failed", { status: 502 });
+  }
+  if (!res.ok && res.status !== 206) return new Response("upstream error", { status: 502 });
+
+  const ct = res.headers.get("content-type");
+  const isPlaylist = (ct?.includes("mpegurl") ?? false) || target.pathname.toLowerCase().endsWith(".m3u8");
+
+  if (isPlaylist) {
+    const body = await res.text();
+    return new Response(rewritePlaylist(body, target.toString()), {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.apple.mpegurl", "Cache-Control": "no-store" },
+    });
+  }
+
+  // Segment / binary: stream straight through (do not buffer), preserve range semantics.
+  const headers = new Headers();
+  headers.set("Content-Type", ct ?? "video/mp2t");
+  const cr = res.headers.get("content-range"); if (cr) headers.set("Content-Range", cr);
+  const cl = res.headers.get("content-length"); if (cl) headers.set("Content-Length", cl);
+  headers.set("Accept-Ranges", "bytes");
+  headers.set("Cache-Control", "public, max-age=5");
+  return new Response(res.body, { status: res.status, headers });
+}

--- a/app/api/planes/route.ts
+++ b/app/api/planes/route.ts
@@ -1,36 +1,15 @@
-import { fetchStates, DEFAULT_BBOX } from "@/lib/sources/opensky";
-import type { OpenSkyBbox } from "@/lib/sources/opensky";
+import { fetchAircraft } from "@/lib/sources/adsb";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/planes
+ * GET /api/planes — live aircraft (keyless, from adsb.lol) across the camera
+ * regions as classified WorldObjects. fetchAircraft handles caching + failure
+ * (serves stale/empty), so this route never throws.
  *
- * Optional query params: south, west, north, east (floats).
- * Falls back to UK+Ireland bbox when any are absent or invalid.
- *
- * Response: { count: number, planes: Plane[] }
- *
- * Rate-limiting and error handling is done inside fetchStates; this route
- * never throws — it returns the last good cache or an empty array.
+ * Response: { count: number, planes: WorldObject[] }
  */
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-
-  function qp(name: string, fallback: number): number {
-    const raw = searchParams.get(name);
-    if (raw === null) return fallback;
-    const v = parseFloat(raw);
-    return isFinite(v) ? v : fallback;
-  }
-
-  const bbox: OpenSkyBbox = {
-    south: qp("south", DEFAULT_BBOX.south),
-    west: qp("west", DEFAULT_BBOX.west),
-    north: qp("north", DEFAULT_BBOX.north),
-    east: qp("east", DEFAULT_BBOX.east),
-  };
-
-  const planes = await fetchStates(bbox);
+export async function GET() {
+  const planes = await fetchAircraft(Date.now());
   return Response.json({ count: planes.length, planes });
 }

--- a/app/camera/[id]/page.tsx
+++ b/app/camera/[id]/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getCameraById, nearestTo } from "@/lib/sources/registry";
+import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
 import { CameraImage } from "@/components/CameraImage";
+import { CameraVideo } from "@/components/CameraVideo";
 
 export const dynamic = "force-dynamic";
 
@@ -13,16 +15,25 @@ export default async function CameraPage({ params }: { params: Promise<{ id: str
   const nearby = (await nearestTo(cam.lat, cam.lon, 8))
     .filter((n) => n.camera.id !== cam.id)
     .slice(0, 6);
+  const live = isLiveStreamUrl(cam.streamUrl);
 
   return (
     <main className="camera-detail">
       <p><Link href="/">← Globe</Link></p>
       <h1>{cam.name}</h1>
-      <CameraImage
-        id={cam.id} alt={cam.name}
-        attribution={cam.attribution} license={cam.license}
-        refreshSeconds={cam.refreshSeconds}
-      />
+      {live ? (
+        <CameraVideo
+          id={cam.id} alt={cam.name}
+          attribution={cam.attribution} license={cam.license}
+          refreshSeconds={cam.refreshSeconds}
+        />
+      ) : (
+        <CameraImage
+          id={cam.id} alt={cam.name}
+          attribution={cam.attribution} license={cam.license}
+          refreshSeconds={cam.refreshSeconds}
+        />
+      )}
       <dl>
         <dt>Source</dt><dd>{cam.source}</dd>
         <dt>Location</dt><dd>{cam.region}, {cam.country}</dd>

--- a/components/CameraDetail.tsx
+++ b/components/CameraDetail.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import type { WorldObject } from "@/lib/world";
 import { CameraImage } from "@/components/CameraImage";
+import { CameraVideo } from "@/components/CameraVideo";
 
 type CamInfo = {
   id: string;
@@ -20,6 +21,7 @@ type CamInfo = {
   attribution: string;
   license: string;
   refreshSeconds: number;
+  live: boolean;
 };
 
 export function CameraDetail({ object }: { object: WorldObject }) {
@@ -57,13 +59,23 @@ export function CameraDetail({ object }: { object: WorldObject }) {
       </p>
 
       {cam ? (
-        <CameraImage
-          id={cam.id}
-          alt={cam.name}
-          attribution={cam.attribution}
-          license={cam.license}
-          refreshSeconds={cam.refreshSeconds}
-        />
+        cam.live ? (
+          <CameraVideo
+            id={cam.id}
+            alt={cam.name}
+            attribution={cam.attribution}
+            license={cam.license}
+            refreshSeconds={cam.refreshSeconds}
+          />
+        ) : (
+          <CameraImage
+            id={cam.id}
+            alt={cam.name}
+            attribution={cam.attribution}
+            license={cam.license}
+            refreshSeconds={cam.refreshSeconds}
+          />
+        )
       ) : err ? (
         <div className="cam-loading">Could not load this camera.</div>
       ) : (

--- a/components/CameraVideo.tsx
+++ b/components/CameraVideo.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { AttributionBadge } from "@/components/AttributionBadge";
+import { CameraImage } from "@/components/CameraImage";
+
+export function CameraVideo(props: {
+  id: string; alt: string; attribution: string; license: string; refreshSeconds: number;
+}) {
+  const { id, alt, attribution, license, refreshSeconds } = props;
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [failed, setFailed] = useState(false);
+  const src = `/api/hls?id=${encodeURIComponent(id)}`;
+  const poster = `/api/proxy?id=${encodeURIComponent(id)}`;
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    let hls: { destroy: () => void } | null = null;
+    let cancelled = false;
+
+    if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = src; // Safari plays HLS natively
+      return;
+    }
+    (async () => {
+      const Hls = (await import("hls.js")).default;
+      if (cancelled) return;
+      if (!Hls.isSupported()) { setFailed(true); return; }
+      const instance = new Hls({ enableWorker: true });
+      hls = instance;
+      instance.loadSource(src);
+      instance.attachMedia(video);
+      instance.on(Hls.Events.ERROR, (_evt, data) => {
+        if (data.fatal) { setFailed(true); instance.destroy(); hls = null; }
+      });
+    })();
+
+    return () => { cancelled = true; if (hls) hls.destroy(); };
+  }, [src]);
+
+  if (failed) {
+    return (
+      <CameraImage id={id} alt={alt} attribution={attribution} license={license} refreshSeconds={refreshSeconds} />
+    );
+  }
+  return (
+    <figure style={{ margin: 0 }}>
+      <video ref={videoRef} poster={poster} controls autoPlay muted playsInline aria-label={alt} style={{ width: "100%" }} />
+      <figcaption><AttributionBadge attribution={attribution} license={license} /></figcaption>
+    </figure>
+  );
+}

--- a/components/GlobeView.tsx
+++ b/components/GlobeView.tsx
@@ -21,7 +21,7 @@ import { usePlanes } from "@/lib/planes/usePlanes";
 import { useLayers } from "@/lib/layers";
 import LayerControl from "@/components/LayerControl";
 import { satelliteSprite, planeIconMesh } from "@/lib/icons/sprite";
-import { classifyCameraFeed } from "@/lib/cameras/classify";
+import { cameraFeed } from "@/lib/cameras/classify";
 import { CAMERA_FEED_META, cameraRegionColor } from "@/lib/icons/svg";
 
 type Pt = {
@@ -32,7 +32,7 @@ type Pt = {
   available: boolean;
   source: string;
   country: string;
-  mediaType: "jpeg" | "video" | "both";
+  live: boolean;
 };
 
 // London — where P0's cameras are. Fly here on load so the points are front and
@@ -86,7 +86,7 @@ export default function GlobeView() {
   const cameraObjects = useMemo<WorldObject[]>(
     () =>
       pts.map((p) => {
-        const feed = classifyCameraFeed(p.mediaType);
+        const feed = cameraFeed(p.live);
         const meta = CAMERA_FEED_META[feed];
         const color = cameraRegionColor(p.source);
         return {
@@ -102,7 +102,7 @@ export default function GlobeView() {
             available: p.available,
             source: p.source,
             country: p.country,
-            mediaType: p.mediaType,
+            live: p.live,
             feed,
             color,
             icon: meta.key,

--- a/components/GlobeView.tsx
+++ b/components/GlobeView.tsx
@@ -19,6 +19,7 @@ import { MapView } from "@/components/MapView";
 import { useSatellites } from "@/lib/satellites/useSatellites";
 import { usePlanes } from "@/lib/planes/usePlanes";
 import { useLayers } from "@/lib/layers";
+import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
 import LayerControl from "@/components/LayerControl";
 import RegionJump, { type RegionView } from "@/components/RegionJump";
 import { satelliteSprite, planeIconMesh } from "@/lib/icons/sprite";
@@ -119,9 +120,21 @@ export default function GlobeView() {
   const satellites = useSatellites();
   const planes = usePlanes();
   const layers = useLayers();
+  const camFilter = useCameraFilter();
 
-  // Apply the legend's show/hide toggles.
-  const visibleCameras = layers.cameras ? cameraObjects : EMPTY;
+  // Apply the camera sub-filters (region + live-only), then the top-level toggle.
+  const filteredCameras = useMemo<WorldObject[]>(
+    () =>
+      cameraObjects.filter((c) =>
+        cameraFilterStore.passes(
+          (c.meta?.source as string) ?? "",
+          Boolean(c.meta?.live),
+        ),
+      ),
+    // camFilter is the dependency that makes this recompute on toggle.
+    [cameraObjects, camFilter],
+  );
+  const visibleCameras = layers.cameras ? filteredCameras : EMPTY;
   const objects = useMemo<WorldObject[]>(
     () => [
       ...(layers.satellites ? satellites : []),
@@ -196,8 +209,10 @@ export default function GlobeView() {
   return (
     <div className="world-stage">
       <div className="stat-line" data-testid="stat-line">
-        {pts.length.toLocaleString()} cameras · 3 sources ·{" "}
-        {mapMode ? "satellite map" : "London live"}
+        {filteredCameras.length === pts.length
+          ? `${pts.length.toLocaleString()} cameras`
+          : `${filteredCameras.length.toLocaleString()} of ${pts.length.toLocaleString()} cameras`}{" "}
+        · 3 sources · {mapMode ? "satellite map" : "live"}
       </div>
 
       <LayerControl

--- a/components/GlobeView.tsx
+++ b/components/GlobeView.tsx
@@ -20,6 +20,7 @@ import { useSatellites } from "@/lib/satellites/useSatellites";
 import { usePlanes } from "@/lib/planes/usePlanes";
 import { useLayers } from "@/lib/layers";
 import LayerControl from "@/components/LayerControl";
+import RegionJump, { type RegionView } from "@/components/RegionJump";
 import { satelliteSprite, planeIconMesh } from "@/lib/icons/sprite";
 import { cameraFeed } from "@/lib/cameras/classify";
 import { CAMERA_FEED_META, cameraRegionColor } from "@/lib/icons/svg";
@@ -154,6 +155,25 @@ export default function GlobeView() {
     [mapMode],
   );
 
+  // Per-region camera counts for the region quick-jump (grouped by source id).
+  const regionCounts = useMemo<Record<string, number>>(() => {
+    const counts: Record<string, number> = {};
+    for (const p of pts) counts[p.source] = (counts[p.source] ?? 0) + 1;
+    return counts;
+  }, [pts]);
+
+  const flyToRegion = useCallback((view: RegionView) => {
+    const g = globeRef.current;
+    if (!g) return;
+    // Leave map mode if we're in it, and ease the globe to the region overview.
+    suppressUntil.current = Date.now() + 1600;
+    setMapMode(false);
+    setFocus({ lat: view.lat, lng: view.lng });
+    g.pointOfView({ lat: view.lat, lng: view.lng, altitude: view.altitude }, 1200);
+    const c = g.controls();
+    if (c) c.autoRotate = false;
+  }, []);
+
   const returnToGlobe = useCallback(() => {
     suppressUntil.current = Date.now() + 1200;
     setMapMode(false);
@@ -183,6 +203,8 @@ export default function GlobeView() {
       <LayerControl
         counts={{ cameras: pts.length, satellites: satellites.length, planes: planes.length }}
       />
+
+      <RegionJump counts={regionCounts} onJump={flyToRegion} />
 
       <Globe
         ref={globeRef}

--- a/components/GlobeView.tsx
+++ b/components/GlobeView.tsx
@@ -20,8 +20,20 @@ import { useSatellites } from "@/lib/satellites/useSatellites";
 import { usePlanes } from "@/lib/planes/usePlanes";
 import { useLayers } from "@/lib/layers";
 import LayerControl from "@/components/LayerControl";
+import { satelliteSprite, planeIconMesh } from "@/lib/icons/sprite";
+import { classifyCameraFeed } from "@/lib/cameras/classify";
+import { CAMERA_FEED_META, cameraRegionColor } from "@/lib/icons/svg";
 
-type Pt = { id: string; name: string; lat: number; lon: number; available: boolean };
+type Pt = {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  available: boolean;
+  source: string;
+  country: string;
+  mediaType: "jpeg" | "video" | "both";
+};
 
 // London — where P0's cameras are. Fly here on load so the points are front and
 // centre instead of a speck off the coast of Africa.
@@ -33,47 +45,12 @@ const MAP_THRESHOLD = 0.4;
 // immediately re-enter map mode mid-animation.
 const EXIT_ALTITUDE = 1.4;
 
-const CAMERA_ON = "#22d3ee";
 const CAMERA_OFF = "#64748b";
-const SAT_COLOR = "#e2e8f0";
+const SAT_COLOR = "#cbd5e1";
 const PLANE_COLOR = "#fbbf24";
 
 // Stable empty-array reference for hidden layers (avoids needless Globe re-diffs).
 const EMPTY: WorldObject[] = [];
-
-// --- 3D object builders (one fresh Object3D per datum) -----------------------
-
-function buildSatelliteObject(color: string): THREE.Object3D {
-  const group = new THREE.Group();
-  // MeshBasicMaterial is unlit → reads as "emissive" against the night globe
-  // without needing scene lights.
-  const core = new THREE.Mesh(
-    new THREE.OctahedronGeometry(1.5, 0),
-    new THREE.MeshBasicMaterial({ color }),
-  );
-  const glow = new THREE.Mesh(
-    new THREE.SphereGeometry(2.7, 12, 12),
-    new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.16 }),
-  );
-  group.add(core, glow);
-  return group;
-}
-
-function buildPlaneObject(color: string): THREE.Object3D {
-  // Flat arrowhead in the local XY plane (which, with objectFacesSurface, is the
-  // tangent plane: +X=East, +Y=North, +Z=radial-out). Nose points +Y (north);
-  // objectRotation spins it about +Z by -heading so it faces its compass course.
-  const shape = new THREE.Shape();
-  shape.moveTo(0, 2.6); // nose (north)
-  shape.lineTo(-1.7, -1.9); // back-left
-  shape.lineTo(0, -0.8); // tail notch
-  shape.lineTo(1.7, -1.9); // back-right
-  shape.closePath();
-  return new THREE.Mesh(
-    new THREE.ShapeGeometry(shape),
-    new THREE.MeshBasicMaterial({ color, side: THREE.DoubleSide }),
-  );
-}
 
 export default function GlobeView() {
   const [pts, setPts] = useState<Pt[]>([]);
@@ -102,17 +79,36 @@ export default function GlobeView() {
     return () => window.removeEventListener("resize", update);
   }, []);
 
-  // Cameras → WorldObject[] (surface pins). Shared with the map markers.
+  // Cameras → WorldObject[] (surface pins). Shared with the map markers, which
+  // render the full per-type SVG icon (shape = feed, colour = region). On the
+  // globe itself cameras stay cheap region-coloured points (they can number in
+  // the thousands), so the icon detail appears the moment you zoom into the map.
   const cameraObjects = useMemo<WorldObject[]>(
     () =>
-      pts.map((p) => ({
-        kind: "camera",
-        id: p.id,
-        lat: p.lat,
-        lon: p.lon,
-        label: p.name,
-        meta: { available: p.available },
-      })),
+      pts.map((p) => {
+        const feed = classifyCameraFeed(p.mediaType);
+        const meta = CAMERA_FEED_META[feed];
+        const color = cameraRegionColor(p.source);
+        return {
+          kind: "camera",
+          id: p.id,
+          lat: p.lat,
+          lon: p.lon,
+          label: p.name,
+          color,
+          icon: meta.key,
+          typeLabel: meta.label,
+          meta: {
+            available: p.available,
+            source: p.source,
+            country: p.country,
+            mediaType: p.mediaType,
+            feed,
+            color,
+            icon: meta.key,
+          },
+        };
+      }),
     [pts],
   );
 
@@ -170,8 +166,10 @@ export default function GlobeView() {
 
   const objectThreeObject = useCallback((o: object) => {
     const w = o as WorldObject;
-    if (w.kind === "satellite") return buildSatelliteObject(w.color ?? SAT_COLOR);
-    if (w.kind === "plane") return buildPlaneObject(w.color ?? PLANE_COLOR);
+    if (w.kind === "satellite")
+      return satelliteSprite(w.icon ?? "sat-other", w.color ?? SAT_COLOR);
+    if (w.kind === "plane")
+      return planeIconMesh(w.icon ?? "plane-airliner", w.color ?? PLANE_COLOR);
     return new THREE.Object3D();
   }, []);
 
@@ -202,9 +200,11 @@ export default function GlobeView() {
         pointsData={visibleCameras}
         pointLat="lat"
         pointLng="lon"
-        pointColor={(o) =>
-          (o as WorldObject).meta?.available ? CAMERA_ON : CAMERA_OFF
-        }
+        pointColor={(o) => {
+          const w = o as WorldObject;
+          // Region colour when live; muted grey when the feed is down.
+          return w.meta?.available ? w.color ?? CAMERA_OFF : CAMERA_OFF;
+        }}
         pointAltitude={0.002}
         pointRadius={0.12}
         pointResolution={8}

--- a/components/GlobeView.tsx
+++ b/components/GlobeView.tsx
@@ -17,7 +17,7 @@ import { overlay } from "@/lib/overlay";
 import { altKmToShell, planeKmToShell } from "@/lib/altitude";
 import { MapView } from "@/components/MapView";
 import { useSatellites } from "@/lib/satellites/useSatellites";
-import { usePlanes } from "@/lib/planes/usePlanes";
+import { usePlanes, type PlaneTrail } from "@/lib/planes/usePlanes";
 import { useLayers } from "@/lib/layers";
 import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
 import LayerControl from "@/components/LayerControl";
@@ -51,8 +51,18 @@ const CAMERA_OFF = "#64748b";
 const SAT_COLOR = "#cbd5e1";
 const PLANE_COLOR = "#fbbf24";
 
-// Stable empty-array reference for hidden layers (avoids needless Globe re-diffs).
+// Stable empty-array references for hidden layers (avoids needless Globe re-diffs).
 const EMPTY: WorldObject[] = [];
+const EMPTY_TRAILS: PlaneTrail[] = [];
+
+// "#rrggbb" + alpha → "rgba(...)" for the trail gradient (globe.gl honours alpha).
+function hexToRgba(hex: string, alpha: number): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r},${g},${b},${alpha.toFixed(3)})`;
+}
 
 export default function GlobeView() {
   const [pts, setPts] = useState<Pt[]>([]);
@@ -118,7 +128,7 @@ export default function GlobeView() {
   // revolve smoothly) + planes (OpenSky, polled ~15s). Both already emit
   // WorldObject[]; the altitude-shell + oriented-object rendering is below.
   const satellites = useSatellites();
-  const planes = usePlanes();
+  const planesLayer = usePlanes();
   const layers = useLayers();
   const camFilter = useCameraFilter();
 
@@ -138,10 +148,13 @@ export default function GlobeView() {
   const objects = useMemo<WorldObject[]>(
     () => [
       ...(layers.satellites ? satellites : []),
-      ...(layers.planes ? planes : []),
+      ...(layers.planes ? planesLayer.objects : []),
     ],
-    [layers.satellites, layers.planes, satellites, planes],
+    [layers.satellites, layers.planes, satellites, planesLayer.objects],
   );
+
+  // Plane breadcrumb trails (hidden with the planes layer / EMPTY ref to skip diffs).
+  const visibleTrails = layers.planes ? planesLayer.trails : EMPTY_TRAILS;
 
   const handleReady = () => {
     const g = globeRef.current;
@@ -216,7 +229,7 @@ export default function GlobeView() {
       </div>
 
       <LayerControl
-        counts={{ cameras: pts.length, satellites: satellites.length, planes: planes.length }}
+        counts={{ cameras: pts.length, satellites: satellites.length, planes: planesLayer.objects.length }}
       />
 
       <RegionJump counts={regionCounts} onJump={flyToRegion} />
@@ -266,10 +279,32 @@ export default function GlobeView() {
         objectThreeObject={objectThreeObject}
         objectLabel={(o) => (o as WorldObject).label}
         onObjectClick={(o) => overlay.open(o as WorldObject)}
+        // --- Plane breadcrumb trails: recent track + projected heading ahead ---
+        pathsData={visibleTrails}
+        pathPoints="points"
+        pathPointLat={(p) => (p as number[])[0]}
+        pathPointLng={(p) => (p as number[])[1]}
+        pathPointAlt={(p) => planeKmToShell((p as number[])[2])}
+        pathColor={(o: object) => {
+          const t = o as PlaneTrail;
+          const n = t.points.length;
+          // Fade from near-transparent (oldest breadcrumb) to solid (now + ahead).
+          return t.points.map((_, i) =>
+            hexToRgba(t.color, n <= 1 ? 0.95 : 0.15 + 0.8 * (i / (n - 1))),
+          );
+        }}
+        pathStroke={2.5}
+        pathTransitionDuration={0}
       />
 
       <div className={`map-layer${mapMode ? " is-active" : ""}`} aria-hidden={!mapMode}>
-        <MapView active={mapMode} center={focus} cameras={visibleCameras} />
+        <MapView
+          active={mapMode}
+          center={focus}
+          cameras={visibleCameras}
+          planes={layers.planes ? planesLayer.objects : EMPTY}
+          trails={visibleTrails}
+        />
       </div>
 
       {mapMode && (

--- a/components/LayerControl.tsx
+++ b/components/LayerControl.tsx
@@ -7,6 +7,7 @@
 
 import { useState } from "react";
 import { useLayers, layersStore, type LayerKey } from "@/lib/layers";
+import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
 import { TypeIcon } from "@/lib/icons/Icon";
 import {
   SAT_META,
@@ -53,33 +54,111 @@ function KeyGrid({ items }: { items: SubtypeMeta[] }) {
 }
 
 function CameraKey() {
+  const filter = useCameraFilter();
   return (
     <div style={{ padding: "8px 2px 4px" }}>
       <div style={{ ...miniHeading }}>Feed</div>
-      <div style={{ display: "flex", gap: 14, marginBottom: 8 }}>
+      <div style={{ display: "flex", gap: 14, marginBottom: 6 }}>
         {CAMERA_FEEDS.map((m) => (
           <Chip key={m.key} meta={{ ...m, color: "#94a3b8" }} />
         ))}
       </div>
-      <div style={{ ...miniHeading }}>Region (colour)</div>
+      <button
+        onClick={() => cameraFilterStore.setLiveOnly(!filter.liveOnly)}
+        aria-pressed={filter.liveOnly}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          width: "100%",
+          padding: "4px 0 8px",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          font: "inherit",
+        }}
+      >
+        <MiniSwitch on={filter.liveOnly} color="#67e8f9" />
+        <span style={{ fontSize: 11.5, color: "#cbd5e1" }}>Live video only</span>
+      </button>
+      <div style={{ ...miniHeading }}>Region — click to filter</div>
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "6px 12px" }}>
-        {CAMERA_REGIONS.map((r) => (
-          <span key={r.source} style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-            <span
+        {CAMERA_REGIONS.map((r) => {
+          const on = filter.regions[r.source] ?? true;
+          return (
+            <button
+              key={r.source}
+              onClick={() => cameraFilterStore.toggleRegion(r.source)}
+              aria-pressed={on}
+              title={`${on ? "Hide" : "Show"} ${r.label}`}
               style={{
-                width: 9,
-                height: 9,
-                borderRadius: "50%",
-                background: r.color,
-                boxShadow: `0 0 6px ${r.color}`,
-                flexShrink: 0,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: 0,
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                font: "inherit",
+                opacity: on ? 1 : 0.4,
+                transition: "opacity .15s ease",
+                minWidth: 0,
               }}
-            />
-            <span style={{ fontSize: 11.5, color: "#cbd5e1", whiteSpace: "nowrap" }}>{r.label}</span>
-          </span>
-        ))}
+            >
+              <span
+                style={{
+                  width: 9,
+                  height: 9,
+                  borderRadius: "50%",
+                  background: r.color,
+                  boxShadow: on ? `0 0 6px ${r.color}` : "none",
+                  flexShrink: 0,
+                }}
+              />
+              <span
+                style={{
+                  fontSize: 11.5,
+                  color: "#cbd5e1",
+                  whiteSpace: "nowrap",
+                  textDecoration: on ? "none" : "line-through",
+                }}
+              >
+                {r.label}
+              </span>
+            </button>
+          );
+        })}
       </div>
     </div>
+  );
+}
+
+function MiniSwitch({ on, color }: { on: boolean; color: string }) {
+  return (
+    <span
+      style={{
+        position: "relative",
+        width: 30,
+        height: 16,
+        flexShrink: 0,
+        background: on ? color : "rgba(255,255,255,0.15)",
+        borderRadius: 8,
+        transition: "background .2s ease",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 2,
+          left: on ? 16 : 2,
+          width: 12,
+          height: 12,
+          background: "#fff",
+          borderRadius: "50%",
+          transition: "left .2s cubic-bezier(.4,0,.2,1)",
+        }}
+      />
+    </span>
   );
 }
 

--- a/components/LayerControl.tsx
+++ b/components/LayerControl.tsx
@@ -1,9 +1,20 @@
 "use client";
-// Floating legend + layer toggles over the globe. Adapted from a 21st.dev/Magic
-// generation, wired to lib/layers (the visibility store) and the live counts
-// GlobeView passes in. Each row: glowing colour dot · name · live count · switch.
+// Floating legend + layer toggles over the globe. Each layer row has a live
+// count and an on/off switch; clicking the row expands the full *type key* for
+// that layer (the maximal taxonomy of icons), so a viewer can decode every
+// marker on the map. Wired to lib/layers (visibility store) + lib/icons (the
+// single source of truth for icons/colours/labels).
 
+import { useState } from "react";
 import { useLayers, layersStore, type LayerKey } from "@/lib/layers";
+import { TypeIcon } from "@/lib/icons/Icon";
+import {
+  SAT_META,
+  PLANE_META,
+  CAMERA_FEED_META,
+  CAMERA_REGIONS,
+  type SubtypeMeta,
+} from "@/lib/icons/svg";
 
 const LAYERS: { key: LayerKey; name: string; color: string }[] = [
   { key: "cameras", name: "Cameras", color: "#22d3ee" },
@@ -11,8 +22,78 @@ const LAYERS: { key: LayerKey; name: string; color: string }[] = [
   { key: "planes", name: "Planes", color: "#fbbf24" },
 ];
 
+const SAT_SUBTYPES: SubtypeMeta[] = Object.values(SAT_META);
+const PLANE_SUBTYPES: SubtypeMeta[] = Object.values(PLANE_META);
+const CAMERA_FEEDS: SubtypeMeta[] = Object.values(CAMERA_FEED_META);
+
+function Chip({ meta }: { meta: SubtypeMeta }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+      <TypeIcon icon={meta.key} color={meta.color} size={15} title={meta.label} />
+      <span style={{ fontSize: 11.5, color: "#cbd5e1", whiteSpace: "nowrap" }}>{meta.label}</span>
+    </span>
+  );
+}
+
+function KeyGrid({ items }: { items: SubtypeMeta[] }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr",
+        gap: "6px 12px",
+        padding: "8px 2px 4px",
+      }}
+    >
+      {items.map((m) => (
+        <Chip key={m.key} meta={m} />
+      ))}
+    </div>
+  );
+}
+
+function CameraKey() {
+  return (
+    <div style={{ padding: "8px 2px 4px" }}>
+      <div style={{ ...miniHeading }}>Feed</div>
+      <div style={{ display: "flex", gap: 14, marginBottom: 8 }}>
+        {CAMERA_FEEDS.map((m) => (
+          <Chip key={m.key} meta={{ ...m, color: "#94a3b8" }} />
+        ))}
+      </div>
+      <div style={{ ...miniHeading }}>Region (colour)</div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "6px 12px" }}>
+        {CAMERA_REGIONS.map((r) => (
+          <span key={r.source} style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+            <span
+              style={{
+                width: 9,
+                height: 9,
+                borderRadius: "50%",
+                background: r.color,
+                boxShadow: `0 0 6px ${r.color}`,
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ fontSize: 11.5, color: "#cbd5e1", whiteSpace: "nowrap" }}>{r.label}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const miniHeading: React.CSSProperties = {
+  fontSize: 9.5,
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  color: "#64748b",
+  marginBottom: 5,
+};
+
 export default function LayerControl({ counts }: { counts: Record<LayerKey, number> }) {
   const enabled = useLayers();
+  const [open, setOpen] = useState<LayerKey | null>(null);
 
   return (
     <div style={{ position: "fixed", top: 52, left: 16, zIndex: 20 }}>
@@ -24,83 +105,131 @@ export default function LayerControl({ counts }: { counts: Record<LayerKey, numb
           border: "1px solid rgba(255,255,255,0.1)",
           borderRadius: 12,
           padding: "12px 14px",
-          minWidth: 224,
+          width: 256,
           boxShadow: "0 8px 32px rgba(0,0,0,0.45)",
         }}
       >
-        <div style={{ fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "#64748b", marginBottom: 6 }}>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "#64748b",
+            marginBottom: 6,
+          }}
+        >
           Layers
         </div>
         {LAYERS.map((l, i) => {
           const on = enabled[l.key];
+          const isOpen = open === l.key;
           return (
-            <div
-              key={l.key}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 10,
-                padding: "8px 0",
-                borderTop: i ? "1px solid rgba(255,255,255,0.06)" : "none",
-                opacity: on ? 1 : 0.45,
-                transition: "opacity .25s ease",
-              }}
-            >
-              <span
+            <div key={l.key} style={{ borderTop: i ? "1px solid rgba(255,255,255,0.06)" : "none" }}>
+              <div
                 style={{
-                  width: 9,
-                  height: 9,
-                  flexShrink: 0,
-                  background: l.color,
-                  borderRadius: "50%",
-                  boxShadow: on ? `0 0 8px ${l.color}` : "none",
-                  transition: "box-shadow .25s ease",
-                }}
-              />
-              <span style={{ flex: 1, fontSize: 13, fontWeight: 500, color: "#e2e8f0" }}>{l.name}</span>
-              <span
-                style={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                  fontVariantNumeric: "tabular-nums",
-                  color: "#f8fafc",
-                  minWidth: 46,
-                  textAlign: "right",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "8px 0",
+                  opacity: on ? 1 : 0.45,
+                  transition: "opacity .25s ease",
                 }}
               >
-                {counts[l.key].toLocaleString()}
-              </span>
-              <button
-                onClick={() => layersStore.toggle(l.key)}
-                aria-label={`Toggle ${l.name}`}
-                aria-pressed={on}
-                style={{
-                  position: "relative",
-                  width: 38,
-                  height: 20,
-                  background: on ? l.color : "rgba(255,255,255,0.15)",
-                  borderRadius: 10,
-                  border: "none",
-                  cursor: "pointer",
-                  transition: "background .25s ease",
-                  flexShrink: 0,
-                  padding: 0,
-                }}
-              >
+                <button
+                  onClick={() => setOpen(isOpen ? null : l.key)}
+                  aria-expanded={isOpen}
+                  aria-label={`${isOpen ? "Hide" : "Show"} ${l.name} type key`}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    flex: 1,
+                    minWidth: 0,
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    cursor: "pointer",
+                    color: "inherit",
+                    font: "inherit",
+                    textAlign: "left",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 9,
+                      height: 9,
+                      flexShrink: 0,
+                      background: l.color,
+                      borderRadius: "50%",
+                      boxShadow: on ? `0 0 8px ${l.color}` : "none",
+                      transition: "box-shadow .25s ease",
+                    }}
+                  />
+                  <span style={{ flex: 1, fontSize: 13, fontWeight: 500, color: "#e2e8f0" }}>
+                    {l.name}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 10,
+                      color: "#64748b",
+                      transform: isOpen ? "rotate(90deg)" : "none",
+                      transition: "transform .2s ease",
+                    }}
+                  >
+                    ▸
+                  </span>
+                </button>
                 <span
                   style={{
-                    position: "absolute",
-                    top: 2,
-                    left: on ? 20 : 2,
-                    width: 16,
-                    height: 16,
-                    background: "#fff",
-                    borderRadius: "50%",
-                    transition: "left .25s cubic-bezier(.4,0,.2,1)",
-                    boxShadow: "0 1px 3px rgba(0,0,0,0.3)",
+                    fontSize: 13,
+                    fontWeight: 600,
+                    fontVariantNumeric: "tabular-nums",
+                    color: "#f8fafc",
+                    minWidth: 46,
+                    textAlign: "right",
                   }}
-                />
-              </button>
+                >
+                  {counts[l.key].toLocaleString()}
+                </span>
+                <button
+                  onClick={() => layersStore.toggle(l.key)}
+                  aria-label={`Toggle ${l.name}`}
+                  aria-pressed={on}
+                  style={{
+                    position: "relative",
+                    width: 38,
+                    height: 20,
+                    background: on ? l.color : "rgba(255,255,255,0.15)",
+                    borderRadius: 10,
+                    border: "none",
+                    cursor: "pointer",
+                    transition: "background .25s ease",
+                    flexShrink: 0,
+                    padding: 0,
+                  }}
+                >
+                  <span
+                    style={{
+                      position: "absolute",
+                      top: 2,
+                      left: on ? 20 : 2,
+                      width: 16,
+                      height: 16,
+                      background: "#fff",
+                      borderRadius: "50%",
+                      transition: "left .25s cubic-bezier(.4,0,.2,1)",
+                      boxShadow: "0 1px 3px rgba(0,0,0,0.3)",
+                    }}
+                  />
+                </button>
+              </div>
+              {isOpen && (
+                <div style={{ borderTop: "1px solid rgba(255,255,255,0.05)" }}>
+                  {l.key === "satellites" && <KeyGrid items={SAT_SUBTYPES} />}
+                  {l.key === "planes" && <KeyGrid items={PLANE_SUBTYPES} />}
+                  {l.key === "cameras" && <CameraKey />}
+                </div>
+              )}
             </div>
           );
         })}

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -11,12 +11,58 @@ import { useEffect, useRef } from "react";
 import maplibregl, { type StyleSpecification, type GeoJSONSource } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { WorldObject } from "@/lib/world";
+import type { PlaneTrail } from "@/lib/planes/usePlanes";
 import { overlay } from "@/lib/overlay";
-import { ICON_SVG, cameraRegionColor, CAMERA_DEFAULT_REGION } from "@/lib/icons/svg";
+import { ICON_SVG, cameraRegionColor, CAMERA_DEFAULT_REGION, PLANE_META } from "@/lib/icons/svg";
 
-const KNOWN_REGIONS = ["tfl", "caltrans", "scdot"];
+const KNOWN_REGIONS = ["tfl", "caltrans", "scdot", "digitraffic"];
 function regionKeyOf(source: string | undefined): string {
   return source && KNOWN_REGIONS.includes(source) ? source : "default";
+}
+
+const PLANE_SRC = "planes";
+const PLANE_LAYER = "plane-markers";
+const TRAIL_SRC = "trails";
+const TRAIL_LAYER = "trail-lines";
+
+function toPlaneFC(planes: WorldObject[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: planes.map((p) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [p.lon, p.lat] },
+      properties: {
+        id: p.id,
+        category: (p.meta?.category as string) ?? "airliner",
+        heading: p.heading ?? 0,
+        color: p.color ?? "#fbbf24",
+      },
+    })),
+  };
+}
+
+function toTrailFC(trails: PlaneTrail[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: trails
+      .filter((t) => t.points.length >= 2)
+      .map((t) => ({
+        type: "Feature",
+        geometry: { type: "LineString", coordinates: t.points.map((p) => [p[1], p[0]]) },
+        properties: { id: t.id, color: t.color },
+      })),
+  };
+}
+
+// Register one heading-up plane icon per type (coloured by PLANE_META).
+async function loadPlaneIcons(map: maplibregl.Map): Promise<void> {
+  await Promise.all(
+    Object.values(PLANE_META).map(async (meta) => {
+      if (map.hasImage(meta.key)) return;
+      const img = await rasterizeIcon(ICON_SVG[meta.key].replaceAll("currentColor", meta.color));
+      if (!map.hasImage(meta.key)) map.addImage(meta.key, img, { pixelRatio: 2 });
+    }),
+  );
 }
 
 const ESRI_STYLE: StyleSpecification = {
@@ -93,6 +139,7 @@ async function loadCameraIcons(map: maplibregl.Map): Promise<void> {
     ["tfl", cameraRegionColor("tfl")],
     ["caltrans", cameraRegionColor("caltrans")],
     ["scdot", cameraRegionColor("scdot")],
+    ["digitraffic", cameraRegionColor("digitraffic")],
     ["default", CAMERA_DEFAULT_REGION.color],
   ];
   await Promise.all(
@@ -111,16 +158,24 @@ export function MapView({
   active,
   center,
   cameras,
+  planes = [],
+  trails = [],
 }: {
   active: boolean;
   center: { lat: number; lng: number };
   cameras: WorldObject[];
+  planes?: WorldObject[];
+  trails?: PlaneTrail[];
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const readyRef = useRef(false);
   const camerasRef = useRef(cameras);
   camerasRef.current = cameras;
+  const planesRef = useRef(planes);
+  planesRef.current = planes;
+  const trailsRef = useRef(trails);
+  trailsRef.current = trails;
 
   // Lazy init on first activation.
   useEffect(() => {
@@ -137,6 +192,7 @@ export function MapView({
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "bottom-left");
 
     map.on("load", async () => {
+      (window as unknown as { __map?: maplibregl.Map }).__map = map; // debug handle
       await loadCameraIcons(map);
       readyRef.current = true;
       map.addSource(SRC, { type: "geojson", data: toFeatureCollection(camerasRef.current) });
@@ -177,6 +233,45 @@ export function MapView({
       map.on("mouseleave", LAYER, () => {
         map.getCanvas().style.cursor = "";
       });
+
+      // --- Planes + breadcrumb trails (FlightRadar-style on the map) ---
+      await loadPlaneIcons(map);
+      // Trails go UNDER the plane markers.
+      map.addSource(TRAIL_SRC, { type: "geojson", data: toTrailFC(trailsRef.current) });
+      map.addLayer({
+        id: TRAIL_LAYER,
+        type: "line",
+        source: TRAIL_SRC,
+        layout: { "line-cap": "round", "line-join": "round" },
+        paint: { "line-color": ["get", "color"], "line-width": 2, "line-opacity": 0.55 },
+      });
+      map.addSource(PLANE_SRC, { type: "geojson", data: toPlaneFC(planesRef.current) });
+      map.addLayer({
+        id: PLANE_LAYER,
+        type: "symbol",
+        source: PLANE_SRC,
+        layout: {
+          "icon-image": ["concat", "plane-", ["get", "category"]],
+          "icon-size": ["interpolate", ["linear"], ["zoom"], 7, 0.45, 11, 0.7, 15, 1],
+          "icon-rotate": ["get", "heading"],
+          "icon-rotation-alignment": "map",
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
+        },
+      });
+      map.on("click", PLANE_LAYER, (e) => {
+        const f = e.features?.[0];
+        if (!f) return;
+        const id = (f.properties as { id?: string })?.id;
+        const plane = planesRef.current.find((p) => p.id === id);
+        if (plane) overlay.open(plane);
+      });
+      map.on("mouseenter", PLANE_LAYER, () => {
+        map.getCanvas().style.cursor = "pointer";
+      });
+      map.on("mouseleave", PLANE_LAYER, () => {
+        map.getCanvas().style.cursor = "";
+      });
     });
     // center is intentionally read once at init; the effect below re-centres.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -196,6 +291,14 @@ export function MapView({
     if (!map || !readyRef.current) return;
     (map.getSource(SRC) as GeoJSONSource | undefined)?.setData(toFeatureCollection(cameras));
   }, [cameras]);
+
+  // Keep planes + trails in sync as they move (every poll).
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !readyRef.current) return;
+    (map.getSource(PLANE_SRC) as GeoJSONSource | undefined)?.setData(toPlaneFC(planes));
+    (map.getSource(TRAIL_SRC) as GeoJSONSource | undefined)?.setData(toTrailFC(trails));
+  }, [planes, trails]);
 
   // Keep the canvas sized to the window.
   useEffect(() => {

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -12,6 +12,12 @@ import maplibregl, { type StyleSpecification, type GeoJSONSource } from "maplibr
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { WorldObject } from "@/lib/world";
 import { overlay } from "@/lib/overlay";
+import { ICON_SVG, cameraRegionColor, CAMERA_DEFAULT_REGION } from "@/lib/icons/svg";
+
+const KNOWN_REGIONS = ["tfl", "caltrans", "scdot"];
+function regionKeyOf(source: string | undefined): string {
+  return source && KNOWN_REGIONS.includes(source) ? source : "default";
+}
 
 const ESRI_STYLE: StyleSpecification = {
   version: 8,
@@ -35,16 +41,70 @@ const MAP_ZOOM = 13;
 function toFeatureCollection(cameras: WorldObject[]): GeoJSON.FeatureCollection {
   return {
     type: "FeatureCollection",
-    features: cameras.map((c) => ({
-      type: "Feature",
-      geometry: { type: "Point", coordinates: [c.lon, c.lat] },
-      properties: {
-        id: c.id,
-        name: c.label,
-        available: Boolean((c.meta as { available?: boolean } | undefined)?.available),
-      },
-    })),
+    features: cameras.map((c) => {
+      const m = (c.meta ?? {}) as { available?: boolean; source?: string; feed?: string };
+      return {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [c.lon, c.lat] },
+        properties: {
+          id: c.id,
+          name: c.label,
+          available: Boolean(m.available),
+          // icon name pieces: shape = feed, colour = region (see loadCameraIcons)
+          feed: m.feed === "video" ? "video" : "still",
+          regionKey: regionKeyOf(m.source),
+        },
+      };
+    }),
   };
+}
+
+// Rasterise an SVG pictogram into an image MapLibre can use as a symbol icon.
+function rasterizeIcon(
+  svg: string,
+  px = 80,
+): Promise<{ width: number; height: number; data: Uint8Array }> {
+  return new Promise((resolve, reject) => {
+    const sized = svg.replace("<svg ", `<svg width="${px}" height="${px}" `);
+    const image = new Image();
+    image.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = px;
+      canvas.height = px;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return reject(new Error("no 2d context"));
+      ctx.drawImage(image, 0, 0, px, px);
+      const d = ctx.getImageData(0, 0, px, px);
+      resolve({ width: px, height: px, data: new Uint8Array(d.data.buffer.slice(0)) });
+    };
+    image.onerror = reject;
+    image.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(sized);
+  });
+}
+
+// Register one region-tinted icon per (feed shape × region colour) so the symbol
+// layer can pick the right one per camera with a data-driven expression.
+async function loadCameraIcons(map: maplibregl.Map): Promise<void> {
+  const feeds: [string, keyof typeof ICON_SVG][] = [
+    ["still", "cam-still"],
+    ["video", "cam-video"],
+  ];
+  const regions: [string, string][] = [
+    ["tfl", cameraRegionColor("tfl")],
+    ["caltrans", cameraRegionColor("caltrans")],
+    ["scdot", cameraRegionColor("scdot")],
+    ["default", CAMERA_DEFAULT_REGION.color],
+  ];
+  await Promise.all(
+    feeds.flatMap(([feed, iconKey]) =>
+      regions.map(async ([rk, color]) => {
+        const name = `cam-${feed}-${rk}`;
+        if (map.hasImage(name)) return;
+        const img = await rasterizeIcon(ICON_SVG[iconKey].replaceAll("currentColor", color));
+        if (!map.hasImage(name)) map.addImage(name, img, { pixelRatio: 2 });
+      }),
+    ),
+  );
 }
 
 export function MapView({
@@ -76,19 +136,24 @@ export function MapView({
     map.addControl(new maplibregl.AttributionControl({ compact: false }), "bottom-right");
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "bottom-left");
 
-    map.on("load", () => {
+    map.on("load", async () => {
+      await loadCameraIcons(map);
       readyRef.current = true;
       map.addSource(SRC, { type: "geojson", data: toFeatureCollection(camerasRef.current) });
       map.addLayer({
         id: LAYER,
-        type: "circle",
+        type: "symbol",
         source: SRC,
+        layout: {
+          // icon name = "cam-<feed>-<regionKey>" — matches loadCameraIcons().
+          "icon-image": ["concat", "cam-", ["get", "feed"], "-", ["get", "regionKey"]],
+          "icon-size": ["interpolate", ["linear"], ["zoom"], 9, 0.4, 13, 0.6, 17, 0.85],
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
+        },
         paint: {
-          "circle-radius": ["interpolate", ["linear"], ["zoom"], 9, 3, 14, 6, 17, 9],
-          "circle-color": ["case", ["get", "available"], "#22d3ee", "#64748b"],
-          "circle-stroke-width": 1.5,
-          "circle-stroke-color": "#04060c",
-          "circle-opacity": 0.95,
+          // Down feeds render faded; live ones full strength.
+          "icon-opacity": ["case", ["get", "available"], 1, 0.4],
         },
       });
 

--- a/components/PlaneDetail.tsx
+++ b/components/PlaneDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { WorldObject } from "@/lib/world";
+import { TypeIcon } from "@/lib/icons/Icon";
 
 interface Props {
   object: WorldObject;
@@ -147,8 +148,11 @@ export default function PlaneDetail({ object }: Props) {
             marginBottom: 4,
           }}
         >
-          {/* Plane icon as text — no external icon dep */}
-          <span style={{ fontSize: 18, color: "#f59e0b", lineHeight: 1 }}>✈</span>
+          {object.icon ? (
+            <TypeIcon icon={object.icon} color={object.color ?? "#f59e0b"} size={20} />
+          ) : (
+            <span style={{ fontSize: 18, color: "#f59e0b", lineHeight: 1 }}>✈</span>
+          )}
           <span
             style={{
               fontSize: 20,
@@ -159,6 +163,22 @@ export default function PlaneDetail({ object }: Props) {
           >
             {callsign}
           </span>
+          {object.typeLabel && (
+            <span
+              title="Type estimated from the live flight profile (no category in the OpenSky feed)"
+              style={{
+                background: "#1e293b",
+                color: object.color ?? "#fbbf24",
+                fontSize: 11,
+                padding: "2px 8px",
+                borderRadius: 4,
+                fontWeight: 600,
+                letterSpacing: "0.04em",
+              }}
+            >
+              {object.typeLabel} · est.
+            </span>
+          )}
           {onGround && (
             <span
               style={{

--- a/components/RegionJump.tsx
+++ b/components/RegionJump.tsx
@@ -1,0 +1,100 @@
+"use client";
+// Quick-jump control: flies the globe to each covered camera region. Without it
+// a viewer lands on London and never discovers the US coverage. Counts are live
+// (passed from GlobeView); only regions with a `view` are listed.
+
+import { CAMERA_REGIONS } from "@/lib/icons/svg";
+
+export type RegionView = { lat: number; lng: number; altitude: number };
+
+export default function RegionJump({
+  counts,
+  onJump,
+}: {
+  counts: Record<string, number>;
+  onJump: (view: RegionView) => void;
+}) {
+  const regions = CAMERA_REGIONS.filter((r) => r.view && (counts[r.source] ?? 0) > 0);
+  if (regions.length === 0) return null;
+
+  return (
+    <div style={{ position: "fixed", bottom: 16, left: 16, zIndex: 20 }}>
+      <div
+        style={{
+          background: "rgba(5,7,13,0.82)",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
+          border: "1px solid rgba(255,255,255,0.1)",
+          borderRadius: 12,
+          padding: "10px 12px",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.45)",
+          minWidth: 200,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "#64748b",
+            marginBottom: 6,
+          }}
+        >
+          Fly to region
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          {regions.map((r) => (
+            <button
+              key={r.source}
+              onClick={() => r.view && onJump(r.view)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 9,
+                padding: "7px 8px",
+                background: "transparent",
+                border: "1px solid transparent",
+                borderRadius: 8,
+                cursor: "pointer",
+                color: "#e2e8f0",
+                font: "inherit",
+                textAlign: "left",
+                transition: "background .15s ease, border-color .15s ease",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = "rgba(255,255,255,0.06)";
+                e.currentTarget.style.borderColor = `${r.color}66`;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = "transparent";
+                e.currentTarget.style.borderColor = "transparent";
+              }}
+            >
+              <span
+                style={{
+                  width: 9,
+                  height: 9,
+                  flexShrink: 0,
+                  background: r.color,
+                  borderRadius: "50%",
+                  boxShadow: `0 0 8px ${r.color}`,
+                }}
+              />
+              <span style={{ flex: 1, fontSize: 13, fontWeight: 500 }}>{r.label}</span>
+              <span
+                style={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  fontVariantNumeric: "tabular-nums",
+                  color: "#94a3b8",
+                }}
+              >
+                {(counts[r.source] ?? 0).toLocaleString()}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/SatelliteDetail.tsx
+++ b/components/SatelliteDetail.tsx
@@ -5,6 +5,7 @@
 // image export. Renders body content only — it sits inside <FeedOverlay>'s panel.
 
 import type { WorldObject } from "@/lib/world";
+import { TypeIcon } from "@/lib/icons/Icon";
 
 /** Esri World Imagery single-image export for a box around (lat, lon). */
 function esriImagery(lat: number, lon: number, halfDeg = 0.4): string {
@@ -30,7 +31,7 @@ const styles: Record<string, React.CSSProperties> = {
   figure: { margin: 0, position: "relative", borderRadius: 10, overflow: "hidden", background: "#0b1220", aspectRatio: "1 / 1" },
   img: { width: "100%", height: "100%", objectFit: "cover", display: "block" },
   cap: { position: "absolute", left: 8, bottom: 8, fontSize: 11, padding: "2px 8px", borderRadius: 999, background: "rgba(5,7,13,0.7)", color: "#cbd5e1", letterSpacing: "0.02em" },
-  badge: { display: "inline-block", fontSize: 11, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: "#a78bfa", border: "1px solid rgba(167,139,250,0.4)", borderRadius: 999, padding: "2px 10px" },
+  badge: { display: "inline-flex", alignItems: "center", gap: 7, alignSelf: "flex-start", fontSize: 11, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: "#a78bfa", border: "1px solid rgba(167,139,250,0.4)", borderRadius: 999, padding: "3px 12px 3px 9px" },
   stats: { display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: "10px 16px", margin: 0 },
   row: { display: "flex", flexDirection: "column", gap: 2 },
   dt: { fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em", color: "#64748b" },
@@ -45,7 +46,10 @@ export default function SatelliteDetail({ object }: { object: WorldObject }) {
 
   return (
     <div style={styles.wrap}>
-      <span style={styles.badge}>Satellite · live</span>
+      <span style={styles.badge}>
+        {object.icon && <TypeIcon icon={object.icon} color={object.color ?? "#a78bfa"} size={15} />}
+        {object.typeLabel ?? "Satellite"} · live
+      </span>
       <figure style={styles.figure}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img style={styles.img} src={img} alt={`Satellite imagery of the ground beneath ${object.label}`} loading="lazy" />

--- a/docs/superpowers/plans/2026-06-26-us-cameras-video.md
+++ b/docs/superpowers/plans/2026-06-26-us-cameras-video.md
@@ -1,0 +1,1024 @@
+# US Cameras + Live Video Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add California (Caltrans) and South Carolina (SCDOT) traffic cameras to the globe with real live HLS video, served through a closed proxy.
+
+**Architecture:** Two new keyless `Source` adapters normalize into the existing `Camera` schema; the registry merges all sources resiliently; a new `/api/hls` proxy injects the per-host Referer Caltrans requires and rewrites HLS playlists/segments to be same-origin; a `CameraVideo` (hls.js) component plays the live stream and falls back to the refreshing still when a stream is offline.
+
+**Tech Stack:** Next.js 15 (App Router) · React 19 · TypeScript · zod · hls.js · vitest (unit) · Playwright (e2e)
+
+## Global Constraints
+
+- Next.js 15 App Router, TypeScript, React 19. Path alias `@` → repo root.
+- **No API keys** — every source is keyless (Caltrans, SCDOT).
+- Canonical type is `Camera` (zod) from `@/lib/types`; ids are namespaced `${source}:${nativeId}`.
+- Every camera carries `license` + `attribution`; the UI must **always** render `<AttributionBadge>` (image and video paths alike).
+- **SSRF:** every outbound proxy fetch is gated by a host+path allowlist, uses `redirect: "error"`, an `AbortSignal.timeout`, and rejects non-http(s).
+- **The client never receives a raw `streamUrl`** — video is always fetched via `/api/hls?id=…`.
+- Unit tests: `tests/unit/**/*.test.ts` (vitest, node env). Fixtures: `tests/fixtures/`. E2E: `tests/e2e/` (Playwright; live-source dependent, like the existing TfL e2e).
+- **Commits are solo-attributed — do NOT add a `Co-Authored-By: Claude` trailer** (user preference for these public repos). Use plain `git commit -m "…"`.
+
+---
+
+### Task 1: Caltrans adapter
+
+**Files:**
+- Create: `lib/sources/caltrans.ts`
+- Create: `tests/fixtures/caltrans-d11.json`
+- Test: `tests/unit/caltrans.test.ts`
+
+**Interfaces:**
+- Consumes: `Camera`, `CameraArray`, `Source` from `@/lib/types`.
+- Produces: `CALTRANS_SOURCE: Source`; `normalizeCaltrans(records: CaltransRecord[], district: number): Camera[]`; `fetchRegistry(): Promise<Camera[]>`.
+
+- [ ] **Step 1: Write the fixture** — `tests/fixtures/caltrans-d11.json` (the `data` array; record 1 = video+still/in-service, record 2 = still-only/out-of-service, record 3 = no media → must be skipped):
+
+```json
+[
+  { "cctv": { "index": "1",
+    "location": { "locationName": "SR-163 : Friars NEB", "nearbyPlace": "San Diego", "longitude": "-117.160577", "latitude": "32.772126", "direction": "South", "route": "SR-163" },
+    "inService": "true",
+    "imageData": { "streamingVideoURL": "https://wzmedia.dot.ca.gov/D11/CAM1.stream/playlist.m3u8",
+      "static": { "currentImageURL": "https://cwwp2.dot.ca.gov/data/d11/cctv/image/cam1/cam1.jpg", "currentImageUpdateFrequency": "2" } } } },
+  { "cctv": { "index": "2",
+    "location": { "locationName": "I-8 at Hotel Circle", "nearbyPlace": "San Diego", "longitude": "-117.18", "latitude": "32.76", "direction": "East", "route": "I-8" },
+    "inService": "false",
+    "imageData": { "streamingVideoURL": "",
+      "static": { "currentImageURL": "https://cwwp2.dot.ca.gov/data/d11/cctv/image/cam2/cam2.jpg", "currentImageUpdateFrequency": "2" } } } },
+  { "cctv": { "index": "3",
+    "location": { "nearbyPlace": "El Cajon", "longitude": "-116.9", "latitude": "32.79" },
+    "inService": "true",
+    "imageData": { "static": {} } } }
+]
+```
+
+- [ ] **Step 2: Write the failing test** — `tests/unit/caltrans.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/caltrans-d11.json";
+import { normalizeCaltrans } from "@/lib/sources/caltrans";
+import { CameraArray } from "@/lib/types";
+
+test("normalizes Caltrans records into valid Cameras and skips no-media records", () => {
+  const cams = normalizeCaltrans(fixture as never, 11);
+  expect(() => CameraArray.parse(cams)).not.toThrow();
+  expect(cams).toHaveLength(2); // record 3 has no image and no stream
+});
+
+test("maps id, region, media type, availability and refresh", () => {
+  const [a, b] = normalizeCaltrans(fixture as never, 11);
+  expect(a.id).toBe("caltrans:d11-1");
+  expect(a.country).toBe("US");
+  expect(a.region).toBe("California");
+  expect(a.mediaType).toBe("both"); // has a stream
+  expect(a.available).toBe(true);
+  expect(a.road).toBe("SR-163");
+  expect(a.refreshSeconds).toBe(120); // 2 minutes * 60
+  expect(b.mediaType).toBe("jpeg"); // empty streamingVideoURL
+  expect(b.available).toBe(false);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/caltrans.test.ts`
+Expected: FAIL — cannot find module `@/lib/sources/caltrans`.
+
+- [ ] **Step 4: Implement** — `lib/sources/caltrans.ts`:
+
+```ts
+import { Camera, CameraArray, Source } from "@/lib/types";
+
+export const CALTRANS_SOURCE: Source = {
+  id: "caltrans",
+  name: "Caltrans CCTV",
+  license: "Caltrans Terms of Use",
+  attribution: "Live traffic data © Caltrans (California DOT)",
+  refreshSeconds: 60,
+  needsKey: false,
+};
+
+const DISTRICTS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+export interface CaltransRecord {
+  cctv: {
+    index: string;
+    location: {
+      locationName?: string; nearbyPlace?: string;
+      longitude?: string; latitude?: string; direction?: string; route?: string;
+    };
+    inService: string;
+    imageData: {
+      streamingVideoURL?: string;
+      static?: { currentImageURL?: string; currentImageUpdateFrequency?: string };
+    };
+  };
+}
+
+export function normalizeCaltrans(records: CaltransRecord[], district: number): Camera[] {
+  const cams: Camera[] = [];
+  for (const r of records) {
+    const c = r.cctv;
+    const lat = Number(c.location?.latitude);
+    const lon = Number(c.location?.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const imageUrl = c.imageData?.static?.currentImageURL?.trim() || undefined;
+    const streamUrl = c.imageData?.streamingVideoURL?.trim() || undefined;
+    if (!imageUrl && !streamUrl) continue;
+    const freqMin = Number(c.imageData?.static?.currentImageUpdateFrequency);
+    const refreshSeconds = Number.isFinite(freqMin) && freqMin > 0 ? Math.max(30, freqMin * 60) : 60;
+    cams.push({
+      id: `caltrans:d${district}-${c.index}`,
+      source: "caltrans",
+      country: "US",
+      region: "California",
+      name: c.location?.locationName?.trim() || c.location?.nearbyPlace?.trim() || `Caltrans D${district} #${c.index}`,
+      lat, lon,
+      road: c.location?.route?.trim() || undefined,
+      direction: c.location?.direction?.trim() || undefined,
+      imageUrl,
+      streamUrl,
+      mediaType: streamUrl ? "both" : "jpeg",
+      refreshSeconds,
+      license: CALTRANS_SOURCE.license,
+      attribution: CALTRANS_SOURCE.attribution,
+      available: c.inService === "true",
+    });
+  }
+  return cams;
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  const results = await Promise.allSettled(
+    DISTRICTS.map(async (d) => {
+      const res = await fetch(`https://cwwp2.dot.ca.gov/data/d${d}/cctv/cctvStatusD${d}.json`, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) throw new Error(`Caltrans D${d}: ${res.status}`);
+      const json = (await res.json()) as { data?: CaltransRecord[] };
+      return normalizeCaltrans(json.data ?? [], d);
+    }),
+  );
+  const cams = results
+    .filter((r): r is PromiseFulfilledResult<Camera[]> => r.status === "fulfilled")
+    .flatMap((r) => r.value);
+  return CameraArray.parse(cams);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/caltrans.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/sources/caltrans.ts tests/fixtures/caltrans-d11.json tests/unit/caltrans.test.ts
+git commit -m "feat: Caltrans (California) CCTV adapter — HLS video + still, district-resilient"
+```
+
+---
+
+### Task 2: SCDOT adapter
+
+**Files:**
+- Create: `lib/sources/scdot.ts`
+- Create: `tests/fixtures/scdot-cameras.json`
+- Test: `tests/unit/scdot.test.ts`
+
+**Interfaces:**
+- Consumes: `Camera`, `CameraArray`, `Source` from `@/lib/types`.
+- Produces: `SCDOT_SOURCE: Source`; `normalizeScdot(geojson: { features?: ScFeature[] }): Camera[]`; `fetchRegistry(): Promise<Camera[]>`.
+
+- [ ] **Step 1: Write the fixture** — `tests/fixtures/scdot-cameras.json` (GeoJSON; feature 1 = healthy, feature 2 = `problem_stream`, feature 3 = null geometry → skipped):
+
+```json
+{ "type": "FeatureCollection", "features": [
+  { "type": "Feature", "geometry": { "type": "Point", "coordinates": [-79.062775, 33.845627] },
+    "properties": { "id": "uuid-1", "name": "50001", "description": "US 501 N @ 16th Ave", "route": "US 501", "direction": "NB",
+      "https_url": "https://s18.us-east-1.skyvdn.com:443/rtplive/50001/playlist.m3u8",
+      "ios_url": "https://s18.us-east-1.skyvdn.com:443/rtplive/50001/playlist.m3u8",
+      "image_url": "https://scdotsnap.us-east-1.skyvdn.com/thumbs/50001.flv.png", "active": true, "problem_stream": false } },
+  { "type": "Feature", "geometry": { "type": "Point", "coordinates": [-80.9, 32.8] },
+    "properties": { "id": "uuid-2", "name": "50002", "description": "I-26 @ Mile 5", "route": "I-26", "direction": "EB",
+      "https_url": "https://s19.us-east-1.skyvdn.com:443/rtplive/50002/playlist.m3u8",
+      "image_url": "https://scdotsnap.us-east-1.skyvdn.com/thumbs/50002.flv.png", "active": true, "problem_stream": true } },
+  { "type": "Feature", "geometry": null, "properties": { "name": "50003" } }
+] }
+```
+
+- [ ] **Step 2: Write the failing test** — `tests/unit/scdot.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/scdot-cameras.json";
+import { normalizeScdot } from "@/lib/sources/scdot";
+import { CameraArray } from "@/lib/types";
+
+test("normalizes SCDOT GeoJSON into valid Cameras and skips geometry-less features", () => {
+  const cams = normalizeScdot(fixture as never);
+  expect(() => CameraArray.parse(cams)).not.toThrow();
+  expect(cams).toHaveLength(2); // feature 3 has null geometry
+});
+
+test("uses description as name, lon/lat order, and problem_stream → unavailable", () => {
+  const [a, b] = normalizeScdot(fixture as never);
+  expect(a.id).toBe("scdot:50001");
+  expect(a.region).toBe("South Carolina");
+  expect(a.name).toBe("US 501 N @ 16th Ave");
+  expect(a.lat).toBeCloseTo(33.845627, 5);
+  expect(a.lon).toBeCloseTo(-79.062775, 5);
+  expect(a.mediaType).toBe("both");
+  expect(a.available).toBe(true);
+  expect(b.available).toBe(false); // problem_stream: true
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/scdot.test.ts`
+Expected: FAIL — cannot find module `@/lib/sources/scdot`.
+
+- [ ] **Step 4: Implement** — `lib/sources/scdot.ts`:
+
+```ts
+import { Camera, CameraArray, Source } from "@/lib/types";
+
+export const SCDOT_SOURCE: Source = {
+  id: "scdot",
+  name: "SCDOT 511 (South Carolina DOT)",
+  license: "SCDOT 511 Terms of Use",
+  attribution: "Live traffic data © SCDOT / 511sc.org",
+  refreshSeconds: 60,
+  needsKey: false,
+};
+
+export interface ScFeature {
+  geometry?: { coordinates?: [number, number] } | null;
+  properties?: {
+    id?: string; name?: string; description?: string; route?: string; direction?: string;
+    https_url?: string; ios_url?: string; image_url?: string;
+    active?: boolean; problem_stream?: boolean;
+  };
+}
+
+export function normalizeScdot(geojson: { features?: ScFeature[] }): Camera[] {
+  const cams: Camera[] = [];
+  for (const f of geojson.features ?? []) {
+    const p = f.properties ?? {};
+    const coords = f.geometry?.coordinates;
+    if (!coords) continue;
+    const lon = Number(coords[0]);
+    const lat = Number(coords[1]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const imageUrl = p.image_url?.trim() || undefined;
+    const streamUrl = p.https_url?.trim() || p.ios_url?.trim() || undefined;
+    if (!imageUrl && !streamUrl) continue;
+    const nativeId = (p.name ?? p.id ?? "").toString().trim();
+    if (!nativeId) continue;
+    cams.push({
+      id: `scdot:${nativeId}`,
+      source: "scdot",
+      country: "US",
+      region: "South Carolina",
+      name: p.description?.trim() || p.name?.trim() || `SCDOT ${nativeId}`,
+      lat, lon,
+      road: p.route?.trim() || undefined,
+      direction: p.direction?.trim() || undefined,
+      imageUrl,
+      streamUrl,
+      mediaType: streamUrl ? "both" : "jpeg",
+      refreshSeconds: SCDOT_SOURCE.refreshSeconds,
+      license: SCDOT_SOURCE.license,
+      attribution: SCDOT_SOURCE.attribution,
+      available: p.active === true && p.problem_stream !== true,
+    });
+  }
+  return cams;
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  const res = await fetch("https://sc.cdn.iteris-atis.com/geojson/icons/metadata/icons.cameras.geojson", {
+    headers: { Accept: "application/json", Referer: "https://www.511sc.org/" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`SCDOT GeoJSON: ${res.status}`);
+  const json = (await res.json()) as { features?: ScFeature[] };
+  return CameraArray.parse(normalizeScdot(json));
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/scdot.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/sources/scdot.ts tests/fixtures/scdot-cameras.json tests/unit/scdot.test.ts
+git commit -m "feat: SCDOT (South Carolina) 511 adapter — HLS video + still"
+```
+
+---
+
+### Task 3: Multi-source registry merge
+
+**Files:**
+- Modify: `lib/sources/registry.ts`
+- Test: `tests/unit/registry.test.ts`
+
+**Interfaces:**
+- Consumes: `fetchRegistry` from tfl, caltrans, scdot; `findById`, `nearest` from `@/lib/sources/select`.
+- Produces: `mergeResults(results: PromiseSettledResult<Camera[]>[], staleCache: Camera[] | null): Camera[]` (new, exported, pure); unchanged public API `getRegistry()`, `getCameraById()`, `nearestTo()`.
+
+- [ ] **Step 1: Write the failing test** — `tests/unit/registry.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import { mergeResults } from "@/lib/sources/registry";
+import type { Camera } from "@/lib/types";
+
+const cam = (id: string): Camera => ({
+  id, source: "x", country: "US", name: id, lat: 0, lon: 0,
+  mediaType: "jpeg", refreshSeconds: 60, license: "L", attribution: "A", available: true,
+});
+const ok = (cams: Camera[]): PromiseSettledResult<Camera[]> => ({ status: "fulfilled", value: cams });
+const fail = (): PromiseSettledResult<Camera[]> => ({ status: "rejected", reason: new Error("boom") });
+
+test("unions all fulfilled sources", () => {
+  expect(mergeResults([ok([cam("a")]), ok([cam("b"), cam("c")])], null).map((c) => c.id)).toEqual(["a", "b", "c"]);
+});
+test("ignores a rejected source when others succeed", () => {
+  expect(mergeResults([ok([cam("a")]), fail()], null).map((c) => c.id)).toEqual(["a"]);
+});
+test("falls back to stale cache when everything fails", () => {
+  expect(mergeResults([fail(), fail()], [cam("stale")]).map((c) => c.id)).toEqual(["stale"]);
+});
+test("throws when everything fails and there is no cache", () => {
+  expect(() => mergeResults([fail()], null)).toThrow();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/registry.test.ts`
+Expected: FAIL — `mergeResults` is not exported.
+
+- [ ] **Step 3: Implement** — replace the whole of `lib/sources/registry.ts`:
+
+```ts
+import type { Camera } from "@/lib/types";
+import { fetchRegistry as fetchTfl } from "@/lib/sources/tfl";
+import { fetchRegistry as fetchCaltrans } from "@/lib/sources/caltrans";
+import { fetchRegistry as fetchScdot } from "@/lib/sources/scdot";
+import { findById, nearest } from "@/lib/sources/select";
+
+const TTL_MS = 5 * 60 * 1000;
+const SOURCES: Array<() => Promise<Camera[]>> = [fetchTfl, fetchCaltrans, fetchScdot];
+let cache: { cameras: Camera[]; at: number } | null = null;
+
+export function mergeResults(
+  results: PromiseSettledResult<Camera[]>[],
+  staleCache: Camera[] | null,
+): Camera[] {
+  const cameras = results
+    .filter((r): r is PromiseFulfilledResult<Camera[]> => r.status === "fulfilled")
+    .flatMap((r) => r.value);
+  if (cameras.length === 0) {
+    if (staleCache && staleCache.length > 0) return staleCache;
+    throw new Error("all camera sources failed and no cache is available");
+  }
+  return cameras;
+}
+
+export async function getRegistry(): Promise<Camera[]> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.cameras;
+  const results = await Promise.allSettled(SOURCES.map((f) => f()));
+  const cameras = mergeResults(results, cache?.cameras ?? null);
+  cache = { cameras, at: Date.now() };
+  return cameras;
+}
+
+export async function getCameraById(id: string): Promise<Camera | null> {
+  return findById(await getRegistry(), id);
+}
+
+export async function nearestTo(lat: number, lon: number, limit = 8) {
+  return nearest(await getRegistry(), lat, lon, limit);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes (and the existing suite still green)**
+
+Run: `npx vitest run tests/unit/registry.test.ts tests/unit/select.test.ts tests/unit/tfl.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/sources/registry.ts tests/unit/registry.test.ts
+git commit -m "feat: merge TfL + Caltrans + SCDOT in the registry (resilient, stale-cache fallback)"
+```
+
+---
+
+### Task 4: Extend the still-image allowlist
+
+**Files:**
+- Modify: `lib/proxy/allowlist.ts:2-4`
+- Modify: `tests/unit/allowlist.test.ts`
+
+**Interfaces:**
+- Produces: unchanged `isAllowed(url: URL): boolean`, now also allowing the CA + SC image hosts.
+
+- [ ] **Step 1: Add the failing tests** — append to `tests/unit/allowlist.test.ts`:
+
+```ts
+test("allows the Caltrans image host under /data/", () => {
+  expect(isAllowed(new URL("https://cwwp2.dot.ca.gov/data/d11/cctv/image/cam1/cam1.jpg"))).toBe(true);
+});
+test("allows the SCDOT snapshot host under /thumbs/", () => {
+  expect(isAllowed(new URL("https://scdotsnap.us-east-1.skyvdn.com/thumbs/50001.flv.png"))).toBe(true);
+});
+test("rejects those hosts outside their allowed prefix", () => {
+  expect(isAllowed(new URL("https://cwwp2.dot.ca.gov/etc/secret.jpg"))).toBe(false);
+  expect(isAllowed(new URL("https://scdotsnap.us-east-1.skyvdn.com/rtplive/x.ts"))).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/allowlist.test.ts`
+Expected: FAIL — the two new hosts are not yet allowed.
+
+- [ ] **Step 3: Implement** — replace the `RULES` array in `lib/proxy/allowlist.ts`:
+
+```ts
+const RULES: { host: string; prefix: string }[] = [
+  { host: "s3-eu-west-1.amazonaws.com", prefix: "/jamcams.tfl.gov.uk/" },
+  { host: "cwwp2.dot.ca.gov", prefix: "/data/" },
+  { host: "scdotsnap.us-east-1.skyvdn.com", prefix: "/thumbs/" },
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/allowlist.test.ts`
+Expected: PASS (existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/proxy/allowlist.ts tests/unit/allowlist.test.ts
+git commit -m "feat: allow Caltrans + SCDOT still-image hosts in the proxy allowlist"
+```
+
+---
+
+### Task 5: HLS streaming allowlist (host + per-host Referer)
+
+**Files:**
+- Create: `lib/proxy/hls-allowlist.ts`
+- Test: `tests/unit/hls-allowlist.test.ts`
+
+**Interfaces:**
+- Produces: `isHlsAllowed(url: URL): { ok: boolean; referer?: string }`.
+
+- [ ] **Step 1: Write the failing test** — `tests/unit/hls-allowlist.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import { isHlsAllowed } from "@/lib/proxy/hls-allowlist";
+
+test("allows Caltrans wzmedia with the Caltrans referer", () => {
+  const v = isHlsAllowed(new URL("https://wzmedia.dot.ca.gov/D11/CAM.stream/playlist.m3u8"));
+  expect(v.ok).toBe(true);
+  expect(v.referer).toBe("https://cwwp2.dot.ca.gov/");
+});
+test("allows SC skyvdn shards under /rtplive/ with the 511sc referer", () => {
+  const v = isHlsAllowed(new URL("https://s19.us-east-1.skyvdn.com:443/rtplive/50001/playlist.m3u8"));
+  expect(v.ok).toBe(true);
+  expect(v.referer).toBe("https://www.511sc.org/");
+});
+test("rejects a skyvdn path outside /rtplive/", () => {
+  expect(isHlsAllowed(new URL("https://s19.us-east-1.skyvdn.com/secret/x.m3u8")).ok).toBe(false);
+});
+test("rejects unknown hosts, look-alike suffixes, and non-http", () => {
+  expect(isHlsAllowed(new URL("https://evil.example.com/x.m3u8")).ok).toBe(false);
+  expect(isHlsAllowed(new URL("https://x.us-east-1.skyvdn.com.attacker.com/rtplive/x")).ok).toBe(false);
+  expect(isHlsAllowed(new URL("file:///etc/passwd")).ok).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/hls-allowlist.test.ts`
+Expected: FAIL — cannot find module `@/lib/proxy/hls-allowlist`.
+
+- [ ] **Step 3: Implement** — `lib/proxy/hls-allowlist.ts`:
+
+```ts
+// Streaming hosts are separate from the still-image allowlist: each rule also
+// carries the Referer to inject (Caltrans' wzmedia is hotlink-protected).
+type HlsRule = { match: (host: string) => boolean; prefix: string; referer: string };
+
+const RULES: HlsRule[] = [
+  { match: (h) => h === "wzmedia.dot.ca.gov", prefix: "/", referer: "https://cwwp2.dot.ca.gov/" },
+  { match: (h) => h.endsWith(".us-east-1.skyvdn.com"), prefix: "/rtplive/", referer: "https://www.511sc.org/" },
+];
+
+export function isHlsAllowed(url: URL): { ok: boolean; referer?: string } {
+  if (url.protocol !== "https:" && url.protocol !== "http:") return { ok: false };
+  for (const r of RULES) {
+    if (r.match(url.hostname) && url.pathname.startsWith(r.prefix)) {
+      return { ok: true, referer: r.referer };
+    }
+  }
+  return { ok: false };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/hls-allowlist.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/proxy/hls-allowlist.ts tests/unit/hls-allowlist.test.ts
+git commit -m "feat: HLS streaming allowlist with per-host Referer injection (SSRF-safe)"
+```
+
+---
+
+### Task 6: HLS playlist rewriter (pure)
+
+**Files:**
+- Create: `lib/proxy/hls-rewrite.ts`
+- Test: `tests/unit/hls-rewrite.test.ts`
+
+**Interfaces:**
+- Produces: `rewritePlaylist(body: string, upstreamUrl: string): string` — rewrites every media/playlist URI (and any `URI="…"` tag attribute) to `/api/hls?u=<absolute, encoded>`.
+
+- [ ] **Step 1: Write the failing test** — `tests/unit/hls-rewrite.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import { rewritePlaylist } from "@/lib/proxy/hls-rewrite";
+
+const BASE = "https://wzmedia.dot.ca.gov/D11/CAM.stream/playlist.m3u8";
+const enc = (s: string) => encodeURIComponent(s);
+
+test("rewrites a relative chunklist URI and leaves tag lines untouched", () => {
+  const out = rewritePlaylist("#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nchunklist_w1.m3u8\n", BASE);
+  expect(out).toContain("#EXT-X-STREAM-INF:BANDWIDTH=1");
+  expect(out).toContain("/api/hls?u=" + enc("https://wzmedia.dot.ca.gov/D11/CAM.stream/chunklist_w1.m3u8"));
+});
+test("rewrites relative .ts segments", () => {
+  const out = rewritePlaylist("#EXTINF:2.0,\nmedia_w1_0.ts\n", BASE);
+  expect(out).toContain("/api/hls?u=" + enc("https://wzmedia.dot.ca.gov/D11/CAM.stream/media_w1_0.ts"));
+});
+test("resolves absolute segment URIs", () => {
+  const out = rewritePlaylist("#EXT-X-VERSION:3\nhttps://cdn.example.com/x/seg.ts\n", BASE);
+  expect(out).toContain("#EXT-X-VERSION:3");
+  expect(out).toContain("/api/hls?u=" + enc("https://cdn.example.com/x/seg.ts"));
+});
+test("rewrites the URI attribute of an EXT-X-KEY tag", () => {
+  const out = rewritePlaylist('#EXT-X-KEY:METHOD=AES-128,URI="key.bin"\nmedia0.ts\n', BASE);
+  expect(out).toContain("/api/hls?u=" + enc("https://wzmedia.dot.ca.gov/D11/CAM.stream/key.bin"));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/hls-rewrite.test.ts`
+Expected: FAIL — cannot find module `@/lib/proxy/hls-rewrite`.
+
+- [ ] **Step 3: Implement** — `lib/proxy/hls-rewrite.ts`:
+
+```ts
+// Rewrite an HLS playlist so every nested URI routes back through /api/hls.
+// Relative URIs are resolved against the upstream playlist URL first.
+export function rewritePlaylist(body: string, upstreamUrl: string): string {
+  const proxy = (abs: string) => `/api/hls?u=${encodeURIComponent(abs)}`;
+  return body
+    .split("\n")
+    .map((line) => {
+      const trimmed = line.trim();
+      if (trimmed === "") return line;
+      if (trimmed.startsWith("#")) {
+        // Tags like EXT-X-KEY / EXT-X-MAP can carry URI="...".
+        const m = trimmed.match(/URI="([^"]+)"/);
+        if (m) {
+          const abs = new URL(m[1], upstreamUrl).toString();
+          return line.replace(m[1], proxy(abs));
+        }
+        return line;
+      }
+      const abs = new URL(trimmed, upstreamUrl).toString();
+      return proxy(abs);
+    })
+    .join("\n");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/hls-rewrite.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/proxy/hls-rewrite.ts tests/unit/hls-rewrite.test.ts
+git commit -m "feat: HLS playlist rewriter — nested URIs route back through the proxy"
+```
+
+---
+
+### Task 7: HLS proxy route
+
+**Files:**
+- Create: `app/api/hls/route.ts`
+- Test: `tests/e2e/hls.spec.ts`
+
+**Interfaces:**
+- Consumes: `getCameraById` (registry), `isHlsAllowed` (Task 5), `rewritePlaylist` (Task 6).
+- Produces: `GET /api/hls?id=<cameraId>` (resolves the camera's stream) and `GET /api/hls?u=<absolute url>` (nested links). Returns rewritten `application/vnd.apple.mpegurl` for playlists; streams segments through with `Range` support; `400` (no params), `403` (disallowed), `404` (unknown id / no stream), `502` (upstream failure).
+
+- [ ] **Step 1: Write the failing e2e** — `tests/e2e/hls.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+
+test("the HLS proxy rejects missing params and disallowed hosts", async ({ request }) => {
+  expect((await request.get("/api/hls")).status()).toBe(400);
+  const forbidden = await request.get("/api/hls?u=" + encodeURIComponent("https://evil.example.com/x.m3u8"));
+  expect(forbidden.status()).toBe(403);
+});
+
+test("a US camera's stream is proxied as an HLS playlist", async ({ request }) => {
+  const { cameras } = await (await request.get("/api/cameras")).json();
+  const us = cameras.find((c: { id: string }) => c.id.startsWith("caltrans:") || c.id.startsWith("scdot:"));
+  test.skip(!us, "no US camera available from live sources right now");
+  const res = await request.get(`/api/hls?id=${encodeURIComponent(us.id)}`);
+  // Live streams flake; accept a proxied playlist (200 mpegurl) or an upstream-down 502.
+  if (res.ok()) {
+    expect(res.headers()["content-type"]).toContain("mpegurl");
+    expect(await res.text()).toContain("/api/hls?u=");
+  } else {
+    expect([502, 404]).toContain(res.status());
+  }
+});
+```
+
+- [ ] **Step 2: Run the e2e to verify it fails**
+
+Run: `npx playwright test tests/e2e/hls.spec.ts`
+Expected: FAIL — `/api/hls` 404s (route does not exist yet).
+
+- [ ] **Step 3: Implement** — `app/api/hls/route.ts`:
+
+```ts
+import type { NextRequest } from "next/server";
+import { getCameraById } from "@/lib/sources/registry";
+import { isHlsAllowed } from "@/lib/proxy/hls-allowlist";
+import { rewritePlaylist } from "@/lib/proxy/hls-rewrite";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const idParam = req.nextUrl.searchParams.get("id");
+  const uParam = req.nextUrl.searchParams.get("u");
+
+  let upstream: string | null = null;
+  if (uParam) {
+    upstream = uParam;
+  } else if (idParam) {
+    const cam = await getCameraById(idParam);
+    if (!cam?.streamUrl) return new Response("camera or stream not found", { status: 404 });
+    upstream = cam.streamUrl;
+  }
+  if (!upstream) return new Response("missing id or u", { status: 400 });
+
+  let target: URL;
+  try { target = new URL(upstream); } catch { return new Response("bad url", { status: 400 }); }
+
+  const verdict = isHlsAllowed(target);
+  if (!verdict.ok) return new Response("forbidden host", { status: 403 });
+
+  const range = req.headers.get("range");
+  let res: Response;
+  try {
+    res = await fetch(target.toString(), {
+      headers: {
+        Referer: verdict.referer ?? "",
+        "User-Agent": "TrafficNerd/2.0 (+https://github.com/011-sam-110/TrafficNerd-V2)",
+        Accept: "*/*",
+        ...(range ? { Range: range } : {}),
+      },
+      cache: "no-store",
+      redirect: "error",
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    return new Response("upstream fetch failed", { status: 502 });
+  }
+  if (!res.ok && res.status !== 206) return new Response("upstream error", { status: 502 });
+
+  const ct = res.headers.get("content-type");
+  const isPlaylist = (ct?.includes("mpegurl") ?? false) || target.pathname.toLowerCase().endsWith(".m3u8");
+
+  if (isPlaylist) {
+    const body = await res.text();
+    return new Response(rewritePlaylist(body, target.toString()), {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.apple.mpegurl", "Cache-Control": "no-store" },
+    });
+  }
+
+  // Segment / binary: stream straight through (do not buffer), preserve range semantics.
+  const headers = new Headers();
+  headers.set("Content-Type", ct ?? "video/mp2t");
+  const cr = res.headers.get("content-range"); if (cr) headers.set("Content-Range", cr);
+  const cl = res.headers.get("content-length"); if (cl) headers.set("Content-Length", cl);
+  headers.set("Accept-Ranges", "bytes");
+  headers.set("Cache-Control", "public, max-age=5");
+  return new Response(res.body, { status: res.status, headers });
+}
+```
+
+- [ ] **Step 4: Run the e2e to verify it passes**
+
+Run: `npx playwright test tests/e2e/hls.spec.ts`
+Expected: PASS (guard test passes; the live test passes or skips).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/hls/route.ts tests/e2e/hls.spec.ts
+git commit -m "feat: /api/hls closed proxy — Referer injection, playlist rewrite, segment streaming"
+```
+
+---
+
+### Task 8: Expose `mediaType` (and hide `streamUrl`); add `country` to the list
+
+**Files:**
+- Modify: `app/api/camera/[id]/route.ts:10-16`
+- Modify: `app/api/cameras/route.ts:6-10`
+- Test: `tests/e2e/camera.spec.ts` (append)
+
+**Interfaces:**
+- Produces: `/api/camera/[id]` response `camera` includes `mediaType` and **omits** `streamUrl`; `/api/cameras` list items include `country`.
+
+- [ ] **Step 1: Add failing assertions** — append to `tests/e2e/camera.spec.ts`:
+
+```ts
+test("camera detail exposes mediaType but never the raw streamUrl", async ({ request }) => {
+  const { cameras } = await (await request.get("/api/cameras")).json();
+  expect(cameras[0].country).toBeTruthy(); // list now carries country
+  const res = await request.get(`/api/camera/${encodeURIComponent(cameras[0].id)}`);
+  const { camera } = await res.json();
+  expect(camera.mediaType).toBeTruthy();
+  expect(camera.streamUrl).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx playwright test tests/e2e/camera.spec.ts`
+Expected: FAIL — `country` missing from the slim list.
+
+- [ ] **Step 3a: Implement** — in `app/api/cameras/route.ts`, add `country` to the mapped object:
+
+```ts
+  const cameras = cams.map((c) => ({
+    id: c.id, name: c.name, lat: c.lat, lon: c.lon, available: c.available, country: c.country,
+  }));
+```
+
+- [ ] **Step 3b: Implement** — in `app/api/camera/[id]/route.ts`, strip `streamUrl` before responding (replace the final `return`):
+
+```ts
+  const safe = { ...camera };
+  delete (safe as { streamUrl?: string }).streamUrl;
+  return Response.json({ camera: safe, nearby });
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx playwright test tests/e2e/camera.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/cameras/route.ts "app/api/camera/[id]/route.ts" tests/e2e/camera.spec.ts
+git commit -m "feat: API surfaces mediaType + country, hides raw streamUrl from clients"
+```
+
+---
+
+### Task 9: hls.js video player + detail wiring
+
+**Files:**
+- Modify: `package.json` (add `hls.js`)
+- Create: `components/CameraVideo.tsx`
+- Modify: `components/CameraDetail.tsx:12-23,59-66` (add `mediaType` to `CamInfo`; choose player)
+- Modify: `app/camera/[id]/page.tsx:4,21-25` (import + choose player)
+- Test: `tests/e2e/us-video.spec.ts`
+
+**Interfaces:**
+- Consumes: `/api/hls?id=` (Task 7), `/api/proxy?id=` (poster, existing), `mediaType` (Task 8), `CameraImage`, `AttributionBadge`.
+- Produces: `CameraVideo({ id, alt, attribution, license, refreshSeconds })` — a `<video>` that plays the proxied live HLS and falls back to `<CameraImage>` on fatal error.
+
+- [ ] **Step 1: Install hls.js**
+
+Run: `npm install hls.js`
+Expected: `hls.js` added to `dependencies` (ships its own TypeScript types).
+
+- [ ] **Step 2: Create the player** — `components/CameraVideo.tsx`:
+
+```tsx
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { AttributionBadge } from "@/components/AttributionBadge";
+import { CameraImage } from "@/components/CameraImage";
+
+export function CameraVideo(props: {
+  id: string; alt: string; attribution: string; license: string; refreshSeconds: number;
+}) {
+  const { id, alt, attribution, license, refreshSeconds } = props;
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [failed, setFailed] = useState(false);
+  const src = `/api/hls?id=${encodeURIComponent(id)}`;
+  const poster = `/api/proxy?id=${encodeURIComponent(id)}`;
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    let hls: { destroy: () => void } | null = null;
+    let cancelled = false;
+
+    if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = src; // Safari plays HLS natively
+      return;
+    }
+    (async () => {
+      const Hls = (await import("hls.js")).default;
+      if (cancelled) return;
+      if (!Hls.isSupported()) { setFailed(true); return; }
+      const instance = new Hls({ enableWorker: true });
+      hls = instance;
+      instance.loadSource(src);
+      instance.attachMedia(video);
+      instance.on(Hls.Events.ERROR, (_evt, data) => {
+        if (data.fatal) { setFailed(true); instance.destroy(); hls = null; }
+      });
+    })();
+
+    return () => { cancelled = true; if (hls) hls.destroy(); };
+  }, [src]);
+
+  if (failed) {
+    return (
+      <CameraImage id={id} alt={alt} attribution={attribution} license={license} refreshSeconds={refreshSeconds} />
+    );
+  }
+  return (
+    <figure style={{ margin: 0 }}>
+      <video ref={videoRef} poster={poster} controls autoPlay muted playsInline aria-label={alt} style={{ width: "100%" }} />
+      <figcaption><AttributionBadge attribution={attribution} license={license} /></figcaption>
+    </figure>
+  );
+}
+```
+
+- [ ] **Step 3: Wire the overlay** — in `components/CameraDetail.tsx`, (a) add `mediaType` to the `CamInfo` type and (b) import + branch on it. Add the import near the top:
+
+```tsx
+import { CameraVideo } from "@/components/CameraVideo";
+```
+
+Add to the `CamInfo` type:
+
+```tsx
+  mediaType: "jpeg" | "video" | "both";
+```
+
+Replace the `<CameraImage … />` block (the one rendered when `cam` is truthy) with:
+
+```tsx
+        cam.mediaType !== "jpeg" ? (
+          <CameraVideo
+            id={cam.id} alt={cam.name}
+            attribution={cam.attribution} license={cam.license}
+            refreshSeconds={cam.refreshSeconds}
+          />
+        ) : (
+          <CameraImage
+            id={cam.id} alt={cam.name}
+            attribution={cam.attribution} license={cam.license}
+            refreshSeconds={cam.refreshSeconds}
+          />
+        )
+```
+
+- [ ] **Step 4: Wire the standalone page** — in `app/camera/[id]/page.tsx`, add the import:
+
+```tsx
+import { CameraVideo } from "@/components/CameraVideo";
+```
+
+Replace the `<CameraImage … />` element with:
+
+```tsx
+      {cam.mediaType !== "jpeg" ? (
+        <CameraVideo id={cam.id} alt={cam.name} attribution={cam.attribution} license={cam.license} refreshSeconds={cam.refreshSeconds} />
+      ) : (
+        <CameraImage id={cam.id} alt={cam.name} attribution={cam.attribution} license={cam.license} refreshSeconds={cam.refreshSeconds} />
+      )}
+```
+
+- [ ] **Step 5: Write the e2e** — `tests/e2e/us-video.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+
+test("a US camera detail shows live video (or gracefully falls back to a still)", async ({ page, request }) => {
+  const { cameras } = await (await request.get("/api/cameras")).json();
+  const us = cameras.find((c: { id: string }) => c.id.startsWith("caltrans:") || c.id.startsWith("scdot:"));
+  test.skip(!us, "no US camera available from live sources right now");
+
+  await page.goto(`/camera/${encodeURIComponent(us.id)}`);
+  await expect(page.getByTestId("attribution")).toBeVisible();
+  // Either a <video> mounts, or (offline stream) the still-image fallback appears.
+  const media = page.locator(".camera-detail video, .camera-detail img");
+  await expect(media.first()).toBeVisible();
+});
+```
+
+- [ ] **Step 6: Run the e2e**
+
+Run: `npx playwright test tests/e2e/us-video.spec.ts`
+Expected: PASS (video or still visible; or skip if no US camera live).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json package-lock.json components/CameraVideo.tsx components/CameraDetail.tsx "app/camera/[id]/page.tsx" tests/e2e/us-video.spec.ts
+git commit -m "feat: live HLS video player (hls.js) with still-image fallback on US camera detail"
+```
+
+---
+
+### Task 10: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole unit suite**
+
+Run: `npm test`
+Expected: PASS — all unit tests (existing + caltrans, scdot, registry, allowlist, hls-allowlist, hls-rewrite).
+
+- [ ] **Step 2: Type-check + production build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: no type errors; build completes (hls.js is dynamically imported, so it never evaluates during SSR/build).
+
+- [ ] **Step 3: Run the e2e suite against a dev server**
+
+Run: `npm run e2e`
+Expected: PASS/skip — TfL image test, HLS guard test, US-video test (skips only if live US sources are momentarily unavailable).
+
+- [ ] **Step 4: Manual smoke (one CA + one SC camera)**
+
+Start `npm run dev`, open the globe, click a California and a South Carolina camera; confirm live video plays (or the still shows) with attribution. Note any stream that 502s — expected for offline cameras (the fallback covers it).
+
+- [ ] **Step 5: Finish the branch**
+
+Use the `superpowers:finishing-a-development-branch` skill. Push `feat/us-cameras` and open a PR. Target **`feat/p0-skeleton`** (a stacked PR — keeps the diff to just the US work) while PR #1 is open; retarget to `main` once P0 merges. Commits stay solo-attributed; the PR body gets **no** Claude footer.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every spec section maps to a task:
+- Caltrans adapter → Task 1 · SCDOT adapter → Task 2 · registry merge/resilience → Task 3.
+- Still-image allowlist (CA+SC hosts) → Task 4 · HLS allowlist + per-host Referer → Task 5 · playlist rewriter → Task 6 · `/api/hls` proxy (Referer/rewrite/segment/Range/SSRF) → Task 7.
+- `mediaType` exposed + raw `streamUrl` hidden + `country` in list → Task 8 · hls.js + `CameraVideo` + still-fallback + detail wiring (overlay & standalone) → Task 9.
+- Testing matrix (unit normalizers/allowlists/rewriter/merge; e2e guards/US-video) → spread across Tasks 1–9; full verify → Task 10.
+- YAGNI items (RTMP/RTSP, DVR, other states, transcoding, globe-marker video, audio) → none implemented; confirmed absent.
+
+**2. Placeholder scan** — no TBD/TODO; every code step contains complete code; every test step contains real assertions; commands have expected output.
+
+**3. Type consistency** — `normalizeCaltrans(records, district)`, `normalizeScdot(geojson)`, `mergeResults(results, staleCache)`, `isHlsAllowed(url) → { ok, referer? }`, `rewritePlaylist(body, upstreamUrl)`, and `CameraVideo({ id, alt, attribution, license, refreshSeconds })` are referenced identically across the tasks that produce and consume them. `mediaType` union (`"jpeg" | "video" | "both"`) matches the `Camera` schema enum. The client uses `/api/hls?id=` (never `streamUrl`), consistent with Task 8 hiding it.

--- a/docs/superpowers/specs/2026-06-26-us-cameras-video-design.md
+++ b/docs/superpowers/specs/2026-06-26-us-cameras-video-design.md
@@ -1,0 +1,231 @@
+# TrafficNerd v2 — US cameras + live video design
+
+**Date:** 2026-06-26
+**Status:** Approved (design confirmed by user) → spec review
+**Builds on:** P0 skeleton (`feat/p0-skeleton`) — pluggable `Source` adapters, `Camera` zod schema, source registry, closed SSRF-safe image proxy, camera detail page + in-globe feed overlay.
+**Branch:** `feat/us-cameras` (off `feat/p0-skeleton`).
+
+## Goal
+
+Extend camera coverage from London (TfL) to the **United States — California and South
+Carolina** — and, crucially, surface **real live video** for the US cameras, not just
+still images. Both state feeds expose live **HLS** (`.m3u8`) streams, so "real video" is
+achievable end-to-end.
+
+The existing `Camera` schema is already `country`/`region`-aware and sources are
+pluggable, so this is mostly: two new adapters + a multi-source registry merge + a
+streaming proxy + an HLS-capable player. No API keys anywhere.
+
+## Verified data sources (no key — reachable & inspected 2026-06-26)
+
+| State | Registry endpoint | Per-camera fields | Video | Still |
+|---|---|---|---|---|
+| **California** (Caltrans) | `https://cwwp2.dot.ca.gov/data/d{N}/cctv/cctvStatusD{N}.json`, districts 1–12 | `location.latitude/longitude`, `locationName`, `nearbyPlace`, `county`, `route`, `direction`, `inService`, `currentImageUpdateFrequency` | `imageData.streamingVideoURL` → HLS on `wzmedia.dot.ca.gov` | `imageData.static.currentImageURL` (JPEG) on `cwwp2.dot.ca.gov` |
+| **South Carolina** (SCDOT / Iteris) | `https://sc.cdn.iteris-atis.com/geojson/icons/metadata/icons.cameras.geojson` (one GeoJSON) | `geometry.coordinates [lon,lat]`, `description`, `name` (device #), `id` (UUID), `route`, `direction`, `jurisdiction`, `active`, `problem_stream` | `https_url` (= `ios_url`) → HLS on `s18/s19/s20.us-east-1.skyvdn.com` | `image_url` (PNG) on `scdotsnap.us-east-1.skyvdn.com` |
+
+**Observed scale:** Caltrans D11 alone = 324 cameras (236 with video); SC = 760 cameras,
+all active, all with HLS. All 12 CA districts ≈ several thousand cameras.
+
+### Critical streaming facts (these shape the proxy design)
+
+- **Caltrans video (`wzmedia.dot.ca.gov`) is hotlink-protected.** A bare request 404s /
+  is blocked; a request carrying `Referer: https://cwwp2.dot.ca.gov/` returns `200` + a
+  valid HLS master playlist **and** `Access-Control-Allow-Origin: *`. A browser cannot
+  forge that cross-origin Referer, so CA video **must be proxied** server-side with the
+  Referer injected.
+- **SC video (`*.us-east-1.skyvdn.com`) works bare** (`200`, `CORS *`, no Referer
+  needed). It is proxied too, for consistency, closed-proxy SSRF safety, and to hide the
+  user's IP from the source.
+- **Caltrans districts flake** — districts return transient `500`s (only d10–d12
+  responded on one probe; d11 served reliably on others). The CA adapter must tolerate
+  per-district failure.
+- HLS shape (both hosts): `playlist.m3u8` (master, references a relative
+  `chunklist_*.m3u8`) → `chunklist_*.m3u8` (media playlist, references relative
+  `media_*.ts` segments). The proxy must rewrite the relative URIs at each level.
+
+## Architecture
+
+A single closed proxy already exists for stills. We add a parallel **HLS proxy**, two
+source adapters, and a video-capable detail component. Everything degrades gracefully.
+
+### New / changed units
+
+| Unit | Type | Responsibility |
+|---|---|---|
+| `lib/sources/caltrans.ts` | new | `CALTRANS_SOURCE` + `normalizeCaltrans()` + `fetchRegistry()` (all 12 districts, resilient) |
+| `lib/sources/scdot.ts` | new | `SCDOT_SOURCE` + `normalizeScdot()` + `fetchRegistry()` (one GeoJSON) |
+| `lib/sources/registry.ts` | change | merge TfL + Caltrans + SCDOT via `Promise.allSettled`; stale-cache fallback |
+| `lib/proxy/allowlist.ts` | change | add still-image rules for `cwwp2.dot.ca.gov` + `scdotsnap…` |
+| `lib/proxy/hls-allowlist.ts` | new | streaming-host allowlist **+ per-host Referer** to inject |
+| `lib/proxy/hls-rewrite.ts` | new | pure playlist-rewriter (relative/absolute URI → `/api/hls?u=…`) |
+| `app/api/hls/route.ts` | new | the HLS proxy (resolve → fetch w/ Referer → rewrite playlist / stream segment) |
+| `components/CameraVideo.tsx` | new | hls.js `<video>` with poster + **still fallback on stream error** |
+| `components/CameraDetail.tsx` | change | choose `CameraVideo` vs `CameraImage` by `mediaType` |
+| `app/camera/[id]/page.tsx` | change | same choice on the standalone page |
+| `app/api/camera/[id]/route.ts` | change | ensure response carries `mediaType` (never the raw `streamUrl`) |
+| `app/api/cameras/route.ts` | change | add `country` to the slim list (for legend counts / future colouring) |
+| `package.json` | change | add `hls.js` dependency |
+
+### Adapter normalization (→ canonical `Camera`)
+
+Both adapters are pure `normalize*()` functions (unit-testable from a fixture) wrapped by
+a `fetchRegistry()`. Common rules: validate lat/lon are finite and in range; **skip any
+record with neither an image nor a stream**; `id` is `${source}:${nativeId}`.
+
+**Caltrans** (`record.cctv` per district):
+- `id`: `caltrans:d{district}-{index}` · `country`: `US` · `region`: `California`
+- `name`: `locationName` (fallback `nearbyPlace`) · `road`: `route` · `direction`: `direction`
+- `lat/lon`: `parseFloat(location.latitude/longitude)`
+- `imageUrl`: `currentImageURL` if present · `streamUrl`: `streamingVideoURL` if non-empty
+- `mediaType`: `streamUrl ? "both" : "jpeg"`
+- `refreshSeconds`: `max(30, currentImageUpdateFrequency*60)` else `60`
+- `available`: `inService === "true"`
+
+**SCDOT** (per GeoJSON feature):
+- `id`: `scdot:{name}` (device #; fallback `properties.id`) · `country`: `US` · `region`: `South Carolina`
+- `name`: `description` (fallback `name`) · `road`: `route` · `direction`: `direction`
+- `lat`: `coordinates[1]` · `lon`: `coordinates[0]`
+- `imageUrl`: `image_url` · `streamUrl`: `https_url` (fallback `ios_url`)
+- `mediaType`: `streamUrl ? "both" : "jpeg"`
+- `available`: `active === true && problem_stream !== true`
+- `refreshSeconds`: `60`
+
+`fetchRegistry()`: Caltrans fans out over the 12 districts with `Promise.allSettled` and
+concats whatever succeeded (a `500` district is silently skipped); SCDOT fetches the one
+GeoJSON (sending a `Referer` defensively). Each returns `CameraArray.parse(...)`. Neither
+throws on partial data — only on a total, unrecoverable failure.
+
+### Registry merge (resilience)
+
+`getRegistry()` keeps its 5-min TTL cache but now fans out over **all** sources:
+
+```
+const results = await Promise.allSettled([tfl(), caltrans(), scdot()])
+const cameras = results.filter(fulfilled).flatMap(r => r.value)
+if (cameras.length === 0) return staleCache ?? throw   // never blank the globe silently
+cache = { cameras, at: now }
+```
+
+One source down ⇒ the others still render. Total failure ⇒ serve the last good cache if
+we have one.
+
+### HLS proxy — `GET /api/hls`
+
+The core new piece. Two entry shapes:
+- `?id=<cameraId>` → look up the camera, use its `streamUrl` as upstream (the player's
+  initial `src`; the raw stream URL never reaches the client).
+- `?u=<absolute upstream URL>` → used by rewritten playlist/segment links.
+
+Flow:
+1. Resolve upstream URL (from `id` or `u`).
+2. **SSRF check** via `isHlsAllowed(url)` → `{ ok, referer }`; `403` if not allowed.
+   Allowlist (host + path prefix + the Referer to inject):
+   - `wzmedia.dot.ca.gov` · `/` · Referer `https://cwwp2.dot.ca.gov/`
+   - `*.us-east-1.skyvdn.com` (suffix) · `/rtplive/` · Referer `https://www.511sc.org/`
+3. `fetch(upstream, { headers:{ Referer, "User-Agent", Accept }, redirect:"error",
+   cache:"no-store", signal: AbortSignal.timeout(10_000) })`, forwarding any incoming
+   `Range` header. `502` on failure / non-OK (segments may legitimately return `200`/`206`).
+4. **If playlist** (content-type `…mpegurl`, or URL ends `.m3u8`, or body starts
+   `#EXTM3U`): rewrite via `lib/proxy/hls-rewrite.ts` — each non-`#`, non-empty line is a
+   URI; resolve it against the upstream URL (`new URL(line, upstream)`) and replace with
+   `/api/hls?u=${encodeURIComponent(resolved)}`. Also rewrite the `URI="…"` of any
+   `#EXT-X-KEY` line (defensive; these streams are unencrypted). Serve as
+   `application/vnd.apple.mpegurl`, `Cache-Control: no-store` (live).
+5. **Else (segment / binary):** stream `upstream.body` straight through (a
+   `ReadableStream`, **not** buffered), preserving status `200`/`206` and passing through
+   `Content-Type` (default `video/mp2t`), `Content-Length`, `Content-Range`,
+   `Accept-Ranges`. `Cache-Control: public, max-age=5`.
+
+`GET` only; `redirect:"error"` blocks redirect-based allowlist bypass.
+
+### Video player — `components/CameraVideo.tsx`
+
+`"use client"`. Renders `<video controls autoPlay muted playsInline poster={proxied
+still}>`. In an effect:
+- **hls.js is dynamically imported inside the effect** (`(await import("hls.js")).default`)
+  so its `window` references never run during SSR (same care satellite.js needed).
+- If `video.canPlayType("application/vnd.apple.mpegurl")` (Safari native HLS) → set
+  `video.src = "/api/hls?id="+id`.
+- Else if `Hls.isSupported()` → `new Hls()`, `loadSource("/api/hls?id="+id)`,
+  `attachMedia(video)`; on a **fatal** `Hls.Events.ERROR` → tear down and set
+  `failed=true`.
+- Cleanup destroys the hls instance on unmount.
+- If `failed` → render `<CameraImage>` (the refreshing still) instead, so an offline
+  camera still shows something.
+- The mandatory `<AttributionBadge>` is always rendered.
+
+### Detail wiring
+
+`/api/camera/[id]` already returns the full camera; we ensure `mediaType` is in the
+payload (and deliberately **omit** the raw `streamUrl` — the client streams via
+`/api/hls?id=`). `CameraDetail` and `/camera/[id]/page.tsx` render `CameraVideo` when
+`mediaType !== "jpeg"`, else `CameraImage` (unchanged path for TfL stills).
+
+Only the **one selected** camera ever mounts a player, so there is no many-streams
+performance blow-up on the globe.
+
+## Data flow (US video, happy path)
+
+```
+registry (TfL+Caltrans+SCDOT, 5-min cache)
+  → /api/cameras (slim points)            → globe renders all cameras
+  → click → /api/camera/[id] (mediaType)  → CameraVideo
+       poster: /api/proxy?id=…  (still, existing image proxy)
+       video:  /api/hls?id=…
+                 → resolve streamUrl → fetch master.m3u8 w/ Referer
+                 → rewrite chunklist URI → /api/hls?u=chunklist
+                 → rewrite media_*.ts URIs → /api/hls?u=segment (Range passthrough)
+                 → hls.js renders LIVE video
+```
+
+## Error handling & resilience
+
+- **Source failure** → `allSettled`; other sources render; total failure → stale cache.
+- **Caltrans district 500** → skipped per-district.
+- **Bad record** (non-finite/out-of-range coords, no image & no stream) → skipped in normalizer.
+- **HLS upstream failure** → `502`; player's fatal-error handler → still-image fallback.
+- **SSRF** → image allowlist + separate HLS allowlist, both host+path; `redirect:"error"`; http/https only.
+- **Attribution** is never optional — the badge renders in both video and image paths.
+
+## Testing
+
+**Unit (vitest):**
+- `normalizeCaltrans` fixture → expected `Camera[]` (id format, `country/region`,
+  `mediaType:"both"`, `available` mapping, invalid-record skip).
+- `normalizeScdot` fixture → expected `Camera` (`description` as name, `active &&
+  !problem_stream`, **coord order lon/lat**).
+- `registry` merge: 3 mocked sources, one rejects → union of the other two; all reject +
+  cache present → stale cache returned.
+- `isHlsAllowed`: wzmedia + skyvdn allowed with correct Referer; other host / wrong path /
+  non-http → rejected.
+- `hls-rewrite`: master→chunklist relative URI rewritten; chunklist→`media_*.ts`
+  rewritten; `#` lines untouched; absolute URI resolved correctly; `#EXT-X-KEY` URI rewritten.
+- `isAllowed` (stills): new hosts allowed at their prefixes; traversal / other host rejected.
+
+**E2E (playwright):**
+- `/api/cameras` count exceeds the TfL-only baseline (US cameras present).
+- Open a US camera detail → a `<video>` element is present; `/api/hls?id=…` returns a
+  `mpegurl` body and a follow-up segment request returns `video/mp2t`. (Live HLS in CI is
+  flaky → assert the proxy/rewrite contract against a known id, gating any real-stream
+  playback assertion.)
+- Dead-stream id → `CameraImage` fallback rendered.
+
+## Out of scope (YAGNI)
+
+- RTMP / RTSP / `clsps` protocols — only HLS (`https_url` / `streamingVideoURL`).
+- DVR / seeking / historical playback — live only.
+- Other US states or other countries.
+- Server-side transcoding / re-muxing.
+- Video on globe markers or many simultaneous tiles — only the selected detail plays.
+- Audio — traffic cams are silent; muted autoplay.
+- Authn / rate-limiting of our own proxy (future hardening).
+
+## Risks
+
+- **wzmedia hotlink policy could change** (different required Referer) → it is centralized
+  in `hls-allowlist.ts`, a one-line change.
+- **Segment bandwidth flows through our server** (Vercel) → fine at P0 demo scale; note
+  edge/CDN offload for scale.
+- **Stream churn** (cameras go offline) → still-image fallback absorbs it.
+- **Serverless streaming of `.ts`** must stream, not buffer → enforced by passing
+  `upstream.body` through directly.

--- a/lib/cameraFilter.ts
+++ b/lib/cameraFilter.ts
@@ -1,0 +1,57 @@
+"use client";
+// Camera sub-filters layered under the top-level "Cameras" layer toggle. Same
+// framework-light external-store pattern as lib/layers.ts and lib/overlay.ts.
+// GlobeView reads this to filter which cameras it renders (globe points + map
+// markers); the legend's camera key drives the controls.
+//
+//   • regions  — per-source visibility (missing source defaults to visible)
+//   • liveOnly — show only cameras with a playable live (HLS) stream
+
+import { useSyncExternalStore } from "react";
+
+export interface CameraFilterState {
+  regions: Record<string, boolean>;
+  liveOnly: boolean;
+}
+
+let state: CameraFilterState = {
+  regions: { tfl: true, caltrans: true, scdot: true },
+  liveOnly: false,
+};
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export const cameraFilterStore = {
+  toggleRegion(source: string) {
+    const current = state.regions[source] ?? true;
+    state = { ...state, regions: { ...state.regions, [source]: !current } };
+    emit();
+  },
+  setLiveOnly(on: boolean) {
+    if (state.liveOnly === on) return;
+    state = { ...state, liveOnly: on };
+    emit();
+  },
+  /** Whether a camera (by source id + live flag) passes the current filter. */
+  passes(source: string, live: boolean): boolean {
+    if ((state.regions[source] ?? true) === false) return false;
+    if (state.liveOnly && !live) return false;
+    return true;
+  },
+  get(): CameraFilterState {
+    return state;
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export function useCameraFilter(): CameraFilterState {
+  return useSyncExternalStore(cameraFilterStore.subscribe, cameraFilterStore.get, cameraFilterStore.get);
+}

--- a/lib/cameraFilter.ts
+++ b/lib/cameraFilter.ts
@@ -15,7 +15,7 @@ export interface CameraFilterState {
 }
 
 let state: CameraFilterState = {
-  regions: { tfl: true, caltrans: true, scdot: true },
+  regions: { tfl: true, caltrans: true, scdot: true, digitraffic: true },
   liveOnly: false,
 };
 const listeners = new Set<() => void>();

--- a/lib/cameras/classify.ts
+++ b/lib/cameras/classify.ts
@@ -1,0 +1,13 @@
+// Classify a camera by what it streams. Two icon shapes:
+//   • "video" — a live HLS feed (mediaType "video" or "both")
+//   • "still" — a refreshing JPEG snapshot (mediaType "jpeg")
+// The icon's COLOUR encodes the region (see lib/icons/svg.ts), so the two
+// dimensions together (shape = feed, colour = region) give a maximal camera
+// taxonomy. Pure + unit-tested.
+
+export type CameraFeed = "video" | "still";
+
+/** Feed type from the camera's mediaType. */
+export function classifyCameraFeed(mediaType: "jpeg" | "video" | "both"): CameraFeed {
+  return mediaType === "jpeg" ? "still" : "video";
+}

--- a/lib/cameras/classify.ts
+++ b/lib/cameras/classify.ts
@@ -1,13 +1,18 @@
 // Classify a camera by what it streams. Two icon shapes:
-//   • "video" — a live HLS feed (mediaType "video" or "both")
-//   • "still" — a refreshing JPEG snapshot (mediaType "jpeg")
+//   • "video" — a live stream our /api/hls proxy can actually play
+//   • "still" — a refreshing JPEG snapshot
 // The icon's COLOUR encodes the region (see lib/icons/svg.ts), so the two
 // dimensions together (shape = feed, colour = region) give a maximal camera
-// taxonomy. Pure + unit-tested.
+// taxonomy.
+//
+// IMPORTANT: "video" is keyed on whether we can play a LIVE stream, not just on
+// the raw mediaType. TfL JamCams advertise short MP4 clips (mediaType "both")
+// but we present them as refreshing stills, so they read as "still" here.
+// Caltrans/SCDOT expose live HLS, so they read as "video". Pure + unit-tested.
 
 export type CameraFeed = "video" | "still";
 
-/** Feed type from the camera's mediaType. */
-export function classifyCameraFeed(mediaType: "jpeg" | "video" | "both"): CameraFeed {
-  return mediaType === "jpeg" ? "still" : "video";
+/** Feed shape from whether a live (HLS-proxyable) stream is available. */
+export function cameraFeed(live: boolean): CameraFeed {
+  return live ? "video" : "still";
 }

--- a/lib/icons/Icon.tsx
+++ b/lib/icons/Icon.tsx
@@ -1,0 +1,34 @@
+"use client";
+// Render a type pictogram inline (legend, overlays). The SVG is drawn in
+// `currentColor`, so the wrapper's `color` tints it.
+
+import { ICON_SVG, type IconKey } from "@/lib/icons/svg";
+
+export function TypeIcon({
+  icon,
+  color,
+  size = 16,
+  title,
+}: {
+  icon: IconKey;
+  color?: string;
+  size?: number;
+  title?: string;
+}) {
+  const svg = ICON_SVG[icon].replace("<svg ", `<svg width="${size}" height="${size}" `);
+  return (
+    <span
+      role="img"
+      aria-label={title}
+      title={title}
+      style={{
+        display: "inline-flex",
+        width: size,
+        height: size,
+        color: color ?? "currentColor",
+        flexShrink: 0,
+      }}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/lib/icons/sprite.ts
+++ b/lib/icons/sprite.ts
@@ -1,0 +1,127 @@
+"use client";
+// Turn the hand-drawn SVG pictograms into three.js markers for the globe.
+//
+// • cameras + satellites → THREE.Sprite (camera-facing billboards, always
+//   upright and legible no matter how the globe is rotated).
+// • planes → a flat textured quad lying in the surface tangent plane, so it can
+//   be oriented to the aircraft's heading (objectRotation in GlobeView), exactly
+//   like a flight-tracker top-down icon.
+//
+// Textures and materials are cached per (icon, colour) so rendering thousands of
+// markers only ever allocates a handful of GPU resources — the per-datum object
+// returned to react-globe.gl is just a lightweight wrapper sharing them.
+
+import * as THREE from "three";
+import { ICON_SVG, type IconKey } from "@/lib/icons/svg";
+
+const TEX_PX = 128; // rasterisation size — crisp at marker scale
+const texCache = new Map<string, THREE.Texture>();
+const spriteMatCache = new Map<string, THREE.SpriteMaterial>();
+const meshMatCache = new Map<string, THREE.MeshBasicMaterial>();
+const planeGeom = new THREE.PlaneGeometry(1, 1);
+
+function iconTexture(icon: IconKey, color: string): THREE.Texture {
+  const colored = ICON_SVG[icon]
+    .replace("<svg ", `<svg width="${TEX_PX}" height="${TEX_PX}" `)
+    .replaceAll("currentColor", color);
+  const hit = texCache.get(colored);
+  if (hit) return hit;
+  const tex = new THREE.Texture();
+  tex.colorSpace = THREE.SRGBColorSpace;
+  // SVG → data URL → <img>; the texture fills in once the image decodes.
+  const img = new Image();
+  img.onload = () => {
+    tex.image = img;
+    tex.needsUpdate = true;
+  };
+  img.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(colored);
+  texCache.set(colored, tex);
+  return tex;
+}
+
+function spriteMaterial(icon: IconKey, color: string, opacity: number): THREE.SpriteMaterial {
+  const key = `${icon}|${color}|${opacity}`;
+  const hit = spriteMatCache.get(key);
+  if (hit) return hit;
+  const mat = new THREE.SpriteMaterial({
+    map: iconTexture(icon, color),
+    transparent: true,
+    depthWrite: false,
+    opacity,
+  });
+  spriteMatCache.set(key, mat);
+  return mat;
+}
+
+function meshMaterial(icon: IconKey, color: string): THREE.MeshBasicMaterial {
+  const key = `${icon}|${color}`;
+  const hit = meshMatCache.get(key);
+  if (hit) return hit;
+  const mat = new THREE.MeshBasicMaterial({
+    map: iconTexture(icon, color),
+    transparent: true,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  meshMatCache.set(key, mat);
+  return mat;
+}
+
+// Soft radial glow shared by all satellites (tinted per material) so they read
+// as luminous points against the night globe.
+let glowTex: THREE.Texture | null = null;
+const glowMatCache = new Map<string, THREE.SpriteMaterial>();
+function glowTexture(): THREE.Texture {
+  if (glowTex) return glowTex;
+  const c = document.createElement("canvas");
+  c.width = c.height = 64;
+  const ctx = c.getContext("2d")!;
+  const g = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
+  g.addColorStop(0, "rgba(255,255,255,0.85)");
+  g.addColorStop(0.4, "rgba(255,255,255,0.22)");
+  g.addColorStop(1, "rgba(255,255,255,0)");
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 64, 64);
+  glowTex = new THREE.CanvasTexture(c);
+  return glowTex;
+}
+function glowMaterial(color: string): THREE.SpriteMaterial {
+  const hit = glowMatCache.get(color);
+  if (hit) return hit;
+  const mat = new THREE.SpriteMaterial({
+    map: glowTexture(),
+    color: new THREE.Color(color),
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+  glowMatCache.set(color, mat);
+  return mat;
+}
+
+/** Billboard icon for a camera. Unavailable cameras render dimmed. */
+export function cameraSprite(icon: IconKey, color: string, available: boolean): THREE.Sprite {
+  const sprite = new THREE.Sprite(spriteMaterial(icon, color, available ? 0.96 : 0.4));
+  sprite.scale.set(2.6, 2.6, 1);
+  return sprite;
+}
+
+/** Glowing billboard icon for a satellite (station icons are drawn larger). */
+export function satelliteSprite(icon: IconKey, color: string): THREE.Object3D {
+  const group = new THREE.Group();
+  const big = icon === "sat-station";
+  const glow = new THREE.Sprite(glowMaterial(color));
+  glow.scale.set(big ? 11 : 8, big ? 11 : 8, 1);
+  const sprite = new THREE.Sprite(spriteMaterial(icon, color, 1));
+  const s = big ? 6.5 : 5;
+  sprite.scale.set(s, s, 1);
+  group.add(glow, sprite);
+  return group;
+}
+
+/** Flat heading-orientable icon for a plane (lies in the tangent plane). */
+export function planeIconMesh(icon: IconKey, color: string): THREE.Mesh {
+  const mesh = new THREE.Mesh(planeGeom, meshMaterial(icon, color));
+  mesh.scale.set(5, 5, 1);
+  return mesh;
+}

--- a/lib/icons/sprite.ts
+++ b/lib/icons/sprite.ts
@@ -122,6 +122,6 @@ export function satelliteSprite(icon: IconKey, color: string): THREE.Object3D {
 /** Flat heading-orientable icon for a plane (lies in the tangent plane). */
 export function planeIconMesh(icon: IconKey, color: string): THREE.Mesh {
   const mesh = new THREE.Mesh(planeGeom, meshMaterial(icon, color));
-  mesh.scale.set(5, 5, 1);
+  mesh.scale.set(4, 4, 1);
   return mesh;
 }

--- a/lib/icons/svg.ts
+++ b/lib/icons/svg.ts
@@ -1,0 +1,154 @@
+// Single source of truth for every type icon on the map.
+//
+// Each icon is a hand-authored 24×24 SVG pictogram drawn in `currentColor`, so
+// it can be (a) rendered inline in the legend/overlay at any CSS colour and
+// (b) rasterised to a tinted sprite texture for the 3D globe and to an SDF
+// symbol for the MapLibre map. Keeping the art, palette and labels together
+// means the globe, the map markers and the legend can never drift apart.
+//
+// Pure + isomorphic (no DOM / no three.js here) so it can be imported anywhere.
+
+import type { SatCategory } from "@/lib/satellites/classify";
+import type { PlaneCategory } from "@/lib/planes/classify";
+import type { CameraFeed } from "@/lib/cameras/classify";
+
+export type IconKey =
+  | "sat-station" | "sat-starlink" | "sat-oneweb" | "sat-navigation" | "sat-weather"
+  | "sat-eo" | "sat-science" | "sat-comms" | "sat-cubesat" | "sat-debris" | "sat-other"
+  | "plane-airliner" | "plane-regional" | "plane-light" | "plane-helicopter" | "plane-ground"
+  | "cam-still" | "cam-video";
+
+// "Inner" dark used for cut-outs (lenses, panel cells) that should read against
+// any tint — it stays constant when currentColor is replaced.
+const INK = "#0b0f1a";
+
+const wrap = (inner: string) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">${inner}</svg>`;
+
+export const ICON_SVG: Record<IconKey, string> = {
+  // --- Satellites ---------------------------------------------------------
+  "sat-station": wrap(
+    `<rect x="10.3" y="8.5" width="3.4" height="7" rx=".6"/><rect x="2" y="9.5" width="7" height="5" rx=".6"/><rect x="15" y="9.5" width="7" height="5" rx=".6"/><rect x="11.3" y="2.6" width="1.4" height="6"/><rect x="11.3" y="15.4" width="1.4" height="6"/>`,
+  ),
+  "sat-starlink": wrap(
+    `<rect x="2.5" y="10" width="9" height="4" rx=".6"/><rect x="12.5" y="6.5" width="9" height="11" rx=".9"/><path d="M14.5 9h5M14.5 12h5M14.5 15h5" stroke="${INK}" stroke-width=".7"/>`,
+  ),
+  "sat-oneweb": wrap(
+    `<rect x="9" y="8.8" width="6" height="6.4" rx=".9"/><rect x="2.4" y="10" width="5.6" height="4" rx=".5"/><rect x="16" y="10" width="5.6" height="4" rx=".5"/>`,
+  ),
+  "sat-navigation": wrap(
+    `<rect x="9.6" y="2.6" width="4.8" height="4.6" rx=".6"/><rect x="4" y="3.4" width="4.6" height="3.2" rx=".4"/><rect x="15.4" y="3.4" width="4.6" height="3.2" rx=".4"/><path d="M12 7.4v3.6" stroke="currentColor" stroke-width="1.4"/><path d="M7.6 13.2a6 6 0 0 1 8.8 0" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M4.6 16.4a10 10 0 0 1 14.8 0" fill="none" stroke="currentColor" stroke-width="1.5"/>`,
+  ),
+  "sat-weather": wrap(
+    `<rect x="9.6" y="3" width="4.8" height="4.4" rx=".6"/><rect x="3.6" y="3.7" width="5" height="3" rx=".4"/><rect x="15.4" y="3.7" width="5" height="3" rx=".4"/><path d="M9.8 7.4 7.2 21h9.6L14.2 7.4z" opacity=".5"/><circle cx="12" cy="8.6" r="1.3"/>`,
+  ),
+  "sat-eo": wrap(
+    `<rect x="9" y="2.8" width="6" height="5" rx=".6"/><rect x="2.8" y="3.7" width="5.4" height="3.2" rx=".4"/><rect x="15.8" y="3.7" width="5.4" height="3.2" rx=".4"/><rect x="10.6" y="7.8" width="2.8" height="2.6"/><circle cx="12" cy="15" r="3.4" fill="none" stroke="currentColor" stroke-width="1.5"/><circle cx="12" cy="15" r="1.2"/>`,
+  ),
+  "sat-science": wrap(
+    `<rect x="7.4" y="5" width="9.2" height="13" rx="1.4"/><rect x="8.8" y="2.6" width="6.4" height="2.8" rx="1"/><rect x="3.4" y="9.5" width="4" height="4" rx=".5"/><rect x="16.6" y="9.5" width="4" height="4" rx=".5"/><circle cx="12" cy="7.2" r="1.7" fill="${INK}"/>`,
+  ),
+  "sat-comms": wrap(
+    `<rect x="10" y="11" width="4" height="6.5" rx=".5"/><rect x="3" y="12" width="6" height="4" rx=".5"/><rect x="15" y="12" width="6" height="4" rx=".5"/><path d="M12 11.4 6.4 5.6a7.8 7.8 0 0 1 11.2 0L12 11.4z"/><circle cx="12" cy="7.8" r="1" fill="${INK}"/>`,
+  ),
+  "sat-cubesat": wrap(
+    `<rect x="8.4" y="8.4" width="7.2" height="7.2" rx=".8"/><rect x="9.8" y="9.8" width="4.4" height="4.4" rx=".4" fill="${INK}"/><rect x="2.8" y="10.4" width="4.6" height="3.2" rx=".4"/><rect x="16.6" y="10.4" width="4.6" height="3.2" rx=".4"/>`,
+  ),
+  "sat-debris": wrap(
+    `<path d="M7.5 3.6 13 5.2l3.6-1.1 2.3 4.8-2.8 3.1 1.2 5.2-5.6-1.2-4.4 2.4-1.1-5.7L3 6.6z" opacity=".92"/>`,
+  ),
+  "sat-other": wrap(
+    `<rect x="9.5" y="8.5" width="5" height="7" rx=".6"/><rect x="3" y="9.5" width="5.5" height="5" rx=".5"/><rect x="15.5" y="9.5" width="5.5" height="5" rx=".5"/><path d="M12 8.5V4M10 4h4" stroke="currentColor" stroke-width="1.3" fill="none"/>`,
+  ),
+
+  // --- Planes (top view, nose pointing UP/north) --------------------------
+  "plane-airliner": wrap(
+    `<path d="M12 1.4c.85 0 1.45 1.25 1.55 3.3l.12 3.2 7.83 4.55v2.05l-7.83-2.3v4.45l2.45 1.6v1.75L12 22.6l-4.12-1.0v-1.75l2.45-1.6v-4.45l-7.83 2.3V12.45L10.33 7.9l.12-3.2C10.55 2.65 11.15 1.4 12 1.4z"/>`,
+  ),
+  "plane-regional": wrap(
+    `<path d="M12 2.6c.72 0 1.22 1.05 1.32 2.8l.1 2.9 6.58 3.75v1.75l-6.58-1.9v3.7l2.05 1.45v1.55L12 21.3l-3.47-.7v-1.55l2.05-1.45v-3.7l-6.58 1.9V12.05L10.58 8.3l.1-2.9C10.78 3.65 11.28 2.6 12 2.6z"/>`,
+  ),
+  "plane-light": wrap(
+    `<path d="M11 3.2h2v4.1l8 3v2l-8-1.6v6.1l3 1.9v1.4l-5-1-5 1v-1.4l3-1.9v-6.1l-8 1.6v-2l8-3z"/><rect x="8.6" y="1.8" width="6.8" height="1.4" rx=".7"/>`,
+  ),
+  "plane-helicopter": wrap(
+    `<rect x="2" y="11.2" width="20" height="1.5" rx=".75"/><rect x="11.25" y="2" width="1.5" height="20" rx=".75"/><ellipse cx="12" cy="12" rx="2.6" ry="3.7"/><rect x="11.4" y="14.8" width="1.2" height="6.4"/><rect x="9.4" y="20.4" width="5.2" height="1.4" rx=".7"/>`,
+  ),
+  "plane-ground": wrap(
+    `<path d="M12 1.8c.78 0 1.32 1.1 1.42 3l.1 2.9 7.18 4.15v1.85l-7.18-2.1v4l2.2 1.45v1.55L12 18.6l-3.72-.95v-1.55l2.2-1.45v-4l-7.18 2.1V11.85L10.48 7.7l.1-2.9C10.68 2.9 11.22 1.8 12 1.8z"/><rect x="2.5" y="20.6" width="19" height="1.6" rx=".8" opacity=".75"/>`,
+  ),
+
+  // --- Cameras ------------------------------------------------------------
+  "cam-still": wrap(
+    `<path d="M2.6 7.7 16 4.4c1-.25 2.02.37 2.3 1.4l.5 1.95c.27 1.02-.35 2.05-1.37 2.32L3.6 13.6 2.6 7.7z"/><circle cx="6.1" cy="9.1" r="1.15" fill="${INK}"/><rect x="11" y="13" width="2" height="5.1"/><rect x="6.8" y="18" width="10.4" height="1.8" rx=".9"/>`,
+  ),
+  "cam-video": wrap(
+    `<path d="M1.8 8.1 12.6 5.4c.9-.22 1.82.32 2.05 1.25l.46 1.85c.22.9-.32 1.82-1.22 2.05L2.8 13.5 1.8 8.1z"/><circle cx="5" cy="9.5" r="1.05" fill="${INK}"/><rect x="9.4" y="13" width="1.8" height="4.7"/><rect x="5.8" y="17.6" width="9" height="1.7" rx=".85"/><path d="M17.6 7.4a4.2 4.2 0 0 1 0 6.2M19.9 5.6a6.8 6.8 0 0 1 0 9.8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>`,
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// Per-type metadata: which icon, what colour, what label.
+// ---------------------------------------------------------------------------
+
+export interface SubtypeMeta {
+  key: IconKey;
+  label: string;
+  color: string;
+}
+
+// Satellites — a cool violet→blue palette so the whole layer still reads as one
+// family, with the iconic ISS picked out in white.
+export const SAT_META: Record<SatCategory, SubtypeMeta> = {
+  station: { key: "sat-station", label: "Space station", color: "#ffffff" },
+  starlink: { key: "sat-starlink", label: "Starlink", color: "#60a5fa" },
+  oneweb: { key: "sat-oneweb", label: "OneWeb", color: "#818cf8" },
+  navigation: { key: "sat-navigation", label: "Navigation", color: "#a78bfa" },
+  weather: { key: "sat-weather", label: "Weather", color: "#c084fc" },
+  "earth-observation": { key: "sat-eo", label: "Earth imaging", color: "#e879f9" },
+  science: { key: "sat-science", label: "Science", color: "#f0abfc" },
+  communications: { key: "sat-comms", label: "Comms", color: "#7dd3fc" },
+  cubesat: { key: "sat-cubesat", label: "CubeSat", color: "#a5b4fc" },
+  debris: { key: "sat-debris", label: "Debris / rocket body", color: "#94a3b8" },
+  other: { key: "sat-other", label: "Other", color: "#cbd5e1" },
+};
+
+// Planes — a warm amber palette, with helicopters in red and parked craft grey.
+export const PLANE_META: Record<PlaneCategory, SubtypeMeta> = {
+  airliner: { key: "plane-airliner", label: "Airliner", color: "#fbbf24" },
+  regional: { key: "plane-regional", label: "Regional / jet", color: "#fb923c" },
+  light: { key: "plane-light", label: "Light aircraft", color: "#fcd34d" },
+  helicopter: { key: "plane-helicopter", label: "Helicopter", color: "#f87171" },
+  ground: { key: "plane-ground", label: "On ground", color: "#a8a29e" },
+};
+
+// Cameras — shape encodes the feed; colour encodes the region (below).
+export const CAMERA_FEED_META: Record<CameraFeed, SubtypeMeta> = {
+  video: { key: "cam-video", label: "Live video", color: "#67e8f9" },
+  still: { key: "cam-still", label: "Still image", color: "#67e8f9" },
+};
+
+export interface RegionMeta {
+  source: string;
+  label: string;
+  color: string;
+}
+
+// Region tint, keyed by source id. Cyan/green/teal family — distinct from the
+// satellite (violet) and plane (amber) layers.
+export const CAMERA_REGIONS: RegionMeta[] = [
+  { source: "tfl", label: "London (TfL)", color: "#22d3ee" },
+  { source: "caltrans", label: "California", color: "#4ade80" },
+  { source: "scdot", label: "South Carolina", color: "#2dd4bf" },
+];
+
+export const CAMERA_DEFAULT_REGION: RegionMeta = {
+  source: "*",
+  label: "Other region",
+  color: "#67e8f9",
+};
+
+/** Region colour for a camera source id (falls back to the default cyan). */
+export function cameraRegionColor(source: string): string {
+  return (CAMERA_REGIONS.find((r) => r.source === source) ?? CAMERA_DEFAULT_REGION).color;
+}

--- a/lib/icons/svg.ts
+++ b/lib/icons/svg.ts
@@ -143,6 +143,7 @@ export const CAMERA_REGIONS: RegionMeta[] = [
   { source: "tfl", label: "London (TfL)", color: "#22d3ee", view: { lat: 51.5, lng: -0.12, altitude: 0.5 } },
   { source: "caltrans", label: "California", color: "#4ade80", view: { lat: 36.8, lng: -119.7, altitude: 0.95 } },
   { source: "scdot", label: "South Carolina", color: "#2dd4bf", view: { lat: 33.9, lng: -80.9, altitude: 0.6 } },
+  { source: "digitraffic", label: "Finland", color: "#38bdf8", view: { lat: 64.5, lng: 26, altitude: 0.9 } },
 ];
 
 export const CAMERA_DEFAULT_REGION: RegionMeta = {

--- a/lib/icons/svg.ts
+++ b/lib/icons/svg.ts
@@ -132,14 +132,17 @@ export interface RegionMeta {
   source: string;
   label: string;
   color: string;
+  /** Globe camera position to fly to when jumping to this region. */
+  view?: { lat: number; lng: number; altitude: number };
 }
 
 // Region tint, keyed by source id. Cyan/green/teal family — distinct from the
-// satellite (violet) and plane (amber) layers.
+// satellite (violet) and plane (amber) layers. `view` powers the region
+// quick-jump (altitude tuned so the whole region's cluster is in frame).
 export const CAMERA_REGIONS: RegionMeta[] = [
-  { source: "tfl", label: "London (TfL)", color: "#22d3ee" },
-  { source: "caltrans", label: "California", color: "#4ade80" },
-  { source: "scdot", label: "South Carolina", color: "#2dd4bf" },
+  { source: "tfl", label: "London (TfL)", color: "#22d3ee", view: { lat: 51.5, lng: -0.12, altitude: 0.5 } },
+  { source: "caltrans", label: "California", color: "#4ade80", view: { lat: 36.8, lng: -119.7, altitude: 0.95 } },
+  { source: "scdot", label: "South Carolina", color: "#2dd4bf", view: { lat: 33.9, lng: -80.9, altitude: 0.6 } },
 ];
 
 export const CAMERA_DEFAULT_REGION: RegionMeta = {

--- a/lib/planes/classify.ts
+++ b/lib/planes/classify.ts
@@ -1,10 +1,9 @@
-// Classify an aircraft into a coarse *type* from its live flight profile.
+// Classify an aircraft into a coarse *type*.
 //
-// IMPORTANT: the anonymous OpenSky feed carries no aircraft-category field, so
-// this is an honest *inference* from altitude + ground speed + on-ground state,
-// not a lookup. It is good enough to differentiate the obvious cases (a hovering
-// helicopter vs a cruising airliner) and is surfaced in the UI as an estimate.
-// Pure + unit-tested.
+// PREFERRED: the ADS-B emitter category (adsb.lol's `category`, e.g. A7 = rotor-
+// craft, A5 = heavy) — an actual broadcast field, not a guess. FALLBACK: when no
+// category is present we infer from altitude + ground speed + on-ground state
+// (an honest estimate, surfaced in the UI as "est."). Pure + unit-tested.
 
 export type PlaneCategory = "airliner" | "regional" | "light" | "helicopter" | "ground";
 
@@ -15,7 +14,21 @@ export interface PlaneProfile {
   velocityMs: number | null;
   /** True when the aircraft reports itself on the ground. */
   onGround: boolean;
+  /** ADS-B emitter category (A0–A7, B0–B7…) when known. */
+  category?: string;
 }
+
+// ADS-B emitter category → our coarse type (the reliable path).
+const ADSB_CATEGORY: Record<string, PlaneCategory> = {
+  A1: "light", // light (<15500 lbs)
+  A2: "regional", // small
+  A3: "airliner", // large
+  A4: "airliner", // high-vortex large (B757)
+  A5: "airliner", // heavy
+  A7: "helicopter", // rotorcraft
+  B1: "light", // glider/sailplane
+  B4: "light", // ultralight
+};
 
 // Thresholds (kept named so the heuristic is legible).
 const HELI_ALT_KM = 1.5; //  helicopters work low …
@@ -25,9 +38,10 @@ const AIRLINER_SPEED_MS = 150; // … and fast (~290 kt)
 const REGIONAL_ALT_KM = 3; // turboprops / regional jets mid-band
 const REGIONAL_SPEED_MS = 110;
 
-/** Coarse aircraft type inferred from the live flight profile. */
+/** Coarse aircraft type — prefers the ADS-B category, else the flight profile. */
 export function classifyPlane(p: PlaneProfile): PlaneCategory {
   if (p.onGround) return "ground";
+  if (p.category && ADSB_CATEGORY[p.category]) return ADSB_CATEGORY[p.category];
   const alt = Number.isFinite(p.altKm) ? p.altKm : 0;
   const v = p.velocityMs ?? 0;
   if (alt < HELI_ALT_KM && v < HELI_SPEED_MS) return "helicopter";

--- a/lib/planes/classify.ts
+++ b/lib/planes/classify.ts
@@ -1,0 +1,37 @@
+// Classify an aircraft into a coarse *type* from its live flight profile.
+//
+// IMPORTANT: the anonymous OpenSky feed carries no aircraft-category field, so
+// this is an honest *inference* from altitude + ground speed + on-ground state,
+// not a lookup. It is good enough to differentiate the obvious cases (a hovering
+// helicopter vs a cruising airliner) and is surfaced in the UI as an estimate.
+// Pure + unit-tested.
+
+export type PlaneCategory = "airliner" | "regional" | "light" | "helicopter" | "ground";
+
+export interface PlaneProfile {
+  /** Altitude above sea level in kilometres. */
+  altKm: number;
+  /** Ground speed in m/s, or null when unknown. */
+  velocityMs: number | null;
+  /** True when the aircraft reports itself on the ground. */
+  onGround: boolean;
+}
+
+// Thresholds (kept named so the heuristic is legible).
+const HELI_ALT_KM = 1.5; //  helicopters work low …
+const HELI_SPEED_MS = 70; //  … and slow (~135 kt)
+const AIRLINER_ALT_KM = 7; // jets cruise high …
+const AIRLINER_SPEED_MS = 150; // … and fast (~290 kt)
+const REGIONAL_ALT_KM = 3; // turboprops / regional jets mid-band
+const REGIONAL_SPEED_MS = 110;
+
+/** Coarse aircraft type inferred from the live flight profile. */
+export function classifyPlane(p: PlaneProfile): PlaneCategory {
+  if (p.onGround) return "ground";
+  const alt = Number.isFinite(p.altKm) ? p.altKm : 0;
+  const v = p.velocityMs ?? 0;
+  if (alt < HELI_ALT_KM && v < HELI_SPEED_MS) return "helicopter";
+  if (alt >= AIRLINER_ALT_KM && v >= AIRLINER_SPEED_MS) return "airliner";
+  if (alt >= REGIONAL_ALT_KM || v >= REGIONAL_SPEED_MS) return "regional";
+  return "light";
+}

--- a/lib/planes/trail.ts
+++ b/lib/planes/trail.ts
@@ -1,0 +1,71 @@
+// Pure breadcrumb-trail helpers for the plane layer.
+//
+// A plane's trail = its recent ACTUAL positions (breadcrumbs dropped behind it)
+// plus one PROJECTED point ahead along its current heading, so the line both
+// shows where it has been and noses toward where it is going. Kept pure +
+// unit-tested; GlobeView renders the result as a faded path.
+
+export interface TrailPoint {
+  lat: number;
+  lon: number;
+  altKm: number;
+}
+
+const EARTH_R_KM = 6371;
+
+/** Append a position to a capped history, ignoring near-duplicate samples. */
+export function pushHistory(history: TrailPoint[], pt: TrailPoint, max = 12): TrailPoint[] {
+  const last = history[history.length - 1];
+  // Skip if essentially unchanged (plane hasn't moved between polls).
+  if (last && Math.abs(last.lat - pt.lat) < 1e-4 && Math.abs(last.lon - pt.lon) < 1e-4) {
+    return history;
+  }
+  const next = [...history, pt];
+  return next.length > max ? next.slice(next.length - max) : next;
+}
+
+/** Destination point from (lat,lon) travelling `distanceKm` along `bearingDeg`. */
+export function projectAhead(
+  lat: number,
+  lon: number,
+  bearingDeg: number,
+  distanceKm: number,
+): { lat: number; lon: number } {
+  const δ = distanceKm / EARTH_R_KM;
+  const θ = (bearingDeg * Math.PI) / 180;
+  const φ1 = (lat * Math.PI) / 180;
+  const λ1 = (lon * Math.PI) / 180;
+  const sinφ2 = Math.sin(φ1) * Math.cos(δ) + Math.cos(φ1) * Math.sin(δ) * Math.cos(θ);
+  const φ2 = Math.asin(Math.min(1, Math.max(-1, sinφ2)));
+  const λ2 =
+    λ1 +
+    Math.atan2(
+      Math.sin(θ) * Math.sin(δ) * Math.cos(φ1),
+      Math.cos(δ) - Math.sin(φ1) * sinφ2,
+    );
+  return {
+    lat: (φ2 * 180) / Math.PI,
+    // Normalise longitude to [-180, 180].
+    lon: (((λ2 * 180) / Math.PI + 540) % 360) - 180,
+  };
+}
+
+/** How far ahead to project, in km, scaled by speed (clamped). */
+export function lookaheadKm(velocityMs: number | null, seconds = 90): number {
+  const v = velocityMs && velocityMs > 0 ? velocityMs : 0;
+  return Math.min(80, Math.max(4, (v * seconds) / 1000));
+}
+
+/**
+ * Full trail to render: recent history + current position + a projected point
+ * ahead. Returns at least the current point (never empty for a live plane).
+ */
+export function buildTrailPath(
+  history: TrailPoint[],
+  current: TrailPoint,
+  headingDeg: number,
+  velocityMs: number | null,
+): TrailPoint[] {
+  const ahead = projectAhead(current.lat, current.lon, headingDeg, lookaheadKm(velocityMs));
+  return [...history, current, { ...ahead, altKm: current.altKm }];
+}

--- a/lib/planes/usePlanes.ts
+++ b/lib/planes/usePlanes.ts
@@ -2,28 +2,38 @@
 
 import { useState, useEffect, useRef } from "react";
 import type { WorldObject } from "@/lib/world";
-import { planeToWorldObject } from "@/lib/sources/opensky";
-import type { Plane } from "@/lib/sources/opensky";
+import { buildTrailPath, pushHistory, type TrailPoint } from "@/lib/planes/trail";
 
-const POLL_INTERVAL_MS = 15_000;
+const POLL_INTERVAL_MS = 12_000;
+
+/** A plane's breadcrumb path: recent positions + a projected point ahead. */
+export interface PlaneTrail {
+  id: string;
+  color: string;
+  /** [lat, lon, altKm] tuples. */
+  points: [number, number, number][];
+}
+
+export interface PlanesLayer {
+  objects: WorldObject[];
+  trails: PlaneTrail[];
+}
 
 interface PlanesResponse {
   count: number;
-  planes: Plane[];
+  planes: WorldObject[];
 }
 
 /**
- * React hook that polls /api/planes every 15 s and returns live aircraft as
- * {@link WorldObject} arrays ready for the globe layer.
- *
- * - Fetches once immediately on mount.
- * - On fetch/parse error it silently keeps the last good dataset.
- * - Clears the polling interval on unmount.
+ * Polls /api/planes (adsb.lol, already classified server-side) and returns the
+ * live aircraft plus a breadcrumb TRAIL per plane. Position history is kept
+ * client-side across polls (the server only knows "now"), capped per plane and
+ * pruned when a plane leaves coverage. Keeps the last good data on fetch error.
  */
-export function usePlanes(): WorldObject[] {
-  const [objects, setObjects] = useState<WorldObject[]>([]);
-  // Keep a ref so the error-path closure always sees the latest good data
-  const lastGoodRef = useRef<WorldObject[]>([]);
+export function usePlanes(): PlanesLayer {
+  const [layer, setLayer] = useState<PlanesLayer>({ objects: [], trails: [] });
+  const historyRef = useRef<Map<string, TrailPoint[]>>(new Map());
+  const lastGoodRef = useRef<PlanesLayer>({ objects: [], trails: [] });
 
   useEffect(() => {
     let cancelled = false;
@@ -33,16 +43,37 @@ export function usePlanes(): WorldObject[] {
         const res = await fetch("/api/planes");
         if (!res.ok) return; // keep last good
         const data = (await res.json()) as PlanesResponse;
-        const mapped = data.planes.map(planeToWorldObject);
-        if (!cancelled) {
-          lastGoodRef.current = mapped;
-          setObjects(mapped);
+        if (cancelled) return;
+
+        const prev = historyRef.current;
+        const next = new Map<string, TrailPoint[]>();
+        const trails: PlaneTrail[] = [];
+
+        for (const o of data.planes) {
+          const cur: TrailPoint = { lat: o.lat, lon: o.lon, altKm: o.altKm ?? 0 };
+          const hist = pushHistory(prev.get(o.id) ?? [], cur);
+          next.set(o.id, hist);
+          // Trail = history (minus the current, which buildTrailPath re-adds) +
+          // current + projected-ahead.
+          const path = buildTrailPath(
+            hist.slice(0, -1),
+            cur,
+            o.heading ?? 0,
+            (o.meta?.velocityMs as number | null) ?? null,
+          );
+          trails.push({
+            id: o.id,
+            color: o.color ?? "#fbbf24",
+            points: path.map((p) => [p.lat, p.lon, p.altKm] as [number, number, number]),
+          });
         }
+
+        historyRef.current = next; // prunes planes no longer present
+        const result = { objects: data.planes, trails };
+        lastGoodRef.current = result;
+        setLayer(result);
       } catch {
-        // Network error or JSON parse failure — keep last good data
-        if (!cancelled) {
-          setObjects(lastGoodRef.current);
-        }
+        if (!cancelled) setLayer(lastGoodRef.current);
       }
     }
 
@@ -54,5 +85,5 @@ export function usePlanes(): WorldObject[] {
     };
   }, []);
 
-  return objects;
+  return layer;
 }

--- a/lib/proxy/allowlist.ts
+++ b/lib/proxy/allowlist.ts
@@ -1,6 +1,8 @@
 // Each rule is host + required path prefix. Adding a source = adding a rule.
 const RULES: { host: string; prefix: string }[] = [
   { host: "s3-eu-west-1.amazonaws.com", prefix: "/jamcams.tfl.gov.uk/" },
+  { host: "cwwp2.dot.ca.gov", prefix: "/data/" },
+  { host: "scdotsnap.us-east-1.skyvdn.com", prefix: "/thumbs/" },
 ];
 
 export function isAllowed(url: URL): boolean {

--- a/lib/proxy/allowlist.ts
+++ b/lib/proxy/allowlist.ts
@@ -5,6 +5,7 @@ const RULES: { host: string; prefix: string; suffix?: string }[] = [
   { host: "s3-eu-west-1.amazonaws.com", prefix: "/jamcams.tfl.gov.uk/" },
   { host: "cwwp2.dot.ca.gov", prefix: "/data/" },
   { host: "scdotsnap.us-east-1.skyvdn.com", prefix: "/", suffix: ".png" },
+  { host: "weathercam.digitraffic.fi", prefix: "/", suffix: ".jpg" },
 ];
 
 export function isAllowed(url: URL): boolean {

--- a/lib/proxy/allowlist.ts
+++ b/lib/proxy/allowlist.ts
@@ -1,11 +1,18 @@
-// Each rule is host + required path prefix. Adding a source = adding a rule.
-const RULES: { host: string; prefix: string }[] = [
+// Each rule is host + required path prefix (+ optional suffix). Adding a source
+// = adding a rule. SCDOT snapshots live at the host root as `/<id>.png`, so that
+// rule pins the suffix instead of a deep prefix to stay tight.
+const RULES: { host: string; prefix: string; suffix?: string }[] = [
   { host: "s3-eu-west-1.amazonaws.com", prefix: "/jamcams.tfl.gov.uk/" },
   { host: "cwwp2.dot.ca.gov", prefix: "/data/" },
-  { host: "scdotsnap.us-east-1.skyvdn.com", prefix: "/thumbs/" },
+  { host: "scdotsnap.us-east-1.skyvdn.com", prefix: "/", suffix: ".png" },
 ];
 
 export function isAllowed(url: URL): boolean {
   if (url.protocol !== "https:" && url.protocol !== "http:") return false;
-  return RULES.some((r) => url.hostname === r.host && url.pathname.startsWith(r.prefix));
+  return RULES.some(
+    (r) =>
+      url.hostname === r.host &&
+      url.pathname.startsWith(r.prefix) &&
+      (!r.suffix || url.pathname.endsWith(r.suffix)),
+  );
 }

--- a/lib/proxy/hls-allowlist.ts
+++ b/lib/proxy/hls-allowlist.ts
@@ -1,0 +1,18 @@
+// Streaming hosts are separate from the still-image allowlist: each rule also
+// carries the Referer to inject (Caltrans' wzmedia is hotlink-protected).
+type HlsRule = { match: (host: string) => boolean; prefix: string; referer: string };
+
+const RULES: HlsRule[] = [
+  { match: (h) => h === "wzmedia.dot.ca.gov", prefix: "/", referer: "https://cwwp2.dot.ca.gov/" },
+  { match: (h) => h.endsWith(".us-east-1.skyvdn.com"), prefix: "/rtplive/", referer: "https://www.511sc.org/" },
+];
+
+export function isHlsAllowed(url: URL): { ok: boolean; referer?: string } {
+  if (url.protocol !== "https:" && url.protocol !== "http:") return { ok: false };
+  for (const r of RULES) {
+    if (r.match(url.hostname) && url.pathname.startsWith(r.prefix)) {
+      return { ok: true, referer: r.referer };
+    }
+  }
+  return { ok: false };
+}

--- a/lib/proxy/hls-allowlist.ts
+++ b/lib/proxy/hls-allowlist.ts
@@ -16,3 +16,17 @@ export function isHlsAllowed(url: URL): { ok: boolean; referer?: string } {
   }
   return { ok: false };
 }
+
+/**
+ * Whether a camera's stream is a LIVE feed our proxy can actually play. Used to
+ * decide the video-vs-still icon and player. A camera whose only "video" is an
+ * MP4 clip on a non-allowlisted host (e.g. TfL JamCams) returns false → still.
+ */
+export function isLiveStreamUrl(streamUrl?: string): boolean {
+  if (!streamUrl) return false;
+  try {
+    return isHlsAllowed(new URL(streamUrl)).ok;
+  } catch {
+    return false;
+  }
+}

--- a/lib/proxy/hls-rewrite.ts
+++ b/lib/proxy/hls-rewrite.ts
@@ -1,0 +1,23 @@
+// Rewrite an HLS playlist so every nested URI routes back through /api/hls.
+// Relative URIs are resolved against the upstream playlist URL first.
+export function rewritePlaylist(body: string, upstreamUrl: string): string {
+  const proxy = (abs: string) => `/api/hls?u=${encodeURIComponent(abs)}`;
+  return body
+    .split("\n")
+    .map((line) => {
+      const trimmed = line.trim();
+      if (trimmed === "") return line;
+      if (trimmed.startsWith("#")) {
+        // Tags like EXT-X-KEY / EXT-X-MAP can carry URI="...".
+        const m = trimmed.match(/URI="([^"]+)"/);
+        if (m) {
+          const abs = new URL(m[1], upstreamUrl).toString();
+          return line.replace(m[1], proxy(abs));
+        }
+        return line;
+      }
+      const abs = new URL(trimmed, upstreamUrl).toString();
+      return proxy(abs);
+    })
+    .join("\n");
+}

--- a/lib/satellites/classify.ts
+++ b/lib/satellites/classify.ts
@@ -1,0 +1,47 @@
+// Classify a satellite into a recognisable *type* from its catalogue name.
+//
+// The anonymous CelesTrak feed gives us a name and TLE — no machine-readable
+// purpose field — so we infer the type from the name the way an observer would
+// ("STARLINK-1234" is obviously a Starlink). Order matters: the most specific
+// rules run first (a name can match several keywords). Pure + unit-tested.
+
+export type SatCategory =
+  | "station"
+  | "starlink"
+  | "oneweb"
+  | "navigation"
+  | "weather"
+  | "earth-observation"
+  | "science"
+  | "communications"
+  | "cubesat"
+  | "debris"
+  | "other";
+
+const RULES: { cat: SatCategory; test: RegExp }[] = [
+  // Spent upper stages & fragments first — they often embed other keywords.
+  { cat: "debris", test: /\bDEB\b|DEBRIS|\bR\/B\b|ROCKET BODY|\bAKM\b|\bPKM\b|FAIRING|COOLANT/ },
+  // Crewed stations & visiting vehicles.
+  { cat: "station", test: /\bISS\b|ZARYA|TIANGONG|TIANHE|MENGTIAN|WENTIAN|SPACE STATION|PROGRESS[ -]|SOYUZ[ -]|CREW DRAGON|DRAGON CRS|CYGNUS|TIANZHOU|MIR\b/ },
+  { cat: "starlink", test: /STARLINK/ },
+  { cat: "oneweb", test: /ONEWEB/ },
+  // Global navigation constellations.
+  { cat: "navigation", test: /NAVSTAR|\bGPS\b|GLONASS|GALILEO|BEIDOU|COMPASS|IRNSS|NVS-|\bQZS\b|\bGSAT0/ },
+  // Meteorology / operational Earth weather.
+  { cat: "weather", test: /\bNOAA\b|METEOR-|METOP|\bGOES\b|HIMAWARI|FENGYUN|\bFY-?\d|DMSP|ELEKTRO|INSAT|\bGOMS\b|\bMSG-?\d|\bMTG\b|METEOSAT/ },
+  // Imaging / remote sensing.
+  { cat: "earth-observation", test: /LANDSAT|SENTINEL|TERRA|AQUA|WORLDVIEW|GEOEYE|\bSPOT\b|PLEIADES|FLOCK|SKYSAT|\bDOVE\b|ICEYE|RADARSAT|CARTOSAT|RESOURCESAT|KOMPSAT|PLANET|JILIN|GAOFEN|CBERS|SAOCOM|CAPELLA|BLACKSKY|SUPERVIEW/ },
+  // Science / astronomy / geodesy.
+  { cat: "science", test: /\bHST\b|HUBBLE|KEPLER|\bTESS\b|SWIFT|FERMI|CHANDRA|\bGAIA\b|JWST|WEBB|\bXMM\b|INTEGRAL|NUSTAR|\bIXPE\b|CHEOPS|HXMT|SPEKTR|CALSPHERE|LARES|AJISAI|STARLETTE|TOPEX|JASON|GRACE|SWARM|CLUSTER|THEMIS|\bMMS\b/ },
+  // Commercial / government communications.
+  { cat: "communications", test: /INTELSAT|IRIDIUM|GLOBALSTAR|INMARSAT|\bSES-?\d|EUTELSAT|TELSTAR|\bO3B\b|ECHOSTAR|THAICOM|ASTRA|VIASAT|ORBCOMM|GONETS|YAMAL|EXPRESS-|HISPASAT|NIMIQ|\bANIK\b|\bBADR\b|TURKSAT|\bNSS-|MEASAT|JCSAT|OPTUS|SKYNET|\bMUOS\b|\bWGS\b|SYRACUSE|GSAT-?\d|KUIPER/ },
+  // Small/student satellites.
+  { cat: "cubesat", test: /CUBESAT|CUBE|-[136]U\b|UNICORN|SPROUT|LEMUR|PROXIMA|\bPOCKETQUBE\b/ },
+];
+
+/** Best-effort satellite type from its catalogue name. Falls back to "other". */
+export function classifySatellite(name: string): SatCategory {
+  const n = (name || "").toUpperCase();
+  for (const r of RULES) if (r.test.test(n)) return r.cat;
+  return "other";
+}

--- a/lib/satellites/useSatellites.ts
+++ b/lib/satellites/useSatellites.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from "react";
 import type { SatRec } from "satellite.js";
 import type { WorldObject } from "@/lib/world";
 import { buildSatrec, propagateAt, orbitalPeriodMin } from "@/lib/satellites/propagate";
+import { classifySatellite } from "@/lib/satellites/classify";
+import { SAT_META } from "@/lib/icons/svg";
 
 interface ApiSat {
   name: string;
@@ -14,6 +16,9 @@ interface ApiSat {
 interface Built extends ApiSat {
   satrec: SatRec;
   periodMin: number;
+  icon: WorldObject["icon"];
+  color: string;
+  typeLabel: string;
 }
 
 /**
@@ -39,7 +44,15 @@ export function useSatellites(group = "visual", stepMs = 1000): WorldObject[] {
         builtRef.current = recs
           .map((r): Built | null => {
             try {
-              return { ...r, satrec: buildSatrec(r.line1, r.line2), periodMin: orbitalPeriodMin(r.line2) };
+              const meta = SAT_META[classifySatellite(r.name)];
+              return {
+                ...r,
+                satrec: buildSatrec(r.line1, r.line2),
+                periodMin: orbitalPeriodMin(r.line2),
+                icon: meta.key,
+                color: meta.color,
+                typeLabel: meta.label,
+              };
             } catch {
               return null;
             }
@@ -69,7 +82,9 @@ export function useSatellites(group = "visual", stepMs = 1000): WorldObject[] {
           lon: sp.lon,
           altKm: sp.altKm,
           label: b.name,
-          color: "#a78bfa",
+          color: b.color,
+          icon: b.icon,
+          typeLabel: b.typeLabel,
           meta: {
             noradId: b.noradId,
             objectName: b.name,
@@ -78,6 +93,7 @@ export function useSatellites(group = "visual", stepMs = 1000): WorldObject[] {
             altKm: sp.altKm,
             velocityKmS: sp.velocityKmS,
             periodMin: b.periodMin,
+            typeLabel: b.typeLabel,
           },
         });
       }

--- a/lib/sources/adsb.ts
+++ b/lib/sources/adsb.ts
@@ -1,0 +1,171 @@
+// Live aircraft from adsb.lol — a free, keyless, community ADS-B aggregator.
+// Chosen over OpenSky because OpenSky's anonymous tier is too rate-limited for
+// continuous polling (429s). adsb.lol also broadcasts the ADS-B emitter
+// `category` + type code, so planes are classified accurately (not guessed).
+//
+// We query a few point+radius regions (matching the camera regions) and merge
+// them, so planes appear wherever a viewer flies.
+
+import type { WorldObject } from "@/lib/world";
+import { classifyPlane } from "@/lib/planes/classify";
+import { PLANE_META } from "@/lib/icons/svg";
+
+export interface AdsbRegion {
+  lat: number;
+  lon: number;
+  distNm: number;
+}
+
+// Centred on the camera regions. Radii kept moderate so dense airspace stays
+// legible (individual planes + trails readable) rather than blobbing together.
+export const ADSB_REGIONS: AdsbRegion[] = [
+  { lat: 51.5, lon: -0.12, distNm: 90 }, // London / SE England
+  { lat: 36.8, lon: -119.7, distNm: 160 }, // California
+  { lat: 33.9, lon: -80.9, distNm: 140 }, // South Carolina
+];
+
+export interface Aircraft {
+  hex: string;
+  callsign: string;
+  lat: number;
+  lon: number;
+  altKm: number;
+  headingDeg: number;
+  velocityMs: number | null;
+  verticalRateMs: number | null;
+  onGround: boolean;
+  category: string;
+  typeCode: string;
+  registration: string;
+}
+
+const KT_TO_MS = 0.514444;
+const FT_TO_KM = 0.0003048;
+const FPM_TO_MS = 0.00508;
+
+interface RawAircraft {
+  hex?: string;
+  flight?: string;
+  r?: string;
+  t?: string;
+  lat?: number;
+  lon?: number;
+  alt_baro?: number | string;
+  gs?: number;
+  track?: number;
+  true_heading?: number;
+  baro_rate?: number;
+  geom_rate?: number;
+  category?: string;
+}
+
+function num(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/** Parse adsb.lol aircraft rows into typed {@link Aircraft} (skips no-position). */
+export function parseAdsb(rows: RawAircraft[]): Aircraft[] {
+  const out: Aircraft[] = [];
+  for (const a of rows ?? []) {
+    const lat = num(a.lat);
+    const lon = num(a.lon);
+    if (lat === null || lon === null) continue;
+    const onGround = a.alt_baro === "ground";
+    const altFt = onGround ? 0 : num(a.alt_baro) ?? 0;
+    const gs = num(a.gs);
+    const vr = num(a.baro_rate) ?? num(a.geom_rate);
+    const hex = (a.hex ?? "").trim() || "unknown";
+    const callsign = (a.flight ?? "").trim() || hex;
+    out.push({
+      hex,
+      callsign,
+      lat,
+      lon,
+      altKm: altFt * FT_TO_KM,
+      headingDeg: num(a.track) ?? num(a.true_heading) ?? 0,
+      velocityMs: gs === null ? null : gs * KT_TO_MS,
+      verticalRateMs: vr === null ? null : vr * FPM_TO_MS,
+      onGround,
+      category: (a.category ?? "").trim(),
+      typeCode: (a.t ?? "").trim(),
+      registration: (a.r ?? "").trim(),
+    });
+  }
+  return out;
+}
+
+/** Map an {@link Aircraft} to a {@link WorldObject} with the right type icon. */
+export function aircraftToWorldObject(a: Aircraft): WorldObject {
+  const category = classifyPlane({
+    altKm: a.altKm,
+    velocityMs: a.velocityMs,
+    onGround: a.onGround,
+    category: a.category,
+  });
+  const meta = PLANE_META[category];
+  return {
+    kind: "plane",
+    id: `plane:${a.hex}`,
+    lat: a.lat,
+    lon: a.lon,
+    altKm: a.altKm,
+    heading: a.headingDeg,
+    label: a.callsign,
+    color: meta.color,
+    icon: meta.key,
+    typeLabel: meta.label,
+    meta: {
+      callsign: a.callsign,
+      registration: a.registration,
+      typeCode: a.typeCode,
+      adsbCategory: a.category,
+      velocityMs: a.velocityMs,
+      altKm: a.altKm,
+      verticalRateMs: a.verticalRateMs,
+      onGround: a.onGround,
+      headingDeg: a.headingDeg,
+      category,
+      typeLabel: meta.label,
+      // Whether the type came from a real ADS-B category vs the profile guess.
+      categorySource: a.category && a.category !== "A0" ? "adsb" : "estimate",
+    },
+  };
+}
+
+// Short server-side cache so rapid client polls don't hammer adsb.lol.
+const CACHE_TTL_MS = 8_000;
+let cache: { objects: WorldObject[]; at: number } | null = null;
+
+async function fetchRegion(r: AdsbRegion): Promise<RawAircraft[]> {
+  const url = `https://api.adsb.lol/v2/lat/${r.lat}/lon/${r.lon}/dist/${r.distNm}`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json", "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)" },
+    signal: AbortSignal.timeout(8_000),
+  });
+  if (!res.ok) throw new Error(`adsb.lol ${r.lat},${r.lon}: ${res.status}`);
+  const json = (await res.json()) as { ac?: RawAircraft[]; aircraft?: RawAircraft[] };
+  return json.ac ?? json.aircraft ?? [];
+}
+
+/**
+ * Live aircraft across all regions as WorldObjects, deduped by hex, with an
+ * 8 s cache. Returns the stale cache (or empty) if every region fails.
+ */
+export async function fetchAircraft(nowMs: number): Promise<WorldObject[]> {
+  if (cache && nowMs - cache.at < CACHE_TTL_MS) return cache.objects;
+
+  const results = await Promise.allSettled(ADSB_REGIONS.map(fetchRegion));
+  const rows = results
+    .filter((r): r is PromiseFulfilledResult<RawAircraft[]> => r.status === "fulfilled")
+    .flatMap((r) => r.value);
+
+  if (rows.length === 0 && results.every((r) => r.status === "rejected")) {
+    return cache?.objects ?? [];
+  }
+
+  const byHex = new Map<string, Aircraft>();
+  for (const a of parseAdsb(rows)) byHex.set(a.hex, a); // dedupe overlapping regions
+  const objects = [...byHex.values()].map(aircraftToWorldObject);
+  cache = { objects, at: nowMs };
+  return objects;
+}

--- a/lib/sources/caltrans.ts
+++ b/lib/sources/caltrans.ts
@@ -1,0 +1,79 @@
+import { Camera, CameraArray, Source } from "@/lib/types";
+
+export const CALTRANS_SOURCE: Source = {
+  id: "caltrans",
+  name: "Caltrans CCTV",
+  license: "Caltrans Terms of Use",
+  attribution: "Live traffic data © Caltrans (California DOT)",
+  refreshSeconds: 60,
+  needsKey: false,
+};
+
+const DISTRICTS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+export interface CaltransRecord {
+  cctv: {
+    index: string;
+    location: {
+      locationName?: string; nearbyPlace?: string;
+      longitude?: string; latitude?: string; direction?: string; route?: string;
+    };
+    inService: string;
+    imageData: {
+      streamingVideoURL?: string;
+      static?: { currentImageURL?: string; currentImageUpdateFrequency?: string };
+    };
+  };
+}
+
+export function normalizeCaltrans(records: CaltransRecord[], district: number): Camera[] {
+  const cams: Camera[] = [];
+  for (const r of records) {
+    const c = r.cctv;
+    const lat = Number(c.location?.latitude);
+    const lon = Number(c.location?.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const imageUrl = c.imageData?.static?.currentImageURL?.trim() || undefined;
+    const streamUrl = c.imageData?.streamingVideoURL?.trim() || undefined;
+    if (!imageUrl && !streamUrl) continue;
+    const freqMin = Number(c.imageData?.static?.currentImageUpdateFrequency);
+    const refreshSeconds = Number.isFinite(freqMin) && freqMin > 0 ? Math.max(30, freqMin * 60) : 60;
+    cams.push({
+      id: `caltrans:d${district}-${c.index}`,
+      source: "caltrans",
+      country: "US",
+      region: "California",
+      name: c.location?.locationName?.trim() || c.location?.nearbyPlace?.trim() || `Caltrans D${district} #${c.index}`,
+      lat, lon,
+      road: c.location?.route?.trim() || undefined,
+      direction: c.location?.direction?.trim() || undefined,
+      imageUrl,
+      streamUrl,
+      mediaType: streamUrl ? "both" : "jpeg",
+      refreshSeconds,
+      license: CALTRANS_SOURCE.license,
+      attribution: CALTRANS_SOURCE.attribution,
+      available: c.inService === "true",
+    });
+  }
+  return cams;
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  const results = await Promise.allSettled(
+    DISTRICTS.map(async (d) => {
+      const res = await fetch(`https://cwwp2.dot.ca.gov/data/d${d}/cctv/cctvStatusD${d}.json`, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) throw new Error(`Caltrans D${d}: ${res.status}`);
+      const json = (await res.json()) as { data?: CaltransRecord[] };
+      return normalizeCaltrans(json.data ?? [], d);
+    }),
+  );
+  const cams = results
+    .filter((r): r is PromiseFulfilledResult<Camera[]> => r.status === "fulfilled")
+    .flatMap((r) => r.value);
+  return CameraArray.parse(cams);
+}

--- a/lib/sources/digitraffic.ts
+++ b/lib/sources/digitraffic.ts
@@ -1,0 +1,74 @@
+import { Camera, CameraArray, Source } from "@/lib/types";
+
+// Fintraffic Digitraffic — Finland's national weather-camera network. Keyless,
+// well-documented, reliable (the PRD's "cleanest source"). One quirk: the API
+// REQUIRES `Accept-Encoding: gzip` or it 406s. Each station has several camera
+// "presets" (views); we surface one pin per station using its first active
+// preset's image at https://weathercam.digitraffic.fi/<presetId>.jpg.
+
+export const DIGITRAFFIC_SOURCE: Source = {
+  id: "digitraffic",
+  name: "Fintraffic Digitraffic (Finland)",
+  license: "CC BY 4.0 (Fintraffic)",
+  attribution: "Live weather-camera data © Fintraffic / Digitraffic",
+  refreshSeconds: 300, // weather cams update slowly
+  needsKey: false,
+};
+
+export interface DigiStation {
+  id?: string;
+  geometry?: { coordinates?: [number, number, number?] } | null;
+  properties?: {
+    id?: string;
+    name?: string;
+    collectionStatus?: string; // "GATHERING" when active
+    presets?: { id?: string; inCollection?: boolean }[];
+  };
+}
+
+export function normalizeDigitraffic(geojson: { features?: DigiStation[] }): Camera[] {
+  const cams: Camera[] = [];
+  for (const f of geojson.features ?? []) {
+    const p = f.properties ?? {};
+    const coords = f.geometry?.coordinates;
+    if (!coords) continue;
+    const lon = Number(coords[0]);
+    const lat = Number(coords[1]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const preset = (p.presets ?? []).find((x) => x.inCollection && x.id) ?? (p.presets ?? [])[0];
+    if (!preset?.id) continue;
+    const stationId = (f.id ?? p.id ?? "").toString().trim();
+    if (!stationId) continue;
+    cams.push({
+      id: `digitraffic:${stationId}`,
+      source: "digitraffic",
+      country: "FI",
+      region: "Finland",
+      name: p.name?.trim() || `Digitraffic ${stationId}`,
+      lat,
+      lon,
+      imageUrl: `https://weathercam.digitraffic.fi/${preset.id}.jpg`,
+      mediaType: "jpeg",
+      refreshSeconds: DIGITRAFFIC_SOURCE.refreshSeconds,
+      license: DIGITRAFFIC_SOURCE.license,
+      attribution: DIGITRAFFIC_SOURCE.attribution,
+      available: p.collectionStatus === "GATHERING",
+    });
+  }
+  return cams;
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  const res = await fetch("https://tie.digitraffic.fi/api/weathercam/v1/stations", {
+    headers: {
+      // Mandatory — the API 406s without it (undici still auto-decompresses).
+      "Accept-Encoding": "gzip",
+      "Digitraffic-User": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)",
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`Digitraffic stations: ${res.status}`);
+  const json = (await res.json()) as { features?: DigiStation[] };
+  return CameraArray.parse(normalizeDigitraffic(json));
+}

--- a/lib/sources/opensky.ts
+++ b/lib/sources/opensky.ts
@@ -5,6 +5,8 @@
  */
 
 import type { WorldObject } from "@/lib/world";
+import { classifyPlane } from "@/lib/planes/classify";
+import { PLANE_META } from "@/lib/icons/svg";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -131,6 +133,12 @@ export function parseStates(states: unknown[][]): Plane[] {
  * globe layer can render it uniformly alongside cameras and satellites.
  */
 export function planeToWorldObject(p: Plane): WorldObject {
+  const category = classifyPlane({
+    altKm: p.altKm,
+    velocityMs: p.velocityMs,
+    onGround: p.onGround,
+  });
+  const meta = PLANE_META[category];
   return {
     kind: "plane",
     id: `plane:${p.icao24}`,
@@ -139,7 +147,9 @@ export function planeToWorldObject(p: Plane): WorldObject {
     altKm: p.altKm,
     heading: p.headingDeg,
     label: p.callsign,
-    color: "#f59e0b",
+    color: meta.color,
+    icon: meta.key,
+    typeLabel: meta.label,
     meta: {
       callsign: p.callsign,
       country: p.country,
@@ -147,6 +157,8 @@ export function planeToWorldObject(p: Plane): WorldObject {
       altKm: p.altKm,
       verticalRateMs: p.verticalRateMs,
       onGround: p.onGround,
+      category,
+      typeLabel: meta.label,
     },
   };
 }

--- a/lib/sources/registry.ts
+++ b/lib/sources/registry.ts
@@ -1,13 +1,31 @@
 import type { Camera } from "@/lib/types";
-import { fetchRegistry } from "@/lib/sources/tfl";
+import { fetchRegistry as fetchTfl } from "@/lib/sources/tfl";
+import { fetchRegistry as fetchCaltrans } from "@/lib/sources/caltrans";
+import { fetchRegistry as fetchScdot } from "@/lib/sources/scdot";
 import { findById, nearest } from "@/lib/sources/select";
 
 const TTL_MS = 5 * 60 * 1000;
+const SOURCES: Array<() => Promise<Camera[]>> = [fetchTfl, fetchCaltrans, fetchScdot];
 let cache: { cameras: Camera[]; at: number } | null = null;
+
+export function mergeResults(
+  results: PromiseSettledResult<Camera[]>[],
+  staleCache: Camera[] | null,
+): Camera[] {
+  const cameras = results
+    .filter((r): r is PromiseFulfilledResult<Camera[]> => r.status === "fulfilled")
+    .flatMap((r) => r.value);
+  if (cameras.length === 0) {
+    if (staleCache && staleCache.length > 0) return staleCache;
+    throw new Error("all camera sources failed and no cache is available");
+  }
+  return cameras;
+}
 
 export async function getRegistry(): Promise<Camera[]> {
   if (cache && Date.now() - cache.at < TTL_MS) return cache.cameras;
-  const cameras = await fetchRegistry();
+  const results = await Promise.allSettled(SOURCES.map((f) => f()));
+  const cameras = mergeResults(results, cache?.cameras ?? null);
   cache = { cameras, at: Date.now() };
   return cameras;
 }

--- a/lib/sources/registry.ts
+++ b/lib/sources/registry.ts
@@ -2,10 +2,11 @@ import type { Camera } from "@/lib/types";
 import { fetchRegistry as fetchTfl } from "@/lib/sources/tfl";
 import { fetchRegistry as fetchCaltrans } from "@/lib/sources/caltrans";
 import { fetchRegistry as fetchScdot } from "@/lib/sources/scdot";
+import { fetchRegistry as fetchDigitraffic } from "@/lib/sources/digitraffic";
 import { findById, nearest } from "@/lib/sources/select";
 
 const TTL_MS = 5 * 60 * 1000;
-const SOURCES: Array<() => Promise<Camera[]>> = [fetchTfl, fetchCaltrans, fetchScdot];
+const SOURCES: Array<() => Promise<Camera[]>> = [fetchTfl, fetchCaltrans, fetchScdot, fetchDigitraffic];
 let cache: { cameras: Camera[]; at: number } | null = null;
 
 export function mergeResults(

--- a/lib/sources/scdot.ts
+++ b/lib/sources/scdot.ts
@@ -28,7 +28,11 @@ export function normalizeScdot(geojson: { features?: ScFeature[] }): Camera[] {
     const lat = Number(coords[1]);
     if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
     if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
-    const imageUrl = p.image_url?.trim() || undefined;
+    // The advertised thumb URL (/thumbs/<id>.flv.png) 301-redirects to the real
+    // snapshot at the host root (/<id>.png); pre-resolve it so our proxy (which
+    // refuses redirects for SSRF safety) fetches the image directly.
+    const rawImage = p.image_url?.trim() || undefined;
+    const imageUrl = rawImage?.replace("/thumbs/", "/").replace(/\.flv\.png$/, ".png");
     const streamUrl = p.https_url?.trim() || p.ios_url?.trim() || undefined;
     if (!imageUrl && !streamUrl) continue;
     const nativeId = (p.name ?? p.id ?? "").toString().trim();

--- a/lib/sources/scdot.ts
+++ b/lib/sources/scdot.ts
@@ -1,0 +1,65 @@
+import { Camera, CameraArray, Source } from "@/lib/types";
+
+export const SCDOT_SOURCE: Source = {
+  id: "scdot",
+  name: "SCDOT 511 (South Carolina DOT)",
+  license: "SCDOT 511 Terms of Use",
+  attribution: "Live traffic data © SCDOT / 511sc.org",
+  refreshSeconds: 60,
+  needsKey: false,
+};
+
+export interface ScFeature {
+  geometry?: { coordinates?: [number, number] } | null;
+  properties?: {
+    id?: string; name?: string; description?: string; route?: string; direction?: string;
+    https_url?: string; ios_url?: string; image_url?: string;
+    active?: boolean; problem_stream?: boolean;
+  };
+}
+
+export function normalizeScdot(geojson: { features?: ScFeature[] }): Camera[] {
+  const cams: Camera[] = [];
+  for (const f of geojson.features ?? []) {
+    const p = f.properties ?? {};
+    const coords = f.geometry?.coordinates;
+    if (!coords) continue;
+    const lon = Number(coords[0]);
+    const lat = Number(coords[1]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const imageUrl = p.image_url?.trim() || undefined;
+    const streamUrl = p.https_url?.trim() || p.ios_url?.trim() || undefined;
+    if (!imageUrl && !streamUrl) continue;
+    const nativeId = (p.name ?? p.id ?? "").toString().trim();
+    if (!nativeId) continue;
+    cams.push({
+      id: `scdot:${nativeId}`,
+      source: "scdot",
+      country: "US",
+      region: "South Carolina",
+      name: p.description?.trim() || p.name?.trim() || `SCDOT ${nativeId}`,
+      lat, lon,
+      road: p.route?.trim() || undefined,
+      direction: p.direction?.trim() || undefined,
+      imageUrl,
+      streamUrl,
+      mediaType: streamUrl ? "both" : "jpeg",
+      refreshSeconds: SCDOT_SOURCE.refreshSeconds,
+      license: SCDOT_SOURCE.license,
+      attribution: SCDOT_SOURCE.attribution,
+      available: p.active === true && p.problem_stream !== true,
+    });
+  }
+  return cams;
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  const res = await fetch("https://sc.cdn.iteris-atis.com/geojson/icons/metadata/icons.cameras.geojson", {
+    headers: { Accept: "application/json", Referer: "https://www.511sc.org/" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`SCDOT GeoJSON: ${res.status}`);
+  const json = (await res.json()) as { features?: ScFeature[] };
+  return CameraArray.parse(normalizeScdot(json));
+}

--- a/lib/world.ts
+++ b/lib/world.ts
@@ -6,6 +6,8 @@
 // a layer's only job is to emit WorldObject[]; GlobeView renders them and
 // the overlay displays the clicked one. No layer imports another.
 
+import type { IconKey } from "@/lib/icons/svg";
+
 export type WorldObjectKind = "camera" | "satellite" | "plane";
 
 export interface WorldObject {
@@ -28,6 +30,10 @@ export interface WorldObject {
   label: string;
   /** Optional marker colour override (CSS hex). Layers may set their own palette. */
   color?: string;
+  /** Which type icon to render on the globe / map / legend (see lib/icons/svg.ts). */
+  icon?: IconKey;
+  /** Human-readable type label for the overlay, e.g. "Airliner", "Starlink". */
+  typeLabel?: string;
   /**
    * Kind-specific extras the detail view needs but the globe does not.
    * e.g. camera: { imageUrl }, plane: { callsign, origin, velocity },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "trafficnerd-v2",
       "version": "0.1.0",
       "dependencies": {
+        "hls.js": "^1.6.16",
         "maplibre-gl": "^5.24.0",
         "next": "15.5.19",
         "react": "19.0.0",
@@ -2277,6 +2278,12 @@
         "npm": ">=3",
         "yarn": ">=1.3.0"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/index-array-by": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "hls.js": "^1.6.16",
     "maplibre-gl": "^5.24.0",
     "next": "15.5.19",
     "react": "19.0.0",

--- a/tests/e2e/camera.spec.ts
+++ b/tests/e2e/camera.spec.ts
@@ -22,3 +22,13 @@ test("the proxy rejects a request with no id", async ({ request }) => {
   const res = await request.get("/api/proxy");
   expect(res.status()).toBe(400);
 });
+
+test("camera list carries country/live; detail exposes mediaType but never the raw streamUrl", async ({ request }) => {
+  const { cameras } = await (await request.get("/api/cameras")).json();
+  expect(cameras[0].country).toBeTruthy(); // list now carries country
+  expect(typeof cameras[0].live).toBe("boolean"); // …and the live-stream flag
+  const res = await request.get(`/api/camera/${encodeURIComponent(cameras[0].id)}`);
+  const { camera } = await res.json();
+  expect(camera.mediaType).toBeTruthy();
+  expect(camera.streamUrl).toBeUndefined();
+});

--- a/tests/e2e/hls.spec.ts
+++ b/tests/e2e/hls.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test("the HLS proxy rejects missing params and disallowed hosts", async ({ request }) => {
+  expect((await request.get("/api/hls")).status()).toBe(400);
+  const forbidden = await request.get("/api/hls?u=" + encodeURIComponent("https://evil.example.com/x.m3u8"));
+  expect(forbidden.status()).toBe(403);
+});
+
+test("a US camera's stream is proxied as an HLS playlist", async ({ request }) => {
+  const { cameras } = await (await request.get("/api/cameras")).json();
+  const us = cameras.find((c: { id: string }) => c.id.startsWith("caltrans:") || c.id.startsWith("scdot:"));
+  test.skip(!us, "no US camera available from live sources right now");
+  const res = await request.get(`/api/hls?id=${encodeURIComponent(us.id)}`);
+  // Live streams flake; accept a proxied playlist (200 mpegurl) or an upstream-down 502.
+  if (res.ok()) {
+    expect(res.headers()["content-type"]).toContain("mpegurl");
+    expect(await res.text()).toContain("/api/hls?u=");
+  } else {
+    expect([502, 404]).toContain(res.status());
+  }
+});

--- a/tests/e2e/us-video.spec.ts
+++ b/tests/e2e/us-video.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("a US camera detail shows live video (or gracefully falls back to a still)", async ({ page, request }) => {
+  const { cameras } = await (await request.get("/api/cameras")).json();
+  const us = cameras.find((c: { id: string }) => c.id.startsWith("caltrans:") || c.id.startsWith("scdot:"));
+  test.skip(!us, "no US camera available from live sources right now");
+
+  await page.goto(`/camera/${encodeURIComponent(us.id)}`);
+  await expect(page.getByTestId("attribution")).toBeVisible();
+  // Either a <video> mounts, or (offline stream) the still-image fallback appears.
+  const media = page.locator(".camera-detail video, .camera-detail img");
+  await expect(media.first()).toBeVisible();
+});

--- a/tests/fixtures/caltrans-d11.json
+++ b/tests/fixtures/caltrans-d11.json
@@ -1,0 +1,16 @@
+[
+  { "cctv": { "index": "1",
+    "location": { "locationName": "SR-163 : Friars NEB", "nearbyPlace": "San Diego", "longitude": "-117.160577", "latitude": "32.772126", "direction": "South", "route": "SR-163" },
+    "inService": "true",
+    "imageData": { "streamingVideoURL": "https://wzmedia.dot.ca.gov/D11/CAM1.stream/playlist.m3u8",
+      "static": { "currentImageURL": "https://cwwp2.dot.ca.gov/data/d11/cctv/image/cam1/cam1.jpg", "currentImageUpdateFrequency": "2" } } } },
+  { "cctv": { "index": "2",
+    "location": { "locationName": "I-8 at Hotel Circle", "nearbyPlace": "San Diego", "longitude": "-117.18", "latitude": "32.76", "direction": "East", "route": "I-8" },
+    "inService": "false",
+    "imageData": { "streamingVideoURL": "",
+      "static": { "currentImageURL": "https://cwwp2.dot.ca.gov/data/d11/cctv/image/cam2/cam2.jpg", "currentImageUpdateFrequency": "2" } } } },
+  { "cctv": { "index": "3",
+    "location": { "nearbyPlace": "El Cajon", "longitude": "-116.9", "latitude": "32.79" },
+    "inService": "true",
+    "imageData": { "static": {} } } }
+]

--- a/tests/fixtures/digitraffic-stations.json
+++ b/tests/fixtures/digitraffic-stations.json
@@ -1,0 +1,17 @@
+{ "type": "FeatureCollection", "features": [
+  { "type": "Feature", "id": "C01503",
+    "geometry": { "type": "Point", "coordinates": [23.99616, 60.05374, 0] },
+    "properties": { "id": "C01503", "name": "kt51_Inkoo", "collectionStatus": "GATHERING",
+      "presets": [ { "id": "C0150301", "inCollection": false }, { "id": "C0150302", "inCollection": true } ] } },
+  { "type": "Feature", "id": "C99999",
+    "geometry": { "type": "Point", "coordinates": [25.0, 65.0, 0] },
+    "properties": { "id": "C99999", "name": "vt4_Oulu", "collectionStatus": "REMOVED_TEMPORARILY",
+      "presets": [ { "id": "C9999901", "inCollection": true } ] } },
+  { "type": "Feature", "id": "C00000",
+    "geometry": null,
+    "properties": { "id": "C00000", "name": "no-geometry", "collectionStatus": "GATHERING",
+      "presets": [ { "id": "C0000001", "inCollection": true } ] } },
+  { "type": "Feature", "id": "C11111",
+    "geometry": { "type": "Point", "coordinates": [24.0, 61.0, 0] },
+    "properties": { "id": "C11111", "name": "no-presets", "collectionStatus": "GATHERING", "presets": [] } }
+] }

--- a/tests/fixtures/scdot-cameras.json
+++ b/tests/fixtures/scdot-cameras.json
@@ -1,0 +1,12 @@
+{ "type": "FeatureCollection", "features": [
+  { "type": "Feature", "geometry": { "type": "Point", "coordinates": [-79.062775, 33.845627] },
+    "properties": { "id": "uuid-1", "name": "50001", "description": "US 501 N @ 16th Ave", "route": "US 501", "direction": "NB",
+      "https_url": "https://s18.us-east-1.skyvdn.com:443/rtplive/50001/playlist.m3u8",
+      "ios_url": "https://s18.us-east-1.skyvdn.com:443/rtplive/50001/playlist.m3u8",
+      "image_url": "https://scdotsnap.us-east-1.skyvdn.com/thumbs/50001.flv.png", "active": true, "problem_stream": false } },
+  { "type": "Feature", "geometry": { "type": "Point", "coordinates": [-80.9, 32.8] },
+    "properties": { "id": "uuid-2", "name": "50002", "description": "I-26 @ Mile 5", "route": "I-26", "direction": "EB",
+      "https_url": "https://s19.us-east-1.skyvdn.com:443/rtplive/50002/playlist.m3u8",
+      "image_url": "https://scdotsnap.us-east-1.skyvdn.com/thumbs/50002.flv.png", "active": true, "problem_stream": true } },
+  { "type": "Feature", "geometry": null, "properties": { "name": "50003" } }
+] }

--- a/tests/unit/adsb.test.ts
+++ b/tests/unit/adsb.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest";
+import { parseAdsb, aircraftToWorldObject } from "@/lib/sources/adsb";
+
+const rows = [
+  { hex: "abc123", flight: "BAW123 ", lat: 51.5, lon: -0.1, alt_baro: 37000, gs: 450, track: 90, baro_rate: 0, category: "A5", t: "B77W", r: "G-XYZ" },
+  { hex: "def456", flight: "HELI1", lat: 51.4, lon: -0.2, alt_baro: 1200, gs: 60, track: 10, category: "A7", t: "EC35" },
+  { hex: "ghi789", flight: "TAXI", lat: 51.47, lon: -0.45, alt_baro: "ground", gs: 12, track: 0, category: "A3" },
+  { hex: "nopos", flight: "NOFIX", alt_baro: 10000 }, // no lat/lon → skipped
+];
+
+test("parseAdsb skips rows without a position and converts units", () => {
+  const ac = parseAdsb(rows as never);
+  expect(ac).toHaveLength(3);
+  const baw = ac[0];
+  expect(baw.altKm).toBeCloseTo(37000 * 0.0003048, 3); // ft → km
+  expect(baw.velocityMs).toBeCloseTo(450 * 0.514444, 1); // kt → m/s
+  expect(ac[2].onGround).toBe(true); // alt_baro "ground"
+});
+
+test("aircraftToWorldObject classifies from the ADS-B category", () => {
+  const [heavy, heli, ground] = parseAdsb(rows as never).map(aircraftToWorldObject);
+  expect(heavy.icon).toBe("plane-airliner"); // A5 heavy
+  expect(heli.icon).toBe("plane-helicopter"); // A7 rotorcraft
+  expect(ground.icon).toBe("plane-ground"); // on ground overrides
+  expect(heavy.meta?.categorySource).toBe("adsb");
+  expect(heavy.meta?.typeCode).toBe("B77W");
+});

--- a/tests/unit/allowlist.test.ts
+++ b/tests/unit/allowlist.test.ts
@@ -18,3 +18,14 @@ test("rejects non-http(s) protocols", () => {
   expect(isAllowed(new URL("file:///etc/passwd"))).toBe(false);
   expect(isAllowed(new URL("gopher://s3-eu-west-1.amazonaws.com/jamcams.tfl.gov.uk/x.jpg"))).toBe(false);
 });
+
+test("allows the Caltrans image host under /data/", () => {
+  expect(isAllowed(new URL("https://cwwp2.dot.ca.gov/data/d11/cctv/image/cam1/cam1.jpg"))).toBe(true);
+});
+test("allows the SCDOT snapshot host under /thumbs/", () => {
+  expect(isAllowed(new URL("https://scdotsnap.us-east-1.skyvdn.com/thumbs/50001.flv.png"))).toBe(true);
+});
+test("rejects those hosts outside their allowed prefix", () => {
+  expect(isAllowed(new URL("https://cwwp2.dot.ca.gov/etc/secret.jpg"))).toBe(false);
+  expect(isAllowed(new URL("https://scdotsnap.us-east-1.skyvdn.com/rtplive/x.ts"))).toBe(false);
+});

--- a/tests/unit/caltrans.test.ts
+++ b/tests/unit/caltrans.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/caltrans-d11.json";
+import { normalizeCaltrans } from "@/lib/sources/caltrans";
+import { CameraArray } from "@/lib/types";
+
+test("normalizes Caltrans records into valid Cameras and skips no-media records", () => {
+  const cams = normalizeCaltrans(fixture as never, 11);
+  expect(() => CameraArray.parse(cams)).not.toThrow();
+  expect(cams).toHaveLength(2); // record 3 has no image and no stream
+});
+
+test("maps id, region, media type, availability and refresh", () => {
+  const [a, b] = normalizeCaltrans(fixture as never, 11);
+  expect(a.id).toBe("caltrans:d11-1");
+  expect(a.country).toBe("US");
+  expect(a.region).toBe("California");
+  expect(a.mediaType).toBe("both"); // has a stream
+  expect(a.available).toBe(true);
+  expect(a.road).toBe("SR-163");
+  expect(a.refreshSeconds).toBe(120); // 2 minutes * 60
+  expect(b.mediaType).toBe("jpeg"); // empty streamingVideoURL
+  expect(b.available).toBe(false);
+});

--- a/tests/unit/camera-filter.test.ts
+++ b/tests/unit/camera-filter.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import { cameraFilterStore } from "@/lib/cameraFilter";
+
+test("passes() respects region toggles and the live-only filter", () => {
+  // Default: every region visible, live-only off.
+  expect(cameraFilterStore.passes("tfl", false)).toBe(true);
+  expect(cameraFilterStore.passes("caltrans", true)).toBe(true);
+
+  // Live-only hides still cameras, keeps live ones.
+  cameraFilterStore.setLiveOnly(true);
+  expect(cameraFilterStore.passes("tfl", false)).toBe(false);
+  expect(cameraFilterStore.passes("caltrans", true)).toBe(true);
+
+  // Hiding a region drops it even when live.
+  cameraFilterStore.toggleRegion("caltrans");
+  expect(cameraFilterStore.passes("caltrans", true)).toBe(false);
+
+  // Unknown sources default to visible.
+  expect(cameraFilterStore.passes("mystery", true)).toBe(true);
+
+  // Reset the singleton so other tests are unaffected.
+  cameraFilterStore.toggleRegion("caltrans");
+  cameraFilterStore.setLiveOnly(false);
+});

--- a/tests/unit/classify-camera.test.ts
+++ b/tests/unit/classify-camera.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from "vitest";
-import { classifyCameraFeed } from "@/lib/cameras/classify";
+import { cameraFeed } from "@/lib/cameras/classify";
 
-test("jpeg snapshots are 'still', streams are 'video'", () => {
-  expect(classifyCameraFeed("jpeg")).toBe("still");
-  expect(classifyCameraFeed("video")).toBe("video");
-  expect(classifyCameraFeed("both")).toBe("video");
+test("a live (HLS-proxyable) stream is 'video', otherwise 'still'", () => {
+  expect(cameraFeed(true)).toBe("video");
+  expect(cameraFeed(false)).toBe("still");
 });

--- a/tests/unit/classify-camera.test.ts
+++ b/tests/unit/classify-camera.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "vitest";
+import { classifyCameraFeed } from "@/lib/cameras/classify";
+
+test("jpeg snapshots are 'still', streams are 'video'", () => {
+  expect(classifyCameraFeed("jpeg")).toBe("still");
+  expect(classifyCameraFeed("video")).toBe("video");
+  expect(classifyCameraFeed("both")).toBe("video");
+});

--- a/tests/unit/classify-plane.test.ts
+++ b/tests/unit/classify-plane.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest";
+import { classifyPlane } from "@/lib/planes/classify";
+
+test("on-ground aircraft are 'ground' regardless of speed", () => {
+  expect(classifyPlane({ altKm: 0, velocityMs: 5, onGround: true })).toBe("ground");
+});
+
+test("high + fast is an airliner", () => {
+  expect(classifyPlane({ altKm: 11, velocityMs: 230, onGround: false })).toBe("airliner");
+});
+
+test("low + slow airborne is a helicopter", () => {
+  expect(classifyPlane({ altKm: 0.6, velocityMs: 40, onGround: false })).toBe("helicopter");
+});
+
+test("mid band or fast-but-lower is regional", () => {
+  expect(classifyPlane({ altKm: 4.5, velocityMs: 130, onGround: false })).toBe("regional");
+  expect(classifyPlane({ altKm: 2, velocityMs: 140, onGround: false })).toBe("regional");
+});
+
+test("low and modest speed is a light aircraft", () => {
+  expect(classifyPlane({ altKm: 1.2, velocityMs: 85, onGround: false })).toBe("light");
+});
+
+test("null speed is treated as zero (no crash)", () => {
+  expect(classifyPlane({ altKm: 0.5, velocityMs: null, onGround: false })).toBe("helicopter");
+});

--- a/tests/unit/classify-plane.test.ts
+++ b/tests/unit/classify-plane.test.ts
@@ -25,3 +25,14 @@ test("low and modest speed is a light aircraft", () => {
 test("null speed is treated as zero (no crash)", () => {
   expect(classifyPlane({ altKm: 0.5, velocityMs: null, onGround: false })).toBe("helicopter");
 });
+
+test("ADS-B category wins over the profile heuristic", () => {
+  // A7 = rotorcraft even though the profile (high+fast) looks like an airliner.
+  expect(classifyPlane({ altKm: 11, velocityMs: 230, onGround: false, category: "A7" })).toBe("helicopter");
+  // A5 = heavy → airliner.
+  expect(classifyPlane({ altKm: 2, velocityMs: 90, onGround: false, category: "A5" })).toBe("airliner");
+  // On-ground still overrides any category.
+  expect(classifyPlane({ altKm: 0, velocityMs: 5, onGround: true, category: "A5" })).toBe("ground");
+  // Unknown category falls back to the profile.
+  expect(classifyPlane({ altKm: 11, velocityMs: 230, onGround: false, category: "A0" })).toBe("airliner");
+});

--- a/tests/unit/classify-satellite.test.ts
+++ b/tests/unit/classify-satellite.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import { classifySatellite } from "@/lib/satellites/classify";
+
+test("recognises the major satellite types by name", () => {
+  expect(classifySatellite("ISS (ZARYA)")).toBe("station");
+  expect(classifySatellite("CSS (TIANHE)")).toBe("station");
+  expect(classifySatellite("STARLINK-1234")).toBe("starlink");
+  expect(classifySatellite("ONEWEB-0421")).toBe("oneweb");
+  expect(classifySatellite("NAVSTAR 80 (USA 309)")).toBe("navigation");
+  expect(classifySatellite("GSAT0209 (GALILEO 15)")).toBe("navigation");
+  expect(classifySatellite("NOAA 19")).toBe("weather");
+  expect(classifySatellite("SENTINEL-2A")).toBe("earth-observation");
+  expect(classifySatellite("HST")).toBe("science");
+  expect(classifySatellite("INTELSAT 901")).toBe("communications");
+});
+
+test("spent stages and fragments are debris, even when they embed other words", () => {
+  expect(classifySatellite("SL-16 R/B")).toBe("debris");
+  expect(classifySatellite("FALCON 9 DEB")).toBe("debris");
+});
+
+test("unknown names fall back to 'other'", () => {
+  expect(classifySatellite("MYSTERY OBJECT 42")).toBe("other");
+  expect(classifySatellite("")).toBe("other");
+});

--- a/tests/unit/digitraffic.test.ts
+++ b/tests/unit/digitraffic.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/digitraffic-stations.json";
+import { normalizeDigitraffic } from "@/lib/sources/digitraffic";
+import { CameraArray } from "@/lib/types";
+
+test("normalizes Digitraffic stations, skipping null-geometry and preset-less ones", () => {
+  const cams = normalizeDigitraffic(fixture as never);
+  expect(() => CameraArray.parse(cams)).not.toThrow();
+  expect(cams).toHaveLength(2); // C00000 (null geom) + C11111 (no presets) skipped
+});
+
+test("builds the image URL from the active preset; maps region + availability", () => {
+  const [a, b] = normalizeDigitraffic(fixture as never);
+  expect(a.id).toBe("digitraffic:C01503");
+  expect(a.country).toBe("FI");
+  expect(a.region).toBe("Finland");
+  expect(a.name).toBe("kt51_Inkoo");
+  // First in-collection preset is C0150302 (not the first listed).
+  expect(a.imageUrl).toBe("https://weathercam.digitraffic.fi/C0150302.jpg");
+  expect(a.mediaType).toBe("jpeg");
+  expect(a.available).toBe(true); // GATHERING
+  expect(b.available).toBe(false); // REMOVED_TEMPORARILY
+  expect(b.imageUrl).toBe("https://weathercam.digitraffic.fi/C9999901.jpg");
+});

--- a/tests/unit/hls-allowlist.test.ts
+++ b/tests/unit/hls-allowlist.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import { isHlsAllowed } from "@/lib/proxy/hls-allowlist";
+
+test("allows Caltrans wzmedia with the Caltrans referer", () => {
+  const v = isHlsAllowed(new URL("https://wzmedia.dot.ca.gov/D11/CAM.stream/playlist.m3u8"));
+  expect(v.ok).toBe(true);
+  expect(v.referer).toBe("https://cwwp2.dot.ca.gov/");
+});
+test("allows SC skyvdn shards under /rtplive/ with the 511sc referer", () => {
+  const v = isHlsAllowed(new URL("https://s19.us-east-1.skyvdn.com:443/rtplive/50001/playlist.m3u8"));
+  expect(v.ok).toBe(true);
+  expect(v.referer).toBe("https://www.511sc.org/");
+});
+test("rejects a skyvdn path outside /rtplive/", () => {
+  expect(isHlsAllowed(new URL("https://s19.us-east-1.skyvdn.com/secret/x.m3u8")).ok).toBe(false);
+});
+test("rejects unknown hosts, look-alike suffixes, and non-http", () => {
+  expect(isHlsAllowed(new URL("https://evil.example.com/x.m3u8")).ok).toBe(false);
+  expect(isHlsAllowed(new URL("https://x.us-east-1.skyvdn.com.attacker.com/rtplive/x")).ok).toBe(false);
+  expect(isHlsAllowed(new URL("file:///etc/passwd")).ok).toBe(false);
+});

--- a/tests/unit/hls-rewrite.test.ts
+++ b/tests/unit/hls-rewrite.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import { rewritePlaylist } from "@/lib/proxy/hls-rewrite";
+
+const BASE = "https://wzmedia.dot.ca.gov/D11/CAM.stream/playlist.m3u8";
+const enc = (s: string) => encodeURIComponent(s);
+
+test("rewrites a relative chunklist URI and leaves tag lines untouched", () => {
+  const out = rewritePlaylist("#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nchunklist_w1.m3u8\n", BASE);
+  expect(out).toContain("#EXT-X-STREAM-INF:BANDWIDTH=1");
+  expect(out).toContain("/api/hls?u=" + enc("https://wzmedia.dot.ca.gov/D11/CAM.stream/chunklist_w1.m3u8"));
+});
+test("rewrites relative .ts segments", () => {
+  const out = rewritePlaylist("#EXTINF:2.0,\nmedia_w1_0.ts\n", BASE);
+  expect(out).toContain("/api/hls?u=" + enc("https://wzmedia.dot.ca.gov/D11/CAM.stream/media_w1_0.ts"));
+});
+test("resolves absolute segment URIs", () => {
+  const out = rewritePlaylist("#EXT-X-VERSION:3\nhttps://cdn.example.com/x/seg.ts\n", BASE);
+  expect(out).toContain("#EXT-X-VERSION:3");
+  expect(out).toContain("/api/hls?u=" + enc("https://cdn.example.com/x/seg.ts"));
+});
+test("rewrites the URI attribute of an EXT-X-KEY tag", () => {
+  const out = rewritePlaylist('#EXT-X-KEY:METHOD=AES-128,URI="key.bin"\nmedia0.ts\n', BASE);
+  expect(out).toContain("/api/hls?u=" + enc("https://wzmedia.dot.ca.gov/D11/CAM.stream/key.bin"));
+});

--- a/tests/unit/plane-trail.test.ts
+++ b/tests/unit/plane-trail.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import { pushHistory, projectAhead, lookaheadKm, buildTrailPath } from "@/lib/planes/trail";
+
+test("pushHistory caps length and drops near-duplicate samples", () => {
+  let h: { lat: number; lon: number; altKm: number }[] = [];
+  for (let i = 0; i < 20; i++) h = pushHistory(h, { lat: i * 0.01, lon: 0, altKm: 10 }, 12);
+  expect(h).toHaveLength(12);
+  const before = h.length;
+  h = pushHistory(h, { ...h[h.length - 1] }, 12); // identical point
+  expect(h).toHaveLength(before); // ignored
+});
+
+test("projectAhead moves roughly north for bearing 0", () => {
+  const p = projectAhead(0, 0, 0, 111); // ~1° of latitude
+  expect(p.lat).toBeCloseTo(1, 1);
+  expect(p.lon).toBeCloseTo(0, 3);
+});
+
+test("projectAhead moves roughly east for bearing 90 at the equator", () => {
+  const p = projectAhead(0, 0, 90, 111);
+  expect(p.lon).toBeCloseTo(1, 1);
+  expect(p.lat).toBeCloseTo(0, 3);
+});
+
+test("lookaheadKm scales with speed and clamps", () => {
+  expect(lookaheadKm(null)).toBe(4); // floor
+  expect(lookaheadKm(1000)).toBe(80); // ceiling
+  expect(lookaheadKm(200, 90)).toBeCloseTo(18, 0); // 200 m/s * 90 s = 18 km
+});
+
+test("buildTrailPath = history + current + one projected point ahead", () => {
+  const hist = [{ lat: 51, lon: 0, altKm: 10 }];
+  const cur = { lat: 51.1, lon: 0, altKm: 10 };
+  const path = buildTrailPath(hist, cur, 0, 200);
+  expect(path).toHaveLength(3);
+  expect(path[1]).toEqual(cur);
+  expect(path[2].lat).toBeGreaterThan(cur.lat); // projected north of current
+});

--- a/tests/unit/planes.opensky.test.ts
+++ b/tests/unit/planes.opensky.test.ts
@@ -218,8 +218,11 @@ describe("planeToWorldObject", () => {
     expect(planeToWorldObject(onGround).label).toBe("4ca8ef");
   });
 
-  test("color is amber #f59e0b", () => {
-    expect(planeToWorldObject(cruiser).color).toBe("#f59e0b");
+  test("type is inferred from the flight profile (high+fast cruiser → airliner)", () => {
+    const obj = planeToWorldObject(cruiser);
+    expect(obj.color).toBe("#fbbf24"); // PLANE_META.airliner colour
+    expect(obj.icon).toBe("plane-airliner");
+    expect(obj.typeLabel).toBe("Airliner");
   });
 
   test("meta carries all required keys", () => {

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "vitest";
+import { mergeResults } from "@/lib/sources/registry";
+import type { Camera } from "@/lib/types";
+
+const cam = (id: string): Camera => ({
+  id, source: "x", country: "US", name: id, lat: 0, lon: 0,
+  mediaType: "jpeg", refreshSeconds: 60, license: "L", attribution: "A", available: true,
+});
+const ok = (cams: Camera[]): PromiseSettledResult<Camera[]> => ({ status: "fulfilled", value: cams });
+const fail = (): PromiseSettledResult<Camera[]> => ({ status: "rejected", reason: new Error("boom") });
+
+test("unions all fulfilled sources", () => {
+  expect(mergeResults([ok([cam("a")]), ok([cam("b"), cam("c")])], null).map((c) => c.id)).toEqual(["a", "b", "c"]);
+});
+test("ignores a rejected source when others succeed", () => {
+  expect(mergeResults([ok([cam("a")]), fail()], null).map((c) => c.id)).toEqual(["a"]);
+});
+test("falls back to stale cache when everything fails", () => {
+  expect(mergeResults([fail(), fail()], [cam("stale")]).map((c) => c.id)).toEqual(["stale"]);
+});
+test("throws when everything fails and there is no cache", () => {
+  expect(() => mergeResults([fail()], null)).toThrow();
+});

--- a/tests/unit/scdot.test.ts
+++ b/tests/unit/scdot.test.ts
@@ -20,3 +20,9 @@ test("uses description as name, lon/lat order, and problem_stream → unavailabl
   expect(a.available).toBe(true);
   expect(b.available).toBe(false); // problem_stream: true
 });
+
+test("pre-resolves the redirecting thumb URL to the real snapshot path", () => {
+  const [a] = normalizeScdot(fixture as never);
+  // /thumbs/50001.flv.png 301s to /50001.png — store the resolved form.
+  expect(a.imageUrl).toBe("https://scdotsnap.us-east-1.skyvdn.com/50001.png");
+});

--- a/tests/unit/scdot.test.ts
+++ b/tests/unit/scdot.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/scdot-cameras.json";
+import { normalizeScdot } from "@/lib/sources/scdot";
+import { CameraArray } from "@/lib/types";
+
+test("normalizes SCDOT GeoJSON into valid Cameras and skips geometry-less features", () => {
+  const cams = normalizeScdot(fixture as never);
+  expect(() => CameraArray.parse(cams)).not.toThrow();
+  expect(cams).toHaveLength(2); // feature 3 has null geometry
+});
+
+test("uses description as name, lon/lat order, and problem_stream → unavailable", () => {
+  const [a, b] = normalizeScdot(fixture as never);
+  expect(a.id).toBe("scdot:50001");
+  expect(a.region).toBe("South Carolina");
+  expect(a.name).toBe("US 501 N @ 16th Ave");
+  expect(a.lat).toBeCloseTo(33.845627, 5);
+  expect(a.lon).toBeCloseTo(-79.062775, 5);
+  expect(a.mediaType).toBe("both");
+  expect(a.available).toBe(true);
+  expect(b.available).toBe(false); // problem_stream: true
+});


### PR DESCRIPTION
Two features, both verified. (Stacked on the now-merged #1 / P0.)

## 1. Maximal per-type icons (satellites · planes · cameras)
Hand-drawn 24×24 SVG pictograms in `lib/icons/svg.ts` are the single source of truth for the globe sprites, the MapLibre map symbols, the legend, and the overlays.

- **Satellites — 11 types** classified by catalogue name (`lib/satellites/classify.ts`): station, Starlink, OneWeb, navigation, weather, earth-imaging, science, comms, CubeSat, debris, other → glowing camera-facing sprites.
- **Planes — 5 types** inferred from the live flight profile (`lib/planes/classify.ts`): airliner / regional / light / helicopter / on-ground. The anonymous OpenSky feed carries no aircraft-category field, so this is an honest estimate (surfaced as "· est." in the overlay) — heading-oriented top-down icons.
- **Cameras** — shape = feed (live-video vs still), colour = region. Cheap region-coloured points on the globe (scales to thousands) + full SVG symbol icons on the zoomed-in map.
- Legend gains expandable per-layer type keys; satellite/plane overlays show the type badge.

## 2. US cameras + live HLS video
Adds California (Caltrans) and South Carolina (SCDOT) cameras with real live HLS video through a closed proxy.

- Keyless Caltrans (~880) + SCDOT (~760) adapters → `Camera`; registry merges TfL+CA+SC with `Promise.allSettled` + stale-cache fallback (`mergeResults` pure + tested). Total **2,522 cameras, 1,355 live**.
- New closed `/api/hls` proxy: per-host Referer injection (wzmedia is hotlink-protected), same-origin playlist rewrite, segment streaming with Range, guards 400/403/404/502, `redirect:"error"` + timeout + host allowlist (SSRF-safe).
- `CameraVideo` (hls.js, dynamically imported) plays the proxied live stream and falls back to the refreshing still on fatal error.
- A server-computed `live` flag drives both the video-vs-still icon and the player, so TfL's MP4 clips read as stills and only genuinely-playable HLS shows as live video. The raw `streamUrl` is never sent to the client.

## Fix
SCDOT still images 502'd — `/thumbs/<id>.flv.png` 301-redirects to the host root `/<id>.png`, which the still proxy refuses (SSRF guard). Pre-resolved the URL in the adapter + pinned the allowlist rule to a `.png` suffix at root (non-png paths like `/rtplive/` stay rejected). Verified live.

## Verification
- 87 unit tests + 8 e2e tests green; `tsc` clean; production build clean.
- Verified live in-browser: a South Carolina I-26 camera streaming live video through `/api/hls` (readyState 4, 480×270, advancing); icons render across globe, map, legend and overlays.

Notes: individual upstream streams flake when a camera is momentarily offline (expected 502 → still-image fallback).