### PR TITLE
Trust/freshness spine for every global signal layer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -197,6 +197,8 @@ a { color: var(--tn-accent); }
 .tn-fresh-lagging { color: var(--tn-lagging); } .tn-fresh-lagging .tn-fresh-dot { background: var(--tn-lagging); }
 .tn-fresh-stale { color: var(--tn-stale); } .tn-fresh-stale .tn-fresh-dot { background: var(--tn-stale); }
 .tn-fresh-down { color: var(--tn-down); } .tn-fresh-down .tn-fresh-dot { background: var(--tn-down); }
+/* empty = fetched OK but nothing to show right now (e.g. no active storms): a calm, dimmed-live dot, not an error. */
+.tn-fresh-empty { color: var(--tn-text-faint); } .tn-fresh-empty .tn-fresh-dot { background: var(--tn-live); opacity: 0.45; }
 
 .tn-toggle { position: relative; width: 36px; height: 20px; border: none; border-radius: 10px; cursor: pointer; padding: 0; transition: background 0.2s ease; flex-shrink: 0; }
 .tn-toggle-knob { position: absolute; top: 2px; width: 16px; height: 16px; background: #fff; border-radius: 50%; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25); transition: left 0.2s cubic-bezier(0.4, 0, 0.2, 1); }

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -31,6 +31,7 @@ import { loadCameraIcons, loadPlaneIcons, loadSatelliteIcons, loadWebcamIcons } 
 import { CAMERA_CLUSTER, WEBCAM_CLUSTER, expandCluster } from "@/lib/map/cluster";
 import { SIGNALS } from "@/lib/signals/registry";
 import { useSignals, signalCountsStore } from "@/lib/signals/store";
+import { signalFreshnessStore } from "@/lib/signals/freshness";
 import type { SignalFeature, SignalSource } from "@/lib/signals/types";
 import { useTimeWindow, windowMsFor, withinWindow } from "@/lib/shell/timeWindow";
 import { useNow } from "@/lib/shell/useNow";
@@ -1019,11 +1020,13 @@ function SignalFeed({
           }));
           onData(id, objs);
           signalCountsStore.set(id, objs.length);
+          signalFreshnessStore.record(id, { ok: true, count: objs.length });
         })
         .catch(() => {
           if (!alive) return;
           onData(id, []);
           signalCountsStore.set(id, 0);
+          signalFreshnessStore.record(id, { ok: false, count: 0 });
         });
     };
     load();
@@ -1034,6 +1037,7 @@ function SignalFeed({
       clearInterval(t);
       onData(id, []);
       signalCountsStore.set(id, null);
+      signalFreshnessStore.clear(id);
     };
   }, [id, source, onData]);
   return null;

--- a/components/shell/LayerRail.tsx
+++ b/components/shell/LayerRail.tsx
@@ -19,6 +19,12 @@ import {
 } from "@/lib/layers";
 import { SIGNALS, signalsByGroup } from "@/lib/signals/registry";
 import { signalsStore, useSignals, useSignalCounts } from "@/lib/signals/store";
+import {
+  useSignalFreshness,
+  classifySignalFreshness,
+  signalFreshAgeMs,
+  signalFreshLabel,
+} from "@/lib/signals/freshness";
 import { useMetrics } from "@/lib/metrics";
 import { useFreshness, classifyFreshness, freshnessAgeMs, type FreshSourceId } from "@/lib/freshness";
 import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
@@ -185,7 +191,27 @@ function LayerRow({
   );
 }
 
-// One global-signal layer: dot + label + attribution + live count + toggle.
+// Per-signal freshness chip — honest "is this layer actually live?" beside each
+// ON signal layer, reading the trust spine (lib/signals/freshness). Only shown
+// when the layer is on (a SignalFeed must be mounted to have a record).
+function SignalFreshNote({ id, refreshMs }: { id: string; refreshMs: number }) {
+  const records = useSignalFreshness();
+  const now = useNow(1000);
+  const raw = records[id];
+  if (!raw) return null; // not mounted / no fetch yet
+  const rec = { ...raw, refreshMs };
+  const state = classifySignalFreshness(rec, now);
+  const age = signalFreshAgeMs(rec, now);
+  const text = signalFreshLabel(state, age == null ? "" : formatAge(age));
+  return (
+    <span className={`tn-fresh tn-fresh-${state}`}>
+      <span className="tn-fresh-dot" aria-hidden />
+      {text}
+    </span>
+  );
+}
+
+// One global-signal layer: dot + label + attribution + freshness + live count + toggle.
 // Mirrors LayerRow but reads the SEPARATE signals store (default off, opt-in).
 function SignalRow({ id }: { id: string }) {
   const source = SIGNALS.find((s) => s.id === id)!;
@@ -202,6 +228,7 @@ function SignalRow({ id }: { id: string }) {
         <div className="tn-layer-main">
           <span className="tn-layer-name">{source.label}</span>
           <span className="tn-layer-source">{source.attribution}</span>
+          {on ? <SignalFreshNote id={id} refreshMs={source.refreshMs} /> : null}
         </div>
       </div>
       <span className="tn-layer-count tn-num">{countLabel}</span>
@@ -251,8 +278,9 @@ function GlobalSignals() {
             </div>
           ))}
           <p className="tn-rail-foot">
-            Opt-in natural-hazard &amp; space-weather layers. Fetched only while on; every feed is
-            keyless, live and attributed.
+            Opt-in intelligence layers — hazards, conflict, cyber, maritime, human cost &amp; the
+            Country Instability Index. Fetched only while on; most are keyless, a few unlock with a
+            free key. Each is attributed and shows its own live freshness.
           </p>
         </div>
       )}

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -13,6 +13,26 @@ registration or an email request. Until a key is set, its layer stays **dormant*
 
 ---
 
+## 0 · Status — what's live now
+
+Keys you've already given me are wired in `.env.local` and **live locally**:
+
+| Key | Layer it powers | State |
+|-----|-----------------|-------|
+| `AISSTREAM_API_KEY` | **Ships (AIS chokepoints)** — real-time vessels at Hormuz/Suez/Malacca/… | ✅ live |
+| `OPENAQ_API_KEY` | **Air quality — stations** — real PM2.5 from ~25.8k OpenAQ monitors | ✅ live |
+| `FIRMS_MAP_KEY` | **Active fires** — NASA VIIRS thermal detections | ✅ live |
+| `ACLED_EMAIL` + `ACLED_PASSWORD` | **Conflict events** + the conflict factor of the Index | ⏳ dormant — login works but the account's **API read access isn't activated yet** (returns 403). Activate it on myACLED and it goes live with no code change. |
+
+**Keyless layers added this session — already live, no key needed:** Internet
+outages (IODA), Space weather (NOAA SWPC), Tropical cyclones (NHC), and the
+flagship **Country Instability Index** (composited from food/displacement/outages,
+verified live across 170 countries). The Index currently caps ~49/100 because the
+conflict factor (ACLED) is dormant — activating ACLED opens it to the full range.
+Every layer now shows a live **freshness dot** in the rail (the trust spine).
+
+---
+
 ## 1 · Intelligence layers — get these (all free)
 
 | # | Source | Unlocks | Free tier | Env var(s) |

--- a/lib/signals/freshness.ts
+++ b/lib/signals/freshness.ts
@@ -1,0 +1,88 @@
+"use client";
+// Per-SIGNAL-layer freshness — the trust spine for the opt-in global feeds.
+//
+// lib/freshness.ts covers the four core layers (cameras/planes/satellites/webcams);
+// its own note calls a per-adapter monitor "the documented next step". This is that
+// step for the signals registry: each <SignalFeed> records the age + outcome of its
+// last fetch here, keyed by the (dynamic) registry source id, and the rail shows an
+// honest dot beside every signal layer. The classifier is pure and unit-tested.
+//
+// The honest "empty" state matters: a feed that fetched successfully but returned
+// nothing (NHC cyclones in the quiet season, no active military flights) is NOT
+// stale or broken — it's "live · none right now". Saying so is the whole point of
+// a no-dead-feeds product.
+
+import { useSyncExternalStore } from "react";
+
+export type SignalFreshState = "unknown" | "live" | "empty" | "lagging" | "stale" | "down";
+
+export interface SignalFreshRecord {
+  /** Epoch ms of the last completed fetch (success or failure), or null before the first. */
+  lastUpdate: number | null;
+  /** Did the last fetch succeed (HTTP ok, no throw)? */
+  ok: boolean;
+  /** Feature count from the last successful fetch. */
+  count: number;
+  /** The source's expected cadence; live/lagging/stale thresholds are multiples of it. */
+  refreshMs: number;
+}
+
+/** Pure age (ms) since the last fetch, or null if never fetched. */
+export function signalFreshAgeMs(r: SignalFreshRecord, now: number): number | null {
+  return r.lastUpdate == null ? null : Math.max(0, now - r.lastUpdate);
+}
+
+/** Pure classifier — unit tested. Empty (fetched-OK-but-zero) is a first-class, honest state. */
+export function classifySignalFreshness(r: SignalFreshRecord, now: number): SignalFreshState {
+  if (!r.ok) return "down";
+  if (r.lastUpdate == null) return "unknown";
+  const age = Math.max(0, now - r.lastUpdate);
+  if (age >= r.refreshMs * 6) return "stale";
+  if (r.count <= 0) return "empty"; // connected, nothing to show right now
+  if (age >= r.refreshMs * 2) return "lagging";
+  return "live";
+}
+
+/** Pure short label for a freshness state, given the age text. */
+export function signalFreshLabel(state: SignalFreshState, ageText: string): string {
+  switch (state) {
+    case "unknown": return "connecting…";
+    case "down": return "unavailable";
+    case "empty": return "live · none right now";
+    case "stale": return `stale · ${ageText} old`;
+    case "lagging": return `updated ${ageText} ago`;
+    case "live": return `updated ${ageText} ago`;
+  }
+}
+
+// --- store (keyed by dynamic signal id; mirrors signalCountsStore) ----------
+
+let records: Record<string, { lastUpdate: number; ok: boolean; count: number }> = {};
+const listeners = new Set<() => void>();
+
+export const signalFreshnessStore = {
+  record(id: string, update: { ok: boolean; count: number }, at: number = Date.now()) {
+    records = { ...records, [id]: { lastUpdate: at, ok: update.ok, count: update.count } };
+    for (const l of listeners) l();
+  },
+  clear(id: string) {
+    if (!(id in records)) return;
+    const next = { ...records };
+    delete next[id];
+    records = next;
+    for (const l of listeners) l();
+  },
+  get(): Record<string, { lastUpdate: number; ok: boolean; count: number }> {
+    return records;
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export function useSignalFreshness(): Record<string, { lastUpdate: number; ok: boolean; count: number }> {
+  return useSyncExternalStore(signalFreshnessStore.subscribe, signalFreshnessStore.get, signalFreshnessStore.get);
+}

--- a/tests/unit/signals-freshness.test.ts
+++ b/tests/unit/signals-freshness.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import {
+  classifySignalFreshness,
+  signalFreshAgeMs,
+  signalFreshLabel,
+  type SignalFreshRecord,
+} from "@/lib/signals/freshness";
+
+const base = (over: Partial<SignalFreshRecord>): SignalFreshRecord => ({
+  lastUpdate: 1_000_000,
+  ok: true,
+  count: 5,
+  refreshMs: 60_000,
+  ...over,
+});
+
+test("a fresh, non-empty fetch is live", () => {
+  const r = base({ lastUpdate: 1_000_000, count: 5 });
+  expect(classifySignalFreshness(r, 1_000_000 + 30_000)).toBe("live"); // < 2× refresh
+});
+
+test("fetched OK but zero features is 'empty', not stale or broken", () => {
+  const r = base({ count: 0 });
+  expect(classifySignalFreshness(r, 1_000_000 + 1_000)).toBe("empty");
+  expect(signalFreshLabel("empty", "")).toBe("live · none right now");
+});
+
+test("ages into lagging then stale by multiples of the cadence", () => {
+  const r = base({ count: 5, refreshMs: 60_000 });
+  expect(classifySignalFreshness(r, 1_000_000 + 60_000 * 3)).toBe("lagging"); // 2×–6×
+  expect(classifySignalFreshness(r, 1_000_000 + 60_000 * 7)).toBe("stale"); // ≥ 6×
+});
+
+test("stale takes precedence over empty once truly old", () => {
+  const r = base({ count: 0, refreshMs: 60_000 });
+  expect(classifySignalFreshness(r, 1_000_000 + 60_000 * 7)).toBe("stale");
+});
+
+test("failed fetch is down; never-fetched is unknown", () => {
+  expect(classifySignalFreshness(base({ ok: false }), 2_000_000)).toBe("down");
+  expect(classifySignalFreshness(base({ lastUpdate: null }), 2_000_000)).toBe("unknown");
+  expect(signalFreshLabel("down", "")).toBe("unavailable");
+  expect(signalFreshLabel("unknown", "")).toBe("connecting…");
+});
+
+test("age helper is null before first fetch, clamped non-negative otherwise", () => {
+  expect(signalFreshAgeMs(base({ lastUpdate: null }), 5)).toBeNull();
+  expect(signalFreshAgeMs(base({ lastUpdate: 1_000 }), 4_000)).toBe(3_000);
+  expect(signalFreshAgeMs(base({ lastUpdate: 5_000 }), 4_000)).toBe(0); // clock skew → clamped
+});


### PR DESCRIPTION
## The trust spine — "is this layer actually live?", per signal

`lib/freshness.ts` covers the four core layers (cameras/planes/satellites/webcams) and its own comment names the gap as *"the documented next step"*: a per-adapter monitor over the signals registry. **This is that step.**

Each `<SignalFeed>` now records the **age + outcome** of its last fetch (keyed by the dynamic registry id), and every **ON** signal layer shows an honest freshness dot in the rail, beside its attribution.

### The honest `empty` state
The whole point of a no-dead-feeds product: a feed that fetched successfully but returned **nothing** — NHC cyclones in the quiet season, no active military flights — reads **"live · none right now"**, not stale and not broken.

States: `live · empty · lagging · stale · down · connecting`. Pure classifier, unit-tested, with explicit precedence (`down > unknown > stale > empty > lagging > live`).

### Also
Corrects the now-inaccurate rail footer ("every feed is keyless") to reflect the real mix — most keyless, a few unlock with a free key — and that each shows its own live freshness.

### Verification
`tsc` clean · vitest **324/324** · `next build` green (the rail prerenders with the new components). Classifier + labels are fully unit-tested; the live interactive dot is best eyeballed once running.

> Stacked on #21. Completes the flagship pairing (Country Instability Index #19 + this trust spine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)