### PR TITLE
Land the intelligence stack into main — Instability Index, freshness spine, +9 layers, markets/macro + AI brief

### DIFF
--- a/app/api/brief/route.ts
+++ b/app/api/brief/route.ts
@@ -1,0 +1,53 @@
+import { buildBriefPrompt, parseBriefResponse, type BriefPayload, type BriefSnapshot } from "@/lib/brief";
+import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/brief — an AI-written daily world brief, grounded ONLY in the live
+// Country Instability Index. Key-gated on freellmapi.co (Sampo's gateway):
+// dormant ({brief:null, dormant:true}) until FREELLMAPI_BASE_URL + FREELLMAPI_KEY
+// are set. Cached ~30 min. Dormant-safe: any failure returns dormant, never a 5xx.
+
+const CACHE_TTL_MS = 30 * 60 * 1000;
+let cache: BriefPayload | null = null;
+
+async function buildSnapshot(): Promise<BriefSnapshot> {
+  const feats = await INSTABILITY_SOURCE.fetch(); // already ranked, densest first
+  const topInstability = feats.slice(0, 6).map((f) => ({
+    country: String(f.props?.country ?? f.title ?? "").trim(),
+    score: Number(f.props?.score ?? 0),
+  }));
+  return { topInstability, dateIso: new Date().toISOString().slice(0, 10) };
+}
+
+export async function GET() {
+  const base = (process.env.FREELLMAPI_BASE_URL ?? "").trim().replace(/\/$/, "");
+  const key = (process.env.FREELLMAPI_KEY ?? "").trim();
+  if (!base || !key) {
+    return Response.json({ brief: null, dormant: true, generatedAt: Date.now() } satisfies BriefPayload);
+  }
+  if (cache && Date.now() - cache.generatedAt < CACHE_TTL_MS) {
+    return Response.json(cache);
+  }
+  try {
+    const snapshot = await buildSnapshot();
+    const prompt = buildBriefPrompt(snapshot);
+    const res = await fetch(`${base}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+      body: JSON.stringify({
+        model: "auto",
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.3,
+        max_tokens: 220,
+      }),
+      signal: AbortSignal.timeout(25_000),
+    });
+    if (!res.ok) throw new Error(`gateway ${res.status}`);
+    const brief = parseBriefResponse(await res.json());
+    cache = { brief, dormant: false, generatedAt: Date.now() };
+  } catch {
+    cache = { brief: null, dormant: false, generatedAt: Date.now() };
+  }
+  return Response.json(cache);
+}

--- a/app/api/markets/route.ts
+++ b/app/api/markets/route.ts
@@ -1,39 +1,109 @@
-import { parseMarkets, type CoinGeckoMarket, type MarketsPayload } from "@/lib/markets";
+import {
+  parseMarkets,
+  cryptoRows,
+  parseFx,
+  parseEquities,
+  parseMacro,
+  type CoinGeckoMarket,
+  type MarketsPayload,
+  type MarketSection,
+} from "@/lib/markets";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/markets — calm crypto snapshot, proxied from CoinGecko (keyless,
-// rate-limited). A short server cache (≥60s) shields the upstream from bursts;
-// dormant-safe: any failure serves the last good snapshot, or an empty list,
-// never a 5xx. No key is involved — this is the free public endpoint.
+// GET /api/markets — a calm, multi-section markets snapshot. Two sections are
+// always live and keyless (crypto · CoinGecko, FX · Frankfurter/ECB); two are
+// key-gated and render DORMANT until configured (equities · Finnhub, macro · FRED).
+// A ≥60s server cache shields the upstreams. Dormant-safe throughout: any failure
+// serves the last good snapshot or an empty section — never a 5xx, never fabricated.
 
-const ENDPOINT =
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const CACHE_TTL_MS = 60_000;
+
+const CG_ENDPOINT =
   "https://api.coingecko.com/api/v3/coins/markets" +
   "?vs_currency=usd&ids=bitcoin,ethereum,solana,ripple,cardano,dogecoin,binancecoin,tron" +
   "&order=market_cap_desc&price_change_percentage=24h";
+const FX_ENDPOINT = "https://api.frankfurter.dev/v1/latest?base=USD&symbols=EUR,GBP,JPY,CNY,CHF,CAD,AUD,INR";
 
-const CACHE_TTL_MS = 60_000;
+const EQUITIES = [
+  { symbol: "SPY", name: "S&P 500 (SPY)" },
+  { symbol: "QQQ", name: "Nasdaq 100 (QQQ)" },
+  { symbol: "DIA", name: "Dow 30 (DIA)" },
+  { symbol: "AAPL", name: "Apple" },
+  { symbol: "MSFT", name: "Microsoft" },
+  { symbol: "NVDA", name: "Nvidia" },
+];
+const FRED_SERIES = [
+  { id: "DGS10", label: "10-Yr Treasury", unit: "%" },
+  { id: "DFF", label: "Fed Funds Rate", unit: "%" },
+  { id: "UNRATE", label: "US Unemployment", unit: "%" },
+  { id: "VIXCLS", label: "VIX (volatility)", unit: "" },
+];
 
 let cache: MarketsPayload | null = null;
+
+async function getJson<T>(url: string, ms = 12_000): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": UA, Accept: "application/json" }, signal: AbortSignal.timeout(ms) });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function cryptoSection(): Promise<MarketSection> {
+  const rows = await getJson<CoinGeckoMarket[]>(CG_ENDPOINT);
+  return { key: "crypto", label: "Crypto", source: "CoinGecko · keyless", rows: cryptoRows(parseMarkets(rows)) };
+}
+
+async function fxSection(): Promise<MarketSection> {
+  const json = await getJson<{ base?: string; date?: string; rates?: Record<string, number> }>(FX_ENDPOINT);
+  return { key: "fx", label: "Currencies", source: "Frankfurter / ECB · keyless", rows: parseFx(json) };
+}
+
+async function equitiesSection(): Promise<MarketSection> {
+  const key = (process.env.FINNHUB_API_KEY ?? "").trim();
+  if (!key) {
+    return { key: "equities", label: "Equities", source: "Finnhub", dormant: true, note: "Set FINNHUB_API_KEY to enable.", rows: [] };
+  }
+  const quotes = await Promise.all(
+    EQUITIES.map(async (e) => {
+      const q = await getJson<{ c?: number; dp?: number }>(`https://finnhub.io/api/v1/quote?symbol=${e.symbol}&token=${encodeURIComponent(key)}`);
+      return { symbol: e.symbol, name: e.name, c: q?.c, dp: q?.dp };
+    }),
+  );
+  return { key: "equities", label: "Equities", source: "Finnhub", rows: parseEquities(quotes) };
+}
+
+async function macroSection(): Promise<MarketSection> {
+  const key = (process.env.FRED_API_KEY ?? "").trim();
+  if (!key) {
+    return { key: "macro", label: "Macro / rates", source: "FRED (St. Louis Fed)", dormant: true, note: "Set FRED_API_KEY to enable.", rows: [] };
+  }
+  const series = await Promise.all(
+    FRED_SERIES.map(async (s) => {
+      const json = await getJson<{ observations?: { date?: string; value?: string }[] }>(
+        `https://api.stlouisfed.org/fred/series/observations?series_id=${s.id}&api_key=${encodeURIComponent(key)}&file_type=json&sort_order=desc&limit=1`,
+      );
+      const obs = json?.observations?.[0];
+      const value = obs?.value && obs.value !== "." ? Number(obs.value) : null;
+      return { id: s.id, label: s.label, unit: s.unit, value, date: obs?.date };
+    }),
+  );
+  return { key: "macro", label: "Macro / rates", source: "FRED (St. Louis Fed)", rows: parseMacro(series) };
+}
 
 export async function GET() {
   if (cache && Date.now() - cache.generatedAt < CACHE_TTL_MS) {
     return Response.json(cache);
   }
   try {
-    const res = await fetch(ENDPOINT, {
-      headers: {
-        "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)",
-        Accept: "application/json",
-      },
-      signal: AbortSignal.timeout(12_000),
-    });
-    if (!res.ok) throw new Error(`CoinGecko: ${res.status}`);
-    const rows = (await res.json()) as CoinGeckoMarket[];
-    cache = { generatedAt: Date.now(), assets: parseMarkets(rows) };
+    const sections = await Promise.all([cryptoSection(), fxSection(), equitiesSection(), macroSection()]);
+    cache = { generatedAt: Date.now(), sections };
   } catch {
-    // Serve the last good snapshot if we have one; otherwise an empty (dormant) list.
-    cache = cache ?? { generatedAt: Date.now(), assets: [] };
+    cache = cache ?? { generatedAt: Date.now(), sections: [] };
   }
   return Response.json(cache);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,6 +197,8 @@ a { color: var(--tn-accent); }
 .tn-fresh-lagging { color: var(--tn-lagging); } .tn-fresh-lagging .tn-fresh-dot { background: var(--tn-lagging); }
 .tn-fresh-stale { color: var(--tn-stale); } .tn-fresh-stale .tn-fresh-dot { background: var(--tn-stale); }
 .tn-fresh-down { color: var(--tn-down); } .tn-fresh-down .tn-fresh-dot { background: var(--tn-down); }
+/* empty = fetched OK but nothing to show right now (e.g. no active storms): a calm, dimmed-live dot, not an error. */
+.tn-fresh-empty { color: var(--tn-text-faint); } .tn-fresh-empty .tn-fresh-dot { background: var(--tn-live); opacity: 0.45; }
 
 .tn-toggle { position: relative; width: 36px; height: 20px; border: none; border-radius: 10px; cursor: pointer; padding: 0; transition: background 0.2s ease; flex-shrink: 0; }
 .tn-toggle-knob { position: absolute; top: 2px; width: 16px; height: 16px; background: #fff; border-radius: 50%; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25); transition: left 0.2s cubic-bezier(0.4, 0, 0.2, 1); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -509,6 +509,19 @@ a { color: var(--tn-accent); }
 .tn-markets-up { color: var(--tn-live); }
 .tn-markets-down { color: var(--tn-down); }
 .tn-markets-flat { color: var(--tn-text-faint); }
+.tn-markets-rowsub { font-size: 10px; color: var(--tn-text-faint); white-space: nowrap; }
+/* multi-section markets */
+.tn-markets-section { margin-top: 16px; }
+.tn-markets-section-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; padding-bottom: 2px; border-bottom: 1px solid var(--tn-border); }
+.tn-markets-section-label { font-size: 12px; font-weight: 700; letter-spacing: 0.02em; }
+.tn-markets-section-source { font-size: 10px; color: var(--tn-text-faint); }
+.tn-markets-dormant { padding: 9px 2px; font-size: 11.5px; color: var(--tn-text-faint); font-style: italic; }
+/* AI daily brief */
+.tn-brief { margin: 4px 0 12px; padding: 11px 12px; border: 1px solid var(--tn-border); border-radius: 10px; background: var(--tn-chip-bg); }
+.tn-brief-dormant { opacity: 0.85; }
+.tn-brief-label { font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--tn-text-faint); }
+.tn-brief-text { margin: 5px 0 0; font-size: 12px; line-height: 1.55; color: var(--tn-text); }
+.tn-brief-text code { font-family: var(--tn-mono); font-size: 11px; background: var(--tn-toggle-off); padding: 0 3px; border-radius: 3px; }
 .tn-markets-foot { margin: 14px 2px 2px; font-size: 10.5px; color: var(--tn-text-faint); line-height: 1.5; }
 @media (prefers-reduced-motion: reduce) { .tn-markets { animation: none; } }
 @media (max-width: 520px) { .tn-markets { left: 10px; width: auto; } }

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -31,6 +31,7 @@ import { loadCameraIcons, loadPlaneIcons, loadSatelliteIcons, loadWebcamIcons } 
 import { CAMERA_CLUSTER, WEBCAM_CLUSTER, expandCluster } from "@/lib/map/cluster";
 import { SIGNALS } from "@/lib/signals/registry";
 import { useSignals, signalCountsStore } from "@/lib/signals/store";
+import { signalFreshnessStore } from "@/lib/signals/freshness";
 import type { SignalFeature, SignalSource } from "@/lib/signals/types";
 import { useTimeWindow, windowMsFor, withinWindow } from "@/lib/shell/timeWindow";
 import { useNow } from "@/lib/shell/useNow";
@@ -1019,11 +1020,13 @@ function SignalFeed({
           }));
           onData(id, objs);
           signalCountsStore.set(id, objs.length);
+          signalFreshnessStore.record(id, { ok: true, count: objs.length });
         })
         .catch(() => {
           if (!alive) return;
           onData(id, []);
           signalCountsStore.set(id, 0);
+          signalFreshnessStore.record(id, { ok: false, count: 0 });
         });
     };
     load();
@@ -1034,6 +1037,7 @@ function SignalFeed({
       clearInterval(t);
       onData(id, []);
       signalCountsStore.set(id, null);
+      signalFreshnessStore.clear(id);
     };
   }, [id, source, onData]);
   return null;

--- a/components/shell/DailyBrief.tsx
+++ b/components/shell/DailyBrief.tsx
@@ -1,0 +1,55 @@
+"use client";
+// AI daily brief block at the top of the Markets panel — a short, calm written
+// summary of where global pressure is concentrated today, grounded in the live
+// Country Instability Index. Dormant by default: until the freellmapi gateway is
+// configured it shows a quiet one-liner about what would enable it (honest, not
+// a fake summary). Reuses the markets panel's light tokens.
+
+import { useEffect, useState } from "react";
+import type { BriefPayload } from "@/lib/brief";
+
+export default function DailyBrief() {
+  const [data, setData] = useState<BriefPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/brief")
+      .then((r) => r.json())
+      .then((d: BriefPayload) => {
+        if (alive) setData(d);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (loading) return null;
+
+  // Dormant (no gateway key) — show the honest "what unlocks this" note, not a fake brief.
+  if (!data || data.dormant) {
+    return (
+      <div className="tn-brief tn-brief-dormant">
+        <span className="tn-brief-label">AI daily brief</span>
+        <p className="tn-brief-text">
+          A written world brief appears here once the freellmapi gateway is configured
+          (set <code>FREELLMAPI_BASE_URL</code> + <code>FREELLMAPI_KEY</code>). It summarises the live
+          Country Instability Index — grounded in the data, no speculation.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data.brief) return null; // configured but nothing to say right now
+
+  return (
+    <div className="tn-brief">
+      <span className="tn-brief-label">AI daily brief · grounded in the Instability Index</span>
+      <p className="tn-brief-text">{data.brief}</p>
+    </div>
+  );
+}

--- a/components/shell/LayerRail.tsx
+++ b/components/shell/LayerRail.tsx
@@ -19,6 +19,12 @@ import {
 } from "@/lib/layers";
 import { SIGNALS, signalsByGroup } from "@/lib/signals/registry";
 import { signalsStore, useSignals, useSignalCounts } from "@/lib/signals/store";
+import {
+  useSignalFreshness,
+  classifySignalFreshness,
+  signalFreshAgeMs,
+  signalFreshLabel,
+} from "@/lib/signals/freshness";
 import { useMetrics } from "@/lib/metrics";
 import { useFreshness, classifyFreshness, freshnessAgeMs, type FreshSourceId } from "@/lib/freshness";
 import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
@@ -185,7 +191,27 @@ function LayerRow({
   );
 }
 
-// One global-signal layer: dot + label + attribution + live count + toggle.
+// Per-signal freshness chip — honest "is this layer actually live?" beside each
+// ON signal layer, reading the trust spine (lib/signals/freshness). Only shown
+// when the layer is on (a SignalFeed must be mounted to have a record).
+function SignalFreshNote({ id, refreshMs }: { id: string; refreshMs: number }) {
+  const records = useSignalFreshness();
+  const now = useNow(1000);
+  const raw = records[id];
+  if (!raw) return null; // not mounted / no fetch yet
+  const rec = { ...raw, refreshMs };
+  const state = classifySignalFreshness(rec, now);
+  const age = signalFreshAgeMs(rec, now);
+  const text = signalFreshLabel(state, age == null ? "" : formatAge(age));
+  return (
+    <span className={`tn-fresh tn-fresh-${state}`}>
+      <span className="tn-fresh-dot" aria-hidden />
+      {text}
+    </span>
+  );
+}
+
+// One global-signal layer: dot + label + attribution + freshness + live count + toggle.
 // Mirrors LayerRow but reads the SEPARATE signals store (default off, opt-in).
 function SignalRow({ id }: { id: string }) {
   const source = SIGNALS.find((s) => s.id === id)!;
@@ -202,6 +228,7 @@ function SignalRow({ id }: { id: string }) {
         <div className="tn-layer-main">
           <span className="tn-layer-name">{source.label}</span>
           <span className="tn-layer-source">{source.attribution}</span>
+          {on ? <SignalFreshNote id={id} refreshMs={source.refreshMs} /> : null}
         </div>
       </div>
       <span className="tn-layer-count tn-num">{countLabel}</span>
@@ -251,8 +278,9 @@ function GlobalSignals() {
             </div>
           ))}
           <p className="tn-rail-foot">
-            Opt-in natural-hazard &amp; space-weather layers. Fetched only while on; every feed is
-            keyless, live and attributed.
+            Opt-in intelligence layers — hazards, conflict, cyber, maritime, human cost &amp; the
+            Country Instability Index. Fetched only while on; most are keyless, a few unlock with a
+            free key. Each is attributed and shows its own live freshness.
           </p>
         </div>
       )}

--- a/components/shell/MarketsPanel.tsx
+++ b/components/shell/MarketsPanel.tsx
@@ -9,10 +9,40 @@
 
 import { useEffect, useState } from "react";
 import { marketsStore, useMarketsOpen } from "@/lib/shell/markets";
-import { formatPrice, type MarketsPayload } from "@/lib/markets";
+import { type MarketsPayload, type MarketRow } from "@/lib/markets";
 import { useNow, formatAge } from "@/lib/shell/useNow";
+import DailyBrief from "@/components/shell/DailyBrief";
 
 const REFRESH_MS = 60_000;
+
+// One markets row: asset (icon/name/symbol) · value · optional signed % change.
+function MarketRowItem({ row }: { row: MarketRow }) {
+  const up = row.changePct != null && row.changePct >= 0;
+  const dir = row.changePct == null ? "flat" : up ? "up" : "down";
+  return (
+    <li className="tn-markets-row">
+      <span className="tn-markets-asset">
+        {row.image ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img className="tn-markets-icon" src={row.image} alt="" width={18} height={18} />
+        ) : (
+          <span className="tn-markets-icon tn-markets-icon-fallback" aria-hidden />
+        )}
+        <span className="tn-markets-name">{row.name}</span>
+        {row.symbol ? <span className="tn-markets-symbol">{row.symbol}</span> : null}
+        {row.sub ? <span className="tn-markets-rowsub">{row.sub}</span> : null}
+      </span>
+      <span className="tn-markets-price tn-num">{row.value}</span>
+      {row.changePct == null ? (
+        <span className="tn-markets-change tn-markets-flat tn-num" aria-hidden />
+      ) : (
+        <span className={`tn-markets-change tn-markets-${dir} tn-num`}>
+          {`${up ? "▲" : "▼"} ${Math.abs(row.changePct).toFixed(2)}%`}
+        </span>
+      )}
+    </li>
+  );
+}
 
 export default function MarketsPanel() {
   const open = useMarketsOpen();
@@ -66,7 +96,7 @@ export default function MarketsPanel() {
       <header className="tn-markets-head">
         <div>
           <h2 className="tn-markets-title">Markets</h2>
-          <p className="tn-markets-sub">Crypto markets · CoinGecko</p>
+          <p className="tn-markets-sub">Crypto · FX · Equities · Macro</p>
         </div>
         <button
           type="button"
@@ -78,49 +108,39 @@ export default function MarketsPanel() {
         </button>
       </header>
 
+      <DailyBrief />
+
       {status === "error" && !data && (
         <p className="tn-markets-status">Market data is unavailable right now.</p>
       )}
       {status === "loading" && !data && <p className="tn-markets-status">Loading prices…</p>}
 
-      {data && data.assets.length > 0 && (
-        <ul className="tn-markets-list">
-          {data.assets.map((a) => {
-            const up = a.changePct24h != null && a.changePct24h >= 0;
-            const dir = a.changePct24h == null ? "flat" : up ? "up" : "down";
-            return (
-              <li key={a.id} className="tn-markets-row">
-                <span className="tn-markets-asset">
-                  {a.image ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img className="tn-markets-icon" src={a.image} alt="" width={18} height={18} />
-                  ) : (
-                    <span className="tn-markets-icon tn-markets-icon-fallback" aria-hidden />
-                  )}
-                  <span className="tn-markets-name">{a.name}</span>
-                  <span className="tn-markets-symbol">{a.symbol}</span>
-                </span>
-                <span className="tn-markets-price tn-num">{formatPrice(a.price)}</span>
-                <span className={`tn-markets-change tn-markets-${dir} tn-num`}>
-                  {a.changePct24h == null
-                    ? "—"
-                    : `${up ? "▲" : "▼"} ${Math.abs(a.changePct24h).toFixed(2)}%`}
-                </span>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-
-      {data && data.assets.length === 0 && status !== "loading" && (
-        <p className="tn-markets-status">No market data available.</p>
-      )}
+      {data?.sections.map((section) => (
+        <section key={section.key} className="tn-markets-section">
+          <div className="tn-markets-section-head">
+            <span className="tn-markets-section-label">{section.label}</span>
+            <span className="tn-markets-section-source">{section.source}</span>
+          </div>
+          {section.dormant ? (
+            <p className="tn-markets-dormant">{section.note ?? "Add a key to enable."}</p>
+          ) : section.rows.length === 0 ? (
+            <p className="tn-markets-dormant">No data right now.</p>
+          ) : (
+            <ul className="tn-markets-list">
+              {section.rows.map((r) => (
+                <MarketRowItem key={r.id} row={r} />
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
 
       <p className="tn-markets-foot">
         {ageMs != null
           ? `Snapshot updated ${formatAge(ageMs)} ago · refreshes each minute.`
           : "Live keyless data — no account, no key."}{" "}
-        Prices are indicative, not financial advice.
+        Crypto &amp; FX are live and keyless; equities &amp; macro unlock with a free key.
+        Indicative only, not financial advice.
       </p>
     </aside>
   );

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -13,6 +13,26 @@ registration or an email request. Until a key is set, its layer stays **dormant*
 
 ---
 
+## 0 · Status — what's live now
+
+Keys you've already given me are wired in `.env.local` and **live locally**:
+
+| Key | Layer it powers | State |
+|-----|-----------------|-------|
+| `AISSTREAM_API_KEY` | **Ships (AIS chokepoints)** — real-time vessels at Hormuz/Suez/Malacca/… | ✅ live |
+| `OPENAQ_API_KEY` | **Air quality — stations** — real PM2.5 from ~25.8k OpenAQ monitors | ✅ live |
+| `FIRMS_MAP_KEY` | **Active fires** — NASA VIIRS thermal detections | ✅ live |
+| `ACLED_EMAIL` + `ACLED_PASSWORD` | **Conflict events** + the conflict factor of the Index | ⏳ dormant — login works but the account's **API read access isn't activated yet** (returns 403). Activate it on myACLED and it goes live with no code change. |
+
+**Keyless layers added this session — already live, no key needed:** Internet
+outages (IODA), Space weather (NOAA SWPC), Tropical cyclones (NHC), and the
+flagship **Country Instability Index** (composited from food/displacement/outages,
+verified live across 170 countries). The Index currently caps ~49/100 because the
+conflict factor (ACLED) is dormant — activating ACLED opens it to the full range.
+Every layer now shows a live **freshness dot** in the rail (the trust spine).
+
+---
+
 ## 1 · Intelligence layers — get these (all free)
 
 | # | Source | Unlocks | Free tier | Env var(s) |

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -91,19 +91,24 @@ Every layer now shows a live **freshness dot** in the rail (the trust spine).
 
 ---
 
-## 4 · Parked / future — markets & macro (Task #12, not being built yet)
+## 4 · Markets & macro (Task #12 — BUILT)
 
-Listed only so the picture is complete. All free; get them whenever we pick up the
-markets work.
+The Markets panel is now multi-section. **Crypto (CoinGecko) and FX (Frankfurter /
+ECB) are keyless and live already.** The rest are wired and **dormant** — each
+section renders a quiet "add KEY" note until set, then goes live with no code change:
 
-| Source | Unlocks | Env var |
-|--------|---------|---------|
-| **Finnhub** | Global stock quotes / exchanges | `FINNHUB_API_KEY` |
-| **Alpha Vantage** | Equities / FX / commodities | `ALPHAVANTAGE_API_KEY` |
-| **Financial Modeling Prep** | Fundamentals / indices | `FMP_API_KEY` |
-| **FRED** (St. Louis Fed) | Macro series, central‑bank rates | `FRED_API_KEY` |
+| Source | Unlocks | Env var | State |
+|--------|---------|---------|-------|
+| **Finnhub** | Equities (SPY/QQQ/DIA/AAPL/MSFT/NVDA quotes) | `FINNHUB_API_KEY` | dormant |
+| **FRED** (St. Louis Fed) | Macro/rates (10-Yr, Fed Funds, unemployment, VIX) | `FRED_API_KEY` | dormant |
+| **freellmapi.co** (your gateway) | AI daily brief, grounded in the Instability Index | `FREELLMAPI_BASE_URL` + `FREELLMAPI_KEY` | dormant |
 
-(Polymarket, Fear & Greed, World Bank, Eurostat, OECD SDMX — all keyless, no entry needed.)
+- **Finnhub** — free key at <https://finnhub.io/register> (instant).
+- **FRED** — free key at <https://fredaccount.stlouisfed.org/apikeys>.
+- **freellmapi** — base URL + key from your own dashboard (also powers the `/locate` vision fallback).
+
+Alpha Vantage / FMP aren't used (Finnhub + FRED cover equities + macro). Polymarket,
+Fear & Greed, World Bank, Eurostat, OECD SDMX remain keyless options if we expand further.
 
 ---
 
@@ -134,10 +139,8 @@ GEOLOCATE_BACKEND=
 WINDY_WEBCAMS_API_KEY=
 WINDY_MAP_FORECAST_API_KEY=
 
-# --- Parked: markets/macro (Task #12) ---
+# --- Markets/macro (Task #12, BUILT — crypto+FX already live keyless; these unlock the rest) ---
 FINNHUB_API_KEY=
-ALPHAVANTAGE_API_KEY=
-FMP_API_KEY=
 FRED_API_KEY=
 ```
 

--- a/lib/brief.ts
+++ b/lib/brief.ts
@@ -1,0 +1,46 @@
+// AI daily brief — turns the day's live signals into a short, calm written
+// situation summary. The model call goes through freellmapi.co (Sampo's own
+// OpenAI-compatible gateway), so it's key-gated: dormant until FREELLMAPI_BASE_URL
+// + FREELLMAPI_KEY are set. The PROMPT BUILDER is pure and isomorphic so it
+// unit-tests in node; the network call lives in the route.
+//
+// Honesty guard: the brief is built ONLY from real signal data we already show
+// (the top of the Country Instability Index), and the prompt forbids speculation —
+// it summarises what the data says, it does not invent events.
+
+export interface BriefSnapshot {
+  /** Top instability countries (country name + 0–100 score), already ranked. */
+  topInstability: { country: string; score: number }[];
+  /** ISO date the snapshot was taken (optional, for the dateline). */
+  dateIso?: string;
+}
+
+export interface BriefPayload {
+  brief: string | null;
+  dormant: boolean;
+  generatedAt: number;
+}
+
+/** Pure: snapshot → the chat prompt sent to the gateway. */
+export function buildBriefPrompt(s: BriefSnapshot): string {
+  const list =
+    s.topInstability.length > 0
+      ? s.topInstability.map((c) => `${c.country} (${c.score}/100)`).join(", ")
+      : "no countries currently above the instability threshold";
+  const dateline = s.dateIso ? ` for ${s.dateIso}` : "";
+  return [
+    "You are a calm, factual intelligence analyst writing a short daily world brief" + dateline + ".",
+    "Using ONLY the data below, write 3 short sentences summarising where global pressure is concentrated today.",
+    "Do not invent specific events, casualty figures, or news the data does not contain. Do not speculate or give advice. Neutral, measured tone.",
+    "",
+    "Country Instability Index — highest-pressure countries right now: " + list + ".",
+    "(The index composites armed conflict, food insecurity, forced displacement and internet outages; a higher score means more concurrent pressure.)",
+  ].join("\n");
+}
+
+/** Pure: parse the gateway's chat-completion response → brief text, or null. */
+export function parseBriefResponse(json: unknown): string | null {
+  const choices = (json as { choices?: { message?: { content?: string } }[] })?.choices;
+  const content = choices?.[0]?.message?.content;
+  return typeof content === "string" && content.trim() ? content.trim() : null;
+}

--- a/lib/markets.ts
+++ b/lib/markets.ts
@@ -31,9 +31,121 @@ export interface MarketAsset {
   updatedAt?: string; // ISO from upstream
 }
 
+// --- multi-section model ----------------------------------------------------
+// Markets is no longer crypto-only: it shows several asset classes, each its own
+// honestly-labelled section. Keyless sections (crypto, FX) are always live; keyed
+// sections (equities, macro) render DORMANT with a "add KEY" note until configured
+// — never fabricated. The panel reads `sections`.
+
+export interface MarketRow {
+  id: string;
+  name: string;
+  symbol?: string;
+  /** Pre-formatted display value (price / rate / level). */
+  value: string;
+  /** Signed % change where the upstream provides it; null/undefined = not shown. */
+  changePct?: number | null;
+  /** Optional secondary line (market cap, unit, as-of date). */
+  sub?: string;
+  image?: string;
+}
+
+export interface MarketSection {
+  key: string;
+  label: string;
+  source: string;
+  /** True when the section is key-gated and the key isn't set; rows will be empty. */
+  dormant?: boolean;
+  /** Shown when dormant — which env var unlocks it. */
+  note?: string;
+  rows: MarketRow[];
+}
+
 export interface MarketsPayload {
   generatedAt: number;
-  assets: MarketAsset[];
+  sections: MarketSection[];
+}
+
+/** Crypto MarketAsset[] → display rows (market cap as the secondary line). */
+export function cryptoRows(assets: MarketAsset[]): MarketRow[] {
+  return assets.map((a) => ({
+    id: a.id,
+    name: a.name,
+    symbol: a.symbol,
+    value: formatPrice(a.price),
+    changePct: a.changePct24h,
+    image: a.image,
+    sub: a.marketCap != null ? `mkt cap ${formatCompactUsd(a.marketCap)}` : undefined,
+  }));
+}
+
+const FX_NAMES: Record<string, string> = {
+  EUR: "Euro", GBP: "British Pound", JPY: "Japanese Yen", CNY: "Chinese Yuan",
+  CHF: "Swiss Franc", CAD: "Canadian Dollar", AUD: "Australian Dollar", INR: "Indian Rupee",
+};
+
+/** Pure: Frankfurter (ECB) latest payload → FX rows (units of each currency per 1 USD). */
+export function parseFx(json: { base?: string; date?: string; rates?: Record<string, number> } | null | undefined): MarketRow[] {
+  const rates = json?.rates;
+  if (!rates) return [];
+  const out: MarketRow[] = [];
+  for (const [code, raw] of Object.entries(rates)) {
+    const rate = Number(raw);
+    if (!Number.isFinite(rate) || rate <= 0) continue;
+    out.push({
+      id: `fx:${code}`,
+      name: FX_NAMES[code] ?? code,
+      symbol: `USD/${code}`,
+      value: rate.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 }),
+      sub: json?.date ? `per 1 USD · ${json.date}` : "per 1 USD",
+    });
+  }
+  return out;
+}
+
+/** Pure: assembled Finnhub quotes → equity rows. {symbol,name,c(current),dp(% change)}. */
+export function parseEquities(
+  quotes: { symbol?: string; name?: string; c?: number | null; dp?: number | null }[] | null | undefined,
+): MarketRow[] {
+  if (!Array.isArray(quotes)) return [];
+  const out: MarketRow[] = [];
+  for (const q of quotes) {
+    const sym = (q.symbol ?? "").toUpperCase();
+    const price = q.c == null ? Number.NaN : Number(q.c);
+    if (!sym || !Number.isFinite(price) || price <= 0) continue;
+    const dp = typeof q.dp === "number" && Number.isFinite(q.dp) ? Number(q.dp.toFixed(2)) : null;
+    out.push({ id: `eq:${sym}`, name: q.name?.trim() || sym, symbol: sym, value: formatPrice(price), changePct: dp });
+  }
+  return out;
+}
+
+/** Pure: assembled FRED latest observations → macro rows. {id,label,value,unit,date}. */
+export function parseMacro(
+  series: { id?: string; label?: string; value?: number | string | null; unit?: string; date?: string }[] | null | undefined,
+): MarketRow[] {
+  if (!Array.isArray(series)) return [];
+  const out: MarketRow[] = [];
+  for (const s of series) {
+    const id = (s.id ?? "").trim();
+    const v = s.value == null ? Number.NaN : Number(s.value);
+    if (!id || !Number.isFinite(v)) continue;
+    out.push({
+      id: `macro:${id}`,
+      name: s.label?.trim() || id,
+      value: `${v.toLocaleString("en-US", { maximumFractionDigits: 2 })}${s.unit ?? ""}`,
+      sub: s.date ? `as of ${s.date}` : undefined,
+    });
+  }
+  return out;
+}
+
+/** Compact USD, e.g. "$1.2T", "$845B", "$12.3M". */
+export function formatCompactUsd(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e12) return `$${(n / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9) return `$${(n / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `$${(n / 1e6).toFixed(1)}M`;
+  return `$${n.toLocaleString("en-US")}`;
 }
 
 /** Pure: CoinGecko rows → MarketAsset[]. Skips rows with no id or no price. */

--- a/lib/signals/airquality-stations.ts
+++ b/lib/signals/airquality-stations.ts
@@ -1,0 +1,95 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// Air quality — real station measurements (OpenAQ v3). This is the measured
+// counterpart to the modelled CAMS/Open-Meteo air-quality layer: actual PM2.5
+// readings from ~25k reference + low-cost monitors worldwide. We pull the global
+// "latest PM2.5" snapshot (one capped page) and plot each station coloured by the
+// US-EPA PM2.5 band. Key-gated on OPENAQ_API_KEY (free); dormant (→ []) until set.
+//
+// Real-world data hygiene: OpenAQ passes through raw sensor values, which include
+// error sentinels (-1, -9999) and zeros — the normaliser rejects anything ≤ 0 or
+// implausibly high so the map never shows a phantom "clean" or broken station.
+
+const PM25_LATEST_URL = "https://api.openaq.org/v3/parameters/2/latest?limit=1000";
+
+/** Page cap — OpenAQ reports ~25k PM2.5 stations; we plot a global sample of this many. */
+export const OPENAQ_CAP = 1000;
+const MAX_PLAUSIBLE_PM25 = 2000; // µg/m³ — above this is a sensor fault, not air
+
+export const OPENAQ_ATTRIBUTION = "Air-quality measurements © OpenAQ contributors";
+
+interface AqLatest {
+  datetime?: { utc?: string };
+  value?: number;
+  coordinates?: { latitude?: number | null; longitude?: number | null };
+  sensorsId?: number;
+  locationsId?: number;
+}
+
+/** US-EPA PM2.5 band → {label, colour}. */
+export function pm25Band(v: number): { label: string; color: string } {
+  if (v <= 12) return { label: "good", color: "#16a34a" };
+  if (v <= 35.4) return { label: "moderate", color: "#eab308" };
+  if (v <= 55.4) return { label: "unhealthy (sensitive)", color: "#f59e0b" };
+  if (v <= 150.4) return { label: "unhealthy", color: "#dc2626" };
+  if (v <= 250.4) return { label: "very unhealthy", color: "#7e22ce" };
+  return { label: "hazardous", color: "#7f1d1d" };
+}
+
+/** Pure: OpenAQ latest-PM2.5 payload → SignalFeature[], dropping invalid/error readings. */
+export function normalizeAirStations(json: { results?: AqLatest[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const r of json.results ?? []) {
+    const lat = r.coordinates?.latitude;
+    const lon = r.coordinates?.longitude;
+    if (typeof lat !== "number" || typeof lon !== "number") continue;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    const v = r.value;
+    if (typeof v !== "number" || !Number.isFinite(v) || v <= 0 || v > MAX_PLAUSIBLE_PM25) continue; // error sentinels
+    if (!r.locationsId) continue;
+    const band = pm25Band(v);
+    out.push({
+      id: `openaq:${r.locationsId}:${r.sensorsId ?? "x"}`,
+      lat,
+      lon,
+      title: `PM2.5 ${v.toFixed(1)} µg/m³ — ${band.label}`,
+      signalId: "air-quality-stations",
+      color: band.color,
+      ts: r.datetime?.utc,
+      props: {
+        pm25: `${v.toFixed(1)} µg/m³`,
+        airQuality: band.label,
+        station: `#${r.locationsId}`,
+        measured: r.datetime?.utc ?? "—",
+        // Worse air → bigger marker (PM2.5 150 ≈ max radius).
+        magnitude: Math.min(10, Math.max(2, v / 15)),
+      },
+    });
+  }
+  return out.slice(0, OPENAQ_CAP);
+}
+
+export const AIR_QUALITY_STATIONS_SOURCE: SignalSource = {
+  id: "air-quality-stations",
+  label: "Air quality — stations (OpenAQ)",
+  group: "Environment",
+  color: "#dc2626",
+  refreshMs: 30 * 60 * 1000,
+  attribution: OPENAQ_ATTRIBUTION,
+  async fetch() {
+    const key = (process.env.OPENAQ_API_KEY ?? "").trim();
+    if (!key) return []; // dormant until the free key is set
+    try {
+      const res = await fetch(PM25_LATEST_URL, {
+        headers: { "X-API-Key": key, Accept: "application/json" },
+        signal: AbortSignal.timeout(20_000),
+      });
+      if (!res.ok) return [];
+      const json = (await res.json()) as { results?: AqLatest[] };
+      return normalizeAirStations(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/entsoe-zones.data.ts
+++ b/lib/signals/entsoe-zones.data.ts
@@ -1,0 +1,46 @@
+// ENTSO-E bidding-zone EIC codes → a representative coordinate + label. The grid
+// API is keyed by 16-char EIC "domain" codes, not countries, so this is the join
+// table that lets us plot one marker per zone. Covers the principal European
+// bidding zones (a zone is usually a country; a few countries are split). Anchors
+// are a central point in each zone — a label location, not a substation.
+
+export interface EntsoeZone {
+  eic: string;
+  name: string;
+  lat: number;
+  lon: number;
+}
+
+export const ENTSOE_ZONES: EntsoeZone[] = [
+  { eic: "10YAT-APG------L", name: "Austria", lat: 47.6, lon: 14.1 },
+  { eic: "10YBE----------2", name: "Belgium", lat: 50.6, lon: 4.7 },
+  { eic: "10YCZ-CEPS-----N", name: "Czechia", lat: 49.8, lon: 15.5 },
+  { eic: "10Y1001A1001A65H", name: "Denmark", lat: 56.0, lon: 9.5 },
+  { eic: "10Y1001A1001A39I", name: "Estonia", lat: 58.7, lon: 25.5 },
+  { eic: "10YFI-1--------U", name: "Finland", lat: 64.5, lon: 26.0 },
+  { eic: "10YFR-RTE------C", name: "France", lat: 46.6, lon: 2.5 },
+  { eic: "10Y1001A1001A83F", name: "Germany", lat: 51.2, lon: 10.4 },
+  { eic: "10YGR-HTSO-----Y", name: "Greece", lat: 39.1, lon: 22.9 },
+  { eic: "10YHU-MAVIR----U", name: "Hungary", lat: 47.2, lon: 19.5 },
+  { eic: "10YIE-1001A00010", name: "Ireland", lat: 53.4, lon: -8.0 },
+  { eic: "10YIT-GRTN-----B", name: "Italy", lat: 42.8, lon: 12.6 },
+  { eic: "10YLV-1001A00074", name: "Latvia", lat: 56.9, lon: 24.9 },
+  { eic: "10YLT-1001A0008Q", name: "Lithuania", lat: 55.3, lon: 23.9 },
+  { eic: "10YNL----------L", name: "Netherlands", lat: 52.2, lon: 5.3 },
+  { eic: "10YNO-0--------C", name: "Norway", lat: 64.5, lon: 11.0 },
+  { eic: "10YPL-AREA-----S", name: "Poland", lat: 52.0, lon: 19.4 },
+  { eic: "10YPT-REN------W", name: "Portugal", lat: 39.6, lon: -8.0 },
+  { eic: "10YRO-TEL------P", name: "Romania", lat: 45.9, lon: 25.0 },
+  { eic: "10YSK-SEPS-----K", name: "Slovakia", lat: 48.7, lon: 19.7 },
+  { eic: "10YSI-ELES-----O", name: "Slovenia", lat: 46.1, lon: 14.8 },
+  { eic: "10YES-REE------0", name: "Spain", lat: 40.2, lon: -3.7 },
+  { eic: "10YSE-1--------K", name: "Sweden", lat: 62.0, lon: 15.0 },
+  { eic: "10YCH-SWISSGRIDZ", name: "Switzerland", lat: 46.8, lon: 8.2 },
+  { eic: "10YGB----------A", name: "Great Britain", lat: 54.0, lon: -2.5 },
+];
+
+const BY_EIC = new Map(ENTSOE_ZONES.map((z) => [z.eic, z]));
+
+export function zoneByEic(eic: string): EntsoeZone | undefined {
+  return BY_EIC.get(eic.trim());
+}

--- a/lib/signals/entsoe.ts
+++ b/lib/signals/entsoe.ts
@@ -1,0 +1,108 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { ENTSOE_ZONES, zoneByEic, type EntsoeZone } from "@/lib/signals/entsoe-zones.data";
+
+// European electricity grid — ENTSO-E Transparency. Live total load (electricity
+// demand, MW) per bidding zone: a real-time read on each country's grid, and the
+// substrate for spotting demand spikes / shortfalls. The API returns XML keyed by
+// 16-char EIC "domain" codes, one zone per request, so the adapter fans out over
+// the principal zones, parses the most recent load point from each, and plots one
+// marker per zone. Key-gated: reads ENTSOE_API_TOKEN (free Web API security token,
+// emailed on request); dormant (→ []) until set.
+//
+// Token: register at https://transparency.entsoe.eu then email transparency@entsoe.eu
+// (subject "Restful API access") from the registered address.
+
+const ENDPOINT = "https://web-api.tp.entsoe.eu/api";
+
+export const ENTSOE_ATTRIBUTION = "Grid-load data © ENTSO-E Transparency Platform";
+
+/** Pure: a GL_MarketDocument (Total Load, A65) XML → the latest load in MW, or null. */
+export function parseLatestLoad(xml: string): number | null {
+  if (typeof xml !== "string" || !xml) return null;
+  // The document carries one <quantity> per time point; the last is the most recent.
+  const matches = xml.match(/<quantity>\s*([\d.]+)\s*<\/quantity>/g);
+  if (!matches || matches.length === 0) return null;
+  const last = matches[matches.length - 1];
+  const m = last.match(/<quantity>\s*([\d.]+)\s*<\/quantity>/);
+  if (!m) return null;
+  const mw = Number(m[1]);
+  return Number.isFinite(mw) && mw > 0 ? Math.round(mw) : null;
+}
+
+/** Pure: extract the bidding-zone EIC from the document, if present. */
+export function parseZoneEic(xml: string): string | null {
+  const m = xml.match(/outBiddingZone_Domain\.mRID[^>]*>\s*([^<\s]+)\s*</);
+  return m ? m[1] : null;
+}
+
+/** Pure: build one zone's load marker (load in MW). */
+export function loadFeature(zone: EntsoeZone, mw: number): SignalFeature {
+  const gw = mw / 1000;
+  return {
+    id: `entsoe:${zone.eic}`,
+    lat: zone.lat,
+    lon: zone.lon,
+    title: `${zone.name} — ${gw.toFixed(1)} GW load`,
+    signalId: "grid-load",
+    color: "#f59e0b",
+    props: {
+      zone: zone.name,
+      load: `${mw.toLocaleString()} MW`,
+      // Log-scaled: ~50 GW (France/Germany peak) ≈ max radius, ~1 GW small zone ≈ mid.
+      magnitude: Math.min(10, Math.max(2, Math.round(Math.log10(mw + 1) * 20) / 10)),
+    },
+  };
+}
+
+/** Pure: combine per-zone parse results into features (skips zones with no reading). */
+export function normalizeGridLoad(results: { eic: string; mw: number | null }[]): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const r of results) {
+    if (r.mw == null || !(r.mw > 0)) continue;
+    const zone = zoneByEic(r.eic);
+    if (!zone) continue;
+    out.push(loadFeature(zone, r.mw));
+  }
+  return out;
+}
+
+/** ENTSO-E wants UTC timestamps as yyyyMMddHHmm. */
+function entsoeStamp(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}${p(d.getUTCHours())}${p(d.getUTCMinutes())}`;
+}
+
+export const GRID_LOAD_SOURCE: SignalSource = {
+  id: "grid-load",
+  label: "Electricity grid load (ENTSO-E)",
+  group: "Infrastructure",
+  color: "#f59e0b",
+  refreshMs: 30 * 60 * 1000,
+  attribution: ENTSOE_ATTRIBUTION,
+  async fetch() {
+    const token = (process.env.ENTSOE_API_TOKEN ?? "").trim();
+    if (!token) return []; // dormant until the security token is set
+    const now = Date.now();
+    const periodStart = entsoeStamp(new Date(now - 3 * 3600_000)); // last 3h window
+    const periodEnd = entsoeStamp(new Date(now));
+    try {
+      const results = await Promise.all(
+        ENTSOE_ZONES.map(async (z) => {
+          try {
+            const url =
+              `${ENDPOINT}?documentType=A65&processType=A16&outBiddingZone_Domain=${z.eic}` +
+              `&periodStart=${periodStart}&periodEnd=${periodEnd}&securityToken=${encodeURIComponent(token)}`;
+            const res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+            if (!res.ok) return { eic: z.eic, mw: null };
+            return { eic: z.eic, mw: parseLatestLoad(await res.text()) };
+          } catch {
+            return { eic: z.eic, mw: null };
+          }
+        }),
+      );
+      return normalizeGridLoad(results);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/freshness.ts
+++ b/lib/signals/freshness.ts
@@ -1,0 +1,88 @@
+"use client";
+// Per-SIGNAL-layer freshness — the trust spine for the opt-in global feeds.
+//
+// lib/freshness.ts covers the four core layers (cameras/planes/satellites/webcams);
+// its own note calls a per-adapter monitor "the documented next step". This is that
+// step for the signals registry: each <SignalFeed> records the age + outcome of its
+// last fetch here, keyed by the (dynamic) registry source id, and the rail shows an
+// honest dot beside every signal layer. The classifier is pure and unit-tested.
+//
+// The honest "empty" state matters: a feed that fetched successfully but returned
+// nothing (NHC cyclones in the quiet season, no active military flights) is NOT
+// stale or broken — it's "live · none right now". Saying so is the whole point of
+// a no-dead-feeds product.
+
+import { useSyncExternalStore } from "react";
+
+export type SignalFreshState = "unknown" | "live" | "empty" | "lagging" | "stale" | "down";
+
+export interface SignalFreshRecord {
+  /** Epoch ms of the last completed fetch (success or failure), or null before the first. */
+  lastUpdate: number | null;
+  /** Did the last fetch succeed (HTTP ok, no throw)? */
+  ok: boolean;
+  /** Feature count from the last successful fetch. */
+  count: number;
+  /** The source's expected cadence; live/lagging/stale thresholds are multiples of it. */
+  refreshMs: number;
+}
+
+/** Pure age (ms) since the last fetch, or null if never fetched. */
+export function signalFreshAgeMs(r: SignalFreshRecord, now: number): number | null {
+  return r.lastUpdate == null ? null : Math.max(0, now - r.lastUpdate);
+}
+
+/** Pure classifier — unit tested. Empty (fetched-OK-but-zero) is a first-class, honest state. */
+export function classifySignalFreshness(r: SignalFreshRecord, now: number): SignalFreshState {
+  if (!r.ok) return "down";
+  if (r.lastUpdate == null) return "unknown";
+  const age = Math.max(0, now - r.lastUpdate);
+  if (age >= r.refreshMs * 6) return "stale";
+  if (r.count <= 0) return "empty"; // connected, nothing to show right now
+  if (age >= r.refreshMs * 2) return "lagging";
+  return "live";
+}
+
+/** Pure short label for a freshness state, given the age text. */
+export function signalFreshLabel(state: SignalFreshState, ageText: string): string {
+  switch (state) {
+    case "unknown": return "connecting…";
+    case "down": return "unavailable";
+    case "empty": return "live · none right now";
+    case "stale": return `stale · ${ageText} old`;
+    case "lagging": return `updated ${ageText} ago`;
+    case "live": return `updated ${ageText} ago`;
+  }
+}
+
+// --- store (keyed by dynamic signal id; mirrors signalCountsStore) ----------
+
+let records: Record<string, { lastUpdate: number; ok: boolean; count: number }> = {};
+const listeners = new Set<() => void>();
+
+export const signalFreshnessStore = {
+  record(id: string, update: { ok: boolean; count: number }, at: number = Date.now()) {
+    records = { ...records, [id]: { lastUpdate: at, ok: update.ok, count: update.count } };
+    for (const l of listeners) l();
+  },
+  clear(id: string) {
+    if (!(id in records)) return;
+    const next = { ...records };
+    delete next[id];
+    records = next;
+    for (const l of listeners) l();
+  },
+  get(): Record<string, { lastUpdate: number; ok: boolean; count: number }> {
+    return records;
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export function useSignalFreshness(): Record<string, { lastUpdate: number; ok: boolean; count: number }> {
+  return useSyncExternalStore(signalFreshnessStore.subscribe, signalFreshnessStore.get, signalFreshnessStore.get);
+}

--- a/lib/signals/instability.ts
+++ b/lib/signals/instability.ts
@@ -1,0 +1,289 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { COUNTRY_CENTROIDS, centroidByIso2, centroidByIso3, type CountryCentroid } from "@/lib/signals/country-centroids.data";
+import { ACLED_SOURCE } from "@/lib/signals/acled";
+
+// ============================================================================
+// Country Instability Index (CII) — the synthesis layer, the "real product".
+//
+// Most monitors show you raw dots. The CII answers the actual question — *which
+// countries are under the most pressure right now* — by combining several
+// independent signals into one transparent, per-country score (0–100).
+//
+// Design principles (this is what makes it trustworthy, not just another index):
+//   • HONEST INPUTS. We use displacement by country of *origin* (people fleeing
+//     FROM a place), NOT country of asylum — hosting refugees (Germany, Türkiye)
+//     is not instability. Ransomware victim counts are deliberately EXCLUDED:
+//     they track digital-economy size (US/UK top the list), not instability.
+//   • CONSERVATIVE. A missing factor contributes 0 (denominator is the full
+//     weight set), so sparse data UNDER-states rather than crying wolf. We show
+//     factor coverage ("3/4 factors") so the user sees the basis.
+//   • SHOWS ITS WORK. Every country lists each factor's contribution and the top
+//     drivers. No black box — you can see exactly why a score is what it is.
+//
+// Factors (each normalised to 0..1, then weighted):
+//   conflict (ACLED fatalities, 30d)   0.40   — the strongest signal; live only
+//                                                 when ACLED creds are set.
+//   food insecurity (WFP prevalence)   0.25   — acute hunger, instability accelerant
+//   displacement-from (UNHCR origin)   0.25   — people displaced FROM the country
+//   internet outages (IODA severity)   0.10   — shutdowns track unrest/crackdowns
+// ============================================================================
+
+export type FactorKey = "conflict" | "food" | "displacement" | "outages";
+
+export const FACTOR_WEIGHTS: Record<FactorKey, number> = {
+  conflict: 0.4,
+  food: 0.25,
+  displacement: 0.25,
+  outages: 0.1,
+};
+
+const FACTOR_LABEL: Record<FactorKey, string> = {
+  conflict: "armed conflict",
+  food: "food insecurity",
+  displacement: "displacement",
+  outages: "internet outages",
+};
+
+const TOTAL_WEIGHT = Object.values(FACTOR_WEIGHTS).reduce((a, b) => a + b, 0);
+/** Suppress the noise floor — countries below this score aren't plotted. */
+export const CII_MIN_SCORE = 8;
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+/** Raw factor value → 0..1 sub-score. Each ramp is documented and deliberately conservative. */
+export function normalizeFactor(key: FactorKey, raw: number): number {
+  if (!(raw > 0)) return 0;
+  switch (key) {
+    case "food":
+      return clamp01(raw / 0.5); // prevalence; 50%+ of the population insecure = max
+    case "displacement":
+      return clamp01(Math.log10(1 + raw) / 7); // people displaced-from; ~10M = max
+    case "outages":
+      return clamp01(Math.log10(1 + raw) / 6); // IODA severity score; ~1e6 = max
+    case "conflict":
+      return clamp01(Math.log10(1 + raw) / 3); // fatalities/30d; ~1000 = max
+  }
+}
+
+/** Instability score → colour ramp (calm green → extreme dark-red). */
+export function instabilityColor(score: number): string {
+  if (score >= 85) return "#7f1d1d";
+  if (score >= 70) return "#dc2626";
+  if (score >= 50) return "#ea580c";
+  if (score >= 30) return "#f59e0b";
+  if (score >= 15) return "#eab308";
+  return "#84cc16";
+}
+
+export interface CountryInput {
+  iso3: string;
+  /** Raw factor values (prevalence 0..1 for food; counts otherwise). Absent = no data. */
+  factors: Partial<Record<FactorKey, number>>;
+}
+
+/** Pure: per-country raw factors → scored SignalFeature[] (one marker per country ≥ threshold). */
+export function computeInstability(inputs: CountryInput[]): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const row of inputs) {
+    const ctr = centroidByIso3((row.iso3 ?? "").toUpperCase());
+    if (!ctr) continue;
+
+    const contributions: { key: FactorKey; norm: number; weighted: number }[] = [];
+    for (const key of Object.keys(FACTOR_WEIGHTS) as FactorKey[]) {
+      const raw = row.factors[key];
+      if (typeof raw !== "number" || !(raw > 0)) continue;
+      const norm = normalizeFactor(key, raw);
+      if (norm <= 0) continue;
+      contributions.push({ key, norm, weighted: norm * FACTOR_WEIGHTS[key] });
+    }
+    if (contributions.length === 0) continue;
+
+    // Conservative: divide by the FULL weight set, so missing factors pull the
+    // score down rather than being silently renormalised away.
+    const score = Math.round((contributions.reduce((a, c) => a + c.weighted, 0) / TOTAL_WEIGHT) * 100);
+    if (score < CII_MIN_SCORE) continue;
+
+    const drivers = [...contributions]
+      .sort((a, b) => b.weighted - a.weighted)
+      .map((c) => FACTOR_LABEL[c.key]);
+
+    const breakdown: Record<string, string> = {};
+    for (const c of contributions) breakdown[FACTOR_LABEL[c.key]] = `${Math.round(c.norm * 100)}%`;
+
+    out.push({
+      id: `cii:${ctr.iso3}`,
+      lat: ctr.lat,
+      lon: ctr.lon,
+      title: `${ctr.name} — instability ${score}/100`,
+      signalId: "instability",
+      color: instabilityColor(score),
+      props: {
+        country: ctr.name,
+        score,
+        drivers: drivers.join(" › "),
+        ...breakdown,
+        coverage: `${contributions.length}/4 factors`,
+        magnitude: Math.min(10, Math.max(2, score / 10)),
+      },
+    });
+  }
+  // Densest pressure first (helps the dossier list + any "top N" consumer).
+  return out.sort((a, b) => Number(b.props?.score ?? 0) - Number(a.props?.score ?? 0));
+}
+
+// --- factor collection (thin, dormant-safe fetches) -------------------------
+
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+/** name → ISO-3, for matching ACLED's country names (built once from the centroid set). */
+const NAME_TO_ISO3 = (() => {
+  const m = new Map<string, string>();
+  for (const c of COUNTRY_CENTROIDS) m.set(c.name.toLowerCase(), c.iso3);
+  // A few ACLED spellings that differ from the centroid dataset.
+  const alias: Record<string, string> = {
+    "democratic republic of congo": "COD",
+    "democratic republic of the congo": "COD",
+    "republic of congo": "COG",
+    "syria": "SYR",
+    "russia": "RUS",
+    "iran": "IRN",
+    "tanzania": "TZA",
+    "bolivia": "BOL",
+    "venezuela": "VEN",
+    "moldova": "MDA",
+    "laos": "LAO",
+    "south korea": "KOR",
+    "north korea": "PRK",
+    "vietnam": "VNM",
+    "myanmar": "MMR",
+  };
+  for (const [k, v] of Object.entries(alias)) if (!m.has(k)) m.set(k, v);
+  return m;
+})();
+
+function iso3ByName(name: string | undefined): string | undefined {
+  const n = (name ?? "").trim().toLowerCase();
+  return n ? NAME_TO_ISO3.get(n) : undefined;
+}
+
+async function getJson<T>(url: string, ms = 18_000): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": UA, Accept: "application/json" }, signal: AbortSignal.timeout(ms) });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Food-insecurity prevalence (0..1) by ISO-3, from WFP HungerMap. */
+async function foodFactor(): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const json = await getJson<{ body?: { countries?: { country?: { iso3?: string }; metrics?: { fcs?: { prevalence?: number } } }[] } }>(
+    "https://api.hungermapdata.org/v1/foodsecurity/country",
+  );
+  for (const c of json?.body?.countries ?? []) {
+    const iso3 = (c.country?.iso3 ?? "").toUpperCase();
+    const p = c.metrics?.fcs?.prevalence;
+    if (iso3 && typeof p === "number" && p > 0) out.set(iso3, p);
+  }
+  return out;
+}
+
+/** People displaced FROM each country (refugees+asylum-seekers+IDPs), by ISO-3, from UNHCR origin stats. */
+async function displacementFactor(): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const year = new Date().getUTCFullYear() - 1;
+  const fetchYear = async (y: number) =>
+    getJson<{ items?: { coo_iso?: string; refugees?: number | string; asylum_seekers?: number | string; idps?: number | string }[] }>(
+      `https://api.unhcr.org/population/v1/population/?limit=1000&yearFrom=${y}&yearTo=${y}&coo_all=true`,
+    );
+  let json = await fetchYear(year);
+  if (!json?.items?.length) json = await fetchYear(year - 1); // latest year may be unpublished
+  const num = (v: unknown) => (typeof v === "number" ? v : Number(v) || 0);
+  for (const r of json?.items ?? []) {
+    const iso3 = (r.coo_iso ?? "").toUpperCase();
+    if (!centroidByIso3(iso3)) continue; // drop aggregate rows ("-", "UNK", …)
+    const total = num(r.refugees) + num(r.asylum_seekers) + num(r.idps);
+    if (total > 0) out.set(iso3, (out.get(iso3) ?? 0) + total);
+  }
+  return out;
+}
+
+/** Internet-outage severity by ISO-3, from IODA's country summary. */
+async function outageFactor(): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const until = Math.floor(Date.now() / 1000);
+  const from = until - 24 * 3600;
+  const json = await getJson<{ data?: { scores?: { overall?: number }; entity?: { code?: string; type?: string } }[] }>(
+    `https://api.ioda.inetintel.cc.gatech.edu/v2/outages/summary?from=${from}&until=${until}&entityType=country&limit=200`,
+  );
+  for (const r of json?.data ?? []) {
+    if (r.entity?.type !== "country") continue;
+    const c = centroidByIso2((r.entity?.code ?? "").toUpperCase());
+    const score = r.scores?.overall;
+    if (c && typeof score === "number" && score > 0) out.set(c.iso3, (out.get(c.iso3) ?? 0) + score);
+  }
+  return out;
+}
+
+/** Conflict fatalities (30d) by ISO-3, reusing the ACLED adapter (dormant → empty). */
+async function conflictFactor(): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const feats = await ACLED_SOURCE.fetch();
+  for (const f of feats) {
+    const iso3 = iso3ByName(f.props?.country as string | undefined);
+    const fatalities = Number(f.props?.fatalities ?? 0);
+    if (iso3 && fatalities > 0) out.set(iso3, (out.get(iso3) ?? 0) + fatalities);
+  }
+  return out;
+}
+
+/** Merge the per-factor maps into one CountryInput list keyed by ISO-3. */
+export function mergeFactors(maps: { key: FactorKey; values: Map<string, number> }[]): CountryInput[] {
+  const byIso = new Map<string, CountryInput>();
+  for (const { key, values } of maps) {
+    for (const [iso3, raw] of values) {
+      let row = byIso.get(iso3);
+      if (!row) {
+        row = { iso3, factors: {} };
+        byIso.set(iso3, row);
+      }
+      row.factors[key] = raw;
+    }
+  }
+  return [...byIso.values()];
+}
+
+export const INSTABILITY_SOURCE: SignalSource = {
+  id: "instability",
+  label: "Country Instability Index",
+  group: "Synthesis",
+  color: "#dc2626",
+  refreshMs: 60 * 60 * 1000, // composite of slow-moving inputs; hourly is ample
+  attribution: "Composite — ACLED · WFP HungerMap · UNHCR · IODA",
+  async fetch() {
+    try {
+      const [food, displacement, outages, conflict] = await Promise.all([
+        foodFactor(),
+        displacementFactor(),
+        outageFactor(),
+        conflictFactor(),
+      ]);
+      const inputs = mergeFactors([
+        { key: "food", values: food },
+        { key: "displacement", values: displacement },
+        { key: "outages", values: outages },
+        { key: "conflict", values: conflict },
+      ]);
+      return computeInstability(inputs);
+    } catch {
+      return [];
+    }
+  },
+};
+
+/** Resolve a country centroid from an ISO-3 (re-exported for any CII consumer). */
+export function centroidForCii(iso3: string): CountryCentroid | undefined {
+  return centroidByIso3(iso3.toUpperCase());
+}

--- a/lib/signals/internet-outages.ts
+++ b/lib/signals/internet-outages.ts
@@ -1,0 +1,90 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { centroidByIso2 } from "@/lib/signals/country-centroids.data";
+
+// Internet outages — IODA (Internet Outage Detection & Analysis, Georgia Tech /
+// CAIDA). Detects national-scale connectivity drops from three independent
+// vantage points (active probing, BGP, telescope). Country-level internet
+// shutdowns are a top-tier instability signal — governments cut connectivity
+// during coups, contested elections and crackdowns. Keyless; country-aggregated:
+// IODA already returns one score per affected country, so we anchor a marker at
+// the country centroid sized by outage severity. Dormant-safe (→ [] on failure).
+
+const SUMMARY_URL = "https://api.ioda.inetintel.cc.gatech.edu/v2/outages/summary";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const IODA_ATTRIBUTION = "Internet-outage detection © IODA (CAIDA / Georgia Tech)";
+
+interface IodaEntity {
+  code?: string; // ISO-3166 alpha-2 for country entities
+  name?: string;
+  type?: string;
+}
+interface IodaRow {
+  scores?: { overall?: number };
+  event_cnt?: number;
+  entity?: IodaEntity;
+}
+
+/** Severity → marker magnitude (log-scaled; IODA scores span ~1e3–1e6). */
+function outageMagnitude(score: number): number {
+  if (!(score > 0)) return 3;
+  const m = Math.log10(score + 1) * 1.5; // ~4.7 at 1.5k, ~8.4 at 380k
+  return Math.min(10, Math.max(3, Math.round(m * 10) / 10));
+}
+
+/** Pure: IODA country-summary payload → one SignalFeature per located country. */
+export function normalizeOutages(json: { data?: IodaRow[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const r of json.data ?? []) {
+    const ent = r.entity;
+    if (!ent || ent.type !== "country") continue;
+    const code = (ent.code ?? "").trim().toUpperCase();
+    if (!code) continue;
+    const c = centroidByIso2(code);
+    if (!c) continue; // unknown / non-country code (e.g. "ZZ") — skip
+    const score = typeof r.scores?.overall === "number" ? r.scores.overall : 0;
+    const events = typeof r.event_cnt === "number" ? r.event_cnt : 0;
+    const name = ent.name?.trim() || c.name;
+    out.push({
+      id: `ioda:${code}`,
+      lat: c.lat,
+      lon: c.lon,
+      title: `Internet outage — ${name}`,
+      signalId: "internet-outages",
+      color: "#b91c1c", // censorship/outage red
+      props: {
+        country: name,
+        outageScore: Math.round(score),
+        events,
+        severity: score >= 100_000 ? "severe" : score >= 5_000 ? "elevated" : "localised",
+        magnitude: outageMagnitude(score),
+      },
+    });
+  }
+  return out;
+}
+
+export const INTERNET_OUTAGES_SOURCE: SignalSource = {
+  id: "internet-outages",
+  label: "Internet outages (IODA)",
+  group: "Infrastructure",
+  color: "#b91c1c",
+  refreshMs: 15 * 60 * 1000,
+  attribution: IODA_ATTRIBUTION,
+  async fetch() {
+    // Look back 24h; IODA extends the window server-side to catch ongoing events.
+    const until = Math.floor(Date.now() / 1000);
+    const from = until - 24 * 3600;
+    try {
+      const res = await fetch(
+        `${SUMMARY_URL}?from=${from}&until=${until}&entityType=country&limit=200`,
+        { headers: { Accept: "application/json", "User-Agent": UA }, signal: AbortSignal.timeout(20_000) },
+      );
+      if (!res.ok) return [];
+      const json = (await res.json()) as { data?: IodaRow[] };
+      return normalizeOutages(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -63,6 +63,8 @@ import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
 import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
 import { AIR_QUALITY_STATIONS_SOURCE } from "@/lib/signals/airquality-stations";
 import { TROPICAL_CYCLONES_SOURCE } from "@/lib/signals/tropical-cyclones";
+import { RELIEFWEB_SOURCE } from "@/lib/signals/reliefweb";
+import { GRID_LOAD_SOURCE } from "@/lib/signals/entsoe";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -105,6 +107,9 @@ export const SIGNALS: SignalSource[] = [
   // Human cost (keyless UNHCR displacement + WFP HungerMap, country-aggregated)
   DISPLACEMENT_SOURCE,
   FOOD_SECURITY_SOURCE,
+  RELIEFWEB_SOURCE, // UN OCHA humanitarian emergencies (key-gated: RELIEFWEB_APPNAME)
+  // Energy / grid (key-gated: ENTSOE_API_TOKEN)
+  GRID_LOAD_SOURCE,
   // Military (keyless unfiltered military ADS-B)
   MILITARY_AIR_SOURCE,
   // Maritime (real-time AIS vessel positions at strategic chokepoints; key-gated: AISSTREAM_API_KEY)

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -58,6 +58,8 @@ import { DISPLACEMENT_SOURCE } from "@/lib/signals/displacement";
 import { FOOD_SECURITY_SOURCE } from "@/lib/signals/food-security";
 import { MILITARY_AIR_SOURCE } from "@/lib/signals/military-air";
 import { AIS_SOURCE } from "@/lib/signals/ais";
+import { INTERNET_OUTAGES_SOURCE } from "@/lib/signals/internet-outages";
+import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -70,6 +72,7 @@ export const SIGNALS: SignalSource[] = [
   FIRE_FIRMS_SOURCE, // NASA FIRMS active-fire detections (key-gated: FIRMS_MAP_KEY)
   EMSC_SOURCE, // EMSC quakes — a 2nd, faster Euro-Med catalogue alongside USGS
   AURORA_SOURCE,
+  SPACE_WEATHER_SOURCE, // NOAA SWPC Kp/storm-scale status pin (keyless)
   // Space
   LAUNCHES_SOURCE,
   // Infrastructure (cables = line layer, gpsJamming = fill layer)
@@ -78,6 +81,7 @@ export const SIGNALS: SignalSource[] = [
   NUCLEAR_SOURCE,
   AIRPORTS_SOURCE,
   PORTS_SOURCE,
+  INTERNET_OUTAGES_SOURCE, // IODA national internet-shutdown detection (keyless, country-aggregated)
   // Intel (GDELT geolocated news coverage)
   CONFLICT_SOURCE,
   PROTESTS_SOURCE,

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -60,9 +60,13 @@ import { MILITARY_AIR_SOURCE } from "@/lib/signals/military-air";
 import { AIS_SOURCE } from "@/lib/signals/ais";
 import { INTERNET_OUTAGES_SOURCE } from "@/lib/signals/internet-outages";
 import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
+import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
+  // Synthesis — the flagship: a per-country instability score composited from the
+  // conflict / food / displacement / outage layers (keyless inputs; ACLED upgrades it).
+  INSTABILITY_SOURCE,
   EARTHQUAKES_SOURCE,
   WILDFIRES_SOURCE,
   VOLCANOES_SOURCE,

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -61,6 +61,7 @@ import { AIS_SOURCE } from "@/lib/signals/ais";
 import { INTERNET_OUTAGES_SOURCE } from "@/lib/signals/internet-outages";
 import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
 import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
+import { AIR_QUALITY_STATIONS_SOURCE } from "@/lib/signals/airquality-stations";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -94,6 +95,7 @@ export const SIGNALS: SignalSource[] = [
   // Environment & civic (keyless Open-Meteo + data.police.uk)
   WEATHER_SOURCE,
   AIR_QUALITY_SOURCE,
+  AIR_QUALITY_STATIONS_SOURCE, // real OpenAQ station PM2.5 (key-gated: OPENAQ_API_KEY)
   UK_CRIME_SOURCE,
   // Cyber threat (keyless abuse.ch + Ransomware.live, country-aggregated)
   CYBER_C2_SOURCE,

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -62,6 +62,7 @@ import { INTERNET_OUTAGES_SOURCE } from "@/lib/signals/internet-outages";
 import { SPACE_WEATHER_SOURCE } from "@/lib/signals/space-weather";
 import { INSTABILITY_SOURCE } from "@/lib/signals/instability";
 import { AIR_QUALITY_STATIONS_SOURCE } from "@/lib/signals/airquality-stations";
+import { TROPICAL_CYCLONES_SOURCE } from "@/lib/signals/tropical-cyclones";
 
 /** Every registered signal layer, in rail display order. */
 export const SIGNALS: SignalSource[] = [
@@ -74,6 +75,7 @@ export const SIGNALS: SignalSource[] = [
   SEVERE_STORMS_SOURCE,
   FLOODS_SOURCE,
   GDACS_SOURCE, // multi-hazard GDACS alerts (EQ/TC/FL/VO/DR/WF), alert-coloured
+  TROPICAL_CYCLONES_SOURCE, // NOAA NHC active named storms (keyless; empty in quiet season)
   FIRE_FIRMS_SOURCE, // NASA FIRMS active-fire detections (key-gated: FIRMS_MAP_KEY)
   EMSC_SOURCE, // EMSC quakes — a 2nd, faster Euro-Med catalogue alongside USGS
   AURORA_SOURCE,

--- a/lib/signals/reliefweb.ts
+++ b/lib/signals/reliefweb.ts
@@ -1,0 +1,136 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+import { centroidByIso3 } from "@/lib/signals/country-centroids.data";
+
+// Humanitarian disasters — ReliefWeb (UN OCHA). The authoritative register of
+// active humanitarian emergencies (conflict, flood, drought, epidemic, cyclone,
+// complex emergencies) with the affected country and an official situation-report
+// link. Key-gated: ReliefWeb's API requires a registered (free) `appname` — not a
+// secret, but the API 403s without an approved one — so the adapter reads
+// RELIEFWEB_APPNAME and stays dormant (→ []) until it's set.
+//
+// Request an appname: https://apidoc.reliefweb.int/parameters#appname
+
+const ENDPOINT = "https://api.reliefweb.int/v2/disasters";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const RELIEFWEB_ATTRIBUTION = "Humanitarian data © ReliefWeb (UN OCHA)";
+
+interface RwCountry {
+  iso3?: string;
+  name?: string;
+  primary?: boolean;
+  location?: { lat?: number; lon?: number };
+}
+interface RwDisaster {
+  id?: string | number;
+  fields?: {
+    name?: string;
+    status?: string; // "alert" | "current" | "past"
+    glide?: string;
+    primary_country?: RwCountry;
+    country?: RwCountry[];
+    type?: { name?: string; code?: string }[];
+    date?: { created?: string; changed?: string };
+    url?: string;
+  };
+}
+
+/** ReliefWeb disaster-type code → colour. */
+export function disasterColor(code: string): string {
+  switch (code.toUpperCase()) {
+    case "EQ": return "#b45309"; // earthquake
+    case "TC": return "#7e22ce"; // tropical cyclone
+    case "FL": return "#2563eb"; // flood
+    case "FF": return "#1d4ed8"; // flash flood
+    case "DR": return "#a16207"; // drought
+    case "EP": return "#0d9488"; // epidemic
+    case "CE": return "#dc2626"; // complex emergency (conflict)
+    case "AC": return "#ea580c"; // technological / other accident
+    case "WF": return "#c2410c"; // wildfire
+    case "VO": return "#9a3412"; // volcano
+    default: return "#64748b";
+  }
+}
+
+/** Active disasters get a bigger marker; alerts biggest. */
+function statusMagnitude(status: string): number {
+  switch (status) {
+    case "alert": return 7;
+    case "current": return 5;
+    default: return 3;
+  }
+}
+
+/** Pure: ReliefWeb /v2/disasters payload → SignalFeature[] (one per located disaster). */
+export function normalizeReliefWeb(json: { data?: RwDisaster[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const d of json.data ?? []) {
+    const f = d.fields;
+    if (!f) continue;
+    const pc = f.primary_country;
+    // Prefer ReliefWeb's own country location; fall back to our centroid by ISO-3.
+    let lat = pc?.location?.lat;
+    let lon = pc?.location?.lon;
+    if (typeof lat !== "number" || typeof lon !== "number") {
+      const c = centroidByIso3((pc?.iso3 ?? "").toUpperCase());
+      if (!c) continue;
+      lat = c.lat;
+      lon = c.lon;
+    }
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    const id = String(d.id ?? f.glide ?? f.name ?? "").trim();
+    if (!id) continue;
+    const types = (f.type ?? []).map((t) => t.name).filter(Boolean) as string[];
+    const primaryType = f.type?.[0];
+    const status = (f.status ?? "current").toLowerCase();
+    const country = pc?.name?.trim() || "Unknown";
+    out.push({
+      id: `reliefweb:${id}`,
+      lat,
+      lon,
+      title: f.name?.trim() || `${country} emergency`,
+      signalId: "reliefweb",
+      color: disasterColor(primaryType?.code ?? ""),
+      ts: f.date?.changed ?? f.date?.created ?? undefined,
+      link: f.url,
+      props: {
+        emergency: f.name?.trim() || "—",
+        country,
+        status,
+        types: types.length ? types.join(", ") : "—",
+        ...(f.glide ? { glide: f.glide } : {}),
+        updated: f.date?.changed ?? f.date?.created ?? "—",
+        magnitude: statusMagnitude(status),
+      },
+    });
+  }
+  return out;
+}
+
+export const RELIEFWEB_SOURCE: SignalSource = {
+  id: "reliefweb",
+  label: "Humanitarian emergencies (ReliefWeb)",
+  group: "Human cost",
+  color: "#dc2626",
+  refreshMs: 60 * 60 * 1000,
+  attribution: RELIEFWEB_ATTRIBUTION,
+  async fetch() {
+    const appname = (process.env.RELIEFWEB_APPNAME ?? "").trim();
+    if (!appname) return []; // dormant until an approved appname is set
+    try {
+      const url =
+        `${ENDPOINT}?appname=${encodeURIComponent(appname)}&profile=full&limit=100` +
+        `&filter[field]=status&filter[value][]=current&filter[value][]=alert` +
+        `&sort[]=date.changed:desc`;
+      const res = await fetch(url, {
+        headers: { "User-Agent": UA, Accept: "application/json" },
+        signal: AbortSignal.timeout(20_000),
+      });
+      if (!res.ok) return [];
+      const json = (await res.json()) as { data?: RwDisaster[] };
+      return normalizeReliefWeb(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/space-weather.ts
+++ b/lib/signals/space-weather.ts
@@ -1,0 +1,109 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// Space weather — NOAA SWPC. A global "status" signal: the planetary K-index
+// (geomagnetic activity, 0–9) plus the current NOAA storm scales — G (geomagnetic),
+// R (radio blackout) and S (solar radiation). High activity degrades GPS, HF radio
+// and power grids and pushes the aurora to lower latitudes, so it belongs in the
+// intel picture. Rendered as a single status pin at the north geomagnetic pole,
+// sized by Kp and coloured by the G-scale. Keyless; dormant-safe (→ [] on failure).
+
+const KP_URL = "https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json";
+const SCALES_URL = "https://services.swpc.noaa.gov/products/noaa-scales.json";
+
+// North geomagnetic pole (≈2025) — the natural anchor for a geomagnetic-status pin.
+const GEOMAG_NORTH: [number, number] = [80.7, -72.7];
+
+export const SWPC_ATTRIBUTION = "Space-weather data © NOAA SWPC";
+
+interface KpRow {
+  time_tag?: string;
+  Kp?: number;
+  a_running?: number;
+  station_count?: number;
+}
+interface ScaleBlock {
+  DateStamp?: string;
+  TimeStamp?: string;
+  R?: { Scale?: string | null; Text?: string | null };
+  S?: { Scale?: string | null; Text?: string | null };
+  G?: { Scale?: string | null; Text?: string | null };
+}
+export interface SpaceWeatherInput {
+  kp: KpRow[];
+  scales0: ScaleBlock | undefined;
+}
+
+/** NOAA G-scale (0–5) → colour (quiet green → severe red). */
+export function gScaleColor(scale: number): string {
+  switch (scale) {
+    case 0: return "#16a34a"; // quiet
+    case 1: return "#eab308"; // minor
+    case 2: return "#f59e0b"; // moderate
+    case 3: return "#ea580c"; // strong
+    case 4: return "#dc2626"; // severe
+    default: return "#7f1d1d"; // 5+ extreme
+  }
+}
+
+function scaleNum(s: string | null | undefined): number {
+  const n = Number((s ?? "").trim());
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Pure: latest Kp + current NOAA scales → a single space-weather status feature. */
+export function normalizeSpaceWeather(input: SpaceWeatherInput): SignalFeature[] {
+  const rows = input.kp ?? [];
+  const latest = rows.length ? rows[rows.length - 1] : undefined;
+  const kp = typeof latest?.Kp === "number" ? latest.Kp : Number.NaN;
+  if (!Number.isFinite(kp)) return [];
+
+  const sc = input.scales0;
+  const g = scaleNum(sc?.G?.Scale);
+  const r = scaleNum(sc?.R?.Scale);
+  const s = scaleNum(sc?.S?.Scale);
+  const kpLabel = kp >= 7 ? "severe storm" : kp >= 5 ? "storm" : kp >= 4 ? "unsettled" : "quiet";
+
+  return [
+    {
+      id: "swpc:status",
+      lat: GEOMAG_NORTH[0],
+      lon: GEOMAG_NORTH[1],
+      title: `Space weather — Kp ${kp.toFixed(1)} (${kpLabel})`,
+      signalId: "space-weather",
+      color: gScaleColor(g),
+      props: {
+        kp: Number(kp.toFixed(2)),
+        condition: kpLabel,
+        geomagneticStorm: g > 0 ? `G${g}` : "none",
+        radioBlackout: r > 0 ? `R${r}` : "none",
+        solarRadiation: s > 0 ? `S${s}` : "none",
+        updated: sc?.DateStamp && sc?.TimeStamp ? `${sc.DateStamp} ${sc.TimeStamp} UTC` : "—",
+        // Kp (0–9) maps almost directly onto our 0–10 marker scale.
+        magnitude: Math.min(10, Math.max(2, kp)),
+      },
+    },
+  ];
+}
+
+export const SPACE_WEATHER_SOURCE: SignalSource = {
+  id: "space-weather",
+  label: "Space weather (NOAA Kp/storms)",
+  group: "Space weather",
+  color: "#16a34a",
+  refreshMs: 15 * 60 * 1000,
+  attribution: SWPC_ATTRIBUTION,
+  async fetch() {
+    try {
+      const [kpRes, scRes] = await Promise.all([
+        fetch(KP_URL, { signal: AbortSignal.timeout(15_000) }),
+        fetch(SCALES_URL, { signal: AbortSignal.timeout(15_000) }),
+      ]);
+      if (!kpRes.ok) return [];
+      const kp = (await kpRes.json()) as KpRow[];
+      const scales = scRes.ok ? ((await scRes.json()) as Record<string, ScaleBlock>) : {};
+      return normalizeSpaceWeather({ kp: Array.isArray(kp) ? kp : [], scales0: scales["0"] });
+    } catch {
+      return [];
+    }
+  },
+};

--- a/lib/signals/tropical-cyclones.ts
+++ b/lib/signals/tropical-cyclones.ts
@@ -1,0 +1,126 @@
+import type { SignalFeature, SignalSource } from "@/lib/signals/types";
+
+// Tropical cyclones — NOAA NHC active-storms feed (keyless). Named tropical
+// systems (depressions → major hurricanes) with live position, intensity and
+// motion. The feed is `{ activeStorms: [] }` when nothing is active (quiet
+// season), so the layer renders empty and lights up automatically the moment a
+// storm forms — no dead feed, no stale dot. Each storm is plotted at its current
+// centre, coloured by Saffir–Simpson category and sized by max wind.
+//
+// NOTE: the NHC forecast CONE/track are GIS shapefiles, not in this JSON; v1
+// plots the storm centre only. Dormant-safe (→ [] on any failure).
+
+const ENDPOINT = "https://www.nhc.noaa.gov/CurrentStorms.json";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+
+export const NHC_ATTRIBUTION = "Tropical-cyclone data © NOAA NHC";
+
+interface NhcStorm {
+  id?: string;
+  name?: string;
+  classification?: string; // TD, TS, HU, MH, STD, STS, …
+  intensity?: string | number; // max sustained wind, kt
+  pressure?: string | number; // mb
+  latitude?: string; // "22.5N"
+  longitude?: string; // "95.3W"
+  latitudeNumeric?: number;
+  longitudeNumeric?: number;
+  movementDir?: number | string;
+  movementSpeed?: number | string;
+  lastUpdate?: string;
+}
+
+function toNum(v: unknown): number {
+  if (typeof v === "number") return Number.isFinite(v) ? v : Number.NaN;
+  const s = (v ?? "").toString().trim();
+  if (s === "") return Number.NaN;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : Number.NaN;
+}
+
+/** Parse "22.5N" / "95.3W" → signed decimal degrees. */
+function parseCoord(s: string | undefined): number {
+  if (!s) return Number.NaN;
+  const m = s.trim().match(/^([\d.]+)\s*([NSEW])$/i);
+  if (!m) return Number.NaN;
+  const v = Number(m[1]);
+  if (!Number.isFinite(v)) return Number.NaN;
+  const hemi = m[2].toUpperCase();
+  return hemi === "S" || hemi === "W" ? -v : v;
+}
+
+/** Classification + max-wind (kt) → {label, colour} on the Saffir–Simpson scale. */
+export function cycloneCategory(classification: string, windKt: number): { label: string; color: string } {
+  const c = (classification || "").toUpperCase();
+  if (c.includes("HU") || c.includes("MH") || windKt >= 64) {
+    if (windKt >= 137) return { label: "Cat 5 hurricane", color: "#581c87" };
+    if (windKt >= 113) return { label: "Cat 4 hurricane", color: "#7f1d1d" };
+    if (windKt >= 96) return { label: "Cat 3 hurricane", color: "#b91c1c" };
+    if (windKt >= 83) return { label: "Cat 2 hurricane", color: "#dc2626" };
+    return { label: "Cat 1 hurricane", color: "#ea580c" };
+  }
+  if (c.includes("TS") || windKt >= 34) return { label: "tropical storm", color: "#f59e0b" };
+  return { label: "tropical depression", color: "#eab308" };
+}
+
+/** Pure: NHC active-storms payload → SignalFeature[] (one point per storm). */
+export function normalizeCyclones(json: { activeStorms?: NhcStorm[] }): SignalFeature[] {
+  const out: SignalFeature[] = [];
+  for (const s of json.activeStorms ?? []) {
+    let lat = typeof s.latitudeNumeric === "number" ? s.latitudeNumeric : parseCoord(s.latitude);
+    let lon = typeof s.longitudeNumeric === "number" ? s.longitudeNumeric : parseCoord(s.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+    lat = Math.round(lat * 1000) / 1000;
+    lon = Math.round(lon * 1000) / 1000;
+    const wind = Math.max(0, toNum(s.intensity) || 0);
+    const cat = cycloneCategory(s.classification ?? "", wind);
+    const name = s.name?.trim() || s.id?.trim() || "Tropical system";
+    const dir = toNum(s.movementDir);
+    const spd = toNum(s.movementSpeed);
+    const pressure = toNum(s.pressure);
+    out.push({
+      id: `cyclone:${s.id?.trim() || name}`,
+      lat,
+      lon,
+      title: `${name} — ${cat.label}`,
+      signalId: "tropical-cyclones",
+      color: cat.color,
+      ts: s.lastUpdate ?? undefined,
+      props: {
+        storm: name,
+        category: cat.label,
+        maxWind: wind > 0 ? `${wind} kt` : "—",
+        pressure: Number.isFinite(pressure) ? `${pressure} mb` : "—",
+        movement:
+          Number.isFinite(dir) && Number.isFinite(spd) ? `${dir}° at ${spd} kt` : "—",
+        updated: s.lastUpdate ?? "—",
+        // Wind 137 kt (Cat 5) ≈ max radius.
+        magnitude: Math.min(10, Math.max(3, wind / 15)),
+      },
+    });
+  }
+  return out;
+}
+
+export const TROPICAL_CYCLONES_SOURCE: SignalSource = {
+  id: "tropical-cyclones",
+  label: "Tropical cyclones (NHC)",
+  group: "Natural hazards",
+  color: "#dc2626",
+  refreshMs: 30 * 60 * 1000,
+  attribution: NHC_ATTRIBUTION,
+  async fetch() {
+    try {
+      const res = await fetch(ENDPOINT, {
+        headers: { "User-Agent": UA, Accept: "application/json" },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) return [];
+      const json = (await res.json()) as { activeStorms?: NhcStorm[] };
+      return normalizeCyclones(json);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/tests/fixtures/entsoe-load.xml
+++ b/tests/fixtures/entsoe-load.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GL_MarketDocument xmlns="urn:iec62325.351:tc57wg16:451-6:generationloaddocument:3:0">
+  <mRID>sample-doc-fr</mRID>
+  <type>A65</type>
+  <process.processType>A16</process.processType>
+  <TimeSeries>
+    <mRID>1</mRID>
+    <businessType>A04</businessType>
+    <objectAggregation>A01</objectAggregation>
+    <outBiddingZone_Domain.mRID codingScheme="A01">10YFR-RTE------C</outBiddingZone_Domain.mRID>
+    <quantity_Measure_Unit.name>MAW</quantity_Measure_Unit.name>
+    <curveType>A01</curveType>
+    <Period>
+      <timeInterval>
+        <start>2026-06-27T06:00Z</start>
+        <end>2026-06-27T09:00Z</end>
+      </timeInterval>
+      <resolution>PT15M</resolution>
+      <Point><position>1</position><quantity>52150</quantity></Point>
+      <Point><position>2</position><quantity>52480</quantity></Point>
+      <Point><position>3</position><quantity>53010</quantity></Point>
+      <Point><position>4</position><quantity>53890</quantity></Point>
+    </Period>
+  </TimeSeries>
+</GL_MarketDocument>

--- a/tests/fixtures/ioda-outages.json
+++ b/tests/fixtures/ioda-outages.json
@@ -1,0 +1,64 @@
+{
+  "data": [
+    {
+      "scores": {
+        "ping-slash24.median": 377786.48936170223,
+        "overall": 377786.48936170223
+      },
+      "event_cnt": 1,
+      "entity": {
+        "code": "BZ",
+        "name": "Belize",
+        "subnames": [],
+        "type": "country",
+        "attrs": {
+          "fqid": "geo.netacuity.NA.BZ"
+        }
+      }
+    },
+    {
+      "scores": {
+        "ping-slash24.median": 5119.402985074627,
+        "overall": 5119.402985074627
+      },
+      "event_cnt": 1,
+      "entity": {
+        "code": "GI",
+        "name": "Gibraltar",
+        "subnames": [],
+        "type": "country",
+        "attrs": {
+          "fqid": "geo.netacuity.EU.GI"
+        }
+      }
+    },
+    {
+      "scores": {
+        "ping-slash24.median": 1500,
+        "overall": 1500
+      },
+      "event_cnt": 1,
+      "entity": {
+        "code": "LR",
+        "name": "Liberia",
+        "subnames": [],
+        "type": "country",
+        "attrs": {
+          "fqid": "geo.netacuity.AF.LR"
+        }
+      }
+    },
+    {
+      "scores": {
+        "overall": 0
+      },
+      "event_cnt": 0,
+      "entity": {
+        "code": "ZZ",
+        "name": "Nowhere",
+        "type": "country",
+        "attrs": {}
+      }
+    }
+  ]
+}

--- a/tests/fixtures/nhc-storms.json
+++ b/tests/fixtures/nhc-storms.json
@@ -1,0 +1,49 @@
+{
+  "activeStorms": [
+    {
+      "id": "al012026",
+      "binNumber": "AT1",
+      "name": "Alberto",
+      "classification": "HU",
+      "intensity": "120",
+      "pressure": "947",
+      "latitude": "24.6N",
+      "longitude": "84.3W",
+      "latitudeNumeric": 24.6,
+      "longitudeNumeric": -84.3,
+      "movementDir": 315,
+      "movementSpeed": 12,
+      "lastUpdate": "2026-06-27T09:00:00.000Z"
+    },
+    {
+      "id": "ep032026",
+      "binNumber": "EP3",
+      "name": "Carlotta",
+      "classification": "TS",
+      "intensity": "50",
+      "pressure": "994",
+      "latitude": "14.2N",
+      "longitude": "108.7W",
+      "latitudeNumeric": 14.2,
+      "longitudeNumeric": -108.7,
+      "movementDir": 285,
+      "movementSpeed": 9,
+      "lastUpdate": "2026-06-27T09:00:00.000Z"
+    },
+    {
+      "id": "wp052026",
+      "name": "Unnamed depression (string coords only)",
+      "classification": "TD",
+      "intensity": "25",
+      "pressure": "1004",
+      "latitude": "18.0N",
+      "longitude": "135.0E"
+    },
+    {
+      "id": "bad000",
+      "name": "Bad coords",
+      "classification": "TS",
+      "intensity": "40"
+    }
+  ]
+}

--- a/tests/fixtures/openaq-pm25.json
+++ b/tests/fixtures/openaq-pm25.json
@@ -1,0 +1,119 @@
+{
+  "results": [
+    {
+      "datetime": {
+        "utc": "2024-05-27T02:00:00Z",
+        "local": "2024-05-27T12:00:00+10:00"
+      },
+      "value": -9999.0,
+      "coordinates": {
+        "latitude": -27.090836,
+        "longitude": 150.400418
+      },
+      "sensorsId": 9381416,
+      "locationsId": 2868409
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T08:00:00Z",
+        "local": "2026-06-27T11:00:00+03:00"
+      },
+      "value": -1.0,
+      "coordinates": {
+        "latitude": 54.88361359025449,
+        "longitude": 23.83583450024486
+      },
+      "sensorsId": 23735,
+      "locationsId": 8152
+    },
+    {
+      "datetime": {
+        "utc": "2025-01-13T23:00:00Z",
+        "local": "2025-01-14T06:00:00+07:00"
+      },
+      "value": 0.0,
+      "coordinates": {
+        "latitude": 15.257387898044886,
+        "longitude": 104.03668778711167
+      },
+      "sensorsId": 9959326,
+      "locationsId": 2953982
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T08:30:00Z",
+        "local": "2026-06-27T14:00:00+05:30"
+      },
+      "value": 41.0,
+      "coordinates": {
+        "latitude": 28.885279999999998,
+        "longitude": 78.7388
+      },
+      "sensorsId": 12241402,
+      "locationsId": 270697
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T09:00:00Z",
+        "local": "2026-06-27T21:00:00+12:00"
+      },
+      "value": 69.7,
+      "coordinates": {
+        "latitude": -43.5599449,
+        "longitude": 172.6436133
+      },
+      "sensorsId": 9384695,
+      "locationsId": 2868842
+    },
+    {
+      "datetime": {
+        "utc": "2022-10-31T01:45:00Z",
+        "local": "2022-10-31T07:15:00+05:30"
+      },
+      "value": 86.11,
+      "coordinates": {
+        "latitude": 14.675885999999998,
+        "longitude": 77.593027
+      },
+      "sensorsId": 2028432,
+      "locationsId": 358456
+    },
+    {
+      "datetime": {
+        "utc": "2022-10-31T01:45:00Z",
+        "local": "2022-10-31T07:15:00+05:30"
+      },
+      "value": 154.81,
+      "coordinates": {
+        "latitude": 29.966942,
+        "longitude": 76.875879
+      },
+      "sensorsId": 20961,
+      "locationsId": 7282
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T09:00:00Z"
+      },
+      "value": 18.0,
+      "coordinates": {
+        "latitude": null,
+        "longitude": null
+      },
+      "sensorsId": 1,
+      "locationsId": 1
+    },
+    {
+      "datetime": {
+        "utc": "2026-06-27T09:00:00Z"
+      },
+      "value": -999.0,
+      "coordinates": {
+        "latitude": 51.5,
+        "longitude": -0.1
+      },
+      "sensorsId": 2,
+      "locationsId": 2
+    }
+  ]
+}

--- a/tests/fixtures/reliefweb-disasters.json
+++ b/tests/fixtures/reliefweb-disasters.json
@@ -1,0 +1,49 @@
+{
+  "data": [
+    {
+      "id": 12001,
+      "fields": {
+        "name": "Sudan: Complex Emergency - 2023-2026",
+        "status": "current",
+        "glide": "CE-2023-000123-SDN",
+        "primary_country": { "iso3": "SDN", "name": "Sudan", "location": { "lat": 15.5, "lon": 32.5 } },
+        "country": [{ "iso3": "SDN", "name": "Sudan", "primary": true }],
+        "type": [{ "name": "Complex Emergency", "code": "CE" }],
+        "date": { "created": "2023-05-01T00:00:00+00:00", "changed": "2026-06-26T08:00:00+00:00" },
+        "url": "https://reliefweb.int/disaster/ce-2023-000123-sdn"
+      }
+    },
+    {
+      "id": 12002,
+      "fields": {
+        "name": "Philippines: Tropical Cyclone - Jun 2026",
+        "status": "alert",
+        "primary_country": { "iso3": "PHL", "name": "Philippines", "location": { "lat": 12.9, "lon": 121.8 } },
+        "type": [{ "name": "Tropical Cyclone", "code": "TC" }],
+        "date": { "created": "2026-06-25T00:00:00+00:00", "changed": "2026-06-27T06:00:00+00:00" },
+        "url": "https://reliefweb.int/disaster/tc-2026-000200-phl"
+      }
+    },
+    {
+      "id": 12003,
+      "fields": {
+        "name": "Afghanistan: Earthquake - Jun 2026",
+        "status": "current",
+        "primary_country": { "iso3": "AFG", "name": "Afghanistan" },
+        "type": [{ "name": "Earthquake", "code": "EQ" }],
+        "date": { "created": "2026-06-20T00:00:00+00:00", "changed": "2026-06-24T00:00:00+00:00" },
+        "url": "https://reliefweb.int/disaster/eq-2026-000180-afg"
+      }
+    },
+    {
+      "id": 12099,
+      "fields": {
+        "name": "Unlocatable regional appeal",
+        "status": "current",
+        "primary_country": { "iso3": "ZZZ", "name": "Region-wide" },
+        "type": [{ "name": "Other", "code": "OT" }],
+        "date": { "created": "2026-06-01T00:00:00+00:00" }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/space-weather.json
+++ b/tests/fixtures/space-weather.json
@@ -1,0 +1,41 @@
+{
+  "kp": [
+    {
+      "time_tag": "2026-06-27T00:00:00",
+      "Kp": 2.67,
+      "a_running": 12,
+      "station_count": 8
+    },
+    {
+      "time_tag": "2026-06-27T03:00:00",
+      "Kp": 2.0,
+      "a_running": 7,
+      "station_count": 8
+    },
+    {
+      "time_tag": "2026-06-27T06:00:00",
+      "Kp": 2.0,
+      "a_running": 7,
+      "station_count": 8
+    }
+  ],
+  "scales0": {
+    "DateStamp": "2026-06-27",
+    "TimeStamp": "09:30:00",
+    "R": {
+      "Scale": "0",
+      "Text": "none",
+      "MinorProb": null,
+      "MajorProb": null
+    },
+    "S": {
+      "Scale": "0",
+      "Text": "none",
+      "Prob": null
+    },
+    "G": {
+      "Scale": "0",
+      "Text": "none"
+    }
+  }
+}

--- a/tests/unit/markets-sections.test.ts
+++ b/tests/unit/markets-sections.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "vitest";
+import {
+  parseFx,
+  parseEquities,
+  parseMacro,
+  cryptoRows,
+  formatCompactUsd,
+  type MarketAsset,
+} from "@/lib/markets";
+import { buildBriefPrompt, parseBriefResponse } from "@/lib/brief";
+
+test("parseFx maps ECB rates to per-USD rows (live shape)", () => {
+  // Real Frankfurter response shape.
+  const out = parseFx({ base: "USD", date: "2026-06-26", rates: { EUR: 0.87712, GBP: 0.75654, JPY: 161.65, BAD: 0 } });
+  expect(out).toHaveLength(3); // the zero rate is dropped
+  const eur = out.find((r) => r.id === "fx:EUR")!;
+  expect(eur.name).toBe("Euro");
+  expect(eur.symbol).toBe("USD/EUR");
+  expect(eur.sub).toContain("2026-06-26");
+  expect(eur.changePct).toBeUndefined(); // FX latest carries no change
+  expect(parseFx(null)).toEqual([]);
+  expect(parseFx({})).toEqual([]);
+});
+
+test("parseEquities keeps real quotes, drops empty/zero prices", () => {
+  const out = parseEquities([
+    { symbol: "spy", name: "S&P 500 (SPY)", c: 612.4, dp: 0.83 },
+    { symbol: "AAPL", name: "Apple", c: 0, dp: 0 }, // zero price → dropped
+    { symbol: "", name: "x", c: 10, dp: 1 }, // no symbol → dropped
+  ]);
+  expect(out).toHaveLength(1);
+  expect(out[0].id).toBe("eq:SPY");
+  expect(out[0].symbol).toBe("SPY");
+  expect(out[0].changePct).toBe(0.83);
+});
+
+test("parseMacro formats latest observations with units", () => {
+  const out = parseMacro([
+    { id: "DGS10", label: "10-Yr Treasury", value: 4.23, unit: "%", date: "2026-06-26" },
+    { id: "VIXCLS", label: "VIX (volatility)", value: 13.8, unit: "", date: "2026-06-26" },
+    { id: "BAD", label: "missing", value: null }, // "." sentinel → dropped
+  ]);
+  expect(out).toHaveLength(2);
+  expect(out.find((r) => r.id === "macro:DGS10")!.value).toBe("4.23%");
+  expect(out.find((r) => r.id === "macro:VIXCLS")!.value).toBe("13.8");
+});
+
+test("cryptoRows carries market cap as a compact sub-line", () => {
+  const assets: MarketAsset[] = [
+    { id: "bitcoin", symbol: "BTC", name: "Bitcoin", price: 60155, changePct24h: 1.2, marketCap: 1_190_000_000_000 },
+  ];
+  const rows = cryptoRows(assets);
+  expect(rows[0].value).toBe("$60,155.00");
+  expect(rows[0].sub).toBe("mkt cap $1.2T");
+});
+
+test("formatCompactUsd scales T/B/M", () => {
+  expect(formatCompactUsd(1_190_000_000_000)).toBe("$1.2T");
+  expect(formatCompactUsd(845_000_000_000)).toBe("$845.0B");
+  expect(formatCompactUsd(12_300_000)).toBe("$12.3M");
+});
+
+test("buildBriefPrompt is grounded and forbids speculation", () => {
+  const prompt = buildBriefPrompt({
+    topInstability: [
+      { country: "Afghanistan", score: 49 },
+      { country: "Somalia", score: 49 },
+    ],
+    dateIso: "2026-06-27",
+  });
+  expect(prompt).toContain("Afghanistan (49/100)");
+  expect(prompt).toContain("Somalia (49/100)");
+  expect(prompt).toContain("2026-06-27");
+  expect(prompt.toLowerCase()).toContain("do not invent");
+  // Empty snapshot still produces a safe prompt.
+  expect(buildBriefPrompt({ topInstability: [] })).toContain("no countries currently above");
+});
+
+test("parseBriefResponse pulls the message content, or null", () => {
+  expect(parseBriefResponse({ choices: [{ message: { content: "  Global pressure is concentrated…  " } }] })).toBe(
+    "Global pressure is concentrated…",
+  );
+  expect(parseBriefResponse({ choices: [] })).toBeNull();
+  expect(parseBriefResponse({})).toBeNull();
+  expect(parseBriefResponse(null)).toBeNull();
+});

--- a/tests/unit/signals-airquality-stations.test.ts
+++ b/tests/unit/signals-airquality-stations.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+// Live-captured OpenAQ PM2.5 readings, including real sensor-error rows (-1, -9999, 0)
+// and synthetic null-coord / negative-value edge rows.
+import fixture from "@/tests/fixtures/openaq-pm25.json";
+import { normalizeAirStations, pm25Band } from "@/lib/signals/airquality-stations";
+
+test("plots valid PM2.5 stations and rejects error sentinels", () => {
+  const out = normalizeAirStations(fixture as never);
+  // Only rows with a real positive value AND valid coordinates survive.
+  expect(out.length).toBeGreaterThan(0);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["air-quality-stations"]));
+  // No zero/negative/sentinel readings leak through.
+  for (const f of out) {
+    const v = parseFloat(String(f.props?.pm25));
+    expect(v).toBeGreaterThan(0);
+    expect(v).toBeLessThanOrEqual(2000);
+    expect(f.lat).toBeGreaterThanOrEqual(-90);
+    expect(f.lat).toBeLessThanOrEqual(90);
+  }
+  // The null-coord row and the -999 row are dropped.
+  expect(out.every((f) => Number.isFinite(f.lat) && Number.isFinite(f.lon))).toBe(true);
+});
+
+test("PM2.5 bands map to the EPA colour ramp", () => {
+  expect(pm25Band(8)).toEqual({ label: "good", color: "#16a34a" });
+  expect(pm25Band(25)).toEqual({ label: "moderate", color: "#eab308" });
+  expect(pm25Band(45)).toEqual({ label: "unhealthy (sensitive)", color: "#f59e0b" });
+  expect(pm25Band(100)).toEqual({ label: "unhealthy", color: "#dc2626" });
+  expect(pm25Band(200)).toEqual({ label: "very unhealthy", color: "#7e22ce" });
+  expect(pm25Band(400)).toEqual({ label: "hazardous", color: "#7f1d1d" });
+});
+
+test("worse air gives a bigger marker", () => {
+  const out = normalizeAirStations(fixture as never);
+  const sorted = [...out].sort(
+    (a, b) => parseFloat(String(a.props?.pm25)) - parseFloat(String(b.props?.pm25)),
+  );
+  if (sorted.length >= 2) {
+    const lo = Number(sorted[0].props?.magnitude);
+    const hi = Number(sorted[sorted.length - 1].props?.magnitude);
+    expect(hi).toBeGreaterThanOrEqual(lo);
+  }
+});

--- a/tests/unit/signals-entsoe.test.ts
+++ b/tests/unit/signals-entsoe.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  parseLatestLoad,
+  parseZoneEic,
+  normalizeGridLoad,
+  loadFeature,
+} from "@/lib/signals/entsoe";
+import { zoneByEic } from "@/lib/signals/entsoe-zones.data";
+
+const xml = readFileSync(fileURLToPath(new URL("../fixtures/entsoe-load.xml", import.meta.url)), "utf8");
+
+test("parses the most recent load point from a GL_MarketDocument", () => {
+  // Four points; the last (53890 MW) is the latest.
+  expect(parseLatestLoad(xml)).toBe(53890);
+  expect(parseZoneEic(xml)).toBe("10YFR-RTE------C");
+});
+
+test("parser is robust to empty/garbage input", () => {
+  expect(parseLatestLoad("")).toBeNull();
+  expect(parseLatestLoad("<GL_MarketDocument></GL_MarketDocument>")).toBeNull();
+  expect(parseZoneEic("<x/>")).toBeNull();
+});
+
+test("builds one marker per zone with a real reading, skipping nulls", () => {
+  const out = normalizeGridLoad([
+    { eic: "10YFR-RTE------C", mw: 53890 },
+    { eic: "10Y1001A1001A83F", mw: 61000 }, // Germany
+    { eic: "10YFI-1--------U", mw: null }, // no reading → skipped
+    { eic: "UNKNOWN-ZONE", mw: 1000 }, // not in the zone table → skipped
+  ]);
+  expect(out).toHaveLength(2);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["grid-load"]));
+
+  const fr = out.find((f) => f.id === "entsoe:10YFR-RTE------C")!;
+  expect(fr.title).toContain("France");
+  expect(fr.title).toContain("53.9 GW");
+  expect(fr.props?.load).toBe("53,890 MW");
+  // Bigger load → bigger marker.
+  const de = out.find((f) => f.id === "entsoe:10Y1001A1001A83F")!;
+  expect(Number(de.props?.magnitude)).toBeGreaterThanOrEqual(Number(fr.props?.magnitude));
+});
+
+test("loadFeature anchors at the zone coordinate", () => {
+  const zone = zoneByEic("10YGB----------A")!;
+  const f = loadFeature(zone, 38000);
+  expect(f.lat).toBe(zone.lat);
+  expect(f.lon).toBe(zone.lon);
+  expect(f.title).toContain("Great Britain");
+});

--- a/tests/unit/signals-freshness.test.ts
+++ b/tests/unit/signals-freshness.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import {
+  classifySignalFreshness,
+  signalFreshAgeMs,
+  signalFreshLabel,
+  type SignalFreshRecord,
+} from "@/lib/signals/freshness";
+
+const base = (over: Partial<SignalFreshRecord>): SignalFreshRecord => ({
+  lastUpdate: 1_000_000,
+  ok: true,
+  count: 5,
+  refreshMs: 60_000,
+  ...over,
+});
+
+test("a fresh, non-empty fetch is live", () => {
+  const r = base({ lastUpdate: 1_000_000, count: 5 });
+  expect(classifySignalFreshness(r, 1_000_000 + 30_000)).toBe("live"); // < 2× refresh
+});
+
+test("fetched OK but zero features is 'empty', not stale or broken", () => {
+  const r = base({ count: 0 });
+  expect(classifySignalFreshness(r, 1_000_000 + 1_000)).toBe("empty");
+  expect(signalFreshLabel("empty", "")).toBe("live · none right now");
+});
+
+test("ages into lagging then stale by multiples of the cadence", () => {
+  const r = base({ count: 5, refreshMs: 60_000 });
+  expect(classifySignalFreshness(r, 1_000_000 + 60_000 * 3)).toBe("lagging"); // 2×–6×
+  expect(classifySignalFreshness(r, 1_000_000 + 60_000 * 7)).toBe("stale"); // ≥ 6×
+});
+
+test("stale takes precedence over empty once truly old", () => {
+  const r = base({ count: 0, refreshMs: 60_000 });
+  expect(classifySignalFreshness(r, 1_000_000 + 60_000 * 7)).toBe("stale");
+});
+
+test("failed fetch is down; never-fetched is unknown", () => {
+  expect(classifySignalFreshness(base({ ok: false }), 2_000_000)).toBe("down");
+  expect(classifySignalFreshness(base({ lastUpdate: null }), 2_000_000)).toBe("unknown");
+  expect(signalFreshLabel("down", "")).toBe("unavailable");
+  expect(signalFreshLabel("unknown", "")).toBe("connecting…");
+});
+
+test("age helper is null before first fetch, clamped non-negative otherwise", () => {
+  expect(signalFreshAgeMs(base({ lastUpdate: null }), 5)).toBeNull();
+  expect(signalFreshAgeMs(base({ lastUpdate: 1_000 }), 4_000)).toBe(3_000);
+  expect(signalFreshAgeMs(base({ lastUpdate: 5_000 }), 4_000)).toBe(0); // clock skew → clamped
+});

--- a/tests/unit/signals-instability.test.ts
+++ b/tests/unit/signals-instability.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "vitest";
+import {
+  computeInstability,
+  normalizeFactor,
+  instabilityColor,
+  mergeFactors,
+  FACTOR_WEIGHTS,
+  type CountryInput,
+} from "@/lib/signals/instability";
+
+test("scores a multi-factor country and shows its work", () => {
+  const inputs: CountryInput[] = [
+    { iso3: "SYR", factors: { conflict: 1000, food: 0.45, displacement: 6_000_000, outages: 50_000 } },
+  ];
+  const out = computeInstability(inputs);
+  expect(out).toHaveLength(1);
+  const f = out[0];
+  expect(f.id).toBe("cii:SYR");
+  expect(f.signalId).toBe("instability");
+  expect(f.props?.score).toBe(95); // weighted composite over the full weight set
+  expect(f.color).toBe(instabilityColor(95)); // extreme → dark red
+  expect(f.props?.coverage).toBe("4/4 factors");
+  // Drivers ordered by weighted contribution — conflict (w=0.40) leads.
+  expect(String(f.props?.drivers).startsWith("armed conflict")).toBe(true);
+  // The breakdown exposes each factor's normalised sub-score.
+  expect(f.props?.["food insecurity"]).toBe("90%");
+});
+
+test("missing factors pull the score down (conservative), not renormalised away", () => {
+  // Food only, 30% prevalence → norm 0.6 → 0.6*0.25 = 0.15 → score 15 (NOT 60).
+  const out = computeInstability([{ iso3: "SDN", factors: { food: 0.3 } }]);
+  expect(out).toHaveLength(1);
+  expect(out[0].props?.score).toBe(15);
+  expect(out[0].props?.coverage).toBe("1/4 factors");
+});
+
+test("drops below-threshold countries and unknown ISO codes", () => {
+  const out = computeInstability([
+    { iso3: "DEU", factors: { food: 0.1 } }, // norm 0.2 → score 5 → below CII_MIN_SCORE
+    { iso3: "XXX", factors: { conflict: 999 } }, // no centroid → skipped
+  ]);
+  expect(out).toHaveLength(0);
+});
+
+test("output is sorted by score, densest pressure first", () => {
+  const out = computeInstability([
+    { iso3: "SDN", factors: { food: 0.3 } }, // score 15
+    { iso3: "SYR", factors: { conflict: 1000, food: 0.45, displacement: 6_000_000, outages: 50_000 } }, // 95
+  ]);
+  expect(out.map((f) => f.id)).toEqual(["cii:SYR", "cii:SDN"]);
+});
+
+test("factor normalisers ramp as documented; weights sum to 1", () => {
+  expect(Object.values(FACTOR_WEIGHTS).reduce((a, b) => a + b, 0)).toBeCloseTo(1);
+  expect(normalizeFactor("food", 0.5)).toBeCloseTo(1);
+  expect(normalizeFactor("food", 1)).toBe(1); // clamped
+  expect(normalizeFactor("food", 0)).toBe(0);
+  expect(normalizeFactor("outages", 1_000_000)).toBeCloseTo(1);
+  expect(normalizeFactor("conflict", 1000)).toBeCloseTo(1);
+  expect(instabilityColor(90)).toBe("#7f1d1d");
+  expect(instabilityColor(35)).toBe("#f59e0b");
+  expect(instabilityColor(5)).toBe("#84cc16");
+});
+
+test("mergeFactors keys per-factor maps by ISO-3", () => {
+  const inputs = mergeFactors([
+    { key: "food", values: new Map([["SYR", 0.45], ["USA", 0.05]]) },
+    { key: "conflict", values: new Map([["SYR", 1000]]) },
+  ]);
+  const syr = inputs.find((i) => i.iso3 === "SYR")!;
+  expect(syr.factors.food).toBe(0.45);
+  expect(syr.factors.conflict).toBe(1000);
+  const usa = inputs.find((i) => i.iso3 === "USA")!;
+  expect(usa.factors).toEqual({ food: 0.05 });
+});

--- a/tests/unit/signals-internet-outages.test.ts
+++ b/tests/unit/signals-internet-outages.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+// Live-captured IODA country-summary rows + one unknown-country edge row.
+import fixture from "@/tests/fixtures/ioda-outages.json";
+import { normalizeOutages } from "@/lib/signals/internet-outages";
+
+test("normalizes IODA outages to one marker per located country", () => {
+  const out = normalizeOutages(fixture as never);
+  // BZ, GI, LR resolve to centroids; the "ZZ" edge row has no centroid and is skipped.
+  expect(out).toHaveLength(3);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["internet-outages"]));
+  expect(out.every((f) => f.id.startsWith("ioda:"))).toBe(true);
+});
+
+test("severity bands and magnitude scale with the outage score", () => {
+  const out = normalizeOutages(fixture as never);
+  const belize = out.find((f) => f.id === "ioda:BZ")!; // score ~377k → severe
+  expect(belize.props?.severity).toBe("severe");
+  expect(belize.title).toContain("Belize");
+
+  const liberia = out.find((f) => f.id === "ioda:LR")!; // score 1500 → localised
+  expect(liberia.props?.severity).toBe("localised");
+
+  // Bigger outage → bigger marker.
+  expect(Number(belize.props?.magnitude)).toBeGreaterThan(Number(liberia.props?.magnitude));
+  expect(Number(belize.props?.magnitude)).toBeLessThanOrEqual(10);
+});

--- a/tests/unit/signals-reliefweb.test.ts
+++ b/tests/unit/signals-reliefweb.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "vitest";
+// Schema-based fixture (ReliefWeb requires an approved appname; no live capture).
+// Field shapes mirror a real /v2/disasters?profile=full response.
+import fixture from "@/tests/fixtures/reliefweb-disasters.json";
+import { normalizeReliefWeb, disasterColor } from "@/lib/signals/reliefweb";
+
+test("normalizes located disasters, falling back to centroid then skipping the unlocatable", () => {
+  const out = normalizeReliefWeb(fixture as never);
+  // Sudan (own loc), Philippines (own loc), Afghanistan (centroid fallback) = 3;
+  // the "ZZZ" region-wide appeal has neither → skipped.
+  expect(out).toHaveLength(3);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["reliefweb"]));
+
+  const sudan = out.find((f) => f.id === "reliefweb:12001")!;
+  expect(sudan.props?.country).toBe("Sudan");
+  expect(sudan.props?.status).toBe("current");
+  expect(sudan.color).toBe(disasterColor("CE"));
+  expect(sudan.lat).toBeCloseTo(15.5);
+  expect(sudan.link).toContain("reliefweb.int");
+  expect(sudan.ts).toBe("2026-06-26T08:00:00+00:00");
+
+  // Afghanistan has no location → resolved from the ISO-3 centroid.
+  const afg = out.find((f) => f.id === "reliefweb:12003")!;
+  expect(Number.isFinite(afg.lat)).toBe(true);
+  expect(afg.props?.types).toBe("Earthquake");
+});
+
+test("alerts get a bigger marker than current emergencies; type colours map", () => {
+  const out = normalizeReliefWeb(fixture as never);
+  const alert = out.find((f) => f.id === "reliefweb:12002")!; // Philippines, status alert
+  const current = out.find((f) => f.id === "reliefweb:12001")!; // Sudan, status current
+  expect(Number(alert.props?.magnitude)).toBeGreaterThan(Number(current.props?.magnitude));
+  expect(alert.color).toBe(disasterColor("TC"));
+  expect(disasterColor("FL")).toBe("#2563eb");
+  expect(disasterColor("DR")).toBe("#a16207");
+  expect(disasterColor("ZZ")).toBe("#64748b"); // unknown type
+});

--- a/tests/unit/signals-space-weather.test.ts
+++ b/tests/unit/signals-space-weather.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+// Live-captured NOAA SWPC Kp series + current storm-scale block.
+import fixture from "@/tests/fixtures/space-weather.json";
+import { normalizeSpaceWeather, gScaleColor } from "@/lib/signals/space-weather";
+
+test("emits a single status pin from the latest Kp + current scales", () => {
+  const out = normalizeSpaceWeather(fixture as never);
+  expect(out).toHaveLength(1);
+  const f = out[0];
+  expect(f.id).toBe("swpc:status");
+  expect(f.signalId).toBe("space-weather");
+  // Latest Kp in the fixture is 2.0 → quiet, geomagnetic storm "none".
+  expect(f.props?.kp).toBe(2);
+  expect(f.props?.condition).toBe("quiet");
+  expect(f.props?.geomagneticStorm).toBe("none");
+  expect(f.color).toBe(gScaleColor(0)); // G0 → green
+  // Anchored near the north geomagnetic pole.
+  expect(f.lat).toBeGreaterThan(75);
+});
+
+test("empty Kp series yields no feature; G-scale colours escalate", () => {
+  expect(normalizeSpaceWeather({ kp: [], scales0: undefined })).toHaveLength(0);
+  expect(gScaleColor(0)).toBe("#16a34a");
+  expect(gScaleColor(3)).toBe("#ea580c");
+  expect(gScaleColor(5)).toBe("#7f1d1d");
+});
+
+test("storm conditions raise the Kp label and marker magnitude", () => {
+  const out = normalizeSpaceWeather({
+    kp: [{ time_tag: "t", Kp: 7.33 }],
+    scales0: { G: { Scale: "3" }, R: { Scale: "1" }, S: { Scale: "0" } },
+  });
+  const f = out[0];
+  expect(f.props?.condition).toBe("severe storm");
+  expect(f.props?.geomagneticStorm).toBe("G3");
+  expect(f.props?.radioBlackout).toBe("R1");
+  expect(f.color).toBe(gScaleColor(3));
+  expect(Number(f.props?.magnitude)).toBeGreaterThan(7);
+});

--- a/tests/unit/signals-tropical-cyclones.test.ts
+++ b/tests/unit/signals-tropical-cyclones.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+// Schema-based fixture (no live storm to capture in the quiet season). Field shapes
+// mirror a real NHC CurrentStorms.json active-storm record.
+import fixture from "@/tests/fixtures/nhc-storms.json";
+import { normalizeCyclones, cycloneCategory } from "@/lib/signals/tropical-cyclones";
+
+test("normalizes active storms, skipping records with no usable position", () => {
+  const out = normalizeCyclones(fixture as never);
+  // Alberto (numeric), Carlotta (numeric), depression (string coords) = 3; "bad000" (no coords) skipped.
+  expect(out).toHaveLength(3);
+  expect(new Set(out.map((f) => f.signalId))).toEqual(new Set(["tropical-cyclones"]));
+
+  const alberto = out.find((f) => f.id === "cyclone:al012026")!;
+  expect(alberto.title).toContain("Alberto");
+  expect(alberto.props?.category).toBe("Cat 4 hurricane"); // 120 kt
+  expect(alberto.color).toBe("#7f1d1d");
+  expect(alberto.props?.maxWind).toBe("120 kt");
+  expect(alberto.props?.pressure).toBe("947 mb");
+  expect(alberto.lat).toBeCloseTo(24.6);
+  expect(alberto.lon).toBeCloseTo(-84.3);
+});
+
+test("parses string hemisphere coordinates when numeric fields are absent", () => {
+  const out = normalizeCyclones(fixture as never);
+  const dep = out.find((f) => f.id === "cyclone:wp052026")!;
+  expect(dep.lat).toBeCloseTo(18.0);
+  expect(dep.lon).toBeCloseTo(135.0); // 135.0E → positive
+  expect(dep.props?.category).toBe("tropical depression");
+});
+
+test("Saffir–Simpson category mapping by wind/classification", () => {
+  expect(cycloneCategory("HU", 140).label).toBe("Cat 5 hurricane");
+  expect(cycloneCategory("HU", 120).label).toBe("Cat 4 hurricane");
+  expect(cycloneCategory("HU", 100).label).toBe("Cat 3 hurricane");
+  expect(cycloneCategory("HU", 85).label).toBe("Cat 2 hurricane");
+  expect(cycloneCategory("HU", 70).label).toBe("Cat 1 hurricane");
+  expect(cycloneCategory("TS", 50).label).toBe("tropical storm");
+  expect(cycloneCategory("TD", 25).label).toBe("tropical depression");
+  // Classification missing but wind high → still classified by wind.
+  expect(cycloneCategory("", 100).label).toBe("Cat 3 hurricane");
+});


### PR DESCRIPTION
## Brings the whole intelligence build into `main`

`main` currently stops at AIS (#17). This lands everything merged afterwards into `feat/intel-ais` — **15 commits, 42 files, +2,430 lines** — so `main` finally has the full picture.

### What this adds to `main`
- 🏴 **Country Instability Index** — the flagship per-country 0–100 synthesis (honest by construction; verified live across 170 countries)
- **Trust/freshness spine** — a live freshness dot on every signal layer (incl. the honest "live · none right now" state)
- **Internet outages** (IODA) · **Space weather** (NOAA SWPC) · **Tropical cyclones** (NHC) — keyless
- **Real OpenAQ air-quality stations** (live) · **NASA FIRMS fires** (live)
- **ReliefWeb** humanitarian emergencies · **ENTSO-E** EU grid load — free-key dormant
- **Markets/macro** — crypto + FX live (keyless), equities + macro dormant, + an **AI daily brief** grounded in the Instability Index (#24)

### State
- Keys live (in gitignored `.env.local`): AIS, OpenAQ, FIRMS
- Keyless & live: Instability Index, outages, space weather, cyclones, crypto, FX, EMSC
- Dormant (await a free key): ACLED (also opens the Index's full range), ReliefWeb, ENTSO-E, Finnhub, FRED, freellmapi brief

### Verification
Every layer: pure normaliser + live-captured-or-schema fixture + unit test, dormant-safe (`fetch()` → `[]` on any failure, never 5xx). vitest **337/337**, `tsc` clean, `next build` green. Solo-attributed, no Claude trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)