### PR TITLE
Tropical cyclones — NOAA NHC active storms (keyless)

### DIFF
--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -62,6 +62,7 @@ import { INTERNET_OUTAGES_SOURCE } from "@/lib/signals/internet-outages";
 import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
 import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
 import { AIR_QUALITY_STATIONS_SOURCE } from "@/lib/signals/airquality-stations";
+import { TROPICAL_CYCLONES_SOURCE } from "@/lib/signals/tropical-cyclones";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -74,6 +75,7 @@ export const SIGNALS: SignalSource[] = [
   SEVERE_STORMS_SOURCE,
   FLOODS_SOURCE,
   GDACS_SOURCE, // multi-hazard GDACS alerts (EQ/TC/FL/VO/DR/WF), alert-coloured
+  TROPICAL_CYCLONES_SOURCE, // NOAA NHC active named storms (keyless; empty in quiet season)
   FIRE_FIRMS_SOURCE, // NASA FIRMS active-fire detections (key-gated: FIRMS_MAP_KEY)
   EMSC_SOURCE, // EMSC quakes — a 2nd, faster Euro-Med catalogue alongside USGS
   AURORA_SOURCE,

--- a/lib/signals/tropical-cyclones.ts
+++ b/lib/signals/tropical-cyclones.ts
@@ -1,0 +1,126 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// Tropical cyclones — NOAA NHC active-storms feed (keyless). Named tropical
+// systems (depressions → major hurricanes) with live position, intensity and
+// motion. The feed is `{ activeStorms: [] }` when nothing is active (quiet
+// season), so the layer renders empty and lights up automatically the moment a
+// storm forms — no dead feed, no stale dot. Each storm is plotted at its current
+// centre, coloured by Saffir–Simpson category and sized by max wind.
+//
+// NOTE: the NHC forecast CONE/track are GIS shapefiles, not in this JSON; v1
+// plots the storm centre only. Dormant-safe (→ [] on any failure).
+
+const ENDPOINT = "https://www.nhc.noaa.gov/CurrentStorms.json";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const NHC_ATTRIBUTION = "Tropical-cyclone data © NOAA NHC";
+
+interface NhcStorm {
+  id?: string;
+  name?: string;
+  classification?: string; // TD, TS, HU, MH, STD, STS, …
+  intensity?: string | number; // max sustained wind, kt
+  pressure?: string | number; // mb
+  latitude?: string; // "22.5N"
+  longitude?: string; // "95.3W"
+  latitudeNumeric?: number;
+  longitudeNumeric?: number;
+  movementDir?: number | string;
+  movementSpeed?: number | string;
+  lastUpdate?: string;
+}
+
+function toNum(v: unknown): number {
+  if (typeof v === "number") return Number.isFinite(v) ? v : Number.NaN;
+  const s = (v ?? "").toString().trim();
+  if (s === "") return Number.NaN;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : Number.NaN;
+}
+
+/** Parse "22.5N" / "95.3W" → signed decimal degrees. */
+function parseCoord(s: string | undefined): number {
+  if (!s) return Number.NaN;
+  const m = s.trim().match(/^([\d.]+)\s*([NSEW])$/i);
+  if (!m) return Number.NaN;
+  const v = Number(m[1]);
+  if (!Number.isFinite(v)) return Number.NaN;
+  const hemi = m[2].toUpperCase();
+  return hemi === "S" || hemi === "W" ? -v : v;
+}
+
+/** Classification + max-wind (kt) → {label, colour} on the Saffir–Simpson scale. */
+export function cycloneCategory(classification: string, windKt: number): { label: string; color: string } {
+  const c = (classification || "").toUpperCase();
+  if (c.includes("HU") || c.includes("MH") || windKt >= 64) {
+    if (windKt >= 137) return { label: "Cat 5 hurricane", color: "#581c87" };
+    if (windKt >= 113) return { label: "Cat 4 hurricane", color: "#7f1d1d" };
+    if (windKt >= 96) return { label: "Cat 3 hurricane", color: "#b91c1c" };
+    if (windKt >= 83) return { label: "Cat 2 hurricane", color: "#dc2626" };
+    return { label: "Cat 1 hurricane", color: "#ea580c" };
+  }
+  if (c.includes("TS") || windKt >= 34) return { label: "tropical storm", color: "#f59e0b" };
+  return { label: "tropical depression", color: "#eab308" };
+}
+
+/** Pure: NHC active-storms payload → SignalFeature[] (one point per storm). */
+export function normalizeCyclones(json: { activeStorms?: NhcStorm[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const s of json.activeStorms ?? []) {
+    let lat = typeof s.latitudeNumeric === "number" ? s.latitudeNumeric : parseCoord(s.latitude);
+    let lon = typeof s.longitudeNumeric === "number" ? s.longitudeNumeric : parseCoord(s.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    lat = Math.round(lat * 1000) / 1000;
+    lon = Math.round(lon * 1000) / 1000;
+    const wind = Math.max(0, toNum(s.intensity) || 0);
+    const cat = cycloneCategory(s.classification ?? "", wind);
+    const name = s.name?.trim() || s.id?.trim() || "Tropical system";
+    const dir = toNum(s.movementDir);
+    const spd = toNum(s.movementSpeed);
+    const pressure = toNum(s.pressure);
+    out.push({
+      id: `cyclone:${s.id?.trim() || name}`,
+      lat,
+      lon,
+      title: `${name} — ${cat.label}`,
+      signalId: "tropical-cyclones",
+      color: cat.color,
+      ts: s.lastUpdate ?? undefined,
+      props: {
+        storm: name,
+        category: cat.label,
+        maxWind: wind > 0 ? `${wind} kt` : "—",
+        pressure: Number.isFinite(pressure) ? `${pressure} mb` : "—",
+        movement:
+          Number.isFinite(dir) && Number.isFinite(spd) ? `${dir}° at ${spd} kt` : "—",
+        updated: s.lastUpdate ?? "—",
+        // Wind 137 kt (Cat 5) ≈ max radius.
+        magnitude: Math.min(10, Math.max(3, wind / 15)),
+      },
+    });
+  }
+  return out;
+}
+
+export const TROPICAL_CYCLONES_SOURCE: SignalSource = {
+  id: "tropical-cyclones",
+  label: "Tropical cyclones (NHC)",
+  group: "Natural hazards",
+  color: "#dc2626",
+  refreshMs: 30 * 60 * 1000,
+  attribution: NHC_ATTRIBUTION,
+  async fetch() {
+    try {
+      const res = await fetch(ENDPOINT, {
+        headers: { "User-Agent": UA, Accept: "application/json" },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) return [];
+      const json = (await res.json()) as { activeStorms?: NhcStorm[] };
+      return normalizeCyclones(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/tests/fixtures/nhc-storms.json
+++ b/tests/fixtures/nhc-storms.json
@@ -1,0 +1,49 @@
+{
+  "activeStorms": [
+    {
+      "id": "al012026",
+      "binNumber": "AT1",
+      "name": "Alberto",
+      "classification": "HU",
+      "intensity": "120",
+      "pressure": "947",
+      "latitude": "24.6N",
+      "longitude": "84.3W",
+      "latitudeNumeric": 24.6,
+      "longitudeNumeric": -84.3,
+      "movementDir": 315,
+      "movementSpeed": 12,
+      "lastUpdate": "2026-06-27T09:00:00.000Z"
+    },
+    {
+      "id": "ep032026",
+      "binNumber": "EP3",
+      "name": "Carlotta",
+      "classification": "TS",
+      "intensity": "50",
+      "pressure": "994",
+      "latitude": "14.2N",
+      "longitude": "108.7W",
+      "latitudeNumeric": 14.2,
+      "longitudeNumeric": -108.7,
+      "movementDir": 285,
+      "movementSpeed": 9,
+      "lastUpdate": "2026-06-27T09:00:00.000Z"
+    },
+    {
+      "id": "wp052026",
+      "name": "Unnamed depression (string coords only)",
+      "classification": "TD",
+      "intensity": "25",
+      "pressure": "1004",
+      "latitude": "18.0N",
+      "longitude": "135.0E"
+    },
+    {
+      "id": "bad000",
+      "name": "Bad coords",
+      "classification": "TS",
+      "intensity": "40"
+    }
+  ]
+}

--- a/tests/unit/signals-tropical-cyclones.test.ts
+++ b/tests/unit/signals-tropical-cyclones.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+// Schema-based fixture (no live storm to capture in the quiet season). Field shapes
+// mirror a real NHC CurrentStorms.json active-storm record.
+import fixture from "@/tests/fixtures/nhc-storms.json";
+import { normalizeCyclones, cycloneCategory } from "@/lib/signals/tropical-cyclones";
+
+test("normalizes active storms, skipping records with no usable position", () => {
+  const out = normalizeCyclones(fixture as never);
+  // Alberto (numeric), Carlotta (numeric), depression (string coords) = 3; "bad000" (no coords) skipped.
+  expect(out).toHaveLength(3);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["tropical-cyclones"]));
+
+  const alberto = out.find((f) => f.id === "cyclone:al012026")!;
+  expect(alberto.title).toContain("Alberto");
+  expect(alberto.props?.category).toBe("Cat 4 hurricane"); // 120 kt
+  expect(alberto.color).toBe("#7f1d1d");
+  expect(alberto.props?.maxWind).toBe("120 kt");
+  expect(alberto.props?.pressure).toBe("947 mb");
+  expect(alberto.lat).toBeCloseTo(24.6);
+  expect(alberto.lon).toBeCloseTo(-84.3);
+});
+
+test("parses string hemisphere coordinates when numeric fields are absent", () => {
+  const out = normalizeCyclones(fixture as never);
+  const dep = out.find((f) => f.id === "cyclone:wp052026")!;
+  expect(dep.lat).toBeCloseTo(18.0);
+  expect(dep.lon).toBeCloseTo(135.0); // 135.0E → positive
+  expect(dep.props?.category).toBe("tropical depression");
+});
+
+test("Saffir–Simpson category mapping by wind/classification", () => {
+  expect(cycloneCategory("HU", 140).label).toBe("Cat 5 hurricane");
+  expect(cycloneCategory("HU", 120).label).toBe("Cat 4 hurricane");
+  expect(cycloneCategory("HU", 100).label).toBe("Cat 3 hurricane");
+  expect(cycloneCategory("HU", 85).label).toBe("Cat 2 hurricane");
+  expect(cycloneCategory("HU", 70).label).toBe("Cat 1 hurricane");
+  expect(cycloneCategory("TS", 50).label).toBe("tropical storm");
+  expect(cycloneCategory("TD", 25).label).toBe("tropical depression");
+  // Classification missing but wind high → still classified by wind.
+  expect(cycloneCategory("", 100).label).toBe("Cat 3 hurricane");
+});


### PR DESCRIPTION
## Tropical cyclones — NOAA National Hurricane Center

Named tropical systems (depressions → major hurricanes) from NHC's active-storms feed, plotted at each storm's current centre, **coloured by Saffir–Simpson category** and sized by max wind. Parses both numeric and `24.6N`/`84.3W` string coordinates.

### No dead feed
The feed is `{ "activeStorms": [] }` when nothing is active — so the layer renders **empty in the quiet season** (verified live: it's empty right now) and lights up automatically the moment a storm forms. No stale dot, no phantom storm — the product's core promise.

Forecast cone/track are NHC GIS shapefiles (not in this JSON); v1 plots the storm centre.

### Verification
Pure normaliser unit-tested against a **schema-based** fixture (Cat-4 hurricane · tropical storm · string-coord depression · a no-coords skip) — none active to capture live. `tsc` clean · vitest **318/318** · `next build` green. Group **Natural hazards**.

> Stacked on #20 (OpenAQ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)