### PR TITLE
Markets/macro expansion (crypto+FX live, equities+macro dormant) + AI daily brief

### DIFF
--- a/app/api/brief/route.ts
+++ b/app/api/brief/route.ts
@@ -1,0 +1,53 @@
+import { buildBriefPrompt, parseBriefResponse, type BriefPayload, type BriefSnapshot } from "@/lib/brief";
+import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/brief — an AI-written daily world brief, grounded ONLY in the live
+// Country Instability Index. Key-gated on freellmapi.co (Sampo's gateway):
+// dormant ({brief:null, dormant:true}) until FREELLMAPI_BASE_URL + FREELLMAPI_KEY
+// are set. Cached ~30 min. Dormant-safe: any failure returns dormant, never a 5xx.
+
+const CACHE_TTL_MS = 30 * 60 * 1000;
+let cache: BriefPayload | null = null;
+
+async function buildSnapshot(): Promise<BriefSnapshot> {
+  const feats = await INSTABILITY_SOURCE.fetch(); // already ranked, densest first
+  const topInstability = feats.slice(0, 6).map((f) => ({
+    country: String(f.props?.country ?? f.title ?? "").trim(),
+    score: Number(f.props?.score ?? 0),
+  }));
+  return { topInstability, dateIso: new Date().toISOString().slice(0, 10) };
+}
+
+export async function GET() {
+  const base = (process.env.FREELLMAPI_BASE_URL ?? "").trim().replace(/\/$/, "");
+  const key = (process.env.FREELLMAPI_KEY ?? "").trim();
+  if (!base || !key) {
+    return Response.json({ brief: null, dormant: true, generatedAt: Date.now() } satisfies BriefPayload);
+  }
+  if (cache && Date.now() - cache.generatedAt < CACHE_TTL_MS) {
+    return Response.json(cache);
+  }
+  try {
+    const snapshot = await buildSnapshot();
+    const prompt = buildBriefPrompt(snapshot);
+    const res = await fetch(`${base}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+      body: JSON.stringify({
+        model: "auto",
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.3,
+        max_tokens: 220,
+      }),
+      signal: AbortSignal.timeout(25_000),
+    });
+    if (!res.ok) throw new Error(`gateway ${res.status}`);
+    const brief = parseBriefResponse(await res.json());
+    cache = { brief, dormant: false, generatedAt: Date.now() };
+  } catch {
+    cache = { brief: null, dormant: false, generatedAt: Date.now() };
+  }
+  return Response.json(cache);
+}

--- a/app/api/markets/route.ts
+++ b/app/api/markets/route.ts
@@ -1,39 +1,109 @@
-import { parseMarkets, type CoinGeckoMarket, type MarketsPayload } from "@/lib/markets";
+import {
+  parseMarkets,
+  cryptoRows,
+  parseFx,
+  parseEquities,
+  parseMacro,
+  type CoinGeckoMarket,
+  type MarketsPayload,
+  type MarketSection,
+} from "@/lib/markets";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/markets — calm crypto snapshot, proxied from CoinGecko (keyless,
-// rate-limited). A short server cache (≥60s) shields the upstream from bursts;
-// dormant-safe: any failure serves the last good snapshot, or an empty list,
-// never a 5xx. No key is involved — this is the free public endpoint.
+// GET /api/markets — a calm, multi-section markets snapshot. Two sections are
+// always live and keyless (crypto · CoinGecko, FX · Frankfurter/ECB); two are
+// key-gated and render DORMANT until configured (equities · Finnhub, macro · FRED).
+// A ≥60s server cache shields the upstreams. Dormant-safe throughout: any failure
+// serves the last good snapshot or an empty section — never a 5xx, never fabricated.
 
-const ENDPOINT =
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const CACHE_TTL_MS = 60_000;
+
+const CG_ENDPOINT =
   "https://api.coingecko.com/api/v3/coins/markets" +
   "?vs_currency=usd&ids=bitcoin,ethereum,solana,ripple,cardano,dogecoin,binancecoin,tron" +
   "&order=market_cap_desc&price_change_percentage=24h";
+const FX_ENDPOINT = "https://api.frankfurter.dev/v1/latest?base=USD&symbols=EUR,GBP,JPY,CNY,CHF,CAD,AUD,INR";
 
-const CACHE_TTL_MS = 60_000;
+const EQUITIES = [
+  { symbol: "SPY", name: "S&P 500 (SPY)" },
+  { symbol: "QQQ", name: "Nasdaq 100 (QQQ)" },
+  { symbol: "DIA", name: "Dow 30 (DIA)" },
+  { symbol: "AAPL", name: "Apple" },
+  { symbol: "MSFT", name: "Microsoft" },
+  { symbol: "NVDA", name: "Nvidia" },
+];
+const FRED_SERIES = [
+  { id: "DGS10", label: "10-Yr Treasury", unit: "%" },
+  { id: "DFF", label: "Fed Funds Rate", unit: "%" },
+  { id: "UNRATE", label: "US Unemployment", unit: "%" },
+  { id: "VIXCLS", label: "VIX (volatility)", unit: "" },
+];
 
 let cache: MarketsPayload | null = null;
+
+async function getJson<T>(url: string, ms = 12_000): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": UA, Accept: "application/json" }, signal: AbortSignal.timeout(ms) });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function cryptoSection(): Promise<MarketSection> {
+  const rows = await getJson<CoinGeckoMarket[]>(CG_ENDPOINT);
+  return { key: "crypto", label: "Crypto", source: "CoinGecko · keyless", rows: cryptoRows(parseMarkets(rows)) };
+}
+
+async function fxSection(): Promise<MarketSection> {
+  const json = await getJson<{ base?: string; date?: string; rates?: Record<string, number> }>(FX_ENDPOINT);
+  return { key: "fx", label: "Currencies", source: "Frankfurter / ECB · keyless", rows: parseFx(json) };
+}
+
+async function equitiesSection(): Promise<MarketSection> {
+  const key = (process.env.FINNHUB_API_KEY ?? "").trim();
+  if (!key) {
+    return { key: "equities", label: "Equities", source: "Finnhub", dormant: true, note: "Set FINNHUB_API_KEY to enable.", rows: [] };
+  }
+  const quotes = await Promise.all(
+    EQUITIES.map(async (e) => {
+      const q = await getJson<{ c?: number; dp?: number }>(`https://finnhub.io/api/v1/quote?symbol=${e.symbol}&token=${encodeURIComponent(key)}`);
+      return { symbol: e.symbol, name: e.name, c: q?.c, dp: q?.dp };
+    }),
+  );
+  return { key: "equities", label: "Equities", source: "Finnhub", rows: parseEquities(quotes) };
+}
+
+async function macroSection(): Promise<MarketSection> {
+  const key = (process.env.FRED_API_KEY ?? "").trim();
+  if (!key) {
+    return { key: "macro", label: "Macro / rates", source: "FRED (St. Louis Fed)", dormant: true, note: "Set FRED_API_KEY to enable.", rows: [] };
+  }
+  const series = await Promise.all(
+    FRED_SERIES.map(async (s) => {
+      const json = await getJson<{ observations?: { date?: string; value?: string }[] }>(
+        `https://api.stlouisfed.org/fred/series/observations?series_id=${s.id}&api_key=${encodeURIComponent(key)}&file_type=json&sort_order=desc&limit=1`,
+      );
+      const obs = json?.observations?.[0];
+      const value = obs?.value && obs.value !== "." ? Number(obs.value) : null;
+      return { id: s.id, label: s.label, unit: s.unit, value, date: obs?.date };
+    }),
+  );
+  return { key: "macro", label: "Macro / rates", source: "FRED (St. Louis Fed)", rows: parseMacro(series) };
+}
 
 export async function GET() {
   if (cache && Date.now() - cache.generatedAt < CACHE_TTL_MS) {
     return Response.json(cache);
   }
   try {
-    const res = await fetch(ENDPOINT, {
-      headers: {
-        "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)",
-        Accept: "application/json",
-      },
-      signal: AbortSignal.timeout(12_000),
-    });
-    if (!res.ok) throw new Error(`CoinGecko: ${res.status}`);
-    const rows = (await res.json()) as CoinGeckoMarket[];
-    cache = { generatedAt: Date.now(), assets: parseMarkets(rows) };
+    const sections = await Promise.all([cryptoSection(), fxSection(), equitiesSection(), macroSection()]);
+    cache = { generatedAt: Date.now(), sections };
   } catch {
-    // Serve the last good snapshot if we have one; otherwise an empty (dormant) list.
-    cache = cache ?? { generatedAt: Date.now(), assets: [] };
+    cache = cache ?? { generatedAt: Date.now(), sections: [] };
   }
   return Response.json(cache);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -509,6 +509,19 @@ a { color: var(--tn-accent); }
 .tn-markets-up { color: var(--tn-live); }
 .tn-markets-down { color: var(--tn-down); }
 .tn-markets-flat { color: var(--tn-text-faint); }
+.tn-markets-rowsub { font-size: 10px; color: var(--tn-text-faint); white-space: nowrap; }
+/* multi-section markets */
+.tn-markets-section { margin-top: 16px; }
+.tn-markets-section-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; padding-bottom: 2px; border-bottom: 1px solid var(--tn-border); }
+.tn-markets-section-label { font-size: 12px; font-weight: 700; letter-spacing: 0.02em; }
+.tn-markets-section-source { font-size: 10px; color: var(--tn-text-faint); }
+.tn-markets-dormant { padding: 9px 2px; font-size: 11.5px; color: var(--tn-text-faint); font-style: italic; }
+/* AI daily brief */
+.tn-brief { margin: 4px 0 12px; padding: 11px 12px; border: 1px solid var(--tn-border); border-radius: 10px; background: var(--tn-chip-bg); }
+.tn-brief-dormant { opacity: 0.85; }
+.tn-brief-label { font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--tn-text-faint); }
+.tn-brief-text { margin: 5px 0 0; font-size: 12px; line-height: 1.55; color: var(--tn-text); }
+.tn-brief-text code { font-family: var(--tn-mono); font-size: 11px; background: var(--tn-toggle-off); padding: 0 3px; border-radius: 3px; }
 .tn-markets-foot { margin: 14px 2px 2px; font-size: 10.5px; color: var(--tn-text-faint); line-height: 1.5; }
 @media (prefers-reduced-motion: reduce) { .tn-markets { animation: none; } }
 @media (max-width: 520px) { .tn-markets { left: 10px; width: auto; } }

--- a/components/shell/DailyBrief.tsx
+++ b/components/shell/DailyBrief.tsx
@@ -1,0 +1,55 @@
+"use client";
+// AI daily brief block at the top of the Markets panel — a short, calm written
+// summary of where global pressure is concentrated today, grounded in the live
+// Country Instability Index. Dormant by default: until the freellmapi gateway is
+// configured it shows a quiet one-liner about what would enable it (honest, not
+// a fake summary). Reuses the markets panel's light tokens.
+
+import { useEffect, useState } from "react";
+import type { BriefPayload } from "@/lib/brief";
+
+export default function DailyBrief() {
+  const [data, setData] = useState<BriefPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/brief")
+      .then((r) => r.json())
+      .then((d: BriefPayload) => {
+        if (alive) setData(d);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (loading) return null;
+
+  // Dormant (no gateway key) — show the honest "what unlocks this" note, not a fake brief.
+  if (!data || data.dormant) {
+    return (
+      <div className="tn-brief tn-brief-dormant">
+        <span className="tn-brief-label">AI daily brief</span>
+        <p className="tn-brief-text">
+          A written world brief appears here once the freellmapi gateway is configured
+          (set <code>FREELLMAPI_BASE_URL</code> + <code>FREELLMAPI_KEY</code>). It summarises the live
+          Country Instability Index — grounded in the data, no speculation.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data.brief) return null; // configured but nothing to say right now
+
+  return (
+    <div className="tn-brief">
+      <span className="tn-brief-label">AI daily brief · grounded in the Instability Index</span>
+      <p className="tn-brief-text">{data.brief}</p>
+    </div>
+  );
+}

--- a/components/shell/MarketsPanel.tsx
+++ b/components/shell/MarketsPanel.tsx
@@ -9,10 +9,40 @@
 
 import { useEffect, useState } from "react";
 import { marketsStore, useMarketsOpen } from "@/lib/shell/markets";
-import { formatPrice, type MarketsPayload } from "@/lib/markets";
+import { type MarketsPayload, type MarketRow } from "@/lib/markets";
 import { useNow, formatAge } from "@/lib/shell/useNow";
+import DailyBrief from "@/components/shell/DailyBrief";
 
 const REFRESH_MS = 60_000;
+
+// One markets row: asset (icon/name/symbol) · value · optional signed % change.
+function MarketRowItem({ row }: { row: MarketRow }) {
+  const up = row.changePct != null && row.changePct >= 0;
+  const dir = row.changePct == null ? "flat" : up ? "up" : "down";
+  return (
+    <li className="tn-markets-row">
+      <span className="tn-markets-asset">
+        {row.image ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img className="tn-markets-icon" src={row.image} alt="" width={18} height={18} />
+        ) : (
+          <span className="tn-markets-icon tn-markets-icon-fallback" aria-hidden />
+        )}
+        <span className="tn-markets-name">{row.name}</span>
+        {row.symbol ? <span className="tn-markets-symbol">{row.symbol}</span> : null}
+        {row.sub ? <span className="tn-markets-rowsub">{row.sub}</span> : null}
+      </span>
+      <span className="tn-markets-price tn-num">{row.value}</span>
+      {row.changePct == null ? (
+        <span className="tn-markets-change tn-markets-flat tn-num" aria-hidden />
+      ) : (
+        <span className={`tn-markets-change tn-markets-${dir} tn-num`}>
+          {`${up ? "▲" : "▼"} ${Math.abs(row.changePct).toFixed(2)}%`}
+        </span>
+      )}
+    </li>
+  );
+}
 
 export default function MarketsPanel() {
   const open = useMarketsOpen();
@@ -66,7 +96,7 @@ export default function MarketsPanel() {
       <header className="tn-markets-head">
         <div>
           <h2 className="tn-markets-title">Markets</h2>
-          <p className="tn-markets-sub">Crypto markets · CoinGecko</p>
+          <p className="tn-markets-sub">Crypto · FX · Equities · Macro</p>
         </div>
         <button
           type="button"
@@ -78,49 +108,39 @@ export default function MarketsPanel() {
         </button>
       </header>
 
+      <DailyBrief />
+
       {status === "error" && !data && (
         <p className="tn-markets-status">Market data is unavailable right now.</p>
       )}
       {status === "loading" && !data && <p className="tn-markets-status">Loading prices…</p>}
 
-      {data && data.assets.length > 0 && (
-        <ul className="tn-markets-list">
-          {data.assets.map((a) => {
-            const up = a.changePct24h != null && a.changePct24h >= 0;
-            const dir = a.changePct24h == null ? "flat" : up ? "up" : "down";
-            return (
-              <li key={a.id} className="tn-markets-row">
-                <span className="tn-markets-asset">
-                  {a.image ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img className="tn-markets-icon" src={a.image} alt="" width={18} height={18} />
-                  ) : (
-                    <span className="tn-markets-icon tn-markets-icon-fallback" aria-hidden />
-                  )}
-                  <span className="tn-markets-name">{a.name}</span>
-                  <span className="tn-markets-symbol">{a.symbol}</span>
-                </span>
-                <span className="tn-markets-price tn-num">{formatPrice(a.price)}</span>
-                <span className={`tn-markets-change tn-markets-${dir} tn-num`}>
-                  {a.changePct24h == null
-                    ? "—"
-                    : `${up ? "▲" : "▼"} ${Math.abs(a.changePct24h).toFixed(2)}%`}
-                </span>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-
-      {data && data.assets.length === 0 && status !== "loading" && (
-        <p className="tn-markets-status">No market data available.</p>
-      )}
+      {data?.sections.map((section) => (
+        <section key={section.key} className="tn-markets-section">
+          <div className="tn-markets-section-head">
+            <span className="tn-markets-section-label">{section.label}</span>
+            <span className="tn-markets-section-source">{section.source}</span>
+          </div>
+          {section.dormant ? (
+            <p className="tn-markets-dormant">{section.note ?? "Add a key to enable."}</p>
+          ) : section.rows.length === 0 ? (
+            <p className="tn-markets-dormant">No data right now.</p>
+          ) : (
+            <ul className="tn-markets-list">
+              {section.rows.map((r) => (
+                <MarketRowItem key={r.id} row={r} />
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
 
       <p className="tn-markets-foot">
         {ageMs != null
           ? `Snapshot updated ${formatAge(ageMs)} ago · refreshes each minute.`
           : "Live keyless data — no account, no key."}{" "}
-        Prices are indicative, not financial advice.
+        Crypto &amp; FX are live and keyless; equities &amp; macro unlock with a free key.
+        Indicative only, not financial advice.
       </p>
     </aside>
   );

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -91,19 +91,24 @@ Every layer now shows a live **freshness dot** in the rail (the trust spine).
 
 ---
 
-## 4 · Parked / future — markets & macro (Task #12, not being built yet)
+## 4 · Markets & macro (Task #12 — BUILT)
 
-Listed only so the picture is complete. All free; get them whenever we pick up the
-markets work.
+The Markets panel is now multi-section. **Crypto (CoinGecko) and FX (Frankfurter /
+ECB) are keyless and live already.** The rest are wired and **dormant** — each
+section renders a quiet "add KEY" note until set, then goes live with no code change:
 
-| Source | Unlocks | Env var |
-|--------|---------|---------|
-| **Finnhub** | Global stock quotes / exchanges | `FINNHUB_API_KEY` |
-| **Alpha Vantage** | Equities / FX / commodities | `ALPHAVANTAGE_API_KEY` |
-| **Financial Modeling Prep** | Fundamentals / indices | `FMP_API_KEY` |
-| **FRED** (St. Louis Fed) | Macro series, central‑bank rates | `FRED_API_KEY` |
+| Source | Unlocks | Env var | State |
+|--------|---------|---------|-------|
+| **Finnhub** | Equities (SPY/QQQ/DIA/AAPL/MSFT/NVDA quotes) | `FINNHUB_API_KEY` | dormant |
+| **FRED** (St. Louis Fed) | Macro/rates (10-Yr, Fed Funds, unemployment, VIX) | `FRED_API_KEY` | dormant |
+| **freellmapi.co** (your gateway) | AI daily brief, grounded in the Instability Index | `FREELLMAPI_BASE_URL` + `FREELLMAPI_KEY` | dormant |
 
-(Polymarket, Fear & Greed, World Bank, Eurostat, OECD SDMX — all keyless, no entry needed.)
+- **Finnhub** — free key at <https://finnhub.io/register> (instant).
+- **FRED** — free key at <https://fredaccount.stlouisfed.org/apikeys>.
+- **freellmapi** — base URL + key from your own dashboard (also powers the `/locate` vision fallback).
+
+Alpha Vantage / FMP aren't used (Finnhub + FRED cover equities + macro). Polymarket,
+Fear & Greed, World Bank, Eurostat, OECD SDMX remain keyless options if we expand further.
 
 ---
 
@@ -134,10 +139,8 @@ GEOLOCATE_BACKEND=
 WINDY_WEBCAMS_API_KEY=
 WINDY_MAP_FORECAST_API_KEY=
 
-# --- Parked: markets/macro (Task #12) ---
+# --- Markets/macro (Task #12, BUILT — crypto+FX already live keyless; these unlock the rest) ---
 FINNHUB_API_KEY=
-ALPHAVANTAGE_API_KEY=
-FMP_API_KEY=
 FRED_API_KEY=
 ```
 

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -1,0 +1,46 @@
+// AI daily brief — turns the day's live signals into a short, calm written
+// situation summary. The model call goes through freellmapi.co (Sampo's own
+// OpenAI-compatible gateway), so it's key-gated: dormant until FREELLMAPI_BASE_URL
+// + FREELLMAPI_KEY are set. The PROMPT BUILDER is pure and isomorphic so it
+// unit-tests in node; the network call lives in the route.
+//
+// Honesty guard: the brief is built ONLY from real signal data we already show
+// (the top of the Country Instability Index), and the prompt forbids speculation —
+// it summarises what the data says, it does not invent events.
+
+export interface BriefSnapshot {
+  /** Top instability countries (country name + 0–100 score), already ranked. */
+  topInstability: { country: string; score: number }[];
+  /** ISO date the snapshot was taken (optional, for the dateline). */
+  dateIso?: string;
+}
+
+export interface BriefPayload {
+  brief: string | null;
+  dormant: boolean;
+  generatedAt: number;
+}
+
+/** Pure: snapshot → the chat prompt sent to the gateway. */
+export function buildBriefPrompt(s: BriefSnapshot): string {
+  const list =
+    s.topInstability.length > 0
+      ? s.topInstability.map((c) => `${c.country} (${c.score}/100)`).join(", ")
+      : "no countries currently above the instability threshold";
+  const dateline = s.dateIso ? ` for ${s.dateIso}` : "";
+  return [
+    "You are a calm, factual intelligence analyst writing a short daily world brief" + dateline + ".",
+    "Using ONLY the data below, write 3 short sentences summarising where global pressure is concentrated today.",
+    "Do not invent specific events, casualty figures, or news the data does not contain. Do not speculate or give advice. Neutral, measured tone.",
+    "",
+    "Country Instability Index — highest-pressure countries right now: " + list + ".",
+    "(The index composites armed conflict, food insecurity, forced displacement and internet outages; a higher score means more concurrent pressure.)",
+  ].join("\n");
+}
+
+/** Pure: parse the gateway's chat-completion response → brief text, or null. */
+export function parseBriefResponse(json: unknown): string | null {
+  const choices = (json as { choices?: { message?: { content?: string } }[] })?.choices;
+  const content = choices?.[0]?.message?.content;
+  return typeof content === "string" && content.trim() ? content.trim() : null;
+}

--- a/lib/markets.ts
+++ b/lib/markets.ts
@@ -31,9 +31,121 @@ export interface MarketAsset {
   updatedAt?: string; // ISO from upstream
 }
 
+// --- multi-section model ----------------------------------------------------
+// Markets is no longer crypto-only: it shows several asset classes, each its own
+// honestly-labelled section. Keyless sections (crypto, FX) are always live; keyed
+// sections (equities, macro) render DORMANT with a "add KEY" note until configured
+// — never fabricated. The panel reads `sections`.
+
+export interface MarketRow {
+  id: string;
+  name: string;
+  symbol?: string;
+  /** Pre-formatted display value (price / rate / level). */
+  value: string;
+  /** Signed % change where the upstream provides it; null/undefined = not shown. */
+  changePct?: number | null;
+  /** Optional secondary line (market cap, unit, as-of date). */
+  sub?: string;
+  image?: string;
+}
+
+export interface MarketSection {
+  key: string;
+  label: string;
+  source: string;
+  /** True when the section is key-gated and the key isn't set; rows will be empty. */
+  dormant?: boolean;
+  /** Shown when dormant — which env var unlocks it. */
+  note?: string;
+  rows: MarketRow[];
+}
+
 export interface MarketsPayload {
   generatedAt: number;
-  assets: MarketAsset[];
+  sections: MarketSection[];
+}
+
+/** Crypto MarketAsset[] → display rows (market cap as the secondary line). */
+export function cryptoRows(assets: MarketAsset[]): MarketRow[] {
+  return assets.map((a) => ({
+    id: a.id,
+    name: a.name,
+    symbol: a.symbol,
+    value: formatPrice(a.price),
+    changePct: a.changePct24h,
+    image: a.image,
+    sub: a.marketCap != null ? `mkt cap ${formatCompactUsd(a.marketCap)}` : undefined,
+  }));
+}
+
+const FX_NAMES: Record<string, string> = {
+  EUR: "Euro", GBP: "British Pound", JPY: "Japanese Yen", CNY: "Chinese Yuan",
+  CHF: "Swiss Franc", CAD: "Canadian Dollar", AUD: "Australian Dollar", INR: "Indian Rupee",
+};
+
+/** Pure: Frankfurter (ECB) latest payload → FX rows (units of each currency per 1 USD). */
+export function parseFx(json: { base?: string; date?: string; rates?: Record<string, number> } | null | undefined): MarketRow[] {
+  const rates = json?.rates;
+  if (!rates) return [];
+  const out: MarketRow[] = [];
+  for (const [code, raw] of Object.entries(rates)) {
+    const rate = Number(raw);
+    if (!Number.isFinite(rate) || rate <= 0) continue;
+    out.push({
+      id: `fx:${code}`,
+      name: FX_NAMES[code] ?? code,
+      symbol: `USD/${code}`,
+      value: rate.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 }),
+      sub: json?.date ? `per 1 USD · ${json.date}` : "per 1 USD",
+    });
+  }
+  return out;
+}
+
+/** Pure: assembled Finnhub quotes → equity rows. {symbol,name,c(current),dp(% change)}. */
+export function parseEquities(
+  quotes: { symbol?: string; name?: string; c?: number | null; dp?: number | null }[] | null | undefined,
+): MarketRow[] {
+  if (!Array.isArray(quotes)) return [];
+  const out: MarketRow[] = [];
+  for (const q of quotes) {
+    const sym = (q.symbol ?? "").toUpperCase();
+    const price = q.c == null ? Number.NaN : Number(q.c);
+    if (!sym || !Number.isFinite(price) || price <= 0) continue;
+    const dp = typeof q.dp === "number" && Number.isFinite(q.dp) ? Number(q.dp.toFixed(2)) : null;
+    out.push({ id: `eq:${sym}`, name: q.name?.trim() || sym, symbol: sym, value: formatPrice(price), changePct: dp });
+  }
+  return out;
+}
+
+/** Pure: assembled FRED latest observations → macro rows. {id,label,value,unit,date}. */
+export function parseMacro(
+  series: { id?: string; label?: string; value?: number | string | null; unit?: string; date?: string }[] | null | undefined,
+): MarketRow[] {
+  if (!Array.isArray(series)) return [];
+  const out: MarketRow[] = [];
+  for (const s of series) {
+    const id = (s.id ?? "").trim();
+    const v = s.value == null ? Number.NaN : Number(s.value);
+    if (!id || !Number.isFinite(v)) continue;
+    out.push({
+      id: `macro:${id}`,
+      name: s.label?.trim() || id,
+      value: `${v.toLocaleString("en-US", { maximumFractionDigits: 2 })}${s.unit ?? ""}`,
+      sub: s.date ? `as of ${s.date}` : undefined,
+    });
+  }
+  return out;
+}
+
+/** Compact USD, e.g. "$1.2T", "$845B", "$12.3M". */
+export function formatCompactUsd(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e12) return `$${(n / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9) return `$${(n / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `$${(n / 1e6).toFixed(1)}M`;
+  return `$${n.toLocaleString("en-US")}`;
 }
 
 /** Pure: CoinGecko rows → MarketAsset[]. Skips rows with no id or no price. */

--- a/tests/unit/markets-sections.test.ts
+++ b/tests/unit/markets-sections.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "vitest";
+import {
+  parseFx,
+  parseEquities,
+  parseMacro,
+  cryptoRows,
+  formatCompactUsd,
+  type MarketAsset,
+} from "@/lib/markets";
+import { buildBriefPrompt, parseBriefResponse } from "@/lib/brief";
+
+test("parseFx maps ECB rates to per-USD rows (live shape)", () => {
+  // Real Frankfurter response shape.
+  const out = parseFx({ base: "USD", date: "2026-06-26", rates: { EUR: 0.87712, GBP: 0.75654, JPY: 161.65, BAD: 0 } });
+  expect(out).toHaveLength(3); // the zero rate is dropped
+  const eur = out.find((r) => r.id === "fx:EUR")!;
+  expect(eur.name).toBe("Euro");
+  expect(eur.symbol).toBe("USD/EUR");
+  expect(eur.sub).toContain("2026-06-26");
+  expect(eur.changePct).toBeUndefined(); // FX latest carries no change
+  expect(parseFx(null)).toEqual([]);
+  expect(parseFx({})).toEqual([]);
+});
+
+test("parseEquities keeps real quotes, drops empty/zero prices", () => {
+  const out = parseEquities([
+    { symbol: "spy", name: "S&P 500 (SPY)", c: 612.4, dp: 0.83 },
+    { symbol: "AAPL", name: "Apple", c: 0, dp: 0 }, // zero price → dropped
+    { symbol: "", name: "x", c: 10, dp: 1 }, // no symbol → dropped
+  ]);
+  expect(out).toHaveLength(1);
+  expect(out[0].id).toBe("eq:SPY");
+  expect(out[0].symbol).toBe("SPY");
+  expect(out[0].changePct).toBe(0.83);
+});
+
+test("parseMacro formats latest observations with units", () => {
+  const out = parseMacro([
+    { id: "DGS10", label: "10-Yr Treasury", value: 4.23, unit: "%", date: "2026-06-26" },
+    { id: "VIXCLS", label: "VIX (volatility)", value: 13.8, unit: "", date: "2026-06-26" },
+    { id: "BAD", label: "missing", value: null }, // "." sentinel → dropped
+  ]);
+  expect(out).toHaveLength(2);
+  expect(out.find((r) => r.id === "macro:DGS10")!.value).toBe("4.23%");
+  expect(out.find((r) => r.id === "macro:VIXCLS")!.value).toBe("13.8");
+});
+
+test("cryptoRows carries market cap as a compact sub-line", () => {
+  const assets: MarketAsset[] = [
+    { id: "bitcoin", symbol: "BTC", name: "Bitcoin", price: 60155, changePct24h: 1.2, marketCap: 1_190_000_000_000 },
+  ];
+  const rows = cryptoRows(assets);
+  expect(rows[0].value).toBe("$60,155.00");
+  expect(rows[0].sub).toBe("mkt cap $1.2T");
+});
+
+test("formatCompactUsd scales T/B/M", () => {
+  expect(formatCompactUsd(1_190_000_000_000)).toBe("$1.2T");
+  expect(formatCompactUsd(845_000_000_000)).toBe("$845.0B");
+  expect(formatCompactUsd(12_300_000)).toBe("$12.3M");
+});
+
+test("buildBriefPrompt is grounded and forbids speculation", () => {
+  const prompt = buildBriefPrompt({
+    topInstability: [
+      { country: "Afghanistan", score: 49 },
+      { country: "Somalia", score: 49 },
+    ],
+    dateIso: "2026-06-27",
+  });
+  expect(prompt).toContain("Afghanistan (49/100)");
+  expect(prompt).toContain("Somalia (49/100)");
+  expect(prompt).toContain("2026-06-27");
+  expect(prompt.toLowerCase()).toContain("do not invent");
+  // Empty snapshot still produces a safe prompt.
+  expect(buildBriefPrompt({ topInstability: [] })).toContain("no countries currently above");
+});
+
+test("parseBriefResponse pulls the message content, or null", () => {
+  expect(parseBriefResponse({ choices: [{ message: { content: "  Global pressure is concentrated…  " } }] })).toBe(
+    "Global pressure is concentrated…",
+  );
+  expect(parseBriefResponse({ choices: [] })).toBeNull();
+  expect(parseBriefResponse({})).toBeNull();
+  expect(parseBriefResponse(null)).toBeNull();
+});


### PR DESCRIPTION
## Un-parks Task #12 — markets goes multi-section + an AI daily brief

The Markets panel was crypto-only. Now it's an honestly-labelled, multi-section board:

| Section | Source | State |
|---------|--------|-------|
| **Crypto** | CoinGecko | keyless · **live** (mkt-cap sub-line) |
| **Currencies** | Frankfurter / ECB | keyless · **live** (8 majors, per 1 USD) |
| **Equities** | Finnhub (SPY/QQQ/DIA/AAPL/MSFT/NVDA) | dormant → `FINNHUB_API_KEY` |
| **Macro / rates** | FRED (10-Yr · Fed Funds · unemployment · VIX) | dormant → `FRED_API_KEY` |

Dormant sections render a quiet *"add KEY to enable"* note — **never fabricated data**. The route assembles all four dormant-safe (any failure → empty section, never 5xx) behind the existing 60s cache.

### 🧠 AI daily brief
New `/api/brief` + a `DailyBrief` block atop the panel: a short written world summary **grounded ONLY in the live Country Instability Index**, via freellmapi.co (your gateway). Key-gated (`FREELLMAPI_BASE_URL` + `FREELLMAPI_KEY`) — dormant shows an honest "what enables this" note. The prompt **forbids inventing events or speculating**.

### Verification
Pure parsers + brief helpers fully unit-tested against **real upstream shapes** (FX verified live against `api.frankfurter.dev`). `tsc` clean · vitest **337/337** · `next build` green.

> ⚠️ Base is `feat/intel-ais` because #18–#23 were merged into that branch, **not into `main`** — see the note I'm leaving on the chat. This PR's diff is markets-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)