### PR TITLE
Intel layers: military flights + food insecurity (keyless) + API-keys doc

### DIFF
--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -1,0 +1,123 @@
+# TrafficNerd‑V2 — API keys & access tokens
+
+Every layer in this app is **keyless-first**: it works with no keys at all. The keys
+below only *unlock additional layers* (or upgrade a modelled layer to real
+measurements). Each source is **free** — most are instant signup, a few need a short
+registration or an email request. Until a key is set, its layer stays **dormant**
+(renders nothing, never errors).
+
+> **How to give me the keys:** fill in the values, or just paste them back to me and
+> I'll wire them in. **Never commit real keys.** They all go in **`.env.local`** at the
+> project root (already git‑ignored). All are **server‑only** — none are exposed to the
+> browser (no `NEXT_PUBLIC_` prefix), so the keys never leave the server.
+
+---
+
+## 1 · Intelligence layers — get these (all free)
+
+| # | Source | Unlocks | Free tier | Env var(s) |
+|---|--------|---------|-----------|-----------|
+| 1 | **AISStream.io** | Real‑time global ship tracking (named vessels, Hormuz/Suez) | Free, no card, WebSocket | `AISSTREAM_API_KEY` |
+| 2 | **ENTSO‑E Transparency** | EU electricity‑grid load / generation mix / cross‑border flows / outages | Free w/ registration | `ENTSOE_API_TOKEN` |
+| 3 | **OpenAQ** | Real air‑quality **station** measurements (upgrades the modelled CAMS layer) | Free | `OPENAQ_API_KEY` |
+| 4 | **UCDP** (Uppsala) | Geocoded conflict events + fatalities (structural conflict history) | Free token | `UCDP_API_TOKEN` |
+| 5 | **ACLED** | Real‑time armed‑conflict & protest events w/ actor attribution | Free, registered | `ACLED_API_KEY` + `ACLED_EMAIL` |
+| 6 | **NASA FIRMS** | VIIRS/MODIS thermal active‑fire detections | Free MAP_KEY | `FIRMS_MAP_KEY` |
+| 7 | **ReliefWeb** (OCHA) | Humanitarian situation reports + disaster declarations | Free *approved appname* (not a secret) | `RELIEFWEB_APPNAME` |
+
+### Where to get each
+
+1. **AISStream.io** — sign up at <https://aisstream.io>, create an API key on the
+   dashboard. (Live vessel positions over a free WebSocket; coverage is terrestrial
+   AIS, ~200 km offshore, so mid‑ocean is patchy.)
+2. **ENTSO‑E** — register at <https://transparency.entsoe.eu> → after confirming your
+   account, email **transparency@entsoe.eu** with subject *"Restful API access"* from
+   your registered address; they reply with a **Web API security token** (usually < 1
+   business day).
+3. **OpenAQ** — register at <https://explore.openaq.org> (or <https://openaq.org>) and
+   generate an API key in your account. (v3 sends it as the `X‑API‑Key` header.)
+4. **UCDP** — request a free API access token via the UCDP API docs at
+   <https://ucdp.uu.se> (the GED REST API now needs an `x‑ucdp‑access‑token` header).
+5. **ACLED** — register at <https://acleddata.com/register> → "Access" → generate an
+   API key. You'll use the key **and** the email you registered with.
+6. **NASA FIRMS** — request a free **MAP_KEY** at
+   <https://firms.modaps.eosdis.nasa.gov/api/area/> (instant, just an email).
+
+---
+
+## 2 · Optional enhancements (free, but we already have a keyless equivalent)
+
+| Source | Adds | Why optional | Env var |
+|--------|------|--------------|---------|
+| **Electricity Maps** | Live carbon/grid mix outside the EU | ENTSO‑E already covers EU grid | `ELECTRICITYMAPS_API_KEY` |
+| **Cloudflare Radar** | A second internet‑outage vantage | We already corroborate via keyless **IODA + RIPEstat** | `CLOUDFLARE_API_TOKEN` |
+
+- **Electricity Maps** — free tier at <https://www.electricitymaps.com/free-tier-api>.
+- **Cloudflare Radar** — any free Cloudflare account → My Profile → API Tokens → token
+  with **Radar Read**: <https://developers.cloudflare.com/radar/get-started/>.
+
+---
+
+## 3 · Already wired, currently dormant (set these to switch existing features on)
+
+| Feature | What it needs | Env var(s) |
+|---------|---------------|-----------|
+| **Photo geolocation** (`/locate`) vision fallback | freellmapi.co gateway (you own it) | `FREELLMAPI_BASE_URL`, `FREELLMAPI_KEY` |
+| **Photo geolocation** GeoCLIP backend (best accuracy) | run `scripts/geolocate_service.py`, point the app at it | `GEOLOCATE_GEOCLIP_URL` (+ optional `GEOLOCATE_BACKEND=geoclip\|llm`) |
+| **Windy webcams** layer | Windy API keys (you said these are already in `.env.local`) | `WINDY_WEBCAMS_API_KEY`, `WINDY_MAP_FORECAST_API_KEY` |
+
+---
+
+## 4 · Parked / future — markets & macro (Task #12, not being built yet)
+
+Listed only so the picture is complete. All free; get them whenever we pick up the
+markets work.
+
+| Source | Unlocks | Env var |
+|--------|---------|---------|
+| **Finnhub** | Global stock quotes / exchanges | `FINNHUB_API_KEY` |
+| **Alpha Vantage** | Equities / FX / commodities | `ALPHAVANTAGE_API_KEY` |
+| **Financial Modeling Prep** | Fundamentals / indices | `FMP_API_KEY` |
+| **FRED** (St. Louis Fed) | Macro series, central‑bank rates | `FRED_API_KEY` |
+
+(Polymarket, Fear & Greed, World Bank, Eurostat, OECD SDMX — all keyless, no entry needed.)
+
+---
+
+## `.env.local` template
+
+Copy this into `.env.local`, fill what you have, leave the rest blank (blank = dormant):
+
+```dotenv
+# --- Intelligence layers (free) ---
+AISSTREAM_API_KEY=
+ENTSOE_API_TOKEN=
+OPENAQ_API_KEY=
+UCDP_API_TOKEN=
+ACLED_API_KEY=
+ACLED_EMAIL=
+FIRMS_MAP_KEY=
+RELIEFWEB_APPNAME=
+
+# --- Optional enhancements ---
+ELECTRICITYMAPS_API_KEY=
+CLOUDFLARE_API_TOKEN=
+
+# --- Already-wired dormant features ---
+FREELLMAPI_BASE_URL=
+FREELLMAPI_KEY=
+GEOLOCATE_GEOCLIP_URL=
+GEOLOCATE_BACKEND=
+WINDY_WEBCAMS_API_KEY=
+WINDY_MAP_FORECAST_API_KEY=
+
+# --- Parked: markets/macro (Task #12) ---
+FINNHUB_API_KEY=
+ALPHAVANTAGE_API_KEY=
+FMP_API_KEY=
+FRED_API_KEY=
+```
+
+> These env‑var names are the contract — when I build each key‑gated adapter it reads
+> exactly these names, so the moment you paste a value the layer goes live with no code
+> change. Nothing here blocks the keyless layers, which keep shipping in parallel.

--- a/lib/signals/food-security.ts
+++ b/lib/signals/food-security.ts
@@ -1,0 +1,92 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { centroidByIso3 } from "@/lib/signals/country-centroids.data";
+import { countMagnitude } from "@/lib/signals/aggregate";
+
+// Food insecurity by country — keyless WFP HungerMap. Acute hunger is a recognised
+// instability accelerant (it would feed the Country Instability Index the way the
+// climate-anomaly signal does). HungerMap publishes, per country, the number and
+// share of people with insufficient food consumption (FCS), a near-real-time
+// nowcast. Country-level → one marker at the centroid, sized by people affected and
+// coloured by prevalence. Confirmed keyless 2026-06-27.
+
+const ENDPOINT = "https://api.hungermapdata.org/v1/foodsecurity/country";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const HUNGERMAP_ATTRIBUTION = "Food-security data © WFP HungerMap LIVE";
+
+interface HmMetric {
+  people?: number;
+  prevalence?: number; // 0–1 share of population
+}
+interface HmCountry {
+  country?: { iso3?: string; name?: string };
+  date?: string;
+  dataType?: string; // "PREDICTION" | "FORECAST" | "ACTUAL DATA" …
+  metrics?: { fcs?: HmMetric; rcsi?: HmMetric };
+}
+
+/** Yellow→deep-red ramp by the share of the population with insufficient food. */
+export function foodInsecurityColor(prevalence: number): string {
+  if (prevalence >= 0.4) return "#7f1d1d";
+  if (prevalence >= 0.25) return "#dc2626";
+  if (prevalence >= 0.15) return "#ea580c";
+  if (prevalence >= 0.05) return "#f59e0b";
+  return "#fbbf24";
+}
+
+/** Pure: HungerMap payload → one SignalFeature per country with a real FCS reading. */
+export function normalizeFoodSecurity(json: { body?: { countries?: HmCountry[] } }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const c of json.body?.countries ?? []) {
+    const iso3 = (c.country?.iso3 ?? "").toUpperCase();
+    const ctr = centroidByIso3(iso3);
+    if (!ctr) continue;
+    const fcs = c.metrics?.fcs;
+    const people = typeof fcs?.people === "number" ? fcs.people : 0;
+    if (people <= 0) continue;
+    const prevalence = typeof fcs?.prevalence === "number" ? fcs.prevalence : 0;
+    const pct = Math.round(prevalence * 100);
+    out.push({
+      id: `food:${iso3}`,
+      lat: ctr.lat,
+      lon: ctr.lon,
+      title: `${ctr.name} — ${people.toLocaleString()} food-insecure (${pct}%)`,
+      signalId: "food-security",
+      color: foodInsecurityColor(prevalence),
+      props: {
+        country: ctr.name,
+        insufficientFood: people.toLocaleString(),
+        prevalence: `${pct}%`,
+        ...(typeof c.metrics?.rcsi?.prevalence === "number"
+          ? { crisisCoping: `${Math.round(c.metrics.rcsi.prevalence * 100)}%` }
+          : {}),
+        basis: c.dataType ?? "—",
+        asOf: c.date ?? "—",
+        magnitude: countMagnitude(people / 100_000),
+      },
+    });
+  }
+  return out;
+}
+
+export const FOOD_SECURITY_SOURCE: SignalSource = {
+  id: "food-security",
+  label: "Food insecurity",
+  group: "Human cost",
+  color: "#ea580c",
+  refreshMs: 6 * 60 * 60 * 1000, // a daily-ish nowcast; 6-hour cache is ample
+  attribution: HUNGERMAP_ATTRIBUTION,
+  async fetch() {
+    try {
+      const res = await fetch(ENDPOINT, {
+        headers: { "User-Agent": UA, Accept: "application/json" },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) return [];
+      const json = (await res.json()) as { body?: { countries?: HmCountry[] } };
+      return normalizeFoodSecurity(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/military-air.ts
+++ b/lib/signals/military-air.ts
@@ -1,0 +1,96 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// Military aircraft worldwide — keyless adsb.lol / adsb.fi `/mil` feed. Most ADS-B
+// aggregators (and OpenSky's anonymous tier) FILTER OUT military traffic, which is
+// exactly the traffic that matters for posture/movement. These two community feeds
+// expose the unfiltered military set globally. One point per live aircraft, with
+// type, callsign, registration, altitude and speed. Confirmed keyless 2026-06-27.
+
+const ENDPOINTS = [
+  "https://api.adsb.lol/v2/mil",
+  "https://opendata.adsb.fi/api/v2/mil", // fallback (also carries a `desc` field)
+];
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const ADSB_MIL_ATTRIBUTION = "Military ADS-B © adsb.lol / adsb.fi (community feeds)";
+
+interface AcRow {
+  hex?: string;
+  flight?: string; // callsign
+  r?: string; // registration / tail
+  t?: string; // ICAO type code, e.g. "C17"
+  desc?: string; // full type description (adsb.fi only)
+  alt_baro?: number | string; // feet, or "ground"
+  gs?: number; // ground speed (kt)
+  track?: number; // heading
+  squawk?: string;
+  lat?: number;
+  lon?: number;
+}
+
+function altitude(a: AcRow["alt_baro"]): string {
+  if (typeof a === "number" && Number.isFinite(a)) return `${a.toLocaleString()} ft`;
+  if (typeof a === "string" && a.toLowerCase() === "ground") return "on ground";
+  return "—";
+}
+
+/** Pure: adsb `/mil` payload → one SignalFeature per aircraft with a position. */
+export function normalizeMilitaryAir(json: { ac?: AcRow[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const a of json.ac ?? []) {
+    const lat = typeof a.lat === "number" ? a.lat : Number.NaN;
+    const lon = typeof a.lon === "number" ? a.lon : Number.NaN;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const hex = (a.hex ?? "").trim();
+    if (!hex) continue;
+    const callsign = (a.flight ?? "").trim();
+    const typeName = a.desc?.trim() || a.t?.trim() || "Military aircraft";
+    out.push({
+      id: `mil:${hex}`,
+      lat,
+      lon,
+      title: `${callsign || hex} — ${typeName}`,
+      signalId: "military-air",
+      color: "#3f6212", // military olive — distinct from civil plane amber
+      props: {
+        callsign: callsign || "—",
+        type: typeName,
+        typeCode: a.t ?? "—",
+        registration: a.r?.trim() || "—",
+        altitude: altitude(a.alt_baro),
+        speed: typeof a.gs === "number" ? `${Math.round(a.gs)} kt` : "—",
+        heading: typeof a.track === "number" ? `${Math.round(a.track)}°` : "—",
+        squawk: a.squawk ?? "—",
+        hex,
+      },
+    });
+  }
+  return out;
+}
+
+export const MILITARY_AIR_SOURCE: SignalSource = {
+  id: "military-air",
+  label: "Military flights",
+  group: "Military",
+  color: "#3f6212",
+  refreshMs: 20_000, // live aircraft — a short cache keeps positions current
+  attribution: ADSB_MIL_ATTRIBUTION,
+  async fetch() {
+    for (const url of ENDPOINTS) {
+      try {
+        const res = await fetch(url, {
+          headers: { "User-Agent": UA, Accept: "application/json" },
+          signal: AbortSignal.timeout(12_000),
+        });
+        if (!res.ok) continue;
+        const json = (await res.json()) as { ac?: AcRow[] };
+        const out = normalizeMilitaryAir(json);
+        if (out.length) return out;
+      } catch {
+        // try the next endpoint
+      }
+    }
+    return []; // dormant-safe: both feeds unreachable → nothing
+  },
+};

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -52,6 +52,8 @@ import { UK_CRIME_SOURCE } from "@/lib/signals/crime";
 import { CYBER_C2_SOURCE } from "@/lib/signals/cyber-c2";
 import { CYBER_RANSOMWARE_SOURCE } from "@/lib/signals/cyber-ransomware";
 import { DISPLACEMENT_SOURCE } from "@/lib/signals/displacement";
+import { FOOD_SECURITY_SOURCE } from "@/lib/signals/food-security";
+import { MILITARY_AIR_SOURCE } from "@/lib/signals/military-air";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -80,8 +82,11 @@ export const SIGNALS: SignalSource[] = [
   // Cyber threat (keyless abuse.ch + Ransomware.live, country-aggregated)
   CYBER_C2_SOURCE,
   CYBER_RANSOMWARE_SOURCE,
-  // Human cost (keyless UNHCR displacement, country-aggregated)
+  // Human cost (keyless UNHCR displacement + WFP HungerMap, country-aggregated)
   DISPLACEMENT_SOURCE,
+  FOOD_SECURITY_SOURCE,
+  // Military (keyless unfiltered military ADS-B)
+  MILITARY_AIR_SOURCE,
 ];
 
 /** Lookup a source by id (the dynamic route + store key). */

--- a/tests/fixtures/adsb-mil.json
+++ b/tests/fixtures/adsb-mil.json
@@ -1,0 +1,95 @@
+{
+  "ac": [
+    {
+      "hex": "ae49c5",
+      "flight": "RCH4139 ",
+      "r": "09-9209",
+      "t": "C17",
+      "alt_baro": 15000,
+      "gs": 397.0,
+      "track": 275.0,
+      "squawk": "2145",
+      "lat": 47.048025,
+      "lon": -120.926613
+    },
+    {
+      "hex": "ae1471",
+      "flight": "RCH4536 ",
+      "r": "07-7179",
+      "t": "C17",
+      "alt_baro": 33000,
+      "gs": 511.1,
+      "track": 58.11,
+      "lat": 37.297746,
+      "lon": -101.995816,
+      "category": "A5"
+    },
+    {
+      "hex": "e200dd",
+      "flight": "ARG01   ",
+      "r": "ARG-01",
+      "t": "B752",
+      "alt_baro": 38000,
+      "gs": 415.4,
+      "track": 227.24,
+      "squawk": "2532",
+      "lat": -32.568458,
+      "lon": -56.091651,
+      "category": "A3"
+    },
+    {
+      "hex": "7101f0",
+      "flight": "SVA9291 ",
+      "r": "HZ-MF5",
+      "t": "GLF4",
+      "alt_baro": 31500,
+      "gs": 530.8,
+      "track": 31.2,
+      "squawk": "3406",
+      "lat": 41.749146,
+      "lon": -5.733178,
+      "category": "A2"
+    },
+    {
+      "hex": "353606",
+      "flight": "AZOR10  ",
+      "r": "T.21-07",
+      "t": "C295",
+      "alt_baro": 4275,
+      "gs": 152.6,
+      "track": 219.95,
+      "squawk": "6540",
+      "lat": 40.24585,
+      "lon": -3.791138,
+      "category": "A2"
+    },
+    {
+      "hex": "43c4ce",
+      "flight": "SHF265  ",
+      "r": "ZD983",
+      "t": "H47",
+      "alt_baro": 2325,
+      "gs": 133.0,
+      "track": 310.0,
+      "squawk": "0010",
+      "lat": 52.456524,
+      "lon": -2.299882
+    },
+    {
+      "hex": "abc123",
+      "flight": "GRND01 ",
+      "t": "H60",
+      "alt_baro": "ground",
+      "gs": 0,
+      "lat": 38.9,
+      "lon": -77.0
+    },
+    {
+      "hex": "deadbe",
+      "flight": "NOPOS1 ",
+      "t": "F16",
+      "alt_baro": 40000,
+      "gs": 450
+    }
+  ]
+}

--- a/tests/fixtures/hungermap-food.json
+++ b/tests/fixtures/hungermap-food.json
@@ -1,0 +1,113 @@
+{
+  "body": {
+    "countries": [
+      {
+        "country": {
+          "id": 1,
+          "name": "Afghanistan",
+          "iso3": "AFG",
+          "iso2": "AF"
+        },
+        "date": "2024-09-14",
+        "dataType": "PREDICTION",
+        "metrics": {
+          "fcs": {
+            "people": 23075100,
+            "prevalence": 0.5709982309895716
+          }
+        }
+      },
+      {
+        "country": {
+          "id": 8,
+          "name": "Angola",
+          "iso3": "AGO",
+          "iso2": "AO"
+        },
+        "date": "2023-12-04",
+        "dataType": "SURVEY",
+        "metrics": {
+          "fcs": {
+            "people": 5281612,
+            "prevalence": 0.15491289185986576
+          }
+        }
+      },
+      {
+        "country": {
+          "id": 13,
+          "name": "Armenia",
+          "iso3": "ARM",
+          "iso2": "AM"
+        },
+        "date": "2024-09-14",
+        "dataType": "PREDICTION",
+        "metrics": {
+          "fcs": {
+            "people": 452539,
+            "prevalence": 0.15331070063897104
+          }
+        }
+      },
+      {
+        "country": {
+          "id": 23,
+          "name": "Bangladesh",
+          "iso3": "BGD",
+          "iso2": "BD"
+        },
+        "date": "2024-09-14",
+        "dataType": "PREDICTION",
+        "metrics": {
+          "fcs": {
+            "people": 51060275,
+            "prevalence": 0.31644477021126693
+          }
+        }
+      },
+      {
+        "country": {
+          "id": 31,
+          "name": "Bhutan",
+          "iso3": "BTN",
+          "iso2": "BT"
+        },
+        "date": "2024-09-14",
+        "dataType": "PREDICTION",
+        "metrics": {
+          "fcs": {
+            "people": 223497,
+            "prevalence": 0.29626070231298546
+          }
+        }
+      },
+      {
+        "country": {
+          "id": 33,
+          "name": "Bolivia",
+          "iso3": "BOL",
+          "iso2": "BO"
+        },
+        "date": "2024-06-04",
+        "dataType": "PREDICTION",
+        "metrics": {
+          "fcs": {
+            "people": 2129458,
+            "prevalence": 0.17736569229248197
+          }
+        }
+      },
+      {
+        "country": {
+          "iso3": "ZZZ",
+          "name": "Nowhere"
+        },
+        "metrics": {
+          "fcs": {
+            "people": 0
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/unit/signals-food-security.test.ts
+++ b/tests/unit/signals-food-security.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/hungermap-food.json";
+import { normalizeFoodSecurity, foodInsecurityColor } from "@/lib/signals/food-security";
+import { centroidByIso3 } from "@/lib/signals/country-centroids.data";
+
+test("normalizes HungerMap food insecurity by country, skipping unknown/zero rows", () => {
+  const out = normalizeFoodSecurity(fixture as never);
+  expect(out).toHaveLength(6); // 6 real countries; the "ZZZ" / zero-people row is dropped
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["food-security"]));
+
+  const afg = out.find((f) => f.id === "food:AFG")!;
+  expect(afg.props?.insufficientFood).toBe((23_075_100).toLocaleString());
+  expect(afg.props?.prevalence).toBe("57%"); // 0.5709… → 57%
+  expect(afg.color).toBe(foodInsecurityColor(0.5709982309895716));
+  expect(afg.ts).toBeUndefined(); // nowcast snapshot, never time-filtered
+  const ctr = centroidByIso3("AFG")!;
+  expect(afg.lon).toBe(ctr.lon);
+});
+
+test("prevalence colour ramp", () => {
+  expect(foodInsecurityColor(0.45)).toBe("#7f1d1d");
+  expect(foodInsecurityColor(0.3)).toBe("#dc2626");
+  expect(foodInsecurityColor(0.18)).toBe("#ea580c");
+  expect(foodInsecurityColor(0.08)).toBe("#f59e0b");
+  expect(foodInsecurityColor(0.02)).toBe("#fbbf24");
+});

--- a/tests/unit/signals-military-air.test.ts
+++ b/tests/unit/signals-military-air.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/adsb-mil.json";
+import { normalizeMilitaryAir } from "@/lib/signals/military-air";
+
+test("normalizes military ADS-B, skipping aircraft with no position", () => {
+  const out = normalizeMilitaryAir(fixture as never);
+  // 6 airborne + 1 grounded (has lat/lon) = 7; the position-less F16 is skipped.
+  expect(out).toHaveLength(7);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["military-air"]));
+  expect(out.every((f) => f.id.startsWith("mil:"))).toBe(true);
+});
+
+test("maps callsign, type, altitude (incl. 'ground') and speed", () => {
+  const out = normalizeMilitaryAir(fixture as never);
+  const c17 = out.find((f) => f.props?.typeCode === "C17")!;
+  expect(c17.title).toContain("RCH"); // a Reach military callsign
+  expect(String(c17.props?.altitude)).toMatch(/ft$/);
+
+  const grounded = out.find((f) => f.id === "mil:abc123")!;
+  expect(grounded.props?.altitude).toBe("on ground");
+  expect(grounded.props?.speed).toBe("0 kt");
+  expect(grounded.ts).toBeUndefined(); // live snapshot, never time-filtered
+});


### PR DESCRIPTION
Two more keyless intel layers (E2 sub-batch), same framework discipline — one adapter + one registry entry + a live-captured fixture & test each, **no `WorldMap` changes**, all dormant-safe.

| Layer | Source (keyless) | Group | Notes |
|---|---|---|---|
| **Military flights** | adsb.lol / adsb.fi `/mil` | Military *(new)* | The unfiltered global military ADS-B set most aggregators hide — one point per aircraft (type, callsign, tail, altitude, speed). ~80 live at capture. |
| **Food insecurity** | WFP **HungerMap** | Human cost | People with insufficient food consumption (FCS) by country, coloured by prevalence — an instability accelerant that will feed the Country Instability Index. Reuses the country-centroid + aggregate scaffolding. |

### Plus: `docs/API_KEYS.md`
The full **free-key roadmap** you asked for — **AISStream, ENTSO‑E, OpenAQ, UCDP, ACLED, NASA FIRMS, ReliefWeb** — each with signup link, free-tier note, the exact env-var name, and a ready `.env.local` template. The env-var names are the contract: drop a key in and its layer goes live with zero code change.

**Note:** ReliefWeb moved onto the key list — its v2 API now requires an *approved appname* (v1 is decommissioned), so it's no longer keyless-instant.

### Verification
- `tsc --noEmit` clean
- `vitest run` — **293 passed** (+4)
- `next build` green (isolated dir; fixtures captured live 2026-06-27)

### Still in this phase (keyless, next)
Space weather as a **status readout** (Kp / G·R·S scales / flares — global scalar, so chrome not dots), BGP/IODA outage corroboration, NHC cyclone forecast cones, OWID disease surveillance, EMSC quakes. Then the trust/freshness spine + Country Instability Index, and the AISStream collector once you've got the key.
