### PR TITLE
Air quality — real OpenAQ stations (PM2.5, key-gated, live)

### DIFF
--- a/lib/signals/airquality-stations.ts
+++ b/lib/signals/airquality-stations.ts
@@ -1,0 +1,95 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// Air quality — real station measurements (OpenAQ v3). This is the measured
+// counterpart to the modelled CAMS/Open-Meteo air-quality layer: actual PM2.5
+// readings from ~25k reference + low-cost monitors worldwide. We pull the global
+// "latest PM2.5" snapshot (one capped page) and plot each station coloured by the
+// US-EPA PM2.5 band. Key-gated on OPENAQ_API_KEY (free); dormant (→ []) until set.
+//
+// Real-world data hygiene: OpenAQ passes through raw sensor values, which include
+// error sentinels (-1, -9999) and zeros — the normaliser rejects anything ≤ 0 or
+// implausibly high so the map never shows a phantom "clean" or broken station.
+
+const PM25_LATEST_URL = "https://api.openaq.org/v3/parameters/2/latest?limit=1000";
+
+/** Page cap — OpenAQ reports ~25k PM2.5 stations; we plot a global sample of this many. */
+export const OPENAQ_CAP = 1000;
+const MAX_PLAUSIBLE_PM25 = 2000; // µg/m³ — above this is a sensor fault, not air
+
+export const OPENAQ_ATTRIBUTION = "Air-quality measurements © OpenAQ contributors";
+
+interface AqLatest {
+  datetime?: { utc?: string };
+  value?: number;
+  coordinates?: { latitude?: number | null; longitude?: number | null };
+  sensorsId?: number;
+  locationsId?: number;
+}
+
+/** US-EPA PM2.5 band → {label, colour}. */
+export function pm25Band(v: number): { label: string; color: string } {
+  if (v <= 12) return { label: "good", color: "#16a34a" };
+  if (v <= 35.4) return { label: "moderate", color: "#eab308" };
+  if (v <= 55.4) return { label: "unhealthy (sensitive)", color: "#f59e0b" };
+  if (v <= 150.4) return { label: "unhealthy", color: "#dc2626" };
+  if (v <= 250.4) return { label: "very unhealthy", color: "#7e22ce" };
+  return { label: "hazardous", color: "#7f1d1d" };
+}
+
+/** Pure: OpenAQ latest-PM2.5 payload → SignalFeature[], dropping invalid/error readings. */
+export function normalizeAirStations(json: { results?: AqLatest[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const r of json.results ?? []) {
+    const lat = r.coordinates?.latitude;
+    const lon = r.coordinates?.longitude;
+    if (typeof lat !== "number" || typeof lon !== "number") continue;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const v = r.value;
+    if (typeof v !== "number" || !Number.isFinite(v) || v <= 0 || v > MAX_PLAUSIBLE_PM25) continue; // error sentinels
+    if (!r.locationsId) continue;
+    const band = pm25Band(v);
+    out.push({
+      id: `openaq:${r.locationsId}:${r.sensorsId ?? "x"}`,
+      lat,
+      lon,
+      title: `PM2.5 ${v.toFixed(1)} µg/m³ — ${band.label}`,
+      signalId: "air-quality-stations",
+      color: band.color,
+      ts: r.datetime?.utc,
+      props: {
+        pm25: `${v.toFixed(1)} µg/m³`,
+        airQuality: band.label,
+        station: `#${r.locationsId}`,
+        measured: r.datetime?.utc ?? "—",
+        // Worse air → bigger marker (PM2.5 150 ≈ max radius).
+        magnitude: Math.min(10, Math.max(2, v / 15)),
+      },
+    });
+  }
+  return out.slice(0, OPENAQ_CAP);
+}
+
+export const AIR_QUALITY_STATIONS_SOURCE: SignalSource = {
+  id: "air-quality-stations",
+  label: "Air quality — stations (OpenAQ)",
+  group: "Environment",
+  color: "#dc2626",
+  refreshMs: 30 * 60 * 1000,
+  attribution: OPENAQ_ATTRIBUTION,
+  async fetch() {
+    const key = (process.env.OPENAQ_API_KEY ?? "").trim();
+    if (!key) return []; // dormant until the free key is set
+    try {
+      const res = await fetch(PM25_LATEST_URL, {
+        headers: { "X-API-Key": key, Accept: "application/json" },
+        signal: AbortSignal.timeout(20_000),
+      });
+      if (!res.ok) return [];
+      const json = (await res.json()) as { results?: AqLatest[] };
+      return normalizeAirStations(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -61,6 +61,7 @@ import { AIS_SOURCE } from "@/lib/signals/ais";
 import { INTERNET_OUTAGES_SOURCE } from "@/lib/signals/internet-outages";
 import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
 import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
+import { AIR_QUALITY_STATIONS_SOURCE } from "@/lib/signals/airquality-stations";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -94,6 +95,7 @@ export const SIGNALS: SignalSource[] = [
   // Environment & civic (keyless Open-Meteo + data.police.uk)
   WEATHER_SOURCE,
   AIR_QUALITY_SOURCE,
+  AIR_QUALITY_STATIONS_SOURCE, // real OpenAQ station PM2.5 (key-gated: OPENAQ_API_KEY)
   UK_CRIME_SOURCE,
   // Cyber threat (keyless abuse.ch + Ransomware.live, country-aggregated)
   CYBER_C2_SOURCE,

--- a/tests/fixtures/openaq-pm25.json
+++ b/tests/fixtures/openaq-pm25.json
@@ -1,0 +1,119 @@
+{
+  "results": [
+    {
+      "datetime": {
+        "utc": "2024-05-27T02:00:00Z",
+        "local": "2024-05-27T12:00:00+10:00"
+      },
+      "value": -9999.0,
+      "coordinates": {
+        "latitude": -27.090836,
+        "longitude": 150.400418
+      },
+      "sensorsId": 9381416,
+      "locationsId": 2868409
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T08:00:00Z",
+        "local": "2026-06-27T11:00:00+03:00"
+      },
+      "value": -1.0,
+      "coordinates": {
+        "latitude": 54.88361359025449,
+        "longitude": 23.83583450024486
+      },
+      "sensorsId": 23735,
+      "locationsId": 8152
+    },
+    {
+      "datetime": {
+        "utc": "2025-01-13T23:00:00Z",
+        "local": "2025-01-14T06:00:00+07:00"
+      },
+      "value": 0.0,
+      "coordinates": {
+        "latitude": 15.257387898044886,
+        "longitude": 104.03668778711167
+      },
+      "sensorsId": 9959326,
+      "locationsId": 2953982
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T08:30:00Z",
+        "local": "2026-06-27T14:00:00+05:30"
+      },
+      "value": 41.0,
+      "coordinates": {
+        "latitude": 28.885279999999998,
+        "longitude": 78.7388
+      },
+      "sensorsId": 12241402,
+      "locationsId": 270697
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T09:00:00Z",
+        "local": "2026-06-27T21:00:00+12:00"
+      },
+      "value": 69.7,
+      "coordinates": {
+        "latitude": -43.5599449,
+        "longitude": 172.6436133
+      },
+      "sensorsId": 9384695,
+      "locationsId": 2868842
+    },
+    {
+      "datetime": {
+        "utc": "2022-10-31T01:45:00Z",
+        "local": "2022-10-31T07:15:00+05:30"
+      },
+      "value": 86.11,
+      "coordinates": {
+        "latitude": 14.675885999999998,
+        "longitude": 77.593027
+      },
+      "sensorsId": 2028432,
+      "locationsId": 358456
+    },
+    {
+      "datetime": {
+        "utc": "2022-10-31T01:45:00Z",
+        "local": "2022-10-31T07:15:00+05:30"
+      },
+      "value": 154.81,
+      "coordinates": {
+        "latitude": 29.966942,
+        "longitude": 76.875879
+      },
+      "sensorsId": 20961,
+      "locationsId": 7282
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T09:00:00Z"
+      },
+      "value": 18.0,
+      "coordinates": {
+        "latitude": null,
+        "longitude": null
+      },
+      "sensorsId": 1,
+      "locationsId": 1
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T09:00:00Z"
+      },
+      "value": -999.0,
+      "coordinates": {
+        "latitude": 51.5,
+        "longitude": -0.1
+      },
+      "sensorsId": 2,
+      "locationsId": 2
+    }
+  ]
+}

--- a/tests/unit/signals-airquality-stations.test.ts
+++ b/tests/unit/signals-airquality-stations.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+// Live-captured OpenAQ PM2.5 readings, including real sensor-error rows (-1, -9999, 0)
+// and synthetic null-coord / negative-value edge rows.
+import fixture from "@/tests/fixtures/openaq-pm25.json";
+import { normalizeAirStations, pm25Band } from "@/lib/signals/airquality-stations";
+
+test("plots valid PM2.5 stations and rejects error sentinels", () => {
+  const out = normalizeAirStations(fixture as never);
+  // Only rows with a real positive value AND valid coordinates survive.
+  expect(out.length).toBeGreaterThan(0);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["air-quality-stations"]));
+  // No zero/negative/sentinel readings leak through.
+  for (const f of out) {
+    const v = parseFloat(String(f.props?.pm25));
+    expect(v).toBeGreaterThan(0);
+    expect(v).toBeLessThanOrEqual(2000);
+    expect(f.lat).toBeGreaterThanOrEqual(-90);
+    expect(f.lat).toBeLessThanOrEqual(90);
+  }
+  // The null-coord row and the -999 row are dropped.
+  expect(out.every((f) => Number.isFinite(f.lat) && Number.isFinite(f.lon))).toBe(true);
+});
+
+test("PM2.5 bands map to the EPA colour ramp", () => {
+  expect(pm25Band(8)).toEqual({ label: "good", color: "#16a34a" });
+  expect(pm25Band(25)).toEqual({ label: "moderate", color: "#eab308" });
+  expect(pm25Band(45)).toEqual({ label: "unhealthy (sensitive)", color: "#f59e0b" });
+  expect(pm25Band(100)).toEqual({ label: "unhealthy", color: "#dc2626" });
+  expect(pm25Band(200)).toEqual({ label: "very unhealthy", color: "#7e22ce" });
+  expect(pm25Band(400)).toEqual({ label: "hazardous", color: "#7f1d1d" });
+});
+
+test("worse air gives a bigger marker", () => {
+  const out = normalizeAirStations(fixture as never);
+  const sorted = [...out].sort(
+    (a, b) => parseFloat(String(a.props?.pm25)) - parseFloat(String(b.props?.pm25)),
+  );
+  if (sorted.length >= 2) {
+    const lo = Number(sorted[0].props?.magnitude);
+    const hi = Number(sorted[sorted.length - 1].props?.magnitude);
+    expect(hi).toBeGreaterThanOrEqual(lo);
+  }
+});


### PR DESCRIPTION
## Measured air quality — OpenAQ stations

The measured counterpart to the modelled (CAMS/Open-Meteo) air-quality layer: **actual PM2.5 readings** from OpenAQ's worldwide monitor network (the live endpoint reports **25,852** stations).

- Pulls the global *latest PM2.5* snapshot (one capped 1000-station page) and plots each station coloured by the **US-EPA PM2.5 band** (good → hazardous), sized by concentration.
- Group **Environment**, beside the modelled layer.

### Real-world data hygiene
OpenAQ passes raw sensor values through — including error sentinels (`-1`, `-9999`) and zeros. The pure normaliser rejects anything `≤ 0`, non-finite, out-of-range coordinates, or implausibly high (`> 2000 µg/m³`), so the map never shows a phantom "clean" or broken station. The fixture deliberately includes those **real captured error rows** so the test proves they're dropped.

### Keys & verification
Key-gated on `OPENAQ_API_KEY` (free) — already wired in gitignored `.env.local`, so it's **live locally**; dormant (→ `[]`) elsewhere until set. `tsc` clean · vitest **315/315** · `next build` green.

> Stacked on #19 (Country Instability Index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)