### PR TITLE
feat(webcams): M4 — Windy global webcams as a distinct live layer

### DIFF
--- a/app/api/webcam-image/route.ts
+++ b/app/api/webcam-image/route.ts
@@ -1,0 +1,55 @@
+import type { NextRequest } from "next/server";
+import { fetchWebcamById, WINDY_SOURCE } from "@/lib/sources/windy";
+import { isAllowed } from "@/lib/proxy/allowlist";
+
+export const dynamic = "force-dynamic";
+
+const UA = "TrafficNerd/2.0 (+https://github.com/011-sam-110/TrafficNerd-V2)";
+
+/**
+ * GET /api/webcam-image?id=windy:<webcamId> — the SSRF-closed image proxy for the
+ * Webcams layer (the analogue of /api/proxy for road cameras). The Windy image
+ * URL token is short-lived, so we ALWAYS re-resolve it server-side from the live
+ * detail endpoint rather than trust a cached/client URL, then proxy the bytes.
+ * The x-windy-api-key stays server-side; the client only ever sees this route.
+ */
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.searchParams.get("id");
+  if (!id) return new Response("missing id", { status: 400 });
+
+  const cam = await fetchWebcamById(id);
+  if (!cam?.imageUrl) return new Response("webcam or image not found", { status: 404 });
+
+  let target: URL;
+  try {
+    target = new URL(cam.imageUrl);
+  } catch {
+    return new Response("bad image url", { status: 500 });
+  }
+  if (!isAllowed(target)) return new Response("forbidden host", { status: 403 });
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target.toString(), {
+      headers: { "User-Agent": UA },
+      cache: "no-store",
+      redirect: "error",
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    return new Response("upstream fetch failed", { status: 502 });
+  }
+  if (!upstream.ok) return new Response("upstream error", { status: 502 });
+
+  const body = await upstream.arrayBuffer();
+  const ct = upstream.headers.get("content-type");
+  const contentType = ct && ct.startsWith("image/") ? ct : "image/jpeg";
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      // Bounded by the source refresh — never re-pull faster than the token cadence.
+      "Cache-Control": `public, max-age=${WINDY_SOURCE.refreshSeconds}, s-maxage=${WINDY_SOURCE.refreshSeconds}`,
+    },
+  });
+}

--- a/app/api/webcams/route.ts
+++ b/app/api/webcams/route.ts
@@ -1,0 +1,30 @@
+import { getWebcams } from "@/lib/webcams/registry";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/webcams — a global sample of Windy webcams as thin markers (the
+ * x-windy-api-key is added server-side, deep in fetchWebcams; it never reaches
+ * the client). Distinct from /api/cameras: webcams are their own layer and never
+ * fold into the road-camera count.
+ *
+ * Image URLs are intentionally omitted here — their tokens are short-lived, so
+ * the dossier re-resolves a fresh image per view through /api/webcam-image.
+ *
+ * Returns {count, webcams[]}. When the key is missing fetchWebcams returns [],
+ * so this responds with an empty list (dormant) rather than crashing.
+ */
+export async function GET() {
+  const webcams = await getWebcams();
+  const thin = webcams.map((w) => ({
+    id: w.id,
+    title: w.title,
+    lat: w.lat,
+    lon: w.lon,
+    country: w.country,
+    region: w.region,
+    available: w.available,
+    detailUrl: w.detailUrl,
+  }));
+  return Response.json({ count: thin.length, webcams: thin });
+}

--- a/components/WebcamDetail.tsx
+++ b/components/WebcamDetail.tsx
@@ -1,0 +1,62 @@
+"use client";
+// In-overlay webcam body (the Windy "Webcams" layer — distinct from road CCTV).
+// Rendered over the still-live globe by <FeedOverlay>. The Windy image token is
+// short-lived, so the picture is pulled through the SSRF-safe /api/webcam-image
+// proxy, which re-resolves a fresh URL server-side on every load. Windy's terms
+// REQUIRE the "Webcams provided by Windy.com" credit plus a link back to the
+// webcam's own Windy page, so both are shown beneath the image.
+
+import { useEffect, useState } from "react";
+import type { WorldObject } from "@/lib/world";
+
+const REFRESH_SECONDS = 600; // matches the free-tier ~10 min image-token cadence
+
+export default function WebcamDetail({ object }: { object: WorldObject }) {
+  const detailUrl = (object.meta?.detailUrl as string | undefined) ?? "https://www.windy.com/webcams";
+  const region = object.meta?.region as string | undefined;
+  const country = object.meta?.country as string | undefined;
+  const available = (object.meta?.available as boolean | undefined) ?? true;
+  const place = [region, country].filter(Boolean).join(", ") || "Public webcam";
+
+  // Cache-bust the proxied image on the token cadence so it stays current.
+  const [bust, setBust] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setBust((b) => b + 1), REFRESH_SECONDS * 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div className="cam-detail">
+      <h2>{object.label}</h2>
+      <p className="cam-sub">{place}</p>
+
+      <figure style={{ margin: 0 }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={`/api/webcam-image?id=${encodeURIComponent(object.id)}&_=${bust}`} alt={object.label} />
+        <figcaption>
+          <span className="attribution" data-testid="attribution">
+            Webcams provided by{" "}
+            <a href={detailUrl} target="_blank" rel="noopener noreferrer">
+              Windy.com
+            </a>
+          </span>
+        </figcaption>
+      </figure>
+
+      <div className="cam-meta">
+        <span className="cam-status">
+          <span className={`dot ${available ? "on" : "off"}`} aria-hidden />
+          {available ? "Active" : "Inactive"}
+        </span>
+        <span>
+          {object.lat.toFixed(4)}, {object.lon.toFixed(4)}
+        </span>
+        <span>Refresh {REFRESH_SECONDS}s</span>
+      </div>
+
+      <a className="cam-open" href={detailUrl} target="_blank" rel="noopener noreferrer">
+        View on Windy ↗
+      </a>
+    </div>
+  );
+}

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -24,10 +24,10 @@ import { metricsStore } from "@/lib/metrics";
 import { freshnessStore } from "@/lib/freshness";
 import { mapViewStore, useMapView, type RegionView } from "@/lib/mapView";
 import { cameraFeed } from "@/lib/cameras/classify";
-import { CAMERA_FEED_META, cameraRegionColor } from "@/lib/icons/svg";
+import { CAMERA_FEED_META, cameraRegionColor, WEBCAM_COLOR } from "@/lib/icons/svg";
 import { BASEMAPS, type BasemapKey } from "@/lib/basemaps";
-import { toCameraFC, toPlaneFC, toTrailFC, toSatelliteFC } from "@/lib/map/features";
-import { loadCameraIcons, loadPlaneIcons, loadSatelliteIcons } from "@/lib/map/icons";
+import { toCameraFC, toPlaneFC, toTrailFC, toSatelliteFC, toWebcamFC } from "@/lib/map/features";
+import { loadCameraIcons, loadPlaneIcons, loadSatelliteIcons, loadWebcamIcons } from "@/lib/map/icons";
 
 type Pt = {
   id: string;
@@ -51,6 +51,9 @@ const TRAIL_LAYER = "trail-lines";
 const SAT_SRC = "satellites";
 const SAT_GLOW_LAYER = "satellite-glow";
 const SAT_LAYER = "satellite-core";
+const WEBCAM_SRC = "webcams";
+const WEBCAM_DOT_LAYER = "webcam-dots"; // cheap rose glows when zoomed out
+const WEBCAM_LAYER = "webcam-markers"; // detailed webcam icons on descent
 const DEM_SRC = "terrain-dem";
 const HILLSHADE_LAYER = "hillshade";
 
@@ -79,6 +82,7 @@ export default function WorldMap() {
   // the top bar can drive them.
   const [satellites, setSatellites] = useState<WorldObject[]>([]);
   const [planesLayer, setPlanesLayer] = useState<PlanesLayer>({ objects: [], trails: [] });
+  const [webcams, setWebcams] = useState<WorldObject[]>([]);
 
   const view = useMapView();
   const basemap = view.basemap;
@@ -138,6 +142,9 @@ export default function WorldMap() {
       freshnessStore.record("satellites", { count: satellites.length, ok: true });
     }
   }, [satellites]);
+  useEffect(() => {
+    metricsStore.set({ webcams: webcams.length });
+  }, [webcams]);
 
   // Refs holding the latest data so addAppLayers (called on every style.load,
   // i.e. each basemap swap) can re-seed sources, and clicks can resolve objects.
@@ -149,6 +156,8 @@ export default function WorldMap() {
   trailsRef.current = planesLayer.trails;
   const satsRef = useRef<WorldObject[]>([]);
   satsRef.current = satellites;
+  const webcamsRef = useRef<WorldObject[]>([]);
+  webcamsRef.current = webcams;
   const layersRef = useRef<LayerState>(layers);
   layersRef.current = layers;
 
@@ -185,6 +194,8 @@ export default function WorldMap() {
     set(CAM_LAYER, l.cameras);
     set(SAT_GLOW_LAYER, l.satellites);
     set(SAT_LAYER, l.satellites);
+    set(WEBCAM_DOT_LAYER, l.webcams);
+    set(WEBCAM_LAYER, l.webcams);
     set(TRAIL_LAYER, l.planes);
     set(PLANE_LAYER, l.planes);
   }, []);
@@ -236,12 +247,18 @@ export default function WorldMap() {
       applyTerrain(map, terrainRef.current);
 
       // Symbol icons are wiped by setStyle — re-rasterise/register them.
-      await Promise.all([loadCameraIcons(map), loadPlaneIcons(map), loadSatelliteIcons(map)]);
+      await Promise.all([
+        loadCameraIcons(map),
+        loadPlaneIcons(map),
+        loadSatelliteIcons(map),
+        loadWebcamIcons(map),
+      ]);
 
       // Sources, seeded from the latest refs.
       ensureGeoJSON(map, TRAIL_SRC, toTrailFC(trailsRef.current));
       ensureGeoJSON(map, SAT_SRC, toSatelliteFC(satsRef.current));
       ensureGeoJSON(map, CAM_SRC, toCameraFC(camerasRef.current));
+      ensureGeoJSON(map, WEBCAM_SRC, toWebcamFC(webcamsRef.current));
       ensureGeoJSON(map, PLANE_SRC, toPlaneFC(planesRef.current));
 
       // Layers, bottom → top.
@@ -323,6 +340,38 @@ export default function WorldMap() {
           paint: { "icon-opacity": ["case", ["get", "available"], 1, 0.4] },
         });
       }
+      if (!map.getLayer(WEBCAM_DOT_LAYER)) {
+        map.addLayer({
+          id: WEBCAM_DOT_LAYER,
+          type: "circle",
+          source: WEBCAM_SRC,
+          layout: { visibility: vis(layersRef.current.webcams) },
+          paint: {
+            "circle-color": WEBCAM_COLOR,
+            "circle-radius": ["interpolate", ["linear"], ["zoom"], 0, 1.3, 3, 2, 6, 3, 9, 4],
+            // Fade the cheap glows out as the detailed icons (minzoom 5) fade in.
+            "circle-opacity": ["interpolate", ["linear"], ["zoom"], 0, 0.5, 3, 0.65, 5, 0.45, 6, 0],
+            "circle-stroke-color": "#ffffff",
+            "circle-stroke-width": ["interpolate", ["linear"], ["zoom"], 0, 0, 5, 0.5],
+            "circle-stroke-opacity": ["interpolate", ["linear"], ["zoom"], 3, 0, 6, 0.5],
+          },
+        });
+      }
+      if (!map.getLayer(WEBCAM_LAYER)) {
+        map.addLayer({
+          id: WEBCAM_LAYER,
+          type: "symbol",
+          source: WEBCAM_SRC,
+          minzoom: 5,
+          layout: {
+            "icon-image": "webcam",
+            "icon-size": ["interpolate", ["linear"], ["zoom"], 5, 0.32, 9, 0.5, 13, 0.65, 17, 0.85],
+            "icon-allow-overlap": true,
+            "icon-ignore-placement": true,
+            visibility: vis(layersRef.current.webcams),
+          },
+        });
+      }
       if (!map.getLayer(PLANE_LAYER)) {
         map.addLayer({
           id: PLANE_LAYER,
@@ -376,8 +425,15 @@ export default function WorldMap() {
       const sat = satsRef.current.find((s) => s.id === id);
       if (sat) overlay.open(sat);
     });
+    const webcamClick = (e: maplibregl.MapLayerMouseEvent) => {
+      const id = (e.features?.[0]?.properties as { id?: string })?.id;
+      const cam = webcamsRef.current.find((w) => w.id === id);
+      if (cam) overlay.open(cam);
+    };
+    map.on("click", WEBCAM_LAYER, webcamClick);
+    map.on("click", WEBCAM_DOT_LAYER, webcamClick);
 
-    for (const layer of [CAM_LAYER, CAM_DOT_LAYER, PLANE_LAYER, SAT_LAYER]) {
+    for (const layer of [CAM_LAYER, CAM_DOT_LAYER, WEBCAM_LAYER, WEBCAM_DOT_LAYER, PLANE_LAYER, SAT_LAYER]) {
       map.on("mouseenter", layer, () => {
         map.getCanvas().style.cursor = "pointer";
       });
@@ -495,6 +551,12 @@ export default function WorldMap() {
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !readyRef.current) return;
+    (map.getSource(WEBCAM_SRC) as GeoJSONSource | undefined)?.setData(toWebcamFC(webcams));
+  }, [webcams]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !readyRef.current) return;
     (map.getSource(PLANE_SRC) as GeoJSONSource | undefined)?.setData(toPlaneFC(planesLayer.objects));
     (map.getSource(TRAIL_SRC) as GeoJSONSource | undefined)?.setData(toTrailFC(planesLayer.trails));
   }, [planesLayer]);
@@ -532,6 +594,7 @@ export default function WorldMap() {
       {layers.cameras && <CamerasFeed onData={setPts} />}
       {layers.planes && <PlanesFeed onData={setPlanesLayer} />}
       {layers.satellites && <SatellitesFeed onData={setSatellites} />}
+      {layers.webcams && <WebcamsFeed onData={setWebcams} />}
     </div>
   );
 }
@@ -578,5 +641,58 @@ function SatellitesFeed({ onData }: { onData: (sats: WorldObject[]) => void }) {
   useEffect(() => {
     onData(sats);
   }, [sats, onData]);
+  return null;
+}
+
+// Windy webcams — a one-shot global sample (the API is rate-limited, so this is a
+// fetched snapshot, not a poll). Thin markers only; the dossier re-resolves the
+// short-lived image URL on click. Mirrors CamerasFeed's hidden-doesn't-fetch gate.
+type WebcamMarker = {
+  id: string;
+  title: string;
+  lat: number;
+  lon: number;
+  country?: string;
+  region?: string;
+  available?: boolean;
+  detailUrl?: string;
+};
+
+function WebcamsFeed({ onData }: { onData: (webcams: WorldObject[]) => void }) {
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/webcams")
+      .then((r) => r.json())
+      .then((d) => {
+        if (!alive) return;
+        const markers = (d.webcams as WebcamMarker[]) ?? [];
+        const objects: WorldObject[] = markers.map((w) => ({
+          kind: "webcam",
+          id: w.id,
+          lat: w.lat,
+          lon: w.lon,
+          label: w.title,
+          color: WEBCAM_COLOR,
+          icon: "webcam",
+          typeLabel: "Webcam",
+          meta: {
+            available: w.available ?? true,
+            region: w.region,
+            country: w.country,
+            detailUrl: w.detailUrl,
+          },
+        }));
+        onData(objects);
+        freshnessStore.record("webcams", { count: objects.length, ok: true });
+      })
+      .catch(() => {
+        if (!alive) return;
+        onData([]);
+        freshnessStore.record("webcams", { count: 0, ok: false });
+      });
+    return () => {
+      alive = false;
+    };
+  }, [onData]);
   return null;
 }

--- a/components/shell/FreshnessTicker.tsx
+++ b/components/shell/FreshnessTicker.tsx
@@ -16,6 +16,7 @@ const TO_LAYER: Record<FreshSourceId, LayerKey> = {
   cameras: "cameras",
   planes: "planes",
   satellites: "satellites",
+  webcams: "webcams",
 };
 
 export default function FreshnessTicker() {

--- a/components/shell/LayerRail.tsx
+++ b/components/shell/LayerRail.tsx
@@ -38,7 +38,7 @@ const LAYER_META: Record<LayerKey, LayerMeta> = {
   planes: { name: "Planes", group: "Air", accent: "#d97706", source: "adsb.lol — live ADS-B", fresh: "planes" },
   satellites: { name: "Satellites", group: "Space", accent: "#7c3aed", source: "CelesTrak TLE · SGP4 (local)", fresh: "satellites" },
   ships: { name: "Ships", group: "Sea", accent: "#0d9488", source: "AIS vessels", planned: true },
-  webcams: { name: "Webcams", group: "Ground", accent: "#0891b2", source: "Windy global webcams", planned: true },
+  webcams: { name: "Webcams", group: "Ground", accent: "#ec4899", source: "Windy.com — global webcams", fresh: "webcams" },
   weather: { name: "Weather", group: "Sky", accent: "#0284c7", source: "Radar & events", planned: true },
 };
 
@@ -185,6 +185,7 @@ export default function LayerRail() {
     if (k === "cameras") return m.camerasTotal || null;
     if (k === "planes") return m.planes;
     if (k === "satellites") return m.satellites;
+    if (k === "webcams") return m.webcams || null;
     return null;
   };
 

--- a/lib/freshness.ts
+++ b/lib/freshness.ts
@@ -13,7 +13,7 @@
 import { useSyncExternalStore } from "react";
 
 export type FreshState = "unknown" | "live" | "lagging" | "stale" | "down";
-export type FreshSourceId = "cameras" | "planes" | "satellites";
+export type FreshSourceId = "cameras" | "planes" | "satellites" | "webcams";
 
 export interface SourceRecord {
   id: FreshSourceId;
@@ -29,13 +29,15 @@ export interface SourceRecord {
   local: boolean;
 }
 
-const ORDER: FreshSourceId[] = ["cameras", "planes", "satellites"];
+const ORDER: FreshSourceId[] = ["cameras", "planes", "satellites", "webcams"];
 
 function seed(): Record<FreshSourceId, SourceRecord> {
   return {
     cameras: { id: "cameras", label: "Cameras", count: 0, ok: true, lastUpdate: null, refreshMs: 300_000, local: false },
     planes: { id: "planes", label: "Planes", count: 0, ok: true, lastUpdate: null, refreshMs: 12_000, local: false },
     satellites: { id: "satellites", label: "Satellites", count: 0, ok: true, lastUpdate: null, refreshMs: 1_000, local: true },
+    // Windy free-tier image tokens last ~10 min, so the layer re-pulls on that cadence.
+    webcams: { id: "webcams", label: "Webcams", count: 0, ok: true, lastUpdate: null, refreshMs: 600_000, local: false },
   };
 }
 

--- a/lib/icons/svg.ts
+++ b/lib/icons/svg.ts
@@ -16,7 +16,8 @@ export type IconKey =
   | "sat-station" | "sat-starlink" | "sat-oneweb" | "sat-navigation" | "sat-weather"
   | "sat-eo" | "sat-science" | "sat-comms" | "sat-cubesat" | "sat-debris" | "sat-other"
   | "plane-airliner" | "plane-regional" | "plane-light" | "plane-helicopter" | "plane-ground"
-  | "cam-still" | "cam-video";
+  | "cam-still" | "cam-video"
+  | "webcam";
 
 // "Inner" dark used for cut-outs (lenses, panel cells) that should read against
 // any tint — it stays constant when currentColor is replaced.
@@ -85,7 +86,20 @@ export const ICON_SVG: Record<IconKey, string> = {
   "cam-video": wrap(
     `<path d="M1.8 8.1 12.6 5.4c.9-.22 1.82.32 2.05 1.25l.46 1.85c.22.9-.32 1.82-1.22 2.05L2.8 13.5 1.8 8.1z"/><circle cx="5" cy="9.5" r="1.05" fill="${INK}"/><rect x="9.4" y="13" width="1.8" height="4.7"/><rect x="5.8" y="17.6" width="9" height="1.7" rx=".85"/><path d="M17.6 7.4a4.2 4.2 0 0 1 0 6.2M19.9 5.6a6.8 6.8 0 0 1 0 9.8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>`,
   ),
+
+  // --- Webcams (Windy) ----------------------------------------------------
+  // A front-facing webcam (monitor body + lens + stand), deliberately distinct
+  // from the angled CCTV "cam-*" pictograms so the public-webcam layer reads as
+  // its own thing on the map and in the legend.
+  webcam: wrap(
+    `<rect x="3.5" y="3.5" width="17" height="13" rx="2.2"/><circle cx="12" cy="10" r="3.9" fill="${INK}"/><circle cx="12" cy="10" r="1.6"/><circle cx="17" cy="6.6" r="1" fill="${INK}"/><rect x="10.7" y="16.5" width="2.6" height="2.8"/><rect x="7.3" y="19" width="9.4" height="1.9" rx=".95"/>`,
+  ),
 };
+
+// Webcams are a DISTINCT layer from road CCTV. They get their own warm rose hue
+// so they never blend into the cool camera family, the amber planes, or the
+// violet satellites. Single source of truth for the layer's identity colour.
+export const WEBCAM_COLOR = "#ec4899";
 
 // ---------------------------------------------------------------------------
 // Per-type metadata: which icon, what colour, what label.

--- a/lib/layers.ts
+++ b/lib/layers.ts
@@ -16,8 +16,8 @@ import { loadPersisted, savePersisted } from "@/lib/shell/persist";
 export type LayerKey = "cameras" | "satellites" | "planes" | "ships" | "webcams" | "weather";
 export type LayerState = Record<LayerKey, boolean>;
 
-export const ACTIVE_LAYERS: readonly LayerKey[] = ["cameras", "planes", "satellites"];
-export const PLANNED_LAYERS: readonly LayerKey[] = ["ships", "webcams", "weather"];
+export const ACTIVE_LAYERS: readonly LayerKey[] = ["cameras", "planes", "satellites", "webcams"];
+export const PLANNED_LAYERS: readonly LayerKey[] = ["ships", "weather"];
 
 const DEFAULT_STATE: LayerState = {
   cameras: true,
@@ -39,7 +39,10 @@ export const LAYER_PRESETS: { id: PresetId; label: string }[] = [
   { id: "air-space", label: "Air + space" },
 ];
 
-// Presets only ever switch ACTIVE layers — planned layers stay off (no data).
+// Presets switch the core cameras/planes/satellites layers. Webcams is active
+// (a live toggle) but stays OUT of the presets on purpose: it is a keyed,
+// rate-limited global sample, so it stays opt-in rather than being pulled in by
+// a one-tap "All". Planned layers (ships/weather) have no data yet.
 export function presetState(id: PresetId): LayerState {
   const off: LayerState = { ...DEFAULT_STATE, cameras: false, satellites: false, planes: false };
   switch (id) {

--- a/lib/map/features.ts
+++ b/lib/map/features.ts
@@ -71,6 +71,18 @@ export function toTrailFC(trails: PlaneTrail[]): GeoJSON.FeatureCollection {
   };
 }
 
+/** Webcams (Windy) → point features. Single hue/icon, so only id + name ride along. */
+export function toWebcamFC(webcams: WorldObject[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: webcams.map((w) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [w.lon, w.lat] },
+      properties: { id: w.id, name: w.label },
+    })),
+  };
+}
+
 /** Satellites → sub-satellite point features (altitude lives in the dossier). */
 export function toSatelliteFC(sats: WorldObject[]): GeoJSON.FeatureCollection {
   return {

--- a/lib/map/icons.ts
+++ b/lib/map/icons.ts
@@ -12,6 +12,7 @@ import {
   CAMERA_DEFAULT_REGION,
   PLANE_META,
   SAT_META,
+  WEBCAM_COLOR,
 } from "@/lib/icons/svg";
 
 /** Rasterise an SVG pictogram into an image MapLibre can use as a symbol icon. */
@@ -75,6 +76,13 @@ export async function loadPlaneIcons(map: maplibregl.Map): Promise<void> {
       if (!map.hasImage(meta.key)) map.addImage(meta.key, img, { pixelRatio: 2 });
     }),
   );
+}
+
+/** Register the single rose-tinted Windy webcam icon. */
+export async function loadWebcamIcons(map: maplibregl.Map): Promise<void> {
+  if (map.hasImage("webcam")) return;
+  const img = await rasterizeIcon(ICON_SVG.webcam.replaceAll("currentColor", WEBCAM_COLOR));
+  if (!map.hasImage("webcam")) map.addImage("webcam", img, { pixelRatio: 2 });
 }
 
 /** Register one icon per satellite category (coloured by SAT_META). */

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -16,9 +16,11 @@ export interface Metrics {
   camerasTotal: number;
   planes: number;
   satellites: number;
+  /** Windy webcams currently loaded (a DISTINCT layer from the road cameras). */
+  webcams: number;
 }
 
-let state: Metrics = { camerasOnline: 0, camerasTotal: 0, planes: 0, satellites: 0 };
+let state: Metrics = { camerasOnline: 0, camerasTotal: 0, planes: 0, satellites: 0, webcams: 0 };
 const listeners = new Set<() => void>();
 
 function shallowEqual(a: Metrics, b: Metrics): boolean {
@@ -26,7 +28,8 @@ function shallowEqual(a: Metrics, b: Metrics): boolean {
     a.camerasOnline === b.camerasOnline &&
     a.camerasTotal === b.camerasTotal &&
     a.planes === b.planes &&
-    a.satellites === b.satellites
+    a.satellites === b.satellites &&
+    a.webcams === b.webcams
   );
 }
 

--- a/lib/overlay-content.tsx
+++ b/lib/overlay-content.tsx
@@ -11,6 +11,7 @@ import type { WorldObject } from "@/lib/world";
 import { CameraDetail } from "@/components/CameraDetail";
 import SatelliteDetail from "@/components/SatelliteDetail";
 import PlaneDetail from "@/components/PlaneDetail";
+import WebcamDetail from "@/components/WebcamDetail";
 
 export function OverlayBody({ object }: { object: WorldObject }) {
   switch (object.kind) {
@@ -20,6 +21,8 @@ export function OverlayBody({ object }: { object: WorldObject }) {
       return <SatelliteDetail object={object} />;
     case "plane":
       return <PlaneDetail object={object} />;
+    case "webcam":
+      return <WebcamDetail object={object} />;
     default:
       return null;
   }

--- a/lib/proxy/allowlist.ts
+++ b/lib/proxy/allowlist.ts
@@ -29,6 +29,10 @@ const RULES: { host: string; prefix: string; suffix?: string }[] = [
   // Scotland Traffic Scotland — the "image" is the camerahtml page; the proxy
   // fetches it and extracts the embedded base64 JPEG (not a direct .jpg).
   { host: "www.traffic.gov.scot", prefix: "/tsis/camerahtml" },
+  // Windy.com webcams — image CDN. URLs look like
+  // /_/<size>/plain/<current|daylight>/<webcamId>/original.jpg (the Webcams layer,
+  // a DISTINCT layer from road CCTV; resolved fresh by /api/webcam-image).
+  { host: "imgproxy.windy.com", prefix: "/_/" },
 ];
 
 export function isAllowed(url: URL): boolean {

--- a/lib/sources/windy.ts
+++ b/lib/sources/windy.ts
@@ -1,0 +1,244 @@
+import { Webcam, WebcamArray, Source } from "@/lib/types";
+
+// Windy.com Webcams API v3 — ~73k global webcams. UNLIKE the road-CCTV adapters
+// this one is KEYED: every request carries an `x-windy-api-key` header injected
+// SERVER-SIDE only (the key never reaches the browser). It is wired into its own
+// /api/webcams path + webcams store, NOT the camera registry, so it stays a
+// distinct "Webcams" sub-layer and never inflates the road-camera counts.
+//
+// Contract (live-verified 2026-06-27 against api.windy.com):
+//   LIST   GET /webcams/api/v3/webcams?bbox={N},{E},{S},{W}&limit&offset&include
+//   DETAIL GET /webcams/api/v3/webcams/{webcamId}?include=images,location,urls
+//   Auth   header  x-windy-api-key: <key>
+//   Free-tier caps: limit ≤ 50, offset ≤ 1000 (paging past 1000 → HTTP 400),
+//     image URLs are tokened and expire ~10 min → re-fetch, never cache them.
+//   total: 73,320 webcams globally. bbox order is north,east,south,west.
+// Mandatory attribution: "Webcams provided by Windy.com" + a per-webcam link
+// back to its Windy page (urls.detail).
+
+const BASE = "https://api.windy.com/webcams/api/v3/webcams";
+const ATTRIBUTION = "Webcams provided by Windy.com";
+
+export const WINDY_SOURCE: Source = {
+  id: "windy",
+  name: "Windy.com Webcams (global)",
+  license: "Windy.com Webcams API — Terms of Service",
+  attribution: ATTRIBUTION,
+  refreshSeconds: 600, // free-tier image tokens last ~10 min; re-pull on this cadence
+  needsKey: true,
+};
+
+// --- Upstream shapes (only the fields we read) ------------------------------
+
+export interface WindyImageSet {
+  icon?: string;
+  thumbnail?: string;
+  preview?: string;
+}
+
+export interface WindyWebcam {
+  webcamId?: number;
+  title?: string;
+  status?: string;
+  lastUpdatedOn?: string;
+  viewCount?: number;
+  categories?: { id?: string; name?: string }[];
+  images?: {
+    current?: WindyImageSet;
+    daylight?: WindyImageSet;
+    sizes?: Record<string, { width?: number; height?: number }>;
+  };
+  location?: {
+    city?: string;
+    region?: string;
+    country?: string;
+    country_code?: string;
+    continent?: string;
+    latitude?: number;
+    longitude?: number;
+  } | null;
+  urls?: { detail?: string; edit?: string; provider?: string };
+}
+
+export interface WindyListResponse {
+  total?: number;
+  webcams?: WindyWebcam[];
+}
+
+// --- Normalization (pure — unit tested) -------------------------------------
+
+/** One upstream webcam → our Webcam, or null when it can't be placed/identified. */
+export function normalizeWindyWebcam(w: WindyWebcam): Webcam | null {
+  const webcamId = w.webcamId;
+  if (webcamId === undefined || webcamId === null) return null;
+
+  const loc = w.location;
+  if (!loc) return null;
+  const lat = Number(loc.latitude);
+  const lon = Number(loc.longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+
+  const cur = w.images?.current ?? {};
+  const status = (w.status ?? "unknown").toString();
+  const id = `windy:${webcamId}`;
+
+  return {
+    id,
+    source: "windy",
+    title: w.title?.trim() || `Webcam ${webcamId}`,
+    lat,
+    lon,
+    country: loc.country_code ? loc.country_code.toUpperCase() : undefined,
+    region: loc.region?.trim() || loc.city?.trim() || undefined,
+    city: loc.city?.trim() || undefined,
+    categories: (w.categories ?? []).map((c) => c.name?.trim()).filter((n): n is string => !!n),
+    // Prefer the larger "preview"; fall back through thumbnail → icon.
+    imageUrl: cur.preview || cur.thumbnail || cur.icon || undefined,
+    thumbnailUrl: cur.thumbnail || cur.icon || undefined,
+    // urls.detail is the canonical attribution link; synthesize it if absent.
+    detailUrl: w.urls?.detail?.trim() || `https://www.windy.com/webcams/${webcamId}`,
+    providerUrl: w.urls?.provider?.trim() || undefined,
+    status,
+    available: status === "active",
+    lastUpdatedOn: w.lastUpdatedOn,
+    license: WINDY_SOURCE.license,
+    attribution: ATTRIBUTION,
+  };
+}
+
+export function normalizeWindy(json: WindyListResponse): Webcam[] {
+  const out: Webcam[] = [];
+  for (const w of json.webcams ?? []) {
+    const n = normalizeWindyWebcam(w);
+    if (n) out.push(n);
+  }
+  return out;
+}
+
+// --- Network ----------------------------------------------------------------
+
+const INCLUDE = "images,location,urls,categories";
+const LIMIT = 50; // free-tier hard cap
+const PAGES_PER_REGION = 2; // 2 × 50 = up to 100 webcams/region (offset 0,50)
+const REGION_CONCURRENCY = 6; // polite + bounded parallelism across page jobs
+const MAX_WEBCAMS = 2000; // safety cap on the merged global sample
+
+// 73k webcams can't be loaded (and offset is free-tier-capped at 1000), so we
+// fan a small bbox query across world regions for a GLOBAL spread, then dedupe.
+// bbox is [north, east, south, west].
+export interface WindyRegion {
+  name: string;
+  bbox: [number, number, number, number];
+}
+
+export const WINDY_REGIONS: WindyRegion[] = [
+  { name: "uk-ireland", bbox: [59, 2, 50, -11] },
+  { name: "w-europe", bbox: [60, 20, 41, -10] },
+  { name: "scandinavia", bbox: [71, 31, 55, 4] },
+  { name: "e-europe", bbox: [60, 41, 40, 20] },
+  { name: "mediterranean", bbox: [46, 36, 30, -6] },
+  { name: "na-west", bbox: [60, -100, 24, -130] },
+  { name: "na-east", bbox: [50, -60, 24, -100] },
+  { name: "latin-america", bbox: [25, -35, -56, -118] },
+  { name: "africa", bbox: [37, 52, -35, -18] },
+  { name: "middle-east", bbox: [42, 63, 12, 34] },
+  { name: "s-asia", bbox: [37, 92, 5, 60] },
+  { name: "e-asia", bbox: [54, 146, 20, 100] },
+  { name: "se-asia", bbox: [23, 141, -11, 92] },
+  { name: "oceania", bbox: [-9, 180, -48, 110] },
+];
+
+/** Tiny bounded-concurrency map — no deps; runs `fn` over items, `limit` at a time. */
+async function mapPool<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < items.length) {
+      const i = cursor++;
+      out[i] = await fn(items[i]);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return out;
+}
+
+function headers(apiKey: string): HeadersInit {
+  return {
+    "x-windy-api-key": apiKey,
+    Accept: "application/json",
+    "User-Agent": "TrafficNerd/2.0 (+https://github.com/011-sam-110/TrafficNerd-V2)",
+  };
+}
+
+async function fetchPage(apiKey: string, bbox: [number, number, number, number], offset: number): Promise<WindyWebcam[]> {
+  const url = `${BASE}?bbox=${bbox.join(",")}&limit=${LIMIT}&offset=${offset}&include=${INCLUDE}&lang=en`;
+  const res = await fetch(url, { headers: headers(apiKey), signal: AbortSignal.timeout(15_000) });
+  if (!res.ok) throw new Error(`Windy webcams ${bbox.join(",")}@${offset}: ${res.status}`);
+  const json = (await res.json()) as WindyListResponse;
+  return json.webcams ?? [];
+}
+
+/**
+ * Fetch a global sample of webcams (region bbox fan-out, deduped by id). Returns
+ * [] — never throws — when no key is configured (the layer stays dormant). A
+ * single failing region degrades gracefully (Promise.allSettled per page).
+ */
+export async function fetchWebcams(apiKey: string | undefined = process.env.WINDY_WEBCAMS_API_KEY): Promise<Webcam[]> {
+  if (!apiKey) {
+    console.warn("[windy] WINDY_WEBCAMS_API_KEY not set — webcams layer is dormant");
+    return [];
+  }
+
+  const jobs: { bbox: [number, number, number, number]; offset: number }[] = [];
+  for (const region of WINDY_REGIONS) {
+    for (let p = 0; p < PAGES_PER_REGION; p++) jobs.push({ bbox: region.bbox, offset: p * LIMIT });
+  }
+
+  const pages = await mapPool(jobs, REGION_CONCURRENCY, (job) =>
+    fetchPage(apiKey, job.bbox, job.offset).catch(() => [] as WindyWebcam[]),
+  );
+
+  // Dedupe by webcamId (overlapping bboxes), normalize, cap, validate.
+  const seen = new Set<number>();
+  const merged: WindyWebcam[] = [];
+  for (const page of pages) {
+    for (const w of page) {
+      if (w.webcamId === undefined || seen.has(w.webcamId)) continue;
+      seen.add(w.webcamId);
+      merged.push(w);
+      if (merged.length >= MAX_WEBCAMS) break;
+    }
+    if (merged.length >= MAX_WEBCAMS) break;
+  }
+
+  return WebcamArray.parse(normalizeWindy({ webcams: merged }));
+}
+
+/**
+ * Fetch ONE webcam's fresh detail (for the image proxy — its image URL token is
+ * short-lived, so the proxy always re-resolves it server-side rather than trust
+ * a cached/client URL). Returns null on any failure or missing key.
+ */
+export async function fetchWebcamById(
+  webcamId: string,
+  apiKey: string | undefined = process.env.WINDY_WEBCAMS_API_KEY,
+): Promise<Webcam | null> {
+  if (!apiKey) return null;
+  // Accept either the namespaced id ("windy:123") or the raw numeric id.
+  const raw = webcamId.startsWith("windy:") ? webcamId.slice("windy:".length) : webcamId;
+  if (!/^\d+$/.test(raw)) return null;
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}/${raw}?include=images,location,urls,categories`, {
+      headers: headers(apiKey),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  // The detail endpoint returns the webcam object directly (not wrapped).
+  const w = (await res.json()) as WindyWebcam;
+  return normalizeWindyWebcam(w);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,34 @@ export const CameraSchema = z.object({
 export type Camera = z.infer<typeof CameraSchema>;
 export const CameraArray = z.array(CameraSchema);
 
+// Windy webcams are a DISTINCT layer from road CCTV (different upstream, keyed,
+// short-lived tokened image URLs) so they get their own normalized shape rather
+// than reusing Camera — keeping the camera registry + counts uncontaminated.
+export const WebcamSchema = z.object({
+  id: z.string(),                       // `windy:${webcamId}`
+  source: z.literal("windy"),
+  title: z.string().min(1),
+  lat: z.number().gte(-90).lte(90),
+  lon: z.number().gte(-180).lte(180),
+  country: z.string().optional(),       // ISO-3166 alpha-2 (location.country_code)
+  region: z.string().optional(),
+  city: z.string().optional(),
+  categories: z.array(z.string()).optional(),
+  // Token-bearing, short-lived (free tier ~10 min) — never cached long-term.
+  imageUrl: z.string().url().optional(),
+  thumbnailUrl: z.string().url().optional(),
+  detailUrl: z.string().url(),          // the webcam's Windy page (attribution link)
+  providerUrl: z.string().url().optional(),
+  status: z.string(),
+  available: z.boolean(),               // status === "active"
+  lastUpdatedOn: z.string().optional(),
+  license: z.string().min(1),
+  attribution: z.string().min(1),
+});
+
+export type Webcam = z.infer<typeof WebcamSchema>;
+export const WebcamArray = z.array(WebcamSchema);
+
 export type Source = {
   id: string;
   name: string;

--- a/lib/webcams/registry.ts
+++ b/lib/webcams/registry.ts
@@ -1,0 +1,36 @@
+import type { Webcam } from "@/lib/types";
+import { fetchWebcams } from "@/lib/sources/windy";
+
+// Server-side webcams cache — the Windy analogue of lib/sources/registry.ts, but
+// kept DELIBERATELY SHORT (8 min, under the free-tier ~10 min image-token expiry)
+// so a marker's image URL is never served stale enough to have expired. Webcams
+// are a distinct layer, so this lives apart from the camera registry and never
+// touches camera counts.
+
+const TTL_MS = 8 * 60 * 1000;
+
+let cache: { webcams: Webcam[]; at: number } | null = null;
+let inflight: Promise<Webcam[]> | null = null;
+
+async function refresh(): Promise<Webcam[]> {
+  const webcams = await fetchWebcams();
+  cache = { webcams, at: Date.now() };
+  return webcams;
+}
+
+/**
+ * Fresh-or-revalidate: a fresh cache returns instantly; a stale cache returns
+ * instantly while a single shared refresh runs behind it. Only a cold call waits.
+ * fetchWebcams never throws (returns [] when the key is absent), so this is safe.
+ */
+export async function getWebcams(): Promise<Webcam[]> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.webcams;
+  if (!inflight) {
+    inflight = refresh()
+      .catch(() => cache?.webcams ?? [])
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return cache ? cache.webcams : inflight;
+}

--- a/lib/world.ts
+++ b/lib/world.ts
@@ -8,7 +8,7 @@
 
 import type { IconKey } from "@/lib/icons/svg";
 
-export type WorldObjectKind = "camera" | "satellite" | "plane";
+export type WorldObjectKind = "camera" | "satellite" | "plane" | "webcam";
 
 export interface WorldObject {
   kind: WorldObjectKind;

--- a/tests/fixtures/windy.json
+++ b/tests/fixtures/windy.json
@@ -1,0 +1,103 @@
+{
+  "total": 1299,
+  "webcams": [
+    {
+      "title": "London: Trafalgar Square",
+      "viewCount": 41434,
+      "webcamId": 1420893641,
+      "status": "active",
+      "lastUpdatedOn": "2026-06-27T02:38:39.000Z",
+      "categories": [{ "id": "city", "name": "City" }, { "id": "traffic", "name": "Traffic" }],
+      "images": {
+        "current": {
+          "icon": "https://imgproxy.windy.com/_/icon/plain/current/1420893641/original.jpg",
+          "thumbnail": "https://imgproxy.windy.com/_/thumbnail/plain/current/1420893641/original.jpg",
+          "preview": "https://imgproxy.windy.com/_/preview/plain/current/1420893641/original.jpg"
+        },
+        "daylight": {
+          "icon": "https://imgproxy.windy.com/_/icon/plain/daylight/1420893641/original.jpg",
+          "thumbnail": "https://imgproxy.windy.com/_/thumbnail/plain/daylight/1420893641/original.jpg",
+          "preview": "https://imgproxy.windy.com/_/preview/plain/daylight/1420893641/original.jpg"
+        },
+        "sizes": {
+          "icon": { "width": 48, "height": 48 },
+          "thumbnail": { "width": 200, "height": 112 },
+          "preview": { "width": 352, "height": 224 }
+        }
+      },
+      "location": {
+        "city": "London",
+        "region": "England",
+        "region_code": "GB.ENG",
+        "country": "United Kingdom",
+        "country_code": "GB",
+        "continent": "Europe",
+        "continent_code": "EU",
+        "latitude": 51.508,
+        "longitude": -0.128
+      },
+      "urls": {
+        "detail": "https://windy.com/webcams/1420893641",
+        "edit": "https://windy.com/webcams/edit/1420893641",
+        "provider": "http://www.example-provider.org/"
+      }
+    },
+    {
+      "title": "Tokyo: Shibuya Crossing",
+      "viewCount": 99000,
+      "webcamId": 1888000002,
+      "status": "inactive",
+      "lastUpdatedOn": "2026-06-26T18:00:00.000Z",
+      "categories": [{ "id": "city", "name": "City" }],
+      "images": {
+        "current": {
+          "icon": "https://imgproxy.windy.com/_/icon/plain/current/1888000002/original.jpg",
+          "thumbnail": "https://imgproxy.windy.com/_/thumbnail/plain/current/1888000002/original.jpg",
+          "preview": "https://imgproxy.windy.com/_/preview/plain/current/1888000002/original.jpg"
+        }
+      },
+      "location": {
+        "city": "Tokyo",
+        "region": "Tokyo",
+        "country": "Japan",
+        "country_code": "JP",
+        "continent": "Asia",
+        "latitude": 35.6595,
+        "longitude": 139.7005
+      },
+      "urls": {
+        "detail": "https://windy.com/webcams/1888000002"
+      }
+    },
+    {
+      "title": "No-image cam (marker only, detail fetched on click)",
+      "webcamId": 1777000003,
+      "status": "active",
+      "location": {
+        "country_code": "es",
+        "latitude": 40.0,
+        "longitude": -3.0
+      },
+      "urls": { "detail": "https://windy.com/webcams/1777000003" }
+    },
+    {
+      "title": "Broken: no location at all",
+      "webcamId": 1999000001,
+      "status": "active",
+      "images": {
+        "current": { "preview": "https://imgproxy.windy.com/_/preview/plain/current/1999000001/original.jpg" }
+      }
+    },
+    {
+      "title": "Broken: missing webcamId",
+      "status": "active",
+      "location": { "country_code": "FR", "latitude": 48.85, "longitude": 2.35 }
+    },
+    {
+      "title": "Broken: out-of-range coordinates",
+      "webcamId": 1666000004,
+      "status": "active",
+      "location": { "country_code": "DE", "latitude": 200, "longitude": 9 }
+    }
+  ]
+}

--- a/tests/unit/layers.test.ts
+++ b/tests/unit/layers.test.ts
@@ -6,8 +6,8 @@ import { layersStore, presetState, ACTIVE_LAYERS, PLANNED_LAYERS } from "@/lib/l
 afterEach(() => layersStore.applyPreset("all"));
 
 test("active and planned layer sets are disjoint and complete", () => {
-  expect(ACTIVE_LAYERS).toEqual(["cameras", "planes", "satellites"]);
-  expect(PLANNED_LAYERS).toEqual(["ships", "webcams", "weather"]);
+  expect(ACTIVE_LAYERS).toEqual(["cameras", "planes", "satellites", "webcams"]);
+  expect(PLANNED_LAYERS).toEqual(["ships", "weather"]);
 });
 
 test("presets only ever switch active layers; planned stay off", () => {

--- a/tests/unit/windy.test.ts
+++ b/tests/unit/windy.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/windy.json";
+import {
+  normalizeWindy,
+  normalizeWindyWebcam,
+  type WindyWebcam,
+  type WindyListResponse,
+} from "@/lib/sources/windy";
+import { WebcamArray } from "@/lib/types";
+
+test("normalizes the live fixture into schema-valid Webcams", () => {
+  const cams = normalizeWindy(fixture as WindyListResponse);
+  expect(cams.length).toBeGreaterThan(0);
+  expect(() => WebcamArray.parse(cams)).not.toThrow();
+});
+
+test("maps id, title, coords, country and the attribution link", () => {
+  const [first] = normalizeWindy(fixture as WindyListResponse);
+  expect(first.id).toBe("windy:1420893641");
+  expect(first.source).toBe("windy");
+  expect(first.title).toBe("London: Trafalgar Square");
+  expect(first.lat).toBeCloseTo(51.508, 3);
+  expect(first.lon).toBeCloseTo(-0.128, 3);
+  expect(first.country).toBe("GB");
+  expect(first.attribution).toBe("Webcams provided by Windy.com");
+  expect(first.available).toBe(true);
+});
+
+test("prefers the larger preview image, falling back through thumbnail → icon", () => {
+  const preview: WindyWebcam = {
+    webcamId: 1,
+    title: "Preview wins",
+    status: "active",
+    images: { current: { icon: "https://h/i.jpg", thumbnail: "https://h/t.jpg", preview: "https://h/p.jpg" } },
+    location: { latitude: 10, longitude: 20, country_code: "us" },
+  };
+  expect(normalizeWindyWebcam(preview)!.imageUrl).toBe("https://h/p.jpg");
+
+  const thumbOnly: WindyWebcam = { ...preview, images: { current: { icon: "https://h/i.jpg", thumbnail: "https://h/t.jpg" } } };
+  expect(normalizeWindyWebcam(thumbOnly)!.imageUrl).toBe("https://h/t.jpg");
+});
+
+test("synthesizes a Windy detail URL when urls.detail is absent", () => {
+  const noUrl: WindyWebcam = {
+    webcamId: 42,
+    title: "No detail url",
+    status: "active",
+    location: { latitude: 1, longitude: 2, country_code: "de" },
+  };
+  expect(normalizeWindyWebcam(noUrl)!.detailUrl).toBe("https://www.windy.com/webcams/42");
+});
+
+test("drops webcams missing an id, a location, or with out-of-range coords", () => {
+  expect(normalizeWindyWebcam({ title: "no id", location: { latitude: 1, longitude: 2 } })).toBeNull();
+  expect(normalizeWindyWebcam({ webcamId: 1, title: "no loc", location: null })).toBeNull();
+  expect(
+    normalizeWindyWebcam({ webcamId: 2, title: "bad coords", location: { latitude: 999, longitude: 2 } }),
+  ).toBeNull();
+});
+
+test("country code is upper-cased to ISO-3166 alpha-2", () => {
+  const lower: WindyWebcam = {
+    webcamId: 7,
+    title: "lower",
+    status: "active",
+    location: { latitude: 1, longitude: 2, country_code: "fr" },
+  };
+  expect(normalizeWindyWebcam(lower)!.country).toBe("FR");
+});


### PR DESCRIPTION
Adds ~73k Windy.com public webcams as their OWN map layer, kept fully separate from the road-CCTV cameras so the honest camera counts are never inflated.

- lib/sources/windy.ts: keyed adapter (x-windy-api-key injected server-side only), region bbox fan-out + dedupe, pure normalization, live-verified against the Windy Webcams API v3 contract.
- app/api/webcams: thin-marker list endpoint; app/api/webcam-image: SSRF- closed image proxy that re-resolves the short-lived tokened URL per view.
- Dormant-safe: no key -> empty list, never crashes.
- Rendered as rose (#ec4899) dots->icons on the globe; click opens a dossier with the live image + mandatory "Webcams provided by Windy.com" credit and a link back to the webcam's Windy page.
- Promoted from a planned row to an active layer (toggle + live count + freshness chip); kept out of the quick presets so the keyed, rate-limited sample stays opt-in.

Gate: tsc clean, vitest 137/137 (+windy adapter tests), next build green.