### PR TITLE
Data layers: weather · air quality · GDACS disasters · UK crime (keyless)

### DIFF
--- a/lib/signals/airquality.ts
+++ b/lib/signals/airquality.ts
@@ -1,0 +1,106 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { WORLD_CITIES, cityCoordParams, type City } from "@/lib/signals/cities.data";
+
+// Live air quality at major world cities — keyless Open-Meteo Air-Quality API.
+// Same one-request-covers-all-cities pattern as the weather layer (multi-coordinate
+// request → index-ordered array → markers at the city's own coordinate). Colour and
+// the dossier band come from the US AQI (EPA categories). Confirmed live 2026-06-27.
+
+const ENDPOINT = "https://air-quality-api.open-meteo.com/v1/air-quality";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const OPEN_METEO_AQ_ATTRIBUTION =
+  "Air-quality data by Open-Meteo.com (CAMS / GEMS), CC BY 4.0";
+
+interface AqPoint {
+  latitude?: number;
+  longitude?: number;
+  current?: {
+    time?: string;
+    pm2_5?: number | null;
+    pm10?: number | null;
+    us_aqi?: number | null;
+    european_aqi?: number | null;
+    nitrogen_dioxide?: number | null;
+    ozone?: number | null;
+  } | null;
+}
+
+/** US AQI band → (category label, colour). The standard EPA six-tier scale. */
+export function usAqiBand(aqi: number): { category: string; color: string } {
+  if (aqi <= 50) return { category: "Good", color: "#16a34a" };
+  if (aqi <= 100) return { category: "Moderate", color: "#eab308" };
+  if (aqi <= 150) return { category: "Unhealthy (sensitive)", color: "#f97316" };
+  if (aqi <= 200) return { category: "Unhealthy", color: "#dc2626" };
+  if (aqi <= 300) return { category: "Very unhealthy", color: "#9333ea" };
+  return { category: "Hazardous", color: "#7f1d1d" };
+}
+
+function meteoTimeToIso(time: string | undefined): string | undefined {
+  if (!time) return undefined;
+  const norm = time.length === 16 ? `${time}:00Z` : time;
+  const t = Date.parse(norm);
+  return Number.isFinite(t) ? new Date(t).toISOString() : undefined;
+}
+
+/**
+ * Pure: Open-Meteo air-quality array + the SAME city list (same order) → one feature
+ * per city with a usable US-AQI reading. Cities with no AQI value are skipped.
+ */
+export function normalizeAirQuality(points: AqPoint[], cities: City[] = WORLD_CITIES): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  points.forEach((pt, i) => {
+    const city = cities[i];
+    const cur = pt?.current;
+    if (!city || !cur) return;
+    const aqi = typeof cur.us_aqi === "number" && Number.isFinite(cur.us_aqi) ? Math.round(cur.us_aqi) : null;
+    if (aqi === null) return;
+    const { category, color } = usAqiBand(aqi);
+    const num = (v: number | null | undefined, unit: string) =>
+      typeof v === "number" && Number.isFinite(v) ? `${v.toFixed(1)} ${unit}` : "—";
+    out.push({
+      id: `airquality:${city.name}`,
+      lat: city.lat,
+      lon: city.lon,
+      title: `${city.name} — AQI ${aqi} (${category})`,
+      signalId: "airquality",
+      color,
+      ts: meteoTimeToIso(cur.time),
+      props: {
+        usAqi: aqi,
+        category,
+        europeanAqi: typeof cur.european_aqi === "number" ? Math.round(cur.european_aqi) : "—",
+        "PM2.5": num(cur.pm2_5, "µg/m³"),
+        PM10: num(cur.pm10, "µg/m³"),
+        "NO₂": num(cur.nitrogen_dioxide, "µg/m³"),
+        "O₃": num(cur.ozone, "µg/m³"),
+        city: `${city.name}, ${city.country}`,
+      },
+    });
+  });
+  return out;
+}
+
+export const AIR_QUALITY_SOURCE: SignalSource = {
+  id: "airquality",
+  label: "Air quality",
+  group: "Environment",
+  color: "#65a30d",
+  refreshMs: 1_800_000, // CAMS air-quality fields update ~hourly; 30 min is comfortable
+  attribution: OPEN_METEO_AQ_ATTRIBUTION,
+  async fetch() {
+    try {
+      const { latitude, longitude } = cityCoordParams();
+      const url =
+        `${ENDPOINT}?latitude=${latitude}&longitude=${longitude}` +
+        `&current=pm2_5,pm10,us_aqi,european_aqi,nitrogen_dioxide,ozone&timezone=GMT`;
+      const res = await fetch(url, { headers: { "User-Agent": UA }, signal: AbortSignal.timeout(15_000) });
+      if (!res.ok) return [];
+      const json = await res.json();
+      const points = Array.isArray(json) ? (json as AqPoint[]) : [json as AqPoint];
+      return normalizeAirQuality(points);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/cities.data.ts
+++ b/lib/signals/cities.data.ts
@@ -1,0 +1,83 @@
+// A curated set of major world cities, spread across every inhabited continent.
+// Open-Meteo's forecast + air-quality APIs are per-coordinate, so the weather and
+// air-quality signal layers fetch this whole list in ONE multi-coordinate request
+// each (Open-Meteo accepts comma-separated lat/lon lists and returns an array in
+// the same order). Keeping the list here — shared, immutable, index-stable — means
+// both adapters place their markers at the city's real coordinates (not Open-Meteo's
+// snapped grid point) by matching the response array index back to this list.
+
+export interface City {
+  name: string;
+  country: string;
+  lat: number;
+  lon: number;
+}
+
+/** ~50 major cities, every continent. Order is the request/response index order. */
+export const WORLD_CITIES: City[] = [
+  // Europe
+  { name: "London", country: "United Kingdom", lat: 51.5074, lon: -0.1278 },
+  { name: "Paris", country: "France", lat: 48.8566, lon: 2.3522 },
+  { name: "Madrid", country: "Spain", lat: 40.4168, lon: -3.7038 },
+  { name: "Berlin", country: "Germany", lat: 52.52, lon: 13.405 },
+  { name: "Rome", country: "Italy", lat: 41.9028, lon: 12.4964 },
+  { name: "Moscow", country: "Russia", lat: 55.7558, lon: 37.6173 },
+  { name: "Istanbul", country: "Türkiye", lat: 41.0082, lon: 28.9784 },
+  { name: "Kyiv", country: "Ukraine", lat: 50.4501, lon: 30.5234 },
+  { name: "Stockholm", country: "Sweden", lat: 59.3293, lon: 18.0686 },
+  { name: "Athens", country: "Greece", lat: 37.9838, lon: 23.7275 },
+  // Africa
+  { name: "Cairo", country: "Egypt", lat: 30.0444, lon: 31.2357 },
+  { name: "Lagos", country: "Nigeria", lat: 6.5244, lon: 3.3792 },
+  { name: "Nairobi", country: "Kenya", lat: -1.2921, lon: 36.8219 },
+  { name: "Johannesburg", country: "South Africa", lat: -26.2041, lon: 28.0473 },
+  { name: "Casablanca", country: "Morocco", lat: 33.5731, lon: -7.5898 },
+  { name: "Addis Ababa", country: "Ethiopia", lat: 9.03, lon: 38.74 },
+  // Middle East / West Asia
+  { name: "Dubai", country: "United Arab Emirates", lat: 25.2048, lon: 55.2708 },
+  { name: "Riyadh", country: "Saudi Arabia", lat: 24.7136, lon: 46.6753 },
+  { name: "Tehran", country: "Iran", lat: 35.6892, lon: 51.389 },
+  { name: "Tel Aviv", country: "Israel", lat: 32.0853, lon: 34.7818 },
+  // South / Central Asia
+  { name: "Delhi", country: "India", lat: 28.6139, lon: 77.209 },
+  { name: "Mumbai", country: "India", lat: 19.076, lon: 72.8777 },
+  { name: "Karachi", country: "Pakistan", lat: 24.8607, lon: 67.0011 },
+  { name: "Dhaka", country: "Bangladesh", lat: 23.8103, lon: 90.4125 },
+  // East / Southeast Asia
+  { name: "Beijing", country: "China", lat: 39.9042, lon: 116.4074 },
+  { name: "Shanghai", country: "China", lat: 31.2304, lon: 121.4737 },
+  { name: "Tokyo", country: "Japan", lat: 35.6762, lon: 139.6503 },
+  { name: "Seoul", country: "South Korea", lat: 37.5665, lon: 126.978 },
+  { name: "Bangkok", country: "Thailand", lat: 13.7563, lon: 100.5018 },
+  { name: "Singapore", country: "Singapore", lat: 1.3521, lon: 103.8198 },
+  { name: "Jakarta", country: "Indonesia", lat: -6.2088, lon: 106.8456 },
+  { name: "Manila", country: "Philippines", lat: 14.5995, lon: 120.9842 },
+  { name: "Hong Kong", country: "China", lat: 22.3193, lon: 114.1694 },
+  { name: "Ho Chi Minh City", country: "Vietnam", lat: 10.8231, lon: 106.6297 },
+  // Oceania
+  { name: "Sydney", country: "Australia", lat: -33.8688, lon: 151.2093 },
+  { name: "Melbourne", country: "Australia", lat: -37.8136, lon: 144.9631 },
+  { name: "Auckland", country: "New Zealand", lat: -36.8485, lon: 174.7633 },
+  // North America
+  { name: "New York", country: "United States", lat: 40.7128, lon: -74.006 },
+  { name: "Los Angeles", country: "United States", lat: 34.0522, lon: -118.2437 },
+  { name: "Chicago", country: "United States", lat: 41.8781, lon: -87.6298 },
+  { name: "Toronto", country: "Canada", lat: 43.6532, lon: -79.3832 },
+  { name: "Mexico City", country: "Mexico", lat: 19.4326, lon: -99.1332 },
+  { name: "Vancouver", country: "Canada", lat: 49.2827, lon: -123.1207 },
+  // South America
+  { name: "São Paulo", country: "Brazil", lat: -23.5505, lon: -46.6333 },
+  { name: "Buenos Aires", country: "Argentina", lat: -34.6037, lon: -58.3816 },
+  { name: "Lima", country: "Peru", lat: -12.0464, lon: -77.0428 },
+  { name: "Bogotá", country: "Colombia", lat: 4.711, lon: -74.0721 },
+  { name: "Santiago", country: "Chile", lat: -33.4489, lon: -70.6693 },
+  { name: "Rio de Janeiro", country: "Brazil", lat: -22.9068, lon: -43.1729 },
+];
+
+/** Comma-joined latitudes / longitudes for a single multi-coordinate Open-Meteo call. */
+export function cityCoordParams(cities: City[] = WORLD_CITIES): { latitude: string; longitude: string } {
+  return {
+    latitude: cities.map((c) => c.lat).join(","),
+    longitude: cities.map((c) => c.lon).join(","),
+  };
+}

--- a/lib/signals/crime.ts
+++ b/lib/signals/crime.ts
@@ -1,0 +1,128 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// UK street-level crime — keyless data.police.uk. The richest open, geocoded crime
+// feed available without a key (England, Wales & Northern Ireland; Police Scotland
+// is not part of this dataset). It is a MONTHLY aggregate, ~2 months in arrears, so
+// features carry NO `ts` (a monthly count is not a real-time event — the time-window
+// filter never hides it; `month` rides in the dossier instead). We pull a 1-mile
+// radius around several major city centres for the latest published month, merge,
+// dedupe and cap. Confirmed live 2026-06-27 (latest month then: 2026-04).
+
+const STREET_ENDPOINT = "https://data.police.uk/api/crimes-street/all-crime";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const POLICE_UK_ATTRIBUTION =
+  "Crime data © data.police.uk, Open Government Licence v3.0";
+
+/** City centres sampled (England & Wales — the keyless dataset's coverage). */
+const CRIME_CITIES: { name: string; lat: number; lng: number }[] = [
+  { name: "London", lat: 51.5074, lng: -0.1278 },
+  { name: "Manchester", lat: 53.4808, lng: -2.2426 },
+  { name: "Birmingham", lat: 52.4862, lng: -1.8904 },
+  { name: "Leeds", lat: 53.8008, lng: -1.5491 },
+  { name: "Liverpool", lat: 53.4084, lng: -2.9916 },
+  { name: "Bristol", lat: 51.4545, lng: -2.5879 },
+];
+
+/** Total markers kept after merge (each city can return 1–5k points/month). */
+export const CRIME_CAP = 1500;
+
+/** Crime category slug → (label, colour). Grouped: violence red, property orange,
+ *  disorder/other amber, fallback slate. */
+const CATEGORY: Record<string, { label: string; color: string }> = {
+  "violent-crime": { label: "Violence & sexual offences", color: "#dc2626" },
+  robbery: { label: "Robbery", color: "#dc2626" },
+  "possession-of-weapons": { label: "Possession of weapons", color: "#dc2626" },
+  burglary: { label: "Burglary", color: "#ea580c" },
+  "vehicle-crime": { label: "Vehicle crime", color: "#ea580c" },
+  "bicycle-theft": { label: "Bicycle theft", color: "#f97316" },
+  "theft-from-the-person": { label: "Theft from the person", color: "#f97316" },
+  shoplifting: { label: "Shoplifting", color: "#f97316" },
+  "other-theft": { label: "Other theft", color: "#f97316" },
+  "criminal-damage-arson": { label: "Criminal damage & arson", color: "#f59e0b" },
+  drugs: { label: "Drugs", color: "#a16207" },
+  "public-order": { label: "Public order", color: "#ca8a04" },
+  "anti-social-behaviour": { label: "Anti-social behaviour", color: "#eab308" },
+  "other-crime": { label: "Other crime", color: "#64748b" },
+};
+
+export function crimeCategory(slug: string): { label: string; color: string } {
+  return CATEGORY[slug] ?? { label: slug.replace(/-/g, " "), color: "#64748b" };
+}
+
+interface CrimeRow {
+  category?: string;
+  location?: { latitude?: string; longitude?: string; street?: { name?: string } | null } | null;
+  outcome_status?: { category?: string } | null;
+  id?: number | string;
+  month?: string;
+}
+
+/**
+ * Pure: data.police.uk rows → SignalFeature[]. Dedupes by crime id and skips rows
+ * with a null/garbled location (the API returns location:null for some records).
+ */
+export function normalizeCrime(rows: CrimeRow[]): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  const seen = new Set<string>();
+  for (const r of rows) {
+    const loc = r.location;
+    if (!loc) continue;
+    const lat = loc.latitude == null ? Number.NaN : Number(loc.latitude);
+    const lon = loc.longitude == null ? Number.NaN : Number(loc.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const id = (r.id ?? "").toString().trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const { label, color } = crimeCategory(r.category ?? "other-crime");
+    const street = loc.street?.name?.trim() || "Unknown street";
+    out.push({
+      id: `ukpolice:${id}`,
+      lat,
+      lon,
+      title: `${label} — ${street}`,
+      signalId: "crime",
+      color,
+      props: {
+        category: label,
+        street,
+        outcome: r.outcome_status?.category?.trim() || "Under investigation",
+        month: r.month ?? "—",
+      },
+    });
+  }
+  return out;
+}
+
+export const UK_CRIME_SOURCE: SignalSource = {
+  id: "crime",
+  label: "UK street crime",
+  group: "Civic safety",
+  color: "#9333ea",
+  refreshMs: 6 * 60 * 60 * 1000, // monthly data; a 6-hour cache is more than enough
+  attribution: POLICE_UK_ATTRIBUTION,
+  async fetch() {
+    try {
+      // Each city in parallel; omitting `date` makes the API use the latest month.
+      const perCity = await Promise.all(
+        CRIME_CITIES.map(async (c) => {
+          try {
+            const res = await fetch(`${STREET_ENDPOINT}?lat=${c.lat}&lng=${c.lng}`, {
+              headers: { "User-Agent": UA, Accept: "application/json" },
+              signal: AbortSignal.timeout(20_000),
+            });
+            if (!res.ok) return [] as CrimeRow[];
+            return (await res.json()) as CrimeRow[];
+          } catch {
+            return [] as CrimeRow[];
+          }
+        }),
+      );
+      const merged = perCity.flat();
+      return normalizeCrime(merged).slice(0, CRIME_CAP);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/gdacs.ts
+++ b/lib/signals/gdacs.ts
@@ -1,0 +1,124 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// GDACS — the Global Disaster Alert & Coordination System (UN/EC). One keyless
+// GeoJSON feed of the CURRENT global disaster picture: earthquakes, tropical
+// cyclones, floods, volcanoes, droughts and wildfires, each with a Green/Orange/Red
+// alert level. Complements the per-hazard feeds (USGS quakes, EONET fires/floods)
+// with a single multi-hazard, severity-scored, alert-coloured overlay. The marker
+// is GDACS's representative centroid. Confirmed live 2026-06-27.
+
+const ENDPOINT = "https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const GDACS_ATTRIBUTION = "Disaster alerts © GDACS (UN OCHA / European Commission JRC)";
+
+/** GDACS event-type code → human label. */
+export function gdacsEventLabel(code: string): string {
+  switch (code) {
+    case "EQ": return "Earthquake";
+    case "TC": return "Tropical cyclone";
+    case "FL": return "Flood";
+    case "VO": return "Volcano";
+    case "DR": return "Drought";
+    case "WF": return "Wildfire";
+    case "TS": return "Tsunami";
+    default: return "Disaster";
+  }
+}
+
+/** GDACS alert level → colour (its own Green/Orange/Red triage). */
+export function gdacsAlertColor(level: string): string {
+  switch ((level || "").toLowerCase()) {
+    case "red": return "#dc2626";
+    case "orange": return "#f59e0b";
+    case "green": return "#16a34a";
+    default: return "#64748b";
+  }
+}
+
+interface GdacsFeature {
+  geometry?: { coordinates?: (number | null)[] } | null;
+  properties?: {
+    eventtype?: string;
+    eventid?: number | string;
+    episodeid?: number | string;
+    name?: string;
+    country?: string;
+    alertlevel?: string;
+    alertscore?: number;
+    fromdate?: string;
+    todate?: string;
+    iscurrent?: string;
+    url?: { report?: string; details?: string } | null;
+    severitydata?: { severitytext?: string } | null;
+  } | null;
+}
+
+/** Treat GDACS's naive UTC timestamps (no zone suffix) as UTC. */
+function gdacsTimeToIso(s: string | undefined): string | undefined {
+  if (!s) return undefined;
+  const norm = /[zZ]|[+-]\d\d:?\d\d$/.test(s) ? s : `${s}Z`;
+  const t = Date.parse(norm);
+  return Number.isFinite(t) ? new Date(t).toISOString() : undefined;
+}
+
+/** Pure: GDACS FeatureCollection → SignalFeature[]. Skips features without coords/id. */
+export function normalizeGdacs(geojson: { features?: GdacsFeature[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const f of geojson.features ?? []) {
+    const p = f.properties ?? {};
+    const c = f.geometry?.coordinates;
+    if (!c) continue;
+    const lon = c[0] == null ? Number.NaN : Number(c[0]);
+    const lat = c[1] == null ? Number.NaN : Number(c[1]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const eventId = (p.eventid ?? "").toString().trim();
+    if (!eventId) continue;
+    const episodeId = (p.episodeid ?? "").toString().trim();
+    const typeLabel = gdacsEventLabel(p.eventtype ?? "");
+    const level = p.alertlevel ?? "Unknown";
+    out.push({
+      id: `gdacs:${eventId}:${episodeId}`,
+      lat,
+      lon,
+      title: p.name?.trim() || `${typeLabel}${p.country ? ` in ${p.country}` : ""}`,
+      signalId: "gdacs",
+      color: gdacsAlertColor(level),
+      link: p.url?.report ?? undefined,
+      ts: gdacsTimeToIso(p.fromdate),
+      props: {
+        hazard: typeLabel,
+        alertLevel: level,
+        severity: p.severitydata?.severitytext?.trim() || "—",
+        country: p.country?.trim() || "—",
+        from: p.fromdate?.slice(0, 10) ?? "—",
+        to: p.todate?.slice(0, 10) ?? "—",
+        ongoing: (p.iscurrent ?? "").toLowerCase() === "true" ? "yes" : "no",
+      },
+    });
+  }
+  return out;
+}
+
+export const GDACS_SOURCE: SignalSource = {
+  id: "gdacs",
+  label: "Disaster alerts",
+  group: "Natural hazards",
+  color: "#e11d48",
+  refreshMs: 600_000, // GDACS regenerates the map feed ~every few minutes
+  attribution: GDACS_ATTRIBUTION,
+  async fetch() {
+    try {
+      const res = await fetch(ENDPOINT, {
+        headers: { "User-Agent": UA, Accept: "application/json" },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) return [];
+      const json = (await res.json()) as { features?: GdacsFeature[] };
+      return normalizeGdacs(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -45,6 +45,10 @@ import { NUCLEAR_SOURCE } from "@/lib/signals/nuclear";
 import { AIRPORTS_SOURCE } from "@/lib/signals/airports";
 import { PORTS_SOURCE } from "@/lib/signals/ports";
 import { CONFLICT_SOURCE, PROTESTS_SOURCE } from "@/lib/signals/gdelt";
+import { GDACS_SOURCE } from "@/lib/signals/gdacs";
+import { WEATHER_SOURCE } from "@/lib/signals/weather";
+import { AIR_QUALITY_SOURCE } from "@/lib/signals/airquality";
+import { UK_CRIME_SOURCE } from "@/lib/signals/crime";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -53,6 +57,7 @@ export const SIGNALS: SignalSource[] = [
   VOLCANOES_SOURCE,
   SEVERE_STORMS_SOURCE,
   FLOODS_SOURCE,
+  GDACS_SOURCE, // multi-hazard GDACS alerts (EQ/TC/FL/VO/DR/WF), alert-coloured
   AURORA_SOURCE,
   // Space
   LAUNCHES_SOURCE,
@@ -65,6 +70,10 @@ export const SIGNALS: SignalSource[] = [
   // Intel (GDELT geolocated news coverage)
   CONFLICT_SOURCE,
   PROTESTS_SOURCE,
+  // Environment & civic (keyless Open-Meteo + data.police.uk)
+  WEATHER_SOURCE,
+  AIR_QUALITY_SOURCE,
+  UK_CRIME_SOURCE,
 ];
 
 /** Lookup a source by id (the dynamic route + store key). */

--- a/lib/signals/weather.ts
+++ b/lib/signals/weather.ts
@@ -1,0 +1,121 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { WORLD_CITIES, cityCoordParams, type City } from "@/lib/signals/cities.data";
+
+// Live weather at major world cities — keyless Open-Meteo "current" forecast.
+// One multi-coordinate request covers the whole WORLD_CITIES list; the response is
+// an array in the same order, so we place each marker at the city's own coordinate
+// (not Open-Meteo's snapped grid point) by index. Colour ramps by temperature;
+// the WMO weather code becomes a human condition + glyph. Confirmed live 2026-06-27.
+
+const ENDPOINT = "https://api.open-meteo.com/v1/forecast";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const OPEN_METEO_ATTRIBUTION = "Weather data by Open-Meteo.com (CC BY 4.0)";
+
+/** One element of Open-Meteo's multi-coordinate response. */
+interface MeteoPoint {
+  latitude?: number;
+  longitude?: number;
+  current?: {
+    time?: string;
+    temperature_2m?: number | null;
+    weather_code?: number | null;
+    wind_speed_10m?: number | null;
+    relative_humidity_2m?: number | null;
+  } | null;
+}
+
+/** WMO 4677 weather-code → short condition + glyph (the codes Open-Meteo emits). */
+export function weatherCodeLabel(code: number): { label: string; glyph: string } {
+  if (code === 0) return { label: "Clear", glyph: "☀" };
+  if (code === 1) return { label: "Mainly clear", glyph: "🌤" };
+  if (code === 2) return { label: "Partly cloudy", glyph: "⛅" };
+  if (code === 3) return { label: "Overcast", glyph: "☁" };
+  if (code === 45 || code === 48) return { label: "Fog", glyph: "🌫" };
+  if (code >= 51 && code <= 57) return { label: "Drizzle", glyph: "🌦" };
+  if (code >= 61 && code <= 67) return { label: "Rain", glyph: "🌧" };
+  if (code >= 71 && code <= 77) return { label: "Snow", glyph: "🌨" };
+  if (code >= 80 && code <= 82) return { label: "Rain showers", glyph: "🌦" };
+  if (code === 85 || code === 86) return { label: "Snow showers", glyph: "🌨" };
+  if (code >= 95) return { label: "Thunderstorm", glyph: "⛈" };
+  return { label: "Unknown", glyph: "•" };
+}
+
+/** Cool→warm temperature ramp (°C). Blue when freezing, deep red in the heat. */
+export function temperatureColor(c: number): string {
+  if (c <= 0) return "#3b82f6";
+  if (c <= 10) return "#38bdf8";
+  if (c <= 18) return "#22c55e";
+  if (c <= 26) return "#eab308";
+  if (c <= 34) return "#f97316";
+  return "#dc2626";
+}
+
+/** Open-Meteo's naive GMT "time" (YYYY-MM-DDTHH:MM) → an ISO-UTC instant, or undefined. */
+function meteoTimeToIso(time: string | undefined): string | undefined {
+  if (!time) return undefined;
+  const norm = time.length === 16 ? `${time}:00Z` : time;
+  const t = Date.parse(norm);
+  return Number.isFinite(t) ? new Date(t).toISOString() : undefined;
+}
+
+/**
+ * Pure: Open-Meteo array + the SAME city list (same order) → one feature per city
+ * with a valid `current` reading. Cities whose entry is missing/garbled are skipped.
+ */
+export function normalizeWeather(points: MeteoPoint[], cities: City[] = WORLD_CITIES): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  points.forEach((pt, i) => {
+    const city = cities[i];
+    const cur = pt?.current;
+    if (!city || !cur) return;
+    const temp = typeof cur.temperature_2m === "number" && Number.isFinite(cur.temperature_2m) ? cur.temperature_2m : null;
+    if (temp === null) return;
+    const code = typeof cur.weather_code === "number" ? cur.weather_code : -1;
+    const { label, glyph } = weatherCodeLabel(code);
+    const wind = typeof cur.wind_speed_10m === "number" ? cur.wind_speed_10m : null;
+    const humidity = typeof cur.relative_humidity_2m === "number" ? cur.relative_humidity_2m : null;
+    out.push({
+      id: `weather:${city.name}`,
+      lat: city.lat,
+      lon: city.lon,
+      title: `${city.name} — ${Math.round(temp)}°C ${glyph} ${label}`,
+      signalId: "weather",
+      color: temperatureColor(temp),
+      ts: meteoTimeToIso(cur.time),
+      props: {
+        temperature: `${temp.toFixed(1)} °C`,
+        conditions: label,
+        wind: wind != null ? `${wind.toFixed(0)} km/h` : "—",
+        humidity: humidity != null ? `${humidity}%` : "—",
+        city: `${city.name}, ${city.country}`,
+      },
+    });
+  });
+  return out;
+}
+
+export const WEATHER_SOURCE: SignalSource = {
+  id: "weather",
+  label: "City weather",
+  group: "Weather",
+  color: "#0284c7",
+  refreshMs: 600_000, // Open-Meteo "current" advances ~every 15 min; 10 min is plenty
+  attribution: OPEN_METEO_ATTRIBUTION,
+  async fetch() {
+    try {
+      const { latitude, longitude } = cityCoordParams();
+      const url =
+        `${ENDPOINT}?latitude=${latitude}&longitude=${longitude}` +
+        `&current=temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m&timezone=GMT`;
+      const res = await fetch(url, { headers: { "User-Agent": UA }, signal: AbortSignal.timeout(15_000) });
+      if (!res.ok) return [];
+      const json = await res.json();
+      // A single-coordinate request returns an object; our multi-city one returns an array.
+      const points = Array.isArray(json) ? (json as MeteoPoint[]) : [json as MeteoPoint];
+      return normalizeWeather(points);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/tests/fixtures/gdacs-events.json
+++ b/tests/fixtures/gdacs-events.json
@@ -1,0 +1,320 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "bbox": [
+        -86.9569176,
+        31.4334994,
+        -86.9569176,
+        31.4334994
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -86.9569176,
+          31.4334994
+        ]
+      },
+      "properties": {
+        "eventtype": "FL",
+        "eventid": 1103888,
+        "episodeid": 28,
+        "eventname": "",
+        "glide": "",
+        "name": "Flood in United States",
+        "description": "Flood in United States",
+        "htmldescription": "Green Flood in United States from: 19 May 2026 01 to: 26 Jun 2026 01.",
+        "icon": "https://www.gdacs.org/images/gdacs_icons/maps/Green/FL.png",
+        "iconoverall": null,
+        "url": {
+          "geometry": "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=FL&eventid=1103888&episodeid=28",
+          "report": "https://www.gdacs.org/report.aspx?eventid=1103888&episodeid=28&eventtype=FL",
+          "details": "https://www.gdacs.org/gdacsapi/api/events/geteventdata?eventtype=FL&eventid=1103888"
+        },
+        "alertlevel": "Green",
+        "alertscore": 1,
+        "episodealertlevel": "Green",
+        "episodealertscore": 0.5,
+        "istemporary": "false",
+        "iscurrent": "true",
+        "country": "United States",
+        "fromdate": "2026-05-19T01:00:00",
+        "todate": "2026-06-26T01:00:00",
+        "datemodified": "2026-06-27T06:17:29",
+        "iso3": "USA",
+        "source": "GLOFAS",
+        "sourceid": "84899988-7634-4433-b172-1cefabf4c906",
+        "polygonlabel": "Centroid",
+        "Class": "Point_Centroid",
+        "affectedcountries": [
+          {
+            "iso2": "US",
+            "iso3": "USA",
+            "countryname": "United States"
+          }
+        ],
+        "severitydata": {
+          "severity": 0.0,
+          "severitytext": "Magnitude 0 ",
+          "severityunit": ""
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "bbox": [
+        152.9318,
+        -4.3413,
+        152.9318,
+        -4.3413
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          152.9318,
+          -4.3413
+        ]
+      },
+      "properties": {
+        "eventtype": "EQ",
+        "eventid": 1548439,
+        "episodeid": 1714476,
+        "eventname": "",
+        "glide": "",
+        "name": "Earthquake in Papua New Guinea",
+        "description": "Earthquake in Papua New Guinea",
+        "htmldescription": "Green M 5.5 Earthquake in Papua New Guinea at: 25 Jun 2026 06:19:38.",
+        "icon": "https://www.gdacs.org/images/gdacs_icons/maps/Green/EQ.png",
+        "iconoverall": null,
+        "url": {
+          "geometry": "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=EQ&eventid=1548439&episodeid=1714476",
+          "report": "https://www.gdacs.org/report.aspx?eventid=1548439&episodeid=1714476&eventtype=EQ",
+          "details": "https://www.gdacs.org/gdacsapi/api/events/geteventdata?eventtype=EQ&eventid=1548439"
+        },
+        "alertlevel": "Green",
+        "alertscore": 1,
+        "episodealertlevel": "Green",
+        "episodealertscore": 0.0,
+        "istemporary": "false",
+        "iscurrent": "true",
+        "country": "Papua New Guinea",
+        "fromdate": "2026-06-25T06:19:38",
+        "todate": "2026-06-25T06:19:38",
+        "datemodified": "2026-06-26T14:03:52",
+        "iso3": "PNG",
+        "source": "NEIC",
+        "sourceid": "us6000t81q",
+        "polygonlabel": "Centroid",
+        "Class": "Point_Centroid",
+        "affectedcountries": [
+          {
+            "iso2": "PG",
+            "iso3": "PNG",
+            "countryname": "Papua New Guinea"
+          }
+        ],
+        "severitydata": {
+          "severity": 5.5,
+          "severitytext": "Magnitude 5.5M, Depth:33km",
+          "severityunit": "M"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "bbox": [
+        142.9,
+        36.4,
+        142.9,
+        36.4
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          142.9,
+          36.4
+        ]
+      },
+      "properties": {
+        "eventtype": "TC",
+        "eventid": 1001278,
+        "episodeid": 19,
+        "eventname": "HIGOS-26",
+        "glide": "",
+        "name": "Tropical Cyclone HIGOS-26",
+        "description": "Tropical Cyclone HIGOS-26",
+        "htmldescription": "Green Tropical Cyclone HIGOS-26 in Japan, Northern Mariana Islands, Guam from: 22 Jun 2026  to: 27 Jun 2026 .",
+        "icon": "https://www.gdacs.org/images/gdacs_icons/maps/Green/TC.png",
+        "iconoverall": null,
+        "url": {
+          "geometry": "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=TC&eventid=1001278&episodeid=19",
+          "report": "https://www.gdacs.org/report.aspx?eventid=1001278&episodeid=19&eventtype=TC",
+          "details": "https://www.gdacs.org/gdacsapi/api/events/geteventdata?eventtype=TC&eventid=1001278"
+        },
+        "alertlevel": "Green",
+        "alertscore": 1,
+        "episodealertlevel": "Green",
+        "episodealertscore": 1.0,
+        "istemporary": "false",
+        "iscurrent": "true",
+        "country": "Japan, Northern Mariana Islands, Guam",
+        "fromdate": "2026-06-22T12:00:00",
+        "todate": "2026-06-27T00:00:00",
+        "datemodified": "2026-06-27T03:35:05",
+        "iso3": "GUM",
+        "source": "JTWC",
+        "sourceid": "",
+        "polygonlabel": "Centroid",
+        "Class": "Point_Centroid",
+        "countryonland": "",
+        "affectedcountries": [
+          {
+            "iso2": "JP",
+            "iso3": "JPN",
+            "countryname": "Japan"
+          },
+          {
+            "iso2": "GU",
+            "iso3": "GUM",
+            "countryname": "Guam"
+          }
+        ],
+        "severitydata": {
+          "severity": 101.8512,
+          "severitytext": "Tropical Storm (maximum wind speed of 102 km/h)",
+          "severityunit": "km/h"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "bbox": [
+        26.6687377174872,
+        -6.451603177418471,
+        26.6687377174872,
+        -6.451603177418471
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          26.6687377174872,
+          -6.451603177418471
+        ]
+      },
+      "properties": {
+        "eventtype": "WF",
+        "eventid": 1028931,
+        "episodeid": 14,
+        "eventname": "",
+        "glide": "",
+        "name": "Forest fires in The Democratic Republic of Congo",
+        "description": "Forest fires in The Democratic Republic of Congo",
+        "htmldescription": "Green Forest fires in The Democratic Republic of Congo from: 12 Jun 2026 to: 26 Jun 2026.",
+        "icon": "https://www.gdacs.org/images/gdacs_icons/maps/Green/WF.png",
+        "iconoverall": null,
+        "url": {
+          "geometry": "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=WF&eventid=1028931&episodeid=14",
+          "report": "https://www.gdacs.org/report.aspx?eventid=1028931&episodeid=14&eventtype=WF",
+          "details": "https://www.gdacs.org/gdacsapi/api/events/geteventdata?eventtype=WF&eventid=1028931"
+        },
+        "alertlevel": "Green",
+        "alertscore": 1,
+        "episodealertlevel": "Green",
+        "episodealertscore": 0.5,
+        "istemporary": "false",
+        "iscurrent": "true",
+        "country": "The Democratic Republic of Congo",
+        "fromdate": "2026-06-12T00:00:00",
+        "todate": "2026-06-26T00:00:00",
+        "datemodified": "2026-06-27T07:14:48",
+        "iso3": "COD",
+        "source": "GWIS",
+        "sourceid": "15337339",
+        "polygonlabel": "Centroid",
+        "Class": "Point_Centroid",
+        "affectedcountries": [],
+        "severitydata": {
+          "severity": 11197.0,
+          "severitytext": "Green impact for forestfire in 11197 ha",
+          "severityunit": "ha"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "bbox": [
+        13.597,
+        -4.459,
+        13.597,
+        -4.459
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.597,
+          -4.459
+        ]
+      },
+      "properties": {
+        "eventtype": "DR",
+        "eventid": 1018344,
+        "episodeid": 14,
+        "eventname": "Angola, Gabon, Congo-2025",
+        "glide": "DR-2025-000234-AGO",
+        "name": "Drought in Angola, Democratic Republic of Congo, Republic of Congo, Gabon",
+        "description": "Drought in Angola, Democratic Republic of Congo, Republic of Congo, Gabon",
+        "htmldescription": "Green Drought in Angola, Democratic Republic of Congo, Republic of Congo, Gabon from: 11 Dec 2025  to: 25 Jun 2026 .",
+        "icon": "https://www.gdacs.org/images/gdacs_icons/maps/Green/DR.png",
+        "iconoverall": null,
+        "url": {
+          "geometry": "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=DR&eventid=1018344&episodeid=14",
+          "report": "https://www.gdacs.org/report.aspx?eventid=1018344&episodeid=14&eventtype=DR",
+          "details": "https://www.gdacs.org/gdacsapi/api/events/geteventdata?eventtype=DR&eventid=1018344"
+        },
+        "alertlevel": "Green",
+        "alertscore": 1,
+        "episodealertlevel": "Green",
+        "episodealertscore": 0.5,
+        "istemporary": "false",
+        "iscurrent": "false",
+        "country": "Angola, Democratic Republic of Congo, Republic of Congo, Gabon",
+        "fromdate": "2025-12-11T00:00:00",
+        "todate": "2026-06-25T00:00:00",
+        "datemodified": "2026-06-27T05:57:08",
+        "iso3": "AGO",
+        "source": "GDO",
+        "sourceid": "",
+        "polygonlabel": "Centroid",
+        "Class": "Point_Centroid",
+        "affectedcountries": [
+          {
+            "iso2": "AO",
+            "iso3": "AGO",
+            "countryname": "Angola"
+          },
+          {
+            "iso2": "CD",
+            "iso3": "COD",
+            "countryname": "Democratic Republic of Congo"
+          },
+          {
+            "iso2": "CG",
+            "iso3": "COG",
+            "countryname": "Republic of Congo"
+          },
+          {
+            "iso2": "GA",
+            "iso3": "GAB",
+            "countryname": "Gabon"
+          }
+        ],
+        "severitydata": {
+          "severity": 113651.0,
+          "severitytext": "Minor impact for agricultural drought in 113651 km2",
+          "severityunit": "km2"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/open-meteo-air.json
+++ b/tests/fixtures/open-meteo-air.json
@@ -1,0 +1,91 @@
+[
+    {
+        "latitude": 51.5,
+        "longitude": -0.10000038,
+        "generationtime_ms": 0.3389120101928711,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 29.0,
+        "current_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "pm2_5": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "pm10": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "us_aqi": "USAQI",
+            "european_aqi": "EAQI",
+            "nitrogen_dioxide": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "ozone": "\u00ce\u00bcg/m\u00c2\u00b3"
+        },
+        "current": {
+            "time": "2026-06-27T07:00",
+            "interval": 3600,
+            "pm2_5": 5.6,
+            "pm10": 7.5,
+            "us_aqi": 32,
+            "european_aqi": 18,
+            "nitrogen_dioxide": 17.8,
+            "ozone": 44.0
+        }
+    },
+    {
+        "latitude": 48.800003,
+        "longitude": 2.3999996,
+        "generationtime_ms": 0.1468658447265625,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 46.0,
+        "location_id": 1,
+        "current_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "pm2_5": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "pm10": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "us_aqi": "USAQI",
+            "european_aqi": "EAQI",
+            "nitrogen_dioxide": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "ozone": "\u00ce\u00bcg/m\u00c2\u00b3"
+        },
+        "current": {
+            "time": "2026-06-27T07:00",
+            "interval": 3600,
+            "pm2_5": 15.2,
+            "pm10": 20.0,
+            "us_aqi": 48,
+            "european_aqi": 27,
+            "nitrogen_dioxide": 14.8,
+            "ozone": 67.0
+        }
+    },
+    {
+        "latitude": 35.700005,
+        "longitude": 139.70001,
+        "generationtime_ms": 0.14579296112060547,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 38.0,
+        "location_id": 2,
+        "current_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "pm2_5": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "pm10": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "us_aqi": "USAQI",
+            "european_aqi": "EAQI",
+            "nitrogen_dioxide": "\u00ce\u00bcg/m\u00c2\u00b3",
+            "ozone": "\u00ce\u00bcg/m\u00c2\u00b3"
+        },
+        "current": {
+            "time": "2026-06-27T07:00",
+            "interval": 3600,
+            "pm2_5": 14.0,
+            "pm10": 14.1,
+            "us_aqi": 47,
+            "european_aqi": 23,
+            "nitrogen_dioxide": 46.2,
+            "ozone": 4.0
+        }
+    }
+]

--- a/tests/fixtures/open-meteo-weather.json
+++ b/tests/fixtures/open-meteo-weather.json
@@ -1,0 +1,79 @@
+[
+    {
+        "latitude": 51.5,
+        "longitude": -0.25,
+        "generationtime_ms": 0.18656253814697266,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 29.0,
+        "current_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature_2m": "\u00c2\u00b0C",
+            "weather_code": "wmo code",
+            "wind_speed_10m": "km/h",
+            "relative_humidity_2m": "%"
+        },
+        "current": {
+            "time": "2026-06-27T07:15",
+            "interval": 900,
+            "temperature_2m": 22.8,
+            "weather_code": 3,
+            "wind_speed_10m": 6.5,
+            "relative_humidity_2m": 70
+        }
+    },
+    {
+        "latitude": 48.84,
+        "longitude": 2.3599997,
+        "generationtime_ms": 0.050187110900878906,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 46.0,
+        "location_id": 1,
+        "current_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature_2m": "\u00c2\u00b0C",
+            "weather_code": "wmo code",
+            "wind_speed_10m": "km/h",
+            "relative_humidity_2m": "%"
+        },
+        "current": {
+            "time": "2026-06-27T07:15",
+            "interval": 900,
+            "temperature_2m": 24.1,
+            "weather_code": 2,
+            "wind_speed_10m": 10.0,
+            "relative_humidity_2m": 52
+        }
+    },
+    {
+        "latitude": 35.7,
+        "longitude": 139.6875,
+        "generationtime_ms": 0.06687641143798828,
+        "utc_offset_seconds": 0,
+        "timezone": "GMT",
+        "timezone_abbreviation": "GMT",
+        "elevation": 38.0,
+        "location_id": 2,
+        "current_units": {
+            "time": "iso8601",
+            "interval": "seconds",
+            "temperature_2m": "\u00c2\u00b0C",
+            "weather_code": "wmo code",
+            "wind_speed_10m": "km/h",
+            "relative_humidity_2m": "%"
+        },
+        "current": {
+            "time": "2026-06-27T07:15",
+            "interval": 900,
+            "temperature_2m": 22.8,
+            "weather_code": 3,
+            "wind_speed_10m": 3.8,
+            "relative_humidity_2m": 99
+        }
+    }
+]

--- a/tests/fixtures/uk-crime.json
+++ b/tests/fixtures/uk-crime.json
@@ -1,0 +1,195 @@
+[
+  {
+    "category": "anti-social-behaviour",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.506236",
+      "street": {
+        "id": 1676347,
+        "name": "On or near Parking Area"
+      },
+      "longitude": "-0.141322"
+    },
+    "context": "",
+    "outcome_status": null,
+    "persistent_id": "",
+    "id": 134642993,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "bicycle-theft",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.507201",
+      "street": {
+        "id": 1677064,
+        "name": "On or near Conference/exhibition Centre"
+      },
+      "longitude": "-0.137387"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Investigation complete; no suspect identified",
+      "date": "2026-04"
+    },
+    "persistent_id": "9bf0024b15ac3d349d271985246207d69fbd287cb8076731bfc011cd95e855db",
+    "id": 134687972,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "burglary",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.496523",
+      "street": {
+        "id": 1677517,
+        "name": "On or near B323"
+      },
+      "longitude": "-0.133731"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Investigation complete; no suspect identified",
+      "date": "2026-04"
+    },
+    "persistent_id": "9c5349190fb3081306848fa51186e9bde2dd3bbe28c1965fad81af45025f33c1",
+    "id": 134677405,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "criminal-damage-arson",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.499488",
+      "street": {
+        "id": 1679222,
+        "name": "On or near Hospital"
+      },
+      "longitude": "-0.118410"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Under investigation",
+      "date": "2026-04"
+    },
+    "persistent_id": "41da4a3d80e00ff7d669507027ec06782636da8230ccec5290886030459053b2",
+    "id": 134668740,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "drugs",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.512013",
+      "street": {
+        "id": 1677575,
+        "name": "On or near Winnett Street"
+      },
+      "longitude": "-0.133502"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Under investigation",
+      "date": "2026-04"
+    },
+    "persistent_id": "0d4e610bba15c6305e3c6cb58a197a91edd2e41fbae43da115d8d43915bd0195",
+    "id": 134724762,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "other-theft",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.516875",
+      "street": {
+        "id": 1676380,
+        "name": "On or near Nightclub"
+      },
+      "longitude": "-0.141807"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Investigation complete; no suspect identified",
+      "date": "2026-04"
+    },
+    "persistent_id": "765bfd24c556feabd8638c8663700c4586ce8c7f4b6cf6aa612425a43f63ca80",
+    "id": 134704559,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "possession-of-weapons",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.493697",
+      "street": {
+        "id": 1677645,
+        "name": "On or near Fynes Street"
+      },
+      "longitude": "-0.133011"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Awaiting court outcome",
+      "date": "2026-04"
+    },
+    "persistent_id": "40fd6543875a0d4d79609626e5f40c3e62d735b96491cc8ccaa86b41b8416c39",
+    "id": 134713347,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "public-order",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.510953",
+      "street": {
+        "id": 1677692,
+        "name": "On or near Nightclub"
+      },
+      "longitude": "-0.133012"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Under investigation",
+      "date": "2026-04"
+    },
+    "persistent_id": "72d3847d0132e58f44ad091965a0576eb9a31c0321d2970975df575068a385b2",
+    "id": 134664960,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "robbery",
+    "location_type": "Force",
+    "location": {
+      "latitude": "51.512513",
+      "street": {
+        "id": 1677559,
+        "name": "On or near Nightclub"
+      },
+      "longitude": "-0.133841"
+    },
+    "context": "",
+    "outcome_status": {
+      "category": "Under investigation",
+      "date": "2026-04"
+    },
+    "persistent_id": "eb7b368f0b2c1437644c0e50110d7ca4b939af6de407e1c58ba9bb89e99f66df",
+    "id": 134678224,
+    "location_subtype": "",
+    "month": "2026-04"
+  },
+  {
+    "category": "other-crime",
+    "location": null,
+    "id": 999999999,
+    "month": "2026-04",
+    "outcome_status": null
+  }
+]

--- a/tests/unit/signals-airquality.test.ts
+++ b/tests/unit/signals-airquality.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/open-meteo-air.json";
+import { normalizeAirQuality, usAqiBand } from "@/lib/signals/airquality";
+import type { City } from "@/lib/signals/cities.data";
+
+const CITIES: City[] = [
+  { name: "London", country: "United Kingdom", lat: 51.5074, lon: -0.1278 },
+  { name: "Paris", country: "France", lat: 48.8566, lon: 2.3522 },
+  { name: "Tokyo", country: "Japan", lat: 35.6762, lon: 139.6503 },
+];
+
+test("normalizes Open-Meteo air quality, one feature per city with a US-AQI reading", () => {
+  const out = normalizeAirQuality(fixture as never, CITIES);
+  expect(out).toHaveLength(3);
+  expect(out.map((f) => f.signalId)).toEqual(["airquality", "airquality", "airquality"]);
+  expect(out[0].id).toBe("airquality:London");
+  expect(out[0].lat).toBe(51.5074);
+
+  const aqi = Math.round((fixture as never[])[0]["current"]["us_aqi"] as number);
+  expect(out[0].props?.usAqi).toBe(aqi);
+  expect(out[0].color).toBe(usAqiBand(aqi).color);
+  expect(out[0].props?.category).toBe(usAqiBand(aqi).category);
+});
+
+test("skips a city with no AQI value", () => {
+  const points = [...(fixture as never[]), { latitude: 0, longitude: 0, current: { us_aqi: null } }];
+  const cities = [...CITIES, { name: "Nowhere", country: "—", lat: 0, lon: 0 }];
+  expect(normalizeAirQuality(points as never, cities)).toHaveLength(3);
+});
+
+test("US AQI bands map to the EPA six-tier scale", () => {
+  expect(usAqiBand(25).category).toBe("Good");
+  expect(usAqiBand(75).category).toBe("Moderate");
+  expect(usAqiBand(125).category).toBe("Unhealthy (sensitive)");
+  expect(usAqiBand(180).category).toBe("Unhealthy");
+  expect(usAqiBand(250).category).toBe("Very unhealthy");
+  expect(usAqiBand(400).category).toBe("Hazardous");
+});

--- a/tests/unit/signals-crime.test.ts
+++ b/tests/unit/signals-crime.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/uk-crime.json";
+import { normalizeCrime, crimeCategory } from "@/lib/signals/crime";
+
+test("normalizes data.police.uk rows, skipping the null-location record", () => {
+  const out = normalizeCrime(fixture as never);
+  expect(out).toHaveLength(9); // 10 rows, the last has location:null
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["crime"]));
+  expect(out[0].id).toBe("ukpolice:134642993");
+  // String "lat"/"lng" are coerced to numbers and placed on the map.
+  expect(out[0].lat).toBeCloseTo(51.506236, 5);
+  expect(out[0].lon).toBeCloseTo(-0.141322, 5);
+  // Monthly aggregate → no real-time timestamp (the time-window filter won't hide it).
+  expect(out[0].ts).toBeUndefined();
+  expect(out[0].props?.month).toBe("2026-04");
+});
+
+test("maps categories to labels/colours and dedupes by crime id", () => {
+  const robbery = normalizeCrime(fixture as never).find((f) => f.id === "ukpolice:134678224");
+  expect(robbery?.props?.category).toBe("Robbery");
+  expect(robbery?.color).toBe("#dc2626");
+
+  // A duplicate id collapses to one feature.
+  const dup = [...(fixture as never[]), (fixture as never[])[0]];
+  expect(normalizeCrime(dup as never)).toHaveLength(9);
+});
+
+test("crimeCategory falls back gracefully for an unknown slug", () => {
+  expect(crimeCategory("anti-social-behaviour").label).toBe("Anti-social behaviour");
+  expect(crimeCategory("made-up-slug")).toEqual({ label: "made up slug", color: "#64748b" });
+});

--- a/tests/unit/signals-gdacs.test.ts
+++ b/tests/unit/signals-gdacs.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/gdacs-events.json";
+import { normalizeGdacs, gdacsEventLabel, gdacsAlertColor } from "@/lib/signals/gdacs";
+
+test("normalizes the GDACS multi-hazard FeatureCollection", () => {
+  const out = normalizeGdacs(fixture as never);
+  expect(out).toHaveLength(5); // FL, EQ, TC, WF, DR — all have coords + an event id
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["gdacs"]));
+
+  const eq = out.find((f) => f.props?.hazard === "Earthquake");
+  expect(eq).toBeDefined();
+  expect(eq!.id).toMatch(/^gdacs:\d+:\d+$/);
+  expect(eq!.title).toContain("Papua New Guinea");
+  expect(eq!.color).toBe(gdacsAlertColor("Green"));
+  expect(typeof eq!.ts).toBe("string"); // fromdate parsed as UTC
+  expect(eq!.props?.country).toBe("Papua New Guinea");
+});
+
+test("skips features with missing/invalid coordinates", () => {
+  const bad = { features: [{ geometry: { coordinates: [null, null] }, properties: { eventid: 1, eventtype: "EQ" } }] };
+  expect(normalizeGdacs(bad as never)).toHaveLength(0);
+});
+
+test("event-type labels and alert-level colours", () => {
+  expect(gdacsEventLabel("TC")).toBe("Tropical cyclone");
+  expect(gdacsEventLabel("WF")).toBe("Wildfire");
+  expect(gdacsEventLabel("??")).toBe("Disaster");
+  expect(gdacsAlertColor("Red")).toBe("#dc2626");
+  expect(gdacsAlertColor("Orange")).toBe("#f59e0b");
+  expect(gdacsAlertColor("Green")).toBe("#16a34a");
+});

--- a/tests/unit/signals-weather.test.ts
+++ b/tests/unit/signals-weather.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/open-meteo-weather.json";
+import { normalizeWeather, weatherCodeLabel, temperatureColor } from "@/lib/signals/weather";
+import type { City } from "@/lib/signals/cities.data";
+
+// The fixture was captured for these three cities, in this order.
+const CITIES: City[] = [
+  { name: "London", country: "United Kingdom", lat: 51.5074, lon: -0.1278 },
+  { name: "Paris", country: "France", lat: 48.8566, lon: 2.3522 },
+  { name: "Tokyo", country: "Japan", lat: 35.6762, lon: 139.6503 },
+];
+
+test("normalizes Open-Meteo current weather, one feature per city at the city's own coords", () => {
+  const out = normalizeWeather(fixture as never, CITIES);
+  expect(out).toHaveLength(3);
+  expect(out.map((f) => f.signalId)).toEqual(["weather", "weather", "weather"]);
+  expect(out[0].id).toBe("weather:London");
+  // Marker sits at the curated city coordinate, not Open-Meteo's snapped grid point.
+  expect(out[0].lat).toBe(51.5074);
+  expect(out[0].lon).toBe(-0.1278);
+  // Colour + temperature prop are derived from the fixture's own reading.
+  const temp = (fixture as never[])[0]["current"]["temperature_2m"] as number;
+  expect(out[0].color).toBe(temperatureColor(temp));
+  expect(out[0].props?.temperature).toBe(`${temp.toFixed(1)} °C`);
+  expect(typeof out[0].ts).toBe("string");
+});
+
+test("skips a city with no usable current reading", () => {
+  const points = [...(fixture as never[]), { latitude: 0, longitude: 0, current: null }];
+  const cities = [...CITIES, { name: "Nowhere", country: "—", lat: 0, lon: 0 }];
+  expect(normalizeWeather(points as never, cities)).toHaveLength(3);
+});
+
+test("WMO code → condition and the temperature ramp", () => {
+  expect(weatherCodeLabel(0).label).toBe("Clear");
+  expect(weatherCodeLabel(95).label).toBe("Thunderstorm");
+  expect(weatherCodeLabel(61).label).toBe("Rain");
+  expect(temperatureColor(-5)).toBe("#3b82f6");
+  expect(temperatureColor(40)).toBe("#dc2626");
+  expect(temperatureColor(20)).toBe("#eab308");
+});


### PR DESCRIPTION
Four new **keyless, opt-in** global signal layers. Each is **one adapter + one registry entry + a live-captured fixture & test**, with **no `WorldMap` changes** — they all render through the existing data-driven signals framework. Every adapter resolves to `[]` on failure (dormant-safe; the generic `/api/signals/[id]` route never 5xxes).

| Layer | Source (keyless) | Group | Notes |
|---|---|---|---|
| **City weather** | Open-Meteo forecast | Weather | Live conditions at ~50 world cities in **one** multi-coordinate request; markers at each city's real coordinate, temperature colour-ramp, WMO code → human condition. |
| **Air quality** | Open-Meteo Air-Quality (CAMS) | Environment | US-AQI + PM2.5 / PM10 / NO₂ / O₃, EPA six-tier colour bands. |
| **Disaster alerts** | GDACS (UN OCHA / EC JRC) | Natural hazards | Global multi-hazard — earthquake / cyclone / flood / volcano / drought / wildfire — with Green/Orange/Red alert colours + severity text. |
| **UK street crime** | data.police.uk | Civic safety | Geocoded street-level crime for the latest published month around six English city centres; merged, deduped, capped (1500), category-coloured. |

### Design notes
- Weather + air quality share a curated `lib/signals/cities.data.ts` and exploit Open-Meteo's comma-separated multi-coordinate request (one HTTP call covers every city; response is index-ordered back to the city list).
- UK crime is a **monthly aggregate ~2 months in arrears**, so its features deliberately carry **no `ts`** — the time-window filter never hides them (honest: a monthly count isn't a real-time event). Police Scotland isn't in this dataset; coverage is England/Wales/NI, documented in the adapter.
- GDACS centroids are its own representative points; `fromdate` is parsed as UTC for the recency filter.

### Verification
- `tsc --noEmit` clean
- `vitest run` — **283 passed** (+12: weather / air quality / GDACS / crime normalizers, fixtures captured live 2026-06-27)
- `next build` green

### Queued next
Markets / macro expansion: dormant stock/energy/macro providers (Finnhub / Alpha Vantage / FMP / FRED, key-gated) + an AI daily-brief via freellmapi.co.
