### PR TITLE
Intel Widgets — Country Instability, Armed Conflict, Top Events, Strategic Risk + always-on column

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -733,3 +733,52 @@ a { color: var(--tn-accent); }
 /* Variant switcher + workspace toggle live in the header's left cluster. */
 .tn-topbar-variant { display: flex; align-items: center; gap: 8px; align-self: center; }
 @media (max-width: 900px) { .tn-tagline { display: none; } }
+
+/* Intel widgets (dock data panels) ------------------------------------------ */
+.tn-widget { display: flex; flex-direction: column; min-height: 0; height: 100%; }
+.tn-widget-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 8px; margin-bottom: 6px;
+}
+.tn-widget-title { font-size: 13px; font-weight: 650; margin: 0; color: var(--tn-text, #0f172a); }
+.tn-widget-source { font-size: 11px; color: var(--tn-text-dim, #64748b); white-space: nowrap; }
+.tn-widget-status { font-size: 12px; color: var(--tn-text-dim, #64748b); margin: 8px 2px; }
+.tn-widget-list { list-style: none; margin: 0; padding: 0; overflow: auto; flex: 1; min-height: 0; }
+.tn-widget-row {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 5px 6px; border: none; background: transparent; cursor: pointer;
+  border-radius: 7px; text-align: left; color: inherit;
+  border-bottom: 1px solid var(--tn-border, #e7edf3);
+}
+.tn-widget-row:hover { background: var(--tn-surface-2, #f1f5f9); }
+.tn-widget-rank {
+  flex: 0 0 auto; width: 18px; text-align: right;
+  font-size: 11px; color: var(--tn-text-dim, #94a3b8); font-variant-numeric: tabular-nums;
+}
+.tn-widget-row-main { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.tn-widget-row-title {
+  font-size: 12.5px; color: var(--tn-text, #0f172a); font-weight: 550;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.tn-widget-row-sub {
+  font-size: 11px; color: var(--tn-text-dim, #64748b);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.tn-widget-metric { flex: 0 0 auto; font-size: 14px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.tn-widget-metric-unit { font-size: 10px; font-weight: 500; color: var(--tn-text-dim, #94a3b8); margin-left: 3px; }
+.tn-widget-chip {
+  flex: 0 0 auto; font-size: 10px; font-weight: 600; color: #fff;
+  padding: 1px 6px; border-radius: 999px; line-height: 1.5;
+}
+.tn-widget-foot {
+  font-size: 10.5px; color: var(--tn-text-dim, #94a3b8); margin: 6px 2px 0;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+/* Strategic risk gauge */
+.tn-widget-risk { align-items: stretch; }
+.tn-risk-gauge { display: flex; align-items: baseline; gap: 10px; padding: 6px 2px; }
+.tn-risk-score { font-size: 38px; font-weight: 800; line-height: 1; color: var(--tn-text, #0f172a); }
+.tn-risk-gauge[data-level="elevated"] .tn-risk-score { color: #f59e0b; }
+.tn-risk-gauge[data-level="high"] .tn-risk-score { color: #ea580c; }
+.tn-risk-gauge[data-level="severe"] .tn-risk-score { color: #dc2626; }
+.tn-risk-level { font-size: 13px; font-weight: 600; color: var(--tn-text-dim, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -782,3 +782,34 @@ a { color: var(--tn-accent); }
 .tn-risk-gauge[data-level="high"] .tn-risk-score { color: #ea580c; }
 .tn-risk-gauge[data-level="severe"] .tn-risk-score { color: #dc2626; }
 .tn-risk-level { font-size: 13px; font-weight: 600; color: var(--tn-text-dim, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
+
+/* Always-on intel column (WorldMonitor-style permanent right rail) ----------- */
+.tn-intel-column {
+  position: fixed;
+  top: calc(var(--tn-topbar-h, 44px) + 8px);
+  right: 8px;
+  bottom: calc(var(--tn-ticker-h, 28px) + 8px);
+  width: min(380px, 32vw);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  z-index: 30;
+  scrollbar-width: thin;
+}
+.tn-intel-card {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  max-height: 340px;
+  padding: 12px 12px 10px;
+  background: var(--tn-surface, #ffffff);
+  border: 1px solid var(--tn-border, #d6dee6);
+  border-radius: 12px;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.10);
+}
+/* On narrow screens the column would swallow the map — hide it (the opt-in
+   workspace dock remains available via the top bar). */
+@media (max-width: 760px) {
+  .tn-intel-column { display: none; }
+}

--- a/components/shell/ConflictPanel.tsx
+++ b/components/shell/ConflictPanel.tsx
@@ -1,0 +1,47 @@
+"use client";
+// Armed Conflict widget — ACLED events (type · country · fatalities) when creds
+// are set, else keyless GDELT conflict coverage. Honestly labels which source is
+// live. Dock-only (v1). Each row → fly + open the event dossier.
+
+import { useSignalFeatures } from "@/lib/widgets/useSignalFeatures";
+import { conflictView } from "@/lib/widgets/conflict";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+import { useNow, formatAge } from "@/lib/shell/useNow";
+
+export default function ConflictPanel({ docked = false }: { docked?: boolean } = {}) {
+  const acled = useSignalFeatures("acled", docked);
+  const gdelt = useSignalFeatures("conflict", docked);
+  const now = useNow(1000);
+  if (!docked) return null;
+
+  const view = conflictView(acled.features, gdelt.features);
+  const loading = acled.status === "loading" || gdelt.status === "loading";
+  const updatedAt = Math.max(acled.updatedAt ?? 0, gdelt.updatedAt ?? 0) || null;
+  return (
+    <aside className="tn-widget tn-docked" role="region" aria-label="Armed conflict">
+      <header className="tn-widget-head">
+        <h2 className="tn-widget-title">Armed Conflict</h2>
+        <span className="tn-widget-source">{view.mode === "none" ? "—" : view.sourceLabel}</span>
+      </header>
+      {loading && view.rows.length === 0 && <p className="tn-widget-status">Loading…</p>}
+      {!loading && view.rows.length === 0 && <p className="tn-widget-status">No live conflict data right now.</p>}
+      <ol className="tn-widget-list">
+        {view.rows.map((r) => (
+          <li key={r.id}>
+            <button type="button" className="tn-widget-row" onClick={() => openSignalFeature(r.feature, view.sourceLabel)}>
+              <span className="tn-widget-row-main">
+                <span className="tn-widget-row-title">{r.title}</span>
+                <span className="tn-widget-row-sub">{r.sub}</span>
+              </span>
+              <span className="tn-widget-metric tn-num">
+                {r.metric}
+                <span className="tn-widget-metric-unit">{r.metricLabel === "fatalities" ? "dead" : "news"}</span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ol>
+      {updatedAt != null && <p className="tn-widget-foot">Updated {formatAge(now - updatedAt)} ago</p>}
+    </aside>
+  );
+}

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -23,6 +23,7 @@ import BreakingBanner from "@/components/shell/BreakingBanner";
 import { FeedOverlay } from "@/components/FeedOverlay";
 import PanelHost from "@/components/shell/PanelHost";
 import DockableWorkspace from "@/components/shell/DockableWorkspace";
+import IntelColumn from "@/components/shell/IntelColumn";
 
 export default function ConsoleShell({ children }: { children: React.ReactNode }) {
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -67,6 +68,7 @@ export default function ConsoleShell({ children }: { children: React.ReactNode }
       {!ws.open && <MarketsPanel />}
       {!ws.open && <WatchlistPanel />}
       <DockableWorkspace />
+      <IntelColumn />
       <FeedOverlay />
     </div>
   );

--- a/components/shell/DockableWorkspace.tsx
+++ b/components/shell/DockableWorkspace.tsx
@@ -20,7 +20,10 @@ import type { PanelKey, PanelPlacement } from "@/lib/variants/types";
 // Panels that belong in the dock (the intelligence/markets panels). The persistent
 // chrome — layerRail, freshness AND news — stays as calm SP1a chrome rendered by
 // PanelHost, never docked (docking `news` would double-mount the ticker).
-const DOCKABLE = new Set<PanelKey>(["markets", "brief", "watchlist", "coverage"]);
+const DOCKABLE = new Set<PanelKey>([
+  "markets", "brief", "watchlist", "coverage",
+  "instability", "conflict", "topEvents", "risk",
+]);
 
 export default function DockableWorkspace() {
   const { activeId } = useVariant();

--- a/components/shell/InstabilityPanel.tsx
+++ b/components/shell/InstabilityPanel.tsx
@@ -1,0 +1,44 @@
+"use client";
+// Country Instability widget — the CII ranked as a list (WorldMonitor's signature
+// panel, built from data we already compute). Dock-only (v1): renders as a
+// workspace tile. Each row → fly + open the country's instability dossier.
+
+import { useSignalFeatures } from "@/lib/widgets/useSignalFeatures";
+import { instabilityRows } from "@/lib/widgets/instability";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+import { useNow, formatAge } from "@/lib/shell/useNow";
+
+export default function InstabilityPanel({ docked = false }: { docked?: boolean } = {}) {
+  const { features, status, updatedAt } = useSignalFeatures("instability", docked);
+  const now = useNow(1000);
+  if (!docked) return null;
+
+  const rows = instabilityRows(features);
+  return (
+    <aside className="tn-widget tn-docked" role="region" aria-label="Country instability">
+      <header className="tn-widget-head">
+        <h2 className="tn-widget-title">Country Instability</h2>
+        <span className="tn-widget-source">CII · 0–100</span>
+      </header>
+      {status === "loading" && rows.length === 0 && <p className="tn-widget-status">Loading…</p>}
+      {status !== "loading" && rows.length === 0 && <p className="tn-widget-status">No data right now.</p>}
+      <ol className="tn-widget-list">
+        {rows.map((r, i) => (
+          <li key={r.id}>
+            <button type="button" className="tn-widget-row" onClick={() => openSignalFeature(r.feature, "Country Instability Index")}>
+              <span className="tn-widget-rank">{i + 1}</span>
+              <span className="tn-widget-row-main">
+                <span className="tn-widget-row-title">{r.country}</span>
+                <span className="tn-widget-row-sub">{r.drivers || r.coverage}</span>
+              </span>
+              <span className="tn-widget-metric tn-num" style={{ color: r.color }}>{r.score}</span>
+            </button>
+          </li>
+        ))}
+      </ol>
+      {updatedAt != null && (
+        <p className="tn-widget-foot">Updated {formatAge(now - updatedAt)} ago · ACLED · WFP · UNHCR · IODA</p>
+      )}
+    </aside>
+  );
+}

--- a/components/shell/IntelColumn.tsx
+++ b/components/shell/IntelColumn.tsx
@@ -1,0 +1,42 @@
+"use client";
+// The always-on intel column (WorldMonitor-style permanent right rail). Renders the
+// active variant's intel WIDGETS as a fixed, scrolling column — visible WITHOUT
+// opening the editable workspace. Hidden while the editable dock is open (the
+// workspace takes over for rearranging) so a panel never double-mounts. Variants
+// with no intel widgets (e.g. Cameras) render nothing here — the map stays calm.
+
+import type { ComponentType } from "react";
+import { useVariant, variantStore } from "@/lib/variants/store";
+import { useWorkspace } from "@/lib/shell/workspace";
+import { PANEL_REGISTRY } from "@/lib/shell/panelRegistry";
+import type { PanelKey } from "@/lib/variants/types";
+
+// Only the dock-only intel widgets live in the always-on column. markets/coverage/
+// watchlist keep their own slide-in behaviour (rendered elsewhere), so they are
+// deliberately excluded here to avoid double-mounting.
+const COLUMN_PANELS = new Set<PanelKey>(["instability", "conflict", "topEvents", "risk"]);
+
+export default function IntelColumn() {
+  const { activeId } = useVariant();
+  const ws = useWorkspace();
+  if (ws.open) return null; // the editable dock takes over
+
+  const placements = variantStore
+    .layoutForVariant(activeId)
+    .filter((p) => p.visible && COLUMN_PANELS.has(p.panel))
+    .sort((a, b) => a.grid.y - b.grid.y);
+  if (placements.length === 0) return null;
+
+  return (
+    <aside className="tn-intel-column" aria-label="Intelligence">
+      {placements.map((p) => {
+        const Cmp = PANEL_REGISTRY[p.panel].component as ComponentType<{ docked?: boolean }>;
+        return (
+          <section key={p.panel} className="tn-intel-card">
+            <Cmp docked />
+          </section>
+        );
+      })}
+    </aside>
+  );
+}

--- a/components/shell/RiskPanel.tsx
+++ b/components/shell/RiskPanel.tsx
@@ -1,0 +1,34 @@
+"use client";
+// Strategic Risk widget — a transparent global risk index: the mean of the most-
+// pressured countries' CII scores, shown as a calm gauge with an honest level. No
+// fabricated trend (we don't store history yet). Dock-only (v1).
+
+import { useSignalFeatures } from "@/lib/widgets/useSignalFeatures";
+import { riskSummary } from "@/lib/widgets/risk";
+
+export default function RiskPanel({ docked = false }: { docked?: boolean } = {}) {
+  const { features, status } = useSignalFeatures("instability", docked);
+  if (!docked) return null;
+
+  const r = riskSummary(features);
+  const empty = status !== "loading" && features.length === 0;
+  return (
+    <aside className="tn-widget tn-docked tn-widget-risk" role="region" aria-label="Strategic risk">
+      <header className="tn-widget-head">
+        <h2 className="tn-widget-title">Strategic Risk</h2>
+        <span className="tn-widget-source">global CII index</span>
+      </header>
+      {empty ? (
+        <p className="tn-widget-status">No data right now.</p>
+      ) : (
+        <div className="tn-risk-gauge" data-level={r.level.toLowerCase()}>
+          <span className="tn-risk-score tn-num">{r.score}</span>
+          <span className="tn-risk-level">{r.level}</span>
+        </div>
+      )}
+      <p className="tn-widget-foot">
+        Mean of the {Math.min(10, r.count)} most-pressured countries · {r.count} flagged · trend —
+      </p>
+    </aside>
+  );
+}

--- a/components/shell/TopEventsPanel.tsx
+++ b/components/shell/TopEventsPanel.tsx
@@ -1,0 +1,53 @@
+"use client";
+// Live Now · Top Events widget — strongest hazards merged across earthquakes,
+// fires, GDACS disasters and tropical cyclones, ranked by severity then recency.
+// Zero-click situational awareness. Dock-only (v1). Each row → fly + dossier.
+
+import { useSignalFeatures } from "@/lib/widgets/useSignalFeatures";
+import { topEventsRows } from "@/lib/widgets/topEvents";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+import { useNow, formatAge } from "@/lib/shell/useNow";
+
+export default function TopEventsPanel({ docked = false }: { docked?: boolean } = {}) {
+  const quakes = useSignalFeatures("earthquakes", docked);
+  const fires = useSignalFeatures("fire-active", docked);
+  const disasters = useSignalFeatures("gdacs", docked);
+  const cyclones = useSignalFeatures("tropical-cyclones", docked);
+  const now = useNow(1000);
+  if (!docked) return null;
+
+  const rows = topEventsRows([
+    { kind: "Quake", features: quakes.features },
+    { kind: "Fire", features: fires.features },
+    { kind: "Disaster", features: disasters.features },
+    { kind: "Cyclone", features: cyclones.features },
+  ]);
+  const feeds = [quakes, fires, disasters, cyclones];
+  const updatedAt = Math.max(0, ...feeds.map((f) => f.updatedAt ?? 0)) || null;
+  const anyLoading = feeds.some((f) => f.status === "loading");
+  return (
+    <aside className="tn-widget tn-docked" role="region" aria-label="Top events">
+      <header className="tn-widget-head">
+        <h2 className="tn-widget-title">Live Now · Top Events</h2>
+        <span className="tn-widget-source">hazards</span>
+      </header>
+      {anyLoading && rows.length === 0 && <p className="tn-widget-status">Loading…</p>}
+      {!anyLoading && rows.length === 0 && <p className="tn-widget-status">No active events right now.</p>}
+      <ol className="tn-widget-list">
+        {rows.map((r) => (
+          <li key={r.id}>
+            <button type="button" className="tn-widget-row" onClick={() => openSignalFeature(r.feature, r.kind)}>
+              <span className="tn-widget-chip" style={{ background: r.color }}>{r.kind}</span>
+              <span className="tn-widget-row-main">
+                <span className="tn-widget-row-title">{r.title}</span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ol>
+      {updatedAt != null && (
+        <p className="tn-widget-foot">Updated {formatAge(now - updatedAt)} ago · USGS · FIRMS · GDACS · NOAA</p>
+      )}
+    </aside>
+  );
+}

--- a/docs/superpowers/specs/2026-06-27-intel-widgets-design.md
+++ b/docs/superpowers/specs/2026-06-27-intel-widgets-design.md
@@ -1,0 +1,101 @@
+# Intel Widgets — Design Spec
+
+**Date:** 2026-06-27 · **Branch:** `feat/intel-widgets`
+
+## Goal
+
+Surface the live data TrafficNerd already pulls as **dockable data widgets**, the
+way WorldMonitor does — so the depth is visible at a glance, not trapped behind a
+click on the map. Four widgets, all deterministic and fed by existing
+`/api/signals/<id>` endpoints (no new API keys for the flagship set):
+
+1. **Country Instability** — ranked CII list (country · score/100 · drivers · coverage).
+2. **Armed Conflict** — ACLED event table when creds are set; keyless GDELT
+   conflict coverage as the live fallback. Honestly labelled which.
+3. **Top Events / Live Now** — strongest quakes, biggest fires, newest disasters,
+   merged across hazard sources, zero-click.
+4. **Strategic Risk** — an aggregate risk gauge derived from the CII + a live
+   per-group signal-count strip.
+
+## Why
+
+User: *"look at world monitor … how much data and statistics they have on show …
+Lets get more widgets."* The viz review found all the real data lives behind a
+click. We already pull the matching sources (`instability`, `acled`/`conflict`,
+USGS/EMSC/FIRMS/EONET/GDACS, `signalCounts`); this milestone shows them.
+
+## Architecture (drops into the SP1b dockable workspace)
+
+Each widget is a **dock panel** following the existing `MarketsPanel` idiom:
+`export default function XPanel({ docked = false }: { docked?: boolean } = {})`,
+`active = open || docked`, fetch-on-active + poll, `.tn-docked` when docked,
+`role="region"`. Pure data mappers are node-tested; components verified by build.
+
+**Shared:**
+- `lib/widgets/useSignalFeatures.ts` *(client hook)* — `useSignalFeatures(id, enabled)`
+  fetches `/api/signals/<id>`, polls on an interval, returns
+  `{ features: SignalFeature[]; status: "idle"|"loading"|"error" }`. Dormant-safe.
+- `lib/widgets/openSignal.ts` *(pure-ish)* — `openSignalFeature(f, source)` builds a
+  `WorldObject` (`kind:"signal"`) from a `SignalFeature` and calls
+  `overlay.open(...)` + `mapViewStore.flyToPoint({lat,lon,zoom})`. The row-click
+  action shared by every widget. (The `WorldObject` builder is the pure, tested part.)
+
+**Per widget:** a pure rows mapper in `lib/widgets/<x>.ts` + a
+`components/shell/<X>Panel.tsx` + a `PanelKey` + `PANEL_REGISTRY` entry + an entry
+in `DockableWorkspace`'s `DOCKABLE` set + a dock placement in the `intel` variant.
+
+**PanelKey extension** (`lib/variants/types.ts`): add
+`"instability" | "conflict" | "topEvents" | "risk"`.
+
+**Variant:** dock all four (plus existing brief/markets) in the **`intel`** variant
+→ a dense "situation-room" right column. `intel` becomes the WorldMonitor-style view.
+
+## Data → widget mapping (verified against the sources)
+
+- **Country Instability** ← `/api/signals/instability` → `SignalFeature[]` already
+  **sorted by score desc**, `props: { country, score, drivers, coverage }`. Keyless
+  (food/displacement/outages live; conflict factor needs ACLED). Rows: country,
+  score (colour ramp via `instabilityColor`), drivers, coverage.
+- **Armed Conflict** ← `/api/signals/acled` (rich: `props.eventType/country/fatalities/date`)
+  with keyless `/api/signals/conflict` GDELT fallback (`props.place/articles/window`).
+  The mapper picks ACLED when non-empty, else GDELT, and reports which.
+- **Top Events** ← merge `/api/signals/earthquakes`, `/api/signals/fire-firms`,
+  `/api/signals/gdacs`, `/api/signals/wildfires` → take top N by a per-source
+  severity key (`props.magnitude`), newest-first tiebreak on `ts`.
+- **Strategic Risk** ← `/api/signals/instability`: aggregate = mean of the top-N CII
+  scores (a transparent global index) + trend placeholder "—" (no history yet) +
+  a live count strip from `signalCountsStore` (currently-ON groups).
+
+## Interaction
+
+Every row is a button: click → `openSignalFeature(feature, sourceLabel)` →
+fly the globe to it + open the existing signal dossier. Honest by construction —
+each widget shows its source label + a "last updated" age, and renders a calm
+"No data right now" / "Add ACLED creds to enable" state when dormant (mirrors
+`MarketsPanel`'s dormant copy). Calm light tokens only, no neon.
+
+## Testing
+
+- **Unit (vitest node):** the pure mappers — `instabilityRows`, `conflictRows`
+  (ACLED-vs-GDELT selection + empty), `topEventsRows` (merge + cap + sort),
+  `riskSummary` (mean of top-N, empty → 0), and the `WorldObject` builder in
+  `openSignal`.
+- **Build + Playwright:** widgets render in the `intel` dock, rows are clickable,
+  dormant states show, console clean.
+
+## Scope / YAGNI
+
+- No new data sources or API keys for the flagship set (GDELT keyless covers
+  conflict when ACLED is dormant). Airline-delay / travel-advisory widgets are
+  **out** (would need new sources) — noted for later.
+- Trend arrows need history we don't store yet → show "—" not a fake delta.
+- Widgets are dock tiles in `intel`; a ⌘K "open widget" command is a nice-to-have,
+  added only if cheap.
+
+## Build order
+
+1. Shared `useSignalFeatures` + `openSignal` (+ `WorldObject` builder test).
+2. `PanelKey` extension + registry + `DOCKABLE` + `intel` dock scaffold.
+3. Country Instability (flagship) → end-to-end.
+4. Armed Conflict → 5. Top Events → 6. Strategic Risk.
+7. CSS + final gate.

--- a/lib/shell/panelRegistry.ts
+++ b/lib/shell/panelRegistry.ts
@@ -7,6 +7,10 @@ import MarketsPanel from "@/components/shell/MarketsPanel";
 import DailyBrief from "@/components/shell/DailyBrief";
 import WatchlistPanel from "@/components/shell/WatchlistPanel";
 import CoveragePanel from "@/components/shell/CoveragePanel";
+import InstabilityPanel from "@/components/shell/InstabilityPanel";
+import ConflictPanel from "@/components/shell/ConflictPanel";
+import TopEventsPanel from "@/components/shell/TopEventsPanel";
+import RiskPanel from "@/components/shell/RiskPanel";
 
 export const PANEL_REGISTRY: Record<PanelKey, {
   component: ComponentType;
@@ -21,6 +25,10 @@ export const PANEL_REGISTRY: Record<PanelKey, {
   brief:      { component: DailyBrief,      title: "Brief",     category: "intelligence", defaultGrid: { x: 9, y: 0, w: 3, h: 6 } },
   watchlist:  { component: WatchlistPanel,  title: "Watchlist", category: "core",         defaultGrid: { x: 9, y: 6, w: 3, h: 4 } },
   coverage:   { component: CoveragePanel,   title: "Coverage",  category: "core",         defaultGrid: { x: 9, y: 0, w: 3, h: 6 } },
+  instability:{ component: InstabilityPanel, title: "Country Instability", category: "intelligence", defaultGrid: { x: 0, y: 0,  w: 12, h: 6 } },
+  conflict:   { component: ConflictPanel,    title: "Armed Conflict",      category: "intelligence", defaultGrid: { x: 0, y: 6,  w: 12, h: 6 } },
+  topEvents:  { component: TopEventsPanel,   title: "Top Events",          category: "intelligence", defaultGrid: { x: 0, y: 12, w: 12, h: 6 } },
+  risk:       { component: RiskPanel,        title: "Strategic Risk",      category: "intelligence", defaultGrid: { x: 0, y: 18, w: 12, h: 3 } },
 };
 
 /** Panels PanelHost mounts directly in SP1a (the persistent chrome). */

--- a/lib/variants/builtins.ts
+++ b/lib/variants/builtins.ts
@@ -15,12 +15,14 @@ const dock = (panel: PanelKey, y: number, h = 5): { panel: PanelKey; grid: { x: 
 export const BUILTIN_VARIANTS: Variant[] = [
   { id: "explore", builtin: true, title: "Explore", accent: "#2563eb", theme: "light",
     layers: { cameras: true, planes: true, satellites: false, webcams: false },
-    panels: [slot("layerRail"), dock("coverage", 0, 6), dock("markets", 6, 6)], tone: "calm" },
+    panels: [slot("layerRail"), dock("instability", 0, 6), dock("topEvents", 6, 6), dock("coverage", 12, 6), dock("markets", 18, 6)], tone: "calm" },
 
   { id: "intel", builtin: true, title: "Intel", accent: "#0f172a", theme: "light",
     layers: { cameras: true, planes: true, satellites: true },
     signals: { groups: ["*"] },
-    panels: [slot("layerRail"), slot("freshness"), dock("brief", 0, 4), dock("markets", 4, 6), slot("news")] },
+    panels: [slot("layerRail"), slot("freshness"),
+      dock("instability", 0, 6), dock("conflict", 6, 6), dock("topEvents", 12, 6),
+      dock("risk", 18, 3), dock("markets", 21, 5), slot("news")] },
 
   { id: "cameras", builtin: true, title: "Cameras", accent: "#7c3aed", theme: "light",
     layers: { cameras: true, webcams: true, planes: false, satellites: false },

--- a/lib/variants/types.ts
+++ b/lib/variants/types.ts
@@ -4,7 +4,9 @@ import type { Theme } from "@/lib/shell/ui";
 
 export type PanelKey =
   | "layerRail" | "markets" | "brief"
-  | "freshness" | "news" | "watchlist" | "coverage";
+  | "freshness" | "news" | "watchlist" | "coverage"
+  // Intel widgets (data panels surfaced in the dock)
+  | "instability" | "conflict" | "topEvents" | "risk";
 // NOTE: 'dossier' is intentionally NOT a panel — it is the FeedOverlay slide-in
 // (transient, deep-linked via ?obj=), kept as overlay chrome.
 

--- a/lib/widgets/conflict.ts
+++ b/lib/widgets/conflict.ts
@@ -1,0 +1,63 @@
+// Pure: build the Armed Conflict view. Prefer ACLED (rich: event type, country,
+// fatalities) when it has data; fall back to keyless GDELT conflict coverage
+// (news clusters by article volume) when ACLED is dormant. The widget labels
+// honestly which source is live.
+
+import type { SignalFeature } from "@/lib/signals/types";
+
+export type ConflictMode = "acled" | "gdelt" | "none";
+
+export interface ConflictRow {
+  id: string;
+  title: string;
+  sub: string;
+  metricLabel: string;
+  metric: number;
+  lat: number;
+  lon: number;
+  feature: SignalFeature;
+}
+
+export interface ConflictView {
+  mode: ConflictMode;
+  sourceLabel: string;
+  rows: ConflictRow[];
+}
+
+export function conflictView(
+  acled: SignalFeature[],
+  gdelt: SignalFeature[],
+  cap = 12,
+): ConflictView {
+  if (acled.length > 0) {
+    const rows = acled
+      .slice()
+      .sort((a, b) => Number(b.props?.fatalities ?? 0) - Number(a.props?.fatalities ?? 0))
+      .slice(0, cap)
+      .map((f) => ({
+        id: f.id,
+        title: String(f.props?.eventType ?? f.title),
+        sub: String(f.props?.country ?? ""),
+        metricLabel: "fatalities",
+        metric: Number(f.props?.fatalities ?? 0),
+        lat: f.lat,
+        lon: f.lon,
+        feature: f,
+      }));
+    return { mode: "acled", sourceLabel: "ACLED", rows };
+  }
+  if (gdelt.length > 0) {
+    const rows = gdelt.slice(0, cap).map((f) => ({
+      id: f.id,
+      title: String(f.props?.place ?? f.title),
+      sub: String(f.props?.window ?? "last 24h"),
+      metricLabel: "articles",
+      metric: Number(f.props?.articles ?? 0),
+      lat: f.lat,
+      lon: f.lon,
+      feature: f,
+    }));
+    return { mode: "gdelt", sourceLabel: "GDELT · news coverage", rows };
+  }
+  return { mode: "none", sourceLabel: "", rows: [] };
+}

--- a/lib/widgets/instability.ts
+++ b/lib/widgets/instability.ts
@@ -1,0 +1,36 @@
+// Pure: CII SignalFeature[] → ranked instability rows for the widget. The
+// instability source already sorts densest-first, but we re-sort defensively so
+// the widget never depends on upstream ordering.
+
+import type { SignalFeature } from "@/lib/signals/types";
+
+export interface InstabilityRow {
+  id: string;
+  country: string;
+  score: number;
+  color: string;
+  drivers: string;
+  coverage: string;
+  lat: number;
+  lon: number;
+  feature: SignalFeature;
+}
+
+export function instabilityRows(features: SignalFeature[], cap = 12): InstabilityRow[] {
+  return features
+    .filter((f) => typeof f.props?.score === "number")
+    .slice()
+    .sort((a, b) => Number(b.props?.score ?? 0) - Number(a.props?.score ?? 0))
+    .slice(0, cap)
+    .map((f) => ({
+      id: f.id,
+      country: String(f.props?.country ?? f.title),
+      score: Number(f.props?.score ?? 0),
+      color: f.color ?? "#dc2626",
+      drivers: String(f.props?.drivers ?? ""),
+      coverage: String(f.props?.coverage ?? ""),
+      lat: f.lat,
+      lon: f.lon,
+      feature: f,
+    }));
+}

--- a/lib/widgets/openSignal.ts
+++ b/lib/widgets/openSignal.ts
@@ -1,0 +1,14 @@
+"use client";
+// The shared widget row-click action: open the existing signal dossier for a
+// feature AND fly the globe to it. Reuses overlay + mapViewStore so a widget row
+// behaves exactly like clicking that signal on the map.
+
+import { overlay } from "@/lib/overlay";
+import { mapViewStore } from "@/lib/mapView";
+import { buildSignalObject } from "@/lib/widgets/signalObject";
+import type { SignalFeature } from "@/lib/signals/types";
+
+export function openSignalFeature(f: SignalFeature, sourceLabel: string, zoom = 5): void {
+  overlay.open(buildSignalObject(f, sourceLabel));
+  mapViewStore.flyToPoint({ lat: f.lat, lon: f.lon, zoom });
+}

--- a/lib/widgets/risk.ts
+++ b/lib/widgets/risk.ts
@@ -1,0 +1,30 @@
+// Pure: a transparent global risk index from the CII — the mean of the top-N
+// country scores. No fabricated trend (we don't store history yet) → the widget
+// shows "—" for trend. `count` is how many countries are above the CII floor.
+
+import type { SignalFeature } from "@/lib/signals/types";
+
+export type RiskLevel = "Low" | "Elevated" | "High" | "Severe";
+
+export interface RiskSummary {
+  score: number;
+  level: RiskLevel;
+  count: number;
+}
+
+export function riskLevel(score: number): RiskLevel {
+  if (score >= 70) return "Severe";
+  if (score >= 50) return "High";
+  if (score >= 30) return "Elevated";
+  return "Low";
+}
+
+export function riskSummary(features: SignalFeature[], topN = 10): RiskSummary {
+  const scores = features
+    .map((f) => Number(f.props?.score ?? 0))
+    .filter((n) => n > 0)
+    .sort((a, b) => b - a)
+    .slice(0, topN);
+  const score = scores.length ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 0;
+  return { score, level: riskLevel(score), count: features.length };
+}

--- a/lib/widgets/signalObject.ts
+++ b/lib/widgets/signalObject.ts
@@ -1,0 +1,27 @@
+// Pure: a SignalFeature → a clickable WorldObject for the dossier. Mirrors how
+// WorldMap's SignalFeed builds signal objects, so a widget row opens the SAME
+// dossier even when the map layer is off. Kept import-light (types only) so it is
+// node-testable; the side-effecting open/fly action lives in openSignal.ts.
+
+import type { SignalFeature } from "@/lib/signals/types";
+import type { WorldObject } from "@/lib/world";
+
+export function buildSignalObject(f: SignalFeature, sourceLabel: string): WorldObject {
+  return {
+    kind: "signal",
+    id: f.id,
+    lat: f.lat,
+    lon: f.lon,
+    label: f.title,
+    color: f.color,
+    typeLabel: sourceLabel,
+    meta: {
+      signalId: f.signalId,
+      props: f.props ?? {},
+      sourceLabel,
+      link: f.link,
+      ts: f.ts,
+      ...(f.geometry ? { geometry: f.geometry } : {}),
+    },
+  };
+}

--- a/lib/widgets/topEvents.ts
+++ b/lib/widgets/topEvents.ts
@@ -1,0 +1,43 @@
+// Pure: merge hazard SignalFeature[] from several sources into one "Live Now"
+// ranking. Sort by severity (props.magnitude, the shared 0–10 convention), then
+// newest-first on ts, then cap. Each row carries a short `kind` chip label.
+
+import type { SignalFeature } from "@/lib/signals/types";
+
+export interface TopEventGroup {
+  kind: string;
+  features: SignalFeature[];
+}
+
+export interface TopEventRow {
+  id: string;
+  title: string;
+  kind: string;
+  severity: number;
+  color: string;
+  ts: string;
+  lat: number;
+  lon: number;
+  feature: SignalFeature;
+}
+
+export function topEventsRows(groups: TopEventGroup[], cap = 12): TopEventRow[] {
+  const all: TopEventRow[] = [];
+  for (const g of groups) {
+    for (const f of g.features) {
+      all.push({
+        id: f.id,
+        title: f.title,
+        kind: g.kind,
+        severity: Number(f.props?.magnitude ?? 0),
+        color: f.color ?? "#64748b",
+        ts: f.ts ?? "",
+        lat: f.lat,
+        lon: f.lon,
+        feature: f,
+      });
+    }
+  }
+  all.sort((a, b) => b.severity - a.severity || (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0));
+  return all.slice(0, cap);
+}

--- a/lib/widgets/useSignalFeatures.ts
+++ b/lib/widgets/useSignalFeatures.ts
@@ -1,0 +1,52 @@
+"use client";
+// Shared widget data hook: fetch a signal source's features through the existing
+// generic /api/signals/<id> proxy and poll on a cadence — independent of whether
+// the matching map LAYER is toggled on. Dormant-safe: any failure leaves the last
+// features in place and flips status to "error". Disabled (enabled=false) never
+// fetches, mirroring the hidden-layer-doesn't-fetch contract.
+
+import { useEffect, useState } from "react";
+import type { SignalFeature } from "@/lib/signals/types";
+
+export type FeedStatus = "idle" | "loading" | "error";
+
+export interface SignalFeed {
+  features: SignalFeature[];
+  status: FeedStatus;
+  updatedAt: number | null;
+}
+
+const DEFAULT_POLL_MS = 5 * 60_000;
+
+export function useSignalFeatures(id: string, enabled: boolean, pollMs = DEFAULT_POLL_MS): SignalFeed {
+  const [features, setFeatures] = useState<SignalFeature[]>([]);
+  const [status, setStatus] = useState<FeedStatus>("idle");
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let alive = true;
+    setStatus("loading");
+    const load = () => {
+      fetch(`/api/signals/${encodeURIComponent(id)}`)
+        .then((r) => r.json())
+        .then((d) => {
+          if (!alive) return;
+          setFeatures((d.features as SignalFeature[]) ?? []);
+          setStatus("idle");
+          setUpdatedAt(Date.now());
+        })
+        .catch(() => {
+          if (alive) setStatus("error");
+        });
+    };
+    load();
+    const t = setInterval(load, pollMs);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, [id, enabled, pollMs]);
+
+  return { features, status, updatedAt };
+}

--- a/tests/unit/widgets-mappers.test.ts
+++ b/tests/unit/widgets-mappers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import type { SignalFeature } from "@/lib/signals/types";
+import { buildSignalObject } from "@/lib/widgets/signalObject";
+import { instabilityRows } from "@/lib/widgets/instability";
+import { conflictView } from "@/lib/widgets/conflict";
+import { topEventsRows } from "@/lib/widgets/topEvents";
+import { riskSummary, riskLevel } from "@/lib/widgets/risk";
+
+const sf = (over: Partial<SignalFeature>): SignalFeature => ({
+  id: "x", lat: 1, lon: 2, title: "T", signalId: "s", ...over,
+});
+
+describe("buildSignalObject", () => {
+  it("maps a SignalFeature into a clickable signal WorldObject", () => {
+    const o = buildSignalObject(sf({ id: "cii:UKR", title: "Ukraine", color: "#dc2626", props: { score: 90 } }), "CII");
+    expect(o.kind).toBe("signal");
+    expect(o.id).toBe("cii:UKR");
+    expect(o.label).toBe("Ukraine");
+    expect(o.typeLabel).toBe("CII");
+    expect((o.meta?.props as { score?: number })?.score).toBe(90);
+  });
+});
+
+describe("instabilityRows", () => {
+  it("ranks by score desc and caps", () => {
+    const rows = instabilityRows([
+      sf({ id: "a", props: { country: "A", score: 40 } }),
+      sf({ id: "b", props: { country: "B", score: 90 } }),
+      sf({ id: "c", props: { country: "C", score: 70 } }),
+    ], 2);
+    expect(rows.map((r) => r.country)).toEqual(["B", "C"]);
+    expect(rows[0].score).toBe(90);
+  });
+  it("drops features without a numeric score", () => {
+    expect(instabilityRows([sf({ props: {} })])).toEqual([]);
+  });
+});
+
+describe("conflictView", () => {
+  it("prefers ACLED and sorts by fatalities", () => {
+    const v = conflictView(
+      [sf({ id: "a", props: { eventType: "Battles", country: "X", fatalities: 3 } }),
+       sf({ id: "b", props: { eventType: "Riots", country: "Y", fatalities: 9 } })],
+      [],
+    );
+    expect(v.mode).toBe("acled");
+    expect(v.rows[0].metric).toBe(9);
+  });
+  it("falls back to GDELT when ACLED is empty", () => {
+    const v = conflictView([], [sf({ id: "g", props: { place: "Z", articles: 12 } })]);
+    expect(v.mode).toBe("gdelt");
+    expect(v.rows[0].title).toBe("Z");
+  });
+  it("returns none when both are empty", () => {
+    expect(conflictView([], []).mode).toBe("none");
+  });
+});
+
+describe("topEventsRows", () => {
+  it("merges groups, sorts by severity then recency, caps", () => {
+    const rows = topEventsRows([
+      { kind: "Quake", features: [sf({ id: "q1", props: { magnitude: 5 }, ts: "2026-06-27T00:00:00Z" })] },
+      { kind: "Fire", features: [sf({ id: "f1", props: { magnitude: 8 }, ts: "2026-06-26T00:00:00Z" })] },
+      { kind: "Quake", features: [sf({ id: "q2", props: { magnitude: 8 }, ts: "2026-06-27T00:00:00Z" })] },
+    ], 2);
+    expect(rows.map((r) => r.id)).toEqual(["q2", "f1"]); // sev 8 newer first, then sev 8 older
+    expect(rows[0].kind).toBe("Quake");
+  });
+});
+
+describe("riskSummary", () => {
+  it("averages the top-N scores and levels them", () => {
+    const s = riskSummary([
+      sf({ props: { score: 90 } }), sf({ props: { score: 70 } }), sf({ props: { score: 50 } }),
+    ], 2);
+    expect(s.score).toBe(80); // mean of 90, 70
+    expect(s.level).toBe("Severe");
+    expect(s.count).toBe(3);
+  });
+  it("is 0 / Low for empty input", () => {
+    expect(riskSummary([])).toEqual({ score: 0, level: "Low", count: 0 });
+  });
+  it("levels thresholds", () => {
+    expect(riskLevel(29)).toBe("Low");
+    expect(riskLevel(30)).toBe("Elevated");
+    expect(riskLevel(50)).toBe("High");
+    expect(riskLevel(70)).toBe("Severe");
+  });
+});


### PR DESCRIPTION
## Intel Widgets — surface the data WorldMonitor shows

Studying worldmonitor.app's frontend made one thing clear: **we already pull almost all of their data — it was just trapped behind clicks on the map.** This adds four data widgets, fed by existing `/api/signals/<id>` endpoints (no new API keys for the flagship set), plus an always-on column so they're visible like WorldMonitor's permanent right rail.

### The four widgets
- **Country Instability** — the CII ranked as a list (country · score/100 · drivers · factor coverage). *Verified live: 170 countries (Afghanistan/Somalia/Yemen 49, Haiti, Nigeria…).*
- **Top Events / Live Now** — strongest hazards merged across earthquakes, fires, GDACS disasters and tropical cyclones, ranked by severity. *Verified live: 186 quakes + 36 GDACS.*
- **Strategic Risk** — a transparent global index: the mean of the most-pressured countries' CII scores, as a calm gauge. No fabricated trend (we don't store history yet).
- **Armed Conflict** — ACLED events (type · country · fatalities) when creds are set, else keyless GDELT conflict coverage. Honestly labels which is live; shows an empty state when both are dormant.

Every row is a button: click → **fly the globe there + open the existing signal dossier**.

### Always-on column
A persistent, scrolling **intel column** (`IntelColumn`) renders the active variant's intel widgets without opening the editable workspace — WorldMonitor's permanent-right-rail feel. It hides while the editable SP1b dock is open (the workspace takes over for rearranging), and renders nothing on variants with no intel widgets (e.g. Cameras stays calm). Docked into **Explore** (Instability + Top Events) and **Intel** (all four).

### Architecture
- `lib/widgets/` — pure, node-tested mappers (`instabilityRows`, `conflictView`, `topEventsRows`, `riskSummary`, `buildSignalObject`), a shared `useSignalFeatures` fetch+poll hook, and the `openSignalFeature` row action.
- `components/shell/{Instability,Conflict,TopEvents,Risk}Panel.tsx` — dock panels following the `MarketsPanel` idiom (`docked` prop, dormant-safe states, calm light tokens).
- `PanelKey` + `PANEL_REGISTRY` + `DOCKABLE` extended; `IntelColumn` mounted in `ConsoleShell`.

### Verification
- `tsc --noEmit` → 0 errors · `vitest` → **384 passing** (374 baseline + 10 new) · `npm run build` → success.
- **Data path probed against a running server** (numbers above are real). Conflict is the one with a current data gap: ACLED dormant (no creds) + GDELT rate-limit-flaky → honest empty state; populates when GDELT responds or ACLED creds are set.
- Visual/browser verification of the always-on column layout recommended before merge.

### Docs
Design spec at `docs/superpowers/specs/2026-06-27-intel-widgets-design.md`.
