### PR TITLE
Internet outages (IODA) + space-weather status (NOAA) — keyless

### DIFF
--- a/lib/signals/internet-outages.ts
+++ b/lib/signals/internet-outages.ts
@@ -1,0 +1,90 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { centroidByIso2 } from "@/lib/signals/country-centroids.data";
+
+// Internet outages — IODA (Internet Outage Detection & Analysis, Georgia Tech /
+// CAIDA). Detects national-scale connectivity drops from three independent
+// vantage points (active probing, BGP, telescope). Country-level internet
+// shutdowns are a top-tier instability signal — governments cut connectivity
+// during coups, contested elections and crackdowns. Keyless; country-aggregated:
+// IODA already returns one score per affected country, so we anchor a marker at
+// the country centroid sized by outage severity. Dormant-safe (→ [] on failure).
+
+const SUMMARY_URL = "https://api.ioda.inetintel.cc.gatech.edu/v2/outages/summary";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const IODA_ATTRIBUTION = "Internet-outage detection © IODA (CAIDA / Georgia Tech)";
+
+interface IodaEntity {
+  code?: string; // ISO-3166 alpha-2 for country entities
+  name?: string;
+  type?: string;
+}
+interface IodaRow {
+  scores?: { overall?: number };
+  event_cnt?: number;
+  entity?: IodaEntity;
+}
+
+/** Severity → marker magnitude (log-scaled; IODA scores span ~1e3–1e6). */
+function outageMagnitude(score: number): number {
+  if (!(score > 0)) return 3;
+  const m = Math.log10(score + 1) * 1.5; // ~4.7 at 1.5k, ~8.4 at 380k
+  return Math.min(10, Math.max(3, Math.round(m * 10) / 10));
+}
+
+/** Pure: IODA country-summary payload → one SignalFeature per located country. */
+export function normalizeOutages(json: { data?: IodaRow[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const r of json.data ?? []) {
+    const ent = r.entity;
+    if (!ent || ent.type !== "country") continue;
+    const code = (ent.code ?? "").trim().toUpperCase();
+    if (!code) continue;
+    const c = centroidByIso2(code);
+    if (!c) continue; // unknown / non-country code (e.g. "ZZ") — skip
+    const score = typeof r.scores?.overall === "number" ? r.scores.overall : 0;
+    const events = typeof r.event_cnt === "number" ? r.event_cnt : 0;
+    const name = ent.name?.trim() || c.name;
+    out.push({
+      id: `ioda:${code}`,
+      lat: c.lat,
+      lon: c.lon,
+      title: `Internet outage — ${name}`,
+      signalId: "internet-outages",
+      color: "#b91c1c", // censorship/outage red
+      props: {
+        country: name,
+        outageScore: Math.round(score),
+        events,
+        severity: score >= 100_000 ? "severe" : score >= 5_000 ? "elevated" : "localised",
+        magnitude: outageMagnitude(score),
+      },
+    });
+  }
+  return out;
+}
+
+export const INTERNET_OUTAGES_SOURCE: SignalSource = {
+  id: "internet-outages",
+  label: "Internet outages (IODA)",
+  group: "Infrastructure",
+  color: "#b91c1c",
+  refreshMs: 15 * 60 * 1000,
+  attribution: IODA_ATTRIBUTION,
+  async fetch() {
+    // Look back 24h; IODA extends the window server-side to catch ongoing events.
+    const until = Math.floor(Date.now() / 1000);
+    const from = until - 24 * 3600;
+    try {
+      const res = await fetch(
+        `${SUMMARY_URL}?from=${from}&until=${until}&entityType=country&limit=200`,
+        { headers: { Accept: "application/json", "User-Agent": UA }, signal: AbortSignal.timeout(20_000) },
+      );
+      if (!res.ok) return [];
+      const json = (await res.json()) as { data?: IodaRow[] };
+      return normalizeOutages(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -58,6 +58,8 @@ import { DISPLACEMENT_SOURCE } from "@/lib/signals/displacement";
 import { FOOD_SECURITY_SOURCE } from "@/lib/signals/food-security";
 import { MILITARY_AIR_SOURCE } from "@/lib/signals/military-air";
 import { AIS_SOURCE } from "@/lib/signals/ais";
+import { INTERNET_OUTAGES_SOURCE } from "@/lib/signals/internet-outages";
+import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -70,6 +72,7 @@ export const SIGNALS: SignalSource[] = [
   FIRE_FIRMS_SOURCE, // NASA FIRMS active-fire detections (key-gated: FIRMS_MAP_KEY)
   EMSC_SOURCE, // EMSC quakes — a 2nd, faster Euro-Med catalogue alongside USGS
   AURORA_SOURCE,
+  SPACE_WEATHER_SOURCE, // NOAA SWPC Kp/storm-scale status pin (keyless)
   // Space
   LAUNCHES_SOURCE,
   // Infrastructure (cables = line layer, gpsJamming = fill layer)
@@ -78,6 +81,7 @@ export const SIGNALS: SignalSource[] = [
   NUCLEAR_SOURCE,
   AIRPORTS_SOURCE,
   PORTS_SOURCE,
+  INTERNET_OUTAGES_SOURCE, // IODA national internet-shutdown detection (keyless, country-aggregated)
   // Intel (GDELT geolocated news coverage)
   CONFLICT_SOURCE,
   PROTESTS_SOURCE,

--- a/lib/signals/space-weather.ts
+++ b/lib/signals/space-weather.ts
@@ -1,0 +1,109 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// Space weather — NOAA SWPC. A global "status" signal: the planetary K-index
+// (geomagnetic activity, 0–9) plus the current NOAA storm scales — G (geomagnetic),
+// R (radio blackout) and S (solar radiation). High activity degrades GPS, HF radio
+// and power grids and pushes the aurora to lower latitudes, so it belongs in the
+// intel picture. Rendered as a single status pin at the north geomagnetic pole,
+// sized by Kp and coloured by the G-scale. Keyless; dormant-safe (→ [] on failure).
+
+const KP_URL = "https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json";
+const SCALES_URL = "https://services.swpc.noaa.gov/products/noaa-scales.json";
+
+// North geomagnetic pole (≈2025) — the natural anchor for a geomagnetic-status pin.
+const GEOMAG_NORTH: [number, number] = [80.7, -72.7];
+
+export const SWPC_ATTRIBUTION = "Space-weather data © NOAA SWPC";
+
+interface KpRow {
+  time_tag?: string;
+  Kp?: number;
+  a_running?: number;
+  station_count?: number;
+}
+interface ScaleBlock {
+  DateStamp?: string;
+  TimeStamp?: string;
+  R?: { Scale?: string | null; Text?: string | null };
+  S?: { Scale?: string | null; Text?: string | null };
+  G?: { Scale?: string | null; Text?: string | null };
+}
+export interface SpaceWeatherInput {
+  kp: KpRow[];
+  scales0: ScaleBlock | undefined;
+}
+
+/** NOAA G-scale (0–5) → colour (quiet green → severe red). */
+export function gScaleColor(scale: number): string {
+  switch (scale) {
+    case 0: return "#16a34a"; // quiet
+    case 1: return "#eab308"; // minor
+    case 2: return "#f59e0b"; // moderate
+    case 3: return "#ea580c"; // strong
+    case 4: return "#dc2626"; // severe
+    default: return "#7f1d1d"; // 5+ extreme
+  }
+}
+
+function scaleNum(s: string | null | undefined): number {
+  const n = Number((s ?? "").trim());
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Pure: latest Kp + current NOAA scales → a single space-weather status feature. */
+export function normalizeSpaceWeather(input: SpaceWeatherInput): SignalFeature[] {
+  const rows = input.kp ?? [];
+  const latest = rows.length ? rows[rows.length - 1] : undefined;
+  const kp = typeof latest?.Kp === "number" ? latest.Kp : Number.NaN;
+  if (!Number.isFinite(kp)) return [];
+
+  const sc = input.scales0;
+  const g = scaleNum(sc?.G?.Scale);
+  const r = scaleNum(sc?.R?.Scale);
+  const s = scaleNum(sc?.S?.Scale);
+  const kpLabel = kp >= 7 ? "severe storm" : kp >= 5 ? "storm" : kp >= 4 ? "unsettled" : "quiet";
+
+  return [
+    {
+      id: "swpc:status",
+      lat: GEOMAG_NORTH[0],
+      lon: GEOMAG_NORTH[1],
+      title: `Space weather — Kp ${kp.toFixed(1)} (${kpLabel})`,
+      signalId: "space-weather",
+      color: gScaleColor(g),
+      props: {
+        kp: Number(kp.toFixed(2)),
+        condition: kpLabel,
+        geomagneticStorm: g > 0 ? `G${g}` : "none",
+        radioBlackout: r > 0 ? `R${r}` : "none",
+        solarRadiation: s > 0 ? `S${s}` : "none",
+        updated: sc?.DateStamp && sc?.TimeStamp ? `${sc.DateStamp} ${sc.TimeStamp} UTC` : "—",
+        // Kp (0–9) maps almost directly onto our 0–10 marker scale.
+        magnitude: Math.min(10, Math.max(2, kp)),
+      },
+    },
+  ];
+}
+
+export const SPACE_WEATHER_SOURCE: SignalSource = {
+  id: "space-weather",
+  label: "Space weather (NOAA Kp/storms)",
+  group: "Space weather",
+  color: "#16a34a",
+  refreshMs: 15 * 60 * 1000,
+  attribution: SWPC_ATTRIBUTION,
+  async fetch() {
+    try {
+      const [kpRes, scRes] = await Promise.all([
+        fetch(KP_URL, { signal: AbortSignal.timeout(15_000) }),
+        fetch(SCALES_URL, { signal: AbortSignal.timeout(15_000) }),
+      ]);
+      if (!kpRes.ok) return [];
+      const kp = (await kpRes.json()) as KpRow[];
+      const scales = scRes.ok ? ((await scRes.json()) as Record<string, ScaleBlock>) : {};
+      return normalizeSpaceWeather({ kp: Array.isArray(kp) ? kp : [], scales0: scales["0"] });
+    } catch {
+      return [];
+    }
+  },
+};

--- a/tests/fixtures/ioda-outages.json
+++ b/tests/fixtures/ioda-outages.json
@@ -1,0 +1,64 @@
+{
+  "data": [
+    {
+      "scores": {
+        "ping-slash24.median": 377786.48936170223,
+        "overall": 377786.48936170223
+      },
+      "event_cnt": 1,
+      "entity": {
+        "code": "BZ",
+        "name": "Belize",
+        "subnames": [],
+        "type": "country",
+        "attrs": {
+          "fqid": "geo.netacuity.NA.BZ"
+        }
+      }
+    },
+    {
+      "scores": {
+        "ping-slash24.median": 5119.402985074627,
+        "overall": 5119.402985074627
+      },
+      "event_cnt": 1,
+      "entity": {
+        "code": "GI",
+        "name": "Gibraltar",
+        "subnames": [],
+        "type": "country",
+        "attrs": {
+          "fqid": "geo.netacuity.EU.GI"
+        }
+      }
+    },
+    {
+      "scores": {
+        "ping-slash24.median": 1500,
+        "overall": 1500
+      },
+      "event_cnt": 1,
+      "entity": {
+        "code": "LR",
+        "name": "Liberia",
+        "subnames": [],
+        "type": "country",
+        "attrs": {
+          "fqid": "geo.netacuity.AF.LR"
+        }
+      }
+    },
+    {
+      "scores": {
+        "overall": 0
+      },
+      "event_cnt": 0,
+      "entity": {
+        "code": "ZZ",
+        "name": "Nowhere",
+        "type": "country",
+        "attrs": {}
+      }
+    }
+  ]
+}

--- a/tests/fixtures/space-weather.json
+++ b/tests/fixtures/space-weather.json
@@ -1,0 +1,41 @@
+{
+  "kp": [
+    {
+      "time_tag": "2026-06-27T00:00:00",
+      "Kp": 2.67,
+      "a_running": 12,
+      "station_count": 8
+    },
+    {
+      "time_tag": "2026-06-27T03:00:00",
+      "Kp": 2.0,
+      "a_running": 7,
+      "station_count": 8
+    },
+    {
+      "time_tag": "2026-06-27T06:00:00",
+      "Kp": 2.0,
+      "a_running": 7,
+      "station_count": 8
+    }
+  ],
+  "scales0": {
+    "DateStamp": "2026-06-27",
+    "TimeStamp": "09:30:00",
+    "R": {
+      "Scale": "0",
+      "Text": "none",
+      "MinorProb": null,
+      "MajorProb": null
+    },
+    "S": {
+      "Scale": "0",
+      "Text": "none",
+      "Prob": null
+    },
+    "G": {
+      "Scale": "0",
+      "Text": "none"
+    }
+  }
+}

--- a/tests/unit/signals-internet-outages.test.ts
+++ b/tests/unit/signals-internet-outages.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+// Live-captured IODA country-summary rows + one unknown-country edge row.
+import fixture from "@/tests/fixtures/ioda-outages.json";
+import { normalizeOutages } from "@/lib/signals/internet-outages";
+
+test("normalizes IODA outages to one marker per located country", () => {
+  const out = normalizeOutages(fixture as never);
+  // BZ, GI, LR resolve to centroids; the "ZZ" edge row has no centroid and is skipped.
+  expect(out).toHaveLength(3);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["internet-outages"]));
+  expect(out.every((f) => f.id.startsWith("ioda:"))).toBe(true);
+});
+
+test("severity bands and magnitude scale with the outage score", () => {
+  const out = normalizeOutages(fixture as never);
+  const belize = out.find((f) => f.id === "ioda:BZ")!; // score ~377k → severe
+  expect(belize.props?.severity).toBe("severe");
+  expect(belize.title).toContain("Belize");
+
+  const liberia = out.find((f) => f.id === "ioda:LR")!; // score 1500 → localised
+  expect(liberia.props?.severity).toBe("localised");
+
+  // Bigger outage → bigger marker.
+  expect(Number(belize.props?.magnitude)).toBeGreaterThan(Number(liberia.props?.magnitude));
+  expect(Number(belize.props?.magnitude)).toBeLessThanOrEqual(10);
+});

--- a/tests/unit/signals-space-weather.test.ts
+++ b/tests/unit/signals-space-weather.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+// Live-captured NOAA SWPC Kp series + current storm-scale block.
+import fixture from "@/tests/fixtures/space-weather.json";
+import { normalizeSpaceWeather, gScaleColor } from "@/lib/signals/space-weather";
+
+test("emits a single status pin from the latest Kp + current scales", () => {
+  const out = normalizeSpaceWeather(fixture as never);
+  expect(out).toHaveLength(1);
+  const f = out[0];
+  expect(f.id).toBe("swpc:status");
+  expect(f.signalId).toBe("space-weather");
+  // Latest Kp in the fixture is 2.0 → quiet, geomagnetic storm "none".
+  expect(f.props?.kp).toBe(2);
+  expect(f.props?.condition).toBe("quiet");
+  expect(f.props?.geomagneticStorm).toBe("none");
+  expect(f.color).toBe(gScaleColor(0)); // G0 → green
+  // Anchored near the north geomagnetic pole.
+  expect(f.lat).toBeGreaterThan(75);
+});
+
+test("empty Kp series yields no feature; G-scale colours escalate", () => {
+  expect(normalizeSpaceWeather({ kp: [], scales0: undefined })).toHaveLength(0);
+  expect(gScaleColor(0)).toBe("#16a34a");
+  expect(gScaleColor(3)).toBe("#ea580c");
+  expect(gScaleColor(5)).toBe("#7f1d1d");
+});
+
+test("storm conditions raise the Kp label and marker magnitude", () => {
+  const out = normalizeSpaceWeather({
+    kp: [{ time_tag: "t", Kp: 7.33 }],
+    scales0: { G: { Scale: "3" }, R: { Scale: "1" }, S: { Scale: "0" } },
+  });
+  const f = out[0];
+  expect(f.props?.condition).toBe("severe storm");
+  expect(f.props?.geomagneticStorm).toBe("G3");
+  expect(f.props?.radioBlackout).toBe("R1");
+  expect(f.color).toBe(gScaleColor(3));
+  expect(Number(f.props?.magnitude)).toBeGreaterThan(7);
+});


### PR DESCRIPTION
## Two keyless intel layers

### 🌐 Internet outages — IODA (CAIDA / Georgia Tech)
National-scale connectivity drops detected from three independent vantage points (active probing · BGP · network telescope). Country-level internet shutdowns are a **top-tier instability signal** — governments cut connectivity during coups, contested elections and crackdowns.

- Country-aggregated: one marker per affected country at its centroid, sized by outage severity, banded **localised / elevated / severe**.
- Group **Infrastructure**. Colour: censorship red `#b91c1c`.

### ☀️ Space weather — NOAA SWPC
Planetary **K-index** (0–9) + the current NOAA storm scales: **G** (geomagnetic), **R** (radio blackout), **S** (solar radiation). High activity degrades GPS, HF radio and power grids and pushes the aurora to lower latitudes.

- Single status pin at the north geomagnetic pole, sized by Kp, coloured by G-scale (quiet green → extreme red).
- Group **Space weather** (beside the aurora oval).

### Verification
- Pure normalisers unit-tested against **live-captured** fixtures (IODA: 3 located countries + 1 unknown-code edge row; SWPC: real Kp series + scale block, plus empty-series and storm-condition cases).
- `tsc` clean · vitest **306/306** · `next build` green.
- Both **keyless** — live immediately, no dormancy.

> Stacked on #17 (AIS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)