### PR TITLE
Widgetize everything: Source Catalog + dockable source widgets

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -783,6 +783,50 @@ a { color: var(--tn-accent); }
 .tn-risk-gauge[data-level="severe"] .tn-risk-score { color: #dc2626; }
 .tn-risk-level { font-size: 13px; font-weight: 600; color: var(--tn-text-dim, #64748b); text-transform: uppercase; letter-spacing: 0.04em; }
 
+/* Source widgets (SP2 "widgetize everything") -------------------------------- */
+.tn-src-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; vertical-align: middle; }
+.tn-src-glance { display: flex; align-items: baseline; gap: 10px; padding: 4px 2px 2px; }
+.tn-src-count { font-size: 30px; font-weight: 800; line-height: 1; color: var(--tn-text, #0f172a); font-variant-numeric: tabular-nums; }
+.tn-src-glance-label { font-size: 11px; color: var(--tn-text-dim, #64748b); }
+.tn-src-delta { font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.tn-src-delta.up { color: var(--tn-live, #16a34a); }
+.tn-src-delta.down { color: var(--tn-down, #dc2626); }
+.tn-src-spark { display: inline-block; width: 64px; height: 18px; margin-left: auto; opacity: 0.9; }
+.tn-src-enable {
+  font: 600 11px/1 var(--tn-sans); margin-left: 4px; padding: 3px 8px; border-radius: 7px;
+  background: var(--tn-accent-soft, #e0f2fe); border: 1px solid var(--tn-border, #d6dee6);
+  color: var(--tn-accent, #0e7d97); cursor: pointer;
+}
+.tn-src-enable:hover { background: var(--tn-hover, #f1f5f9); }
+.tn-src-mapon {
+  font: 600 10.5px/1 var(--tn-sans); padding: 2px 6px; border-radius: 6px;
+  background: transparent; border: 1px solid var(--tn-border, #d6dee6);
+  color: var(--tn-text-dim, #64748b); cursor: pointer; white-space: nowrap;
+}
+.tn-src-mapon[aria-checked="true"] { color: var(--tn-accent, #0e7d97); border-color: var(--tn-accent, #0e7d97); }
+.tn-src-pop {
+  flex: 0 0 auto; font-size: 13px; line-height: 1; padding: 2px 5px; border-radius: 6px;
+  background: transparent; border: 1px solid transparent; color: var(--tn-text-faint, #94a3b8); cursor: pointer;
+}
+.tn-src-pop:hover { color: var(--tn-accent, #0e7d97); border-color: var(--tn-border, #d6dee6); background: var(--tn-surface-2, #f1f5f9); }
+
+/* Catalog rail additions (search, widget toggle, counter) -------------------- */
+.tn-widget-toggle {
+  flex: 0 0 auto; width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center;
+  font-size: 13px; line-height: 1; border-radius: 6px; cursor: pointer;
+  background: transparent; border: 1px solid var(--tn-border, #d6dee6); color: var(--tn-text-faint, #94a3b8);
+}
+.tn-widget-toggle:hover { color: var(--tn-accent, #0e7d97); border-color: var(--tn-accent, #0e7d97); }
+.tn-widget-toggle[data-on="true"] { color: #fff; background: var(--tn-accent, #0e7d97); border-color: var(--tn-accent, #0e7d97); }
+.tn-cat-search {
+  width: 100%; margin: 2px 0 8px; padding: 7px 10px; border-radius: 9px;
+  font: 400 12.5px/1.2 var(--tn-sans); color: var(--tn-text, #0f172a);
+  background: var(--tn-surface, #fff); border: 1px solid var(--tn-border, #d6dee6);
+}
+.tn-cat-search:focus { outline: none; border-color: var(--tn-accent, #0e7d97); }
+.tn-cat-count { font: 700 11px/1 var(--tn-sans); color: var(--tn-text-dim, #64748b); margin-left: auto; padding-right: 8px; font-variant-numeric: tabular-nums; }
+.tn-subhead-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+
 /* Always-on intel column (WorldMonitor-style permanent right rail) ----------- */
 .tn-intel-column {
   position: fixed;

--- a/components/shell/DockableWorkspace.tsx
+++ b/components/shell/DockableWorkspace.tsx
@@ -6,6 +6,11 @@
 // resizable while editing. onLayoutChange feeds the draft buffer (read fresh from
 // the store to dodge stale closures); WorkspaceBar commits it. See
 // docs/superpowers/research/2026-06-27-sp1b-rgl-spike.md for the API rationale.
+//
+// Tiles resolve in two ways: a registered PanelKey renders its PANEL_REGISTRY
+// component; a dynamic widget key (`source:<id>` / `rollup:<group>`, added by the
+// Source Catalog) renders a docked <SourceWidget>. This is the seam that lets
+// "widgetize everything" share one grid with the intel panels.
 import type { ComponentType } from "react";
 import { ResponsiveGridLayout, useContainerWidth } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
@@ -14,16 +19,26 @@ import { useVariant, variantStore } from "@/lib/variants/store";
 import { useWorkspace, workspaceStore } from "@/lib/shell/workspace";
 import { placementsToRglItems, rglItemsToPlacements, type RglItem } from "@/lib/variants/layout";
 import { PANEL_REGISTRY } from "@/lib/shell/panelRegistry";
+import { widgetForKey } from "@/lib/widgets/registry";
 import PanelTile from "@/components/shell/PanelTile";
-import type { PanelKey, PanelPlacement } from "@/lib/variants/types";
+import SourceWidget from "@/components/shell/SourceWidget";
+import type { PanelPlacement } from "@/lib/variants/types";
 
-// Panels that belong in the dock (the intelligence/markets panels). The persistent
-// chrome — layerRail, freshness AND news — stays as calm SP1a chrome rendered by
-// PanelHost, never docked (docking `news` would double-mount the ticker).
-const DOCKABLE = new Set<PanelKey>([
+// Registered panels that belong in the dock (the intelligence/markets panels). The
+// persistent chrome — layerRail, freshness AND news — stays as calm SP1a chrome
+// rendered by PanelHost, never docked (docking `news` would double-mount the ticker).
+const DOCKABLE = new Set<string>([
   "markets", "brief", "watchlist", "coverage",
   "instability", "conflict", "topEvents", "risk",
 ]);
+
+/** A placement is dockable if it is a known dock panel OR a dynamic widget key. */
+function isDockable(key: string): boolean {
+  return DOCKABLE.has(key) || key.startsWith("source:") || key.startsWith("rollup:");
+}
+
+type RegEntry = { component: ComponentType<{ docked?: boolean }>; title: string };
+const REGISTRY = PANEL_REGISTRY as Record<string, RegEntry>;
 
 export default function DockableWorkspace() {
   const { activeId } = useVariant();
@@ -33,7 +48,7 @@ export default function DockableWorkspace() {
   if (!ws.open) return null;
 
   const source = ws.editing && ws.draft ? ws.draft : variantStore.layoutForVariant(activeId);
-  const placements: PanelPlacement[] = source.filter((p) => p.visible && DOCKABLE.has(p.panel));
+  const placements: PanelPlacement[] = source.filter((p) => p.visible && isDockable(p.panel));
   const items: RglItem[] = placementsToRglItems(placements);
 
   return (
@@ -53,17 +68,20 @@ export default function DockableWorkspace() {
               const st = workspaceStore.get();
               if (!st.editing) return;
               const next: RglItem[] = (layout as Array<{ i: string; x: number; y: number; w: number; h: number }>).map(
-                (l) => ({ i: l.i as PanelKey, x: l.x, y: l.y, w: l.w, h: l.h }),
+                (l) => ({ i: l.i, x: l.x, y: l.y, w: l.w, h: l.h }),
               );
               workspaceStore.updateDraft(rglItemsToPlacements(next, st.draft ?? placements));
             }}
           >
             {placements.map((p) => {
-              const Cmp = PANEL_REGISTRY[p.panel].component as ComponentType<{ docked?: boolean }>;
+              const reg = REGISTRY[p.panel];
+              const widget = reg ? null : widgetForKey(p.panel);
+              const title = reg ? reg.title : widget?.title ?? p.panel;
+              const Cmp = reg?.component;
               return (
                 <div key={p.panel}>
-                  <PanelTile title={PANEL_REGISTRY[p.panel].title} editing={ws.editing}>
-                    <Cmp docked />
+                  <PanelTile title={title} editing={ws.editing}>
+                    {Cmp ? <Cmp docked /> : widget ? <SourceWidget widget={widget} docked /> : null}
                   </PanelTile>
                 </div>
               );

--- a/components/shell/IntelColumn.tsx
+++ b/components/shell/IntelColumn.tsx
@@ -9,12 +9,12 @@ import type { ComponentType } from "react";
 import { useVariant, variantStore } from "@/lib/variants/store";
 import { useWorkspace } from "@/lib/shell/workspace";
 import { PANEL_REGISTRY } from "@/lib/shell/panelRegistry";
-import type { PanelKey } from "@/lib/variants/types";
 
 // Only the dock-only intel widgets live in the always-on column. markets/coverage/
 // watchlist keep their own slide-in behaviour (rendered elsewhere), so they are
 // deliberately excluded here to avoid double-mounting.
-const COLUMN_PANELS = new Set<PanelKey>(["instability", "conflict", "topEvents", "risk"]);
+const COLUMN_PANELS = new Set<string>(["instability", "conflict", "topEvents", "risk"]);
+const REGISTRY = PANEL_REGISTRY as Record<string, { component: ComponentType<{ docked?: boolean }>; title: string }>;
 
 export default function IntelColumn() {
   const { activeId } = useVariant();
@@ -30,7 +30,7 @@ export default function IntelColumn() {
   return (
     <aside className="tn-intel-column" aria-label="Intelligence">
       {placements.map((p) => {
-        const Cmp = PANEL_REGISTRY[p.panel].component as ComponentType<{ docked?: boolean }>;
+        const Cmp = REGISTRY[p.panel].component;
         return (
           <section key={p.panel} className="tn-intel-card">
             <Cmp docked />

--- a/components/shell/SourceCatalog.tsx
+++ b/components/shell/SourceCatalog.tsx
@@ -1,12 +1,15 @@
 "use client";
-// Left layer rail — the calm-light reframe of the ops-console left panel.
-// Collapsible, persistent. Lists each world layer with an on/off toggle, a live
-// tabular count, and a tiny source + freshness note. Cameras expand to the
-// region + live-only sub-filters. Planned layers (Ships/Webcams/Weather) render
-// disabled so the structure is visible without shipping dead toggles.
-//
-// Toggling a layer flips lib/layers — and because WorldMap mounts each data hook
-// only while its layer is on, a hidden layer stops fetching/ticking entirely.
+// Source Catalog — the redesigned left rail. It is LayerRail's full control set
+// (presets, monitor bar, camera region/live filters, global-signal feeds, coverage/
+// markets/watchlist entry points) PLUS the "widgetize everything" affordances:
+//   • a search box that filters every source by label,
+//   • a per-source ▦ toggle that docks/undocks that source as its own widget tile,
+//   • a per-group ▦ toggle that docks the group's roll-up widget,
+//   • a header counter of how many sources are currently widgeted.
+// Map on/off still flips lib/layers / lib/signals (so a hidden source stops
+// fetching); the widget toggle writes the active variant's dock layout via
+// lib/widgets/dock. Both states are shown side by side so the rail is the one
+// place to answer "is this on the map, and is it a widget?".
 
 import { useState } from "react";
 import {
@@ -17,7 +20,7 @@ import {
   PLANNED_LAYERS,
   type LayerKey,
 } from "@/lib/layers";
-import { SIGNALS, signalsByGroup } from "@/lib/signals/registry";
+import { signalsByGroup } from "@/lib/signals/registry";
 import { signalsStore, useSignals, useSignalCounts } from "@/lib/signals/store";
 import {
   useSignalFreshness,
@@ -36,6 +39,10 @@ import { CAMERA_REGIONS, CAMERA_FEED_META } from "@/lib/icons/svg";
 import { useT } from "@/lib/i18n/store";
 import MonitorBar from "@/components/shell/MonitorBar";
 import TimeWindowControl from "@/components/shell/TimeWindowControl";
+import { useVariant, useLayout } from "@/lib/variants/store";
+import { toggleTileDock } from "@/lib/widgets/dock";
+import { sourceKey, rollupKey } from "@/lib/widgets/registry";
+import { SOURCE_CATALOG } from "@/lib/sources/catalog";
 
 interface LayerMeta {
   name: string;
@@ -67,6 +74,23 @@ function Toggle({ on, accent, onClick, label }: { on: boolean; accent: string; o
       style={{ background: on ? accent : "var(--tn-toggle-off)" }}
     >
       <span className="tn-toggle-knob" style={{ left: on ? 18 : 2 }} />
+    </button>
+  );
+}
+
+// ＋ / ▦ — adds or removes this source (or group roll-up) as a dock widget tile.
+function WidgetToggle({ on, label, onClick }: { on: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="tn-widget-toggle"
+      data-on={on}
+      aria-pressed={on}
+      title={on ? `Remove the ${label} widget` : `Add ${label} as a widget`}
+      aria-label={on ? `Remove the ${label} widget` : `Add ${label} as a widget`}
+      onClick={onClick}
+    >
+      {on ? "▦" : "＋"}
     </button>
   );
 }
@@ -142,10 +166,14 @@ function LayerRow({
   layerKey,
   count,
   expandable,
+  widgeted,
+  activeId,
 }: {
   layerKey: LayerKey;
   count: number | null;
   expandable?: boolean;
+  widgeted: boolean;
+  activeId: string;
 }) {
   const layers = useLayers();
   const meta = LAYER_META[layerKey];
@@ -184,20 +212,18 @@ function LayerRow({
         </div>
       </button>
       <span className="tn-layer-count tn-num">{count == null ? "—" : count.toLocaleString()}</span>
+      <WidgetToggle on={widgeted} label={meta.name} onClick={() => toggleTileDock(activeId, sourceKey(layerKey))} />
       <Toggle on={on} accent={meta.accent} label={`Toggle ${meta.name}`} onClick={() => layersStore.toggle(layerKey)} />
       {expandable && open && on ? <CameraFilters /> : null}
     </div>
   );
 }
 
-// Per-signal freshness chip — honest "is this layer actually live?" beside each
-// ON signal layer, reading the trust spine (lib/signals/freshness). Only shown
-// when the layer is on (a SignalFeed must be mounted to have a record).
 function SignalFreshNote({ id, refreshMs }: { id: string; refreshMs: number }) {
   const records = useSignalFreshness();
   const now = useNow(1000);
   const raw = records[id];
-  if (!raw) return null; // not mounted / no fetch yet
+  if (!raw) return null;
   const rec = { ...raw, refreshMs };
   const state = classifySignalFreshness(rec, now);
   const age = signalFreshAgeMs(rec, now);
@@ -210,10 +236,23 @@ function SignalFreshNote({ id, refreshMs }: { id: string; refreshMs: number }) {
   );
 }
 
-// One global-signal layer: dot + label + attribution + freshness + live count + toggle.
-// Mirrors LayerRow but reads the SEPARATE signals store (default off, opt-in).
-function SignalRow({ id }: { id: string }) {
-  const source = SIGNALS.find((s) => s.id === id)!;
+function SignalRow({
+  id,
+  label,
+  color,
+  attribution,
+  refreshMs,
+  widgeted,
+  activeId,
+}: {
+  id: string;
+  label: string;
+  color: string;
+  attribution: string;
+  refreshMs: number;
+  widgeted: boolean;
+  activeId: string;
+}) {
   const on = useSignals()[id] === true;
   const count = useSignalCounts()[id];
   const countLabel = count != null ? count.toLocaleString() : on ? "…" : "—";
@@ -222,60 +261,85 @@ function SignalRow({ id }: { id: string }) {
       <div className="tn-layer-head" style={{ cursor: "default" }}>
         <span
           className="tn-layer-dot"
-          style={{ background: source.color, boxShadow: on ? `0 0 7px ${source.color}88` : "none" }}
+          style={{ background: color, boxShadow: on ? `0 0 7px ${color}88` : "none" }}
         />
         <div className="tn-layer-main">
-          <span className="tn-layer-name">{source.label}</span>
-          <span className="tn-layer-source">{source.attribution}</span>
-          {on ? <SignalFreshNote id={id} refreshMs={source.refreshMs} /> : null}
+          <span className="tn-layer-name">{label}</span>
+          <span className="tn-layer-source">{attribution}</span>
+          {on ? <SignalFreshNote id={id} refreshMs={refreshMs} /> : null}
         </div>
       </div>
       <span className="tn-layer-count tn-num">{countLabel}</span>
-      <Toggle
-        on={on}
-        accent={source.color}
-        label={`Toggle ${source.label}`}
-        onClick={() => signalsStore.toggle(id)}
-      />
+      <WidgetToggle on={widgeted} label={label} onClick={() => toggleTileDock(activeId, sourceKey(id))} />
+      <Toggle on={on} accent={color} label={`Toggle ${label}`} onClick={() => signalsStore.toggle(id)} />
     </div>
   );
 }
 
-// Collapsible "Global signals" section. Default COLLAPSED — these are heavy,
-// global, opt-in feeds, so they stay out of the way until deliberately opened.
-function GlobalSignals() {
+function GlobalSignals({
+  match,
+  forceOpen,
+  activeId,
+  widgetedIds,
+}: {
+  match: (label: string) => boolean;
+  forceOpen: boolean;
+  activeId: string;
+  widgetedIds: Set<string>;
+}) {
   const [open, setOpen] = useState(false);
   const groups = signalsByGroup();
   const onCount = useSignals();
   const t = useT();
-  const activeCount = SIGNALS.filter((s) => onCount[s.id]).length;
+  const isOpen = open || forceOpen;
+  const activeCount = SOURCE_CATALOG.filter((s) => s.kind === "signal" && onCount[s.id]).length;
   return (
     <div className="tn-signals">
       <button
         type="button"
         className="tn-signals-header"
         onClick={() => setOpen((o) => !o)}
-        aria-expanded={open}
+        aria-expanded={isOpen}
       >
         <span className="tn-signals-title">
           {t("sectionGlobalSignals")}
           {activeCount > 0 ? <span className="tn-signals-badge">{activeCount}</span> : null}
         </span>
-        <span className="tn-layer-caret" data-open={open}>
+        <span className="tn-layer-caret" data-open={isOpen}>
           ›
         </span>
       </button>
-      {open && (
+      {isOpen && (
         <div className="tn-signals-body">
           <TimeWindowControl />
-          {groups.map((g) => (
-            <div key={g.group} className="tn-rail-section">
-              <div className="tn-subhead">{g.group}</div>
-              {g.sources.map((s) => (
-                <SignalRow key={s.id} id={s.id} />
-              ))}
-            </div>
-          ))}
+          {groups.map((g) => {
+            const sources = g.sources.filter((s) => match(s.label));
+            if (sources.length === 0) return null;
+            return (
+              <div key={g.group} className="tn-rail-section">
+                <div className="tn-subhead tn-subhead-row">
+                  <span>{g.group}</span>
+                  <WidgetToggle
+                    on={widgetedIds.has(rollupKey(g.group))}
+                    label={`${g.group} roll-up`}
+                    onClick={() => toggleTileDock(activeId, rollupKey(g.group))}
+                  />
+                </div>
+                {sources.map((s) => (
+                  <SignalRow
+                    key={s.id}
+                    id={s.id}
+                    label={s.label}
+                    color={s.color}
+                    attribution={s.attribution}
+                    refreshMs={s.refreshMs}
+                    widgeted={widgetedIds.has(sourceKey(s.id))}
+                    activeId={activeId}
+                  />
+                ))}
+              </div>
+            );
+          })}
           <p className="tn-rail-foot">
             Opt-in intelligence layers — hazards, conflict, cyber, maritime, human cost &amp; the
             Country Instability Index. Fetched only while on; most are keyless, a few unlock with a
@@ -287,10 +351,21 @@ function GlobalSignals() {
   );
 }
 
-export default function LayerRail() {
+export default function SourceCatalog() {
   const [railOpen, setRailOpen] = useState(true);
+  const [query, setQuery] = useState("");
   const m = useMetrics();
   const t = useT();
+  const { activeId } = useVariant();
+  const layout = useLayout(activeId);
+
+  const widgetedIds = new Set(layout.filter((p) => p.visible).map((p) => p.panel));
+  const widgetCount = layout.filter(
+    (p) => p.visible && (p.panel.startsWith("source:") || p.panel.startsWith("rollup:")),
+  ).length;
+
+  const q = query.trim().toLowerCase();
+  const match = (label: string): boolean => q === "" || label.toLowerCase().includes(q);
 
   const count = (k: LayerKey): number | null => {
     if (k === "cameras") return m.camerasTotal || null;
@@ -302,21 +377,36 @@ export default function LayerRail() {
 
   if (!railOpen) {
     return (
-      <button type="button" className="tn-rail-fab" onClick={() => setRailOpen(true)} title="Show layers">
+      <button type="button" className="tn-rail-fab" onClick={() => setRailOpen(true)} title="Show sources">
         <span className="tn-rail-fab-bars" aria-hidden>≡</span>
-        {t("railLayers")}
+        Sources
       </button>
     );
   }
 
+  const visibleActive = ACTIVE_LAYERS.filter((k) => match(LAYER_META[k].name));
+  const visiblePlanned = q === "" ? PLANNED_LAYERS : PLANNED_LAYERS.filter((k) => match(LAYER_META[k].name));
+
   return (
-    <aside className="tn-rail" aria-label={t("railLayers")}>
+    <aside className="tn-rail" aria-label="Sources">
       <div className="tn-rail-header">
-        <span className="tn-rail-title">{t("railLayers")}</span>
-        <button type="button" className="tn-rail-collapse" onClick={() => setRailOpen(false)} aria-label="Collapse layers">
+        <span className="tn-rail-title">Sources</span>
+        <span className="tn-cat-count" title="Sources docked as widgets">
+          {widgetCount} ▦
+        </span>
+        <button type="button" className="tn-rail-collapse" onClick={() => setRailOpen(false)} aria-label="Collapse sources">
           ‹
         </button>
       </div>
+
+      <input
+        type="search"
+        className="tn-cat-search"
+        placeholder="Search sources…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Search sources"
+      />
 
       <MonitorBar />
 
@@ -329,22 +419,32 @@ export default function LayerRail() {
       </div>
 
       <div className="tn-rail-section">
-        {ACTIVE_LAYERS.map((k) => (
-          <LayerRow key={k} layerKey={k} count={count(k)} expandable={k === "cameras"} />
+        {visibleActive.map((k) => (
+          <LayerRow
+            key={k}
+            layerKey={k}
+            count={count(k)}
+            expandable={k === "cameras"}
+            widgeted={widgetedIds.has(sourceKey(k))}
+            activeId={activeId}
+          />
         ))}
       </div>
 
+      {visiblePlanned.length > 0 ? (
+        <>
+          <div className="tn-rail-divider" />
+          <div className="tn-rail-section">
+            {visiblePlanned.map((k) => (
+              <LayerRow key={k} layerKey={k} count={null} widgeted={false} activeId={activeId} />
+            ))}
+          </div>
+        </>
+      ) : null}
+
       <div className="tn-rail-divider" />
 
-      <div className="tn-rail-section">
-        {PLANNED_LAYERS.map((k) => (
-          <LayerRow key={k} layerKey={k} count={null} />
-        ))}
-      </div>
-
-      <div className="tn-rail-divider" />
-
-      <GlobalSignals />
+      <GlobalSignals match={match} forceOpen={q !== ""} activeId={activeId} widgetedIds={widgetedIds} />
 
       <div className="tn-rail-divider" />
 
@@ -360,7 +460,7 @@ export default function LayerRail() {
         ★ {t("sectionSaved")}
       </button>
 
-      <p className="tn-rail-foot">Only layers you can see are fetched. Everything here is a real, live, attributable feed.</p>
+      <p className="tn-rail-foot">Only sources you can see are fetched. ▦ docks any source as a live widget.</p>
     </aside>
   );
 }

--- a/components/shell/SourceWidget.tsx
+++ b/components/shell/SourceWidget.tsx
@@ -1,0 +1,183 @@
+"use client";
+// A docked monitor tile for any catalog source — the "widgetize everything" unit.
+// Two shapes share one chrome (the intel-widget .tn-widget vocabulary):
+//   • rollup  — a category (catalog `group`): a live summed total + a row per
+//     constituent source, each with its own count/freshness and a ⤢ pop-out that
+//     adds that single source as its own tile.
+//   • source  — a single leaf: a hero count + ▴/▾ delta + a glance sparkline.
+// Read-only: every number comes from useSourceLive reading the EXISTING stores;
+// nothing here starts a fetch. The map toggle mirrors the source's layer/signal
+// on-state so the tile and the map stay in lockstep.
+
+import { getCatalogSource } from "@/lib/sources/catalog";
+import { useSourceLive, toggleSourceMap } from "@/lib/sources/live";
+import { useCountHistory, deltaOf, trendOf } from "@/lib/widgets/history";
+import { constituentIds, rollupCount } from "@/lib/widgets/rollup";
+import { addTileToDock } from "@/lib/widgets/dock";
+import { sourceKey, type WidgetDescriptor } from "@/lib/widgets/registry";
+import { useVariant } from "@/lib/variants/store";
+import { useMetrics } from "@/lib/metrics";
+import { useSignalCounts } from "@/lib/signals/store";
+import type { FreshKind } from "@/lib/sources/freshKind";
+
+const FRESH_LABEL: Record<FreshKind, string> = {
+  off: "off",
+  unknown: "connecting…",
+  live: "live",
+  empty: "live · none now",
+  lagging: "lagging",
+  stale: "stale",
+  down: "unavailable",
+};
+
+function fmtCount(n: number | null): string {
+  return n == null ? "—" : n.toLocaleString();
+}
+
+// Freshness pip — the state class lives on the PARENT so the existing
+// `.tn-fresh-<state> .tn-fresh-dot` rules colour the inner dot.
+function FreshDot({ fresh }: { fresh: FreshKind }) {
+  return (
+    <span className={`tn-fresh tn-fresh-${fresh}`} role="img" aria-label={FRESH_LABEL[fresh]} title={FRESH_LABEL[fresh]}>
+      <span className="tn-fresh-dot" aria-hidden />
+    </span>
+  );
+}
+
+function Sparkline({ points, color }: { points: number[]; color: string }) {
+  if (points.length < 2) return <span className="tn-src-spark" aria-hidden />;
+  const W = 64;
+  const H = 18;
+  const n = points.length;
+  const d = points
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${((i / (n - 1)) * W).toFixed(1)} ${(H - p * H).toFixed(1)}`)
+    .join(" ");
+  return (
+    <svg className="tn-src-spark" width={W} height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" aria-hidden>
+      <path d={d} fill="none" stroke={color} strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function LeafWidget({ id }: { id: string }) {
+  const source = getCatalogSource(id);
+  const live = useSourceLive(id);
+  const hist = useCountHistory(id);
+  if (!source) {
+    return (
+      <aside className="tn-widget tn-docked">
+        <p className="tn-widget-status">Unknown source “{id}”.</p>
+      </aside>
+    );
+  }
+  const delta = deltaOf(hist);
+  return (
+    <aside className="tn-widget tn-docked" role="region" aria-label={source.label}>
+      <header className="tn-widget-head">
+        <h3 className="tn-widget-title">
+          <span className="tn-src-dot" style={{ background: source.color }} aria-hidden /> {source.label}
+        </h3>
+        <FreshDot fresh={live.fresh} />
+      </header>
+      {!live.hasData ? (
+        <p className="tn-widget-status">
+          Off — enable on the map to monitor it.{" "}
+          <button type="button" className="tn-src-enable" onClick={() => toggleSourceMap(id, true)}>
+            Enable
+          </button>
+        </p>
+      ) : (
+        <div className="tn-src-glance">
+          <span className="tn-src-count tn-num">{fmtCount(live.count)}</span>
+          {delta !== 0 ? (
+            <span className={`tn-src-delta ${delta > 0 ? "up" : "down"}`}>
+              {delta > 0 ? "▴" : "▾"}
+              {Math.abs(delta)}
+            </span>
+          ) : null}
+          <Sparkline points={trendOf(hist, 16)} color={source.color} />
+        </div>
+      )}
+      <p className="tn-widget-foot">
+        <span className="tn-widget-source">{source.attribution}</span>{" "}
+        <button
+          type="button"
+          className="tn-src-mapon"
+          role="switch"
+          aria-checked={live.mapOn}
+          onClick={() => toggleSourceMap(id, !live.mapOn)}
+        >
+          ◇ {live.mapOn ? "on map" : "off map"}
+        </button>
+      </p>
+    </aside>
+  );
+}
+
+function RollupRow({ id, activeId }: { id: string; activeId: string }) {
+  const source = getCatalogSource(id);
+  const live = useSourceLive(id);
+  if (!source) return null;
+  return (
+    <li className="tn-widget-row">
+      <span className="tn-src-dot" style={{ background: source.color }} aria-hidden />
+      <span className="tn-widget-row-main">
+        <span className="tn-widget-row-title">{source.label}</span>
+      </span>
+      <FreshDot fresh={live.fresh} />
+      <span className="tn-widget-metric tn-num">{fmtCount(live.count)}</span>
+      <button
+        type="button"
+        className="tn-src-pop"
+        title={`Add ${source.label} as its own widget`}
+        aria-label={`Add ${source.label} as its own widget`}
+        onClick={() => addTileToDock(activeId, sourceKey(id))}
+      >
+        ⤢
+      </button>
+    </li>
+  );
+}
+
+// Live roll-up total without per-id hooks: core counts come from metrics, signal
+// counts from the signals store — summed by the pure rollupCount helper.
+function useRollupCount(ids: string[]): number | null {
+  const m = useMetrics();
+  const sig = useSignalCounts();
+  const counts: Record<string, number | undefined> = {};
+  for (const id of ids) {
+    if (id === "cameras") counts[id] = m.camerasTotal || undefined;
+    else if (id === "planes") counts[id] = m.planes || undefined;
+    else if (id === "satellites") counts[id] = m.satellites || undefined;
+    else if (id === "webcams") counts[id] = m.webcams || undefined;
+    else counts[id] = sig[id] ?? undefined;
+  }
+  return rollupCount(counts, ids);
+}
+
+function RollupWidget({ group }: { group: string }) {
+  const { activeId } = useVariant();
+  const ids = constituentIds(group);
+  const total = useRollupCount(ids);
+  return (
+    <aside className="tn-widget tn-docked" role="region" aria-label={group}>
+      <header className="tn-widget-head">
+        <h3 className="tn-widget-title">{group}</h3>
+        <span className="tn-widget-source">{ids.length} source{ids.length === 1 ? "" : "s"}</span>
+      </header>
+      <div className="tn-src-glance">
+        <span className="tn-src-count tn-num">{fmtCount(total)}</span>
+        <span className="tn-src-glance-label">tracked now</span>
+      </div>
+      <ol className="tn-widget-list">
+        {ids.map((id) => (
+          <RollupRow key={id} id={id} activeId={activeId} />
+        ))}
+      </ol>
+    </aside>
+  );
+}
+
+export default function SourceWidget({ widget }: { widget: WidgetDescriptor; docked?: boolean }) {
+  return widget.kind === "rollup" ? <RollupWidget group={widget.ref} /> : <LeafWidget id={widget.ref} />;
+}

--- a/lib/shell/panelRegistry.ts
+++ b/lib/shell/panelRegistry.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from "react";
 import type { PanelKey } from "@/lib/variants/types";
-import LayerRail from "@/components/shell/LayerRail";
+import SourceCatalog from "@/components/shell/SourceCatalog";
 import FreshnessTicker from "@/components/shell/FreshnessTicker";
 import NewsTicker from "@/components/shell/NewsTicker";
 import MarketsPanel from "@/components/shell/MarketsPanel";
@@ -18,7 +18,7 @@ export const PANEL_REGISTRY: Record<PanelKey, {
   category: "core" | "intelligence" | "markets";
   defaultGrid: { x: number; y: number; w: number; h: number };
 }> = {
-  layerRail:  { component: LayerRail,      title: "Layers",    category: "core",         defaultGrid: { x: 0, y: 0, w: 3, h: 8 } },
+  layerRail:  { component: SourceCatalog,  title: "Sources",   category: "core",         defaultGrid: { x: 0, y: 0, w: 3, h: 8 } },
   freshness:  { component: FreshnessTicker, title: "Freshness", category: "core",         defaultGrid: { x: 0, y: 8, w: 12, h: 1 } },
   news:       { component: NewsTicker,      title: "News",      category: "intelligence", defaultGrid: { x: 0, y: 7, w: 12, h: 1 } },
   markets:    { component: MarketsPanel,    title: "Markets",   category: "markets",      defaultGrid: { x: 9, y: 0, w: 3, h: 6 } },

--- a/lib/sources/catalog.ts
+++ b/lib/sources/catalog.ts
@@ -1,0 +1,69 @@
+// The single unified view over every monitorable data source: the 4 bespoke core
+// layers (lib/layers.ts) and the 39 data-driven signals (lib/signals/registry.ts),
+// flattened behind one descriptor so the catalog UI and the widget grid can be
+// data-driven off ONE list. Pure + isomorphic (node-testable): static descriptors
+// only — live count/freshness are read from the existing stores by lib/sources/live.ts.
+
+import { SIGNALS } from "@/lib/signals/registry";
+
+export type SourceKind = "core" | "signal";
+
+export interface CatalogSource {
+  id: string;
+  kind: SourceKind;
+  label: string;
+  group: string;
+  color: string;
+  attribution: string;
+  refreshMs: number;
+  /** Env var that unlocks the source, if key-gated (drives the "needs key" state later). */
+  keyEnv?: string;
+}
+
+export const CORE_IDS = ["cameras", "planes", "satellites", "webcams"] as const;
+
+// Core-layer descriptors. refreshMs mirrors lib/freshness.ts seed(); groups use the
+// roll-up vocabulary (a group with one source still yields a valid 1-source roll-up).
+const CORE_SOURCES: CatalogSource[] = [
+  { id: "cameras",    kind: "core", label: "Cameras",    group: "Cameras",  color: "#0e7d97", attribution: "TfL · Caltrans · SCDOT · Digitraffic · 511 · DriveBC", refreshMs: 300_000 },
+  { id: "webcams",    kind: "core", label: "Webcams",    group: "Cameras",  color: "#ec4899", attribution: "Windy.com — global webcams", refreshMs: 600_000 },
+  { id: "planes",     kind: "core", label: "Planes",     group: "Aviation", color: "#d97706", attribution: "adsb.lol — live ADS-B", refreshMs: 12_000 },
+  { id: "satellites", kind: "core", label: "Satellites", group: "Space",    color: "#7c3aed", attribution: "CelesTrak TLE · SGP4 (local)", refreshMs: 1_000 },
+];
+
+const SIGNAL_SOURCES: CatalogSource[] = SIGNALS.map((s) => ({
+  id: s.id,
+  kind: "signal" as const,
+  label: s.label,
+  group: s.group,
+  color: s.color,
+  attribution: s.attribution,
+  refreshMs: s.refreshMs,
+}));
+
+/** Core first (always-relevant transport layers), then signals in registry order. */
+export const SOURCE_CATALOG: CatalogSource[] = [...CORE_SOURCES, ...SIGNAL_SOURCES];
+
+const BY_ID = new Map(SOURCE_CATALOG.map((s) => [s.id, s]));
+
+export function getCatalogSource(id: string): CatalogSource | undefined {
+  return BY_ID.get(id);
+}
+
+export function kindOf(id: string): SourceKind {
+  return (CORE_IDS as readonly string[]).includes(id) ? "core" : "signal";
+}
+
+/** Grouped by `group`, preserving first-seen order — drives the catalog + roll-ups. */
+export function catalogByGroup(): { group: string; sources: CatalogSource[] }[] {
+  const out: { group: string; sources: CatalogSource[] }[] = [];
+  for (const s of SOURCE_CATALOG) {
+    let g = out.find((x) => x.group === s.group);
+    if (!g) {
+      g = { group: s.group, sources: [] };
+      out.push(g);
+    }
+    g.sources.push(s);
+  }
+  return out;
+}

--- a/lib/sources/freshKind.ts
+++ b/lib/sources/freshKind.ts
@@ -1,0 +1,38 @@
+// One freshness vocabulary across the two different per-source freshness systems:
+// core layers (lib/freshness.ts → FreshState) and signals (lib/signals/freshness.ts
+// → SignalFreshState, which adds the honest "empty" = connected-but-zero state).
+// `off` is added for a placed widget whose source is not currently being fetched
+// (Phase 1: no widget-driven fetch yet). Pure + node-testable.
+
+import type { FreshState } from "@/lib/freshness";
+import type { SignalFreshState } from "@/lib/signals/freshness";
+
+export type FreshKind = "off" | "unknown" | "live" | "empty" | "lagging" | "stale" | "down";
+
+export function unifyCoreFresh(s: FreshState): FreshKind {
+  return s; // FreshState ⊂ FreshKind
+}
+
+export function unifySignalFresh(s: SignalFreshState): FreshKind {
+  return s; // SignalFreshState ⊂ FreshKind
+}
+
+// Higher = worse. Healthy (live/empty) lowest; broken (down) highest. `off`/`unknown`
+// sit mid: not an error, but not delivering data either.
+const RANK: Record<FreshKind, number> = {
+  live: 0,
+  empty: 0,
+  lagging: 1,
+  off: 2,
+  unknown: 2,
+  stale: 3,
+  down: 4,
+};
+
+export function freshRank(k: FreshKind): number {
+  return RANK[k];
+}
+
+export function worseFresh(a: FreshKind, b: FreshKind): FreshKind {
+  return RANK[b] > RANK[a] ? b : a;
+}

--- a/lib/sources/live.ts
+++ b/lib/sources/live.ts
@@ -1,0 +1,77 @@
+"use client";
+// Bridges a CatalogSource to its LIVE state by reading the EXISTING stores — core
+// layers via metrics + lib/freshness, signals via signalCounts + lib/signals/freshness.
+// No fetch is started here (Phase 1: widgets are read-only). Also records each count
+// into countHistoryStore so widgets get a delta + sparkline for free.
+
+import { useEffect } from "react";
+import { getCatalogSource, kindOf } from "@/lib/sources/catalog";
+import { unifyCoreFresh, unifySignalFresh, type FreshKind } from "@/lib/sources/freshKind";
+import { countHistoryStore } from "@/lib/widgets/history";
+import { useMetrics, type Metrics } from "@/lib/metrics";
+import { useFreshness, classifyFreshness, type FreshSourceId } from "@/lib/freshness";
+import { useSignals, useSignalCounts, signalsStore } from "@/lib/signals/store";
+import { useSignalFreshness, classifySignalFreshness } from "@/lib/signals/freshness";
+import { useLayers, layersStore, type LayerKey } from "@/lib/layers";
+import { useNow } from "@/lib/shell/useNow";
+
+export interface SourceLive {
+  count: number | null;
+  fresh: FreshKind;
+  mapOn: boolean;
+  hasData: boolean;
+}
+
+function coreCount(id: string, m: Metrics): number | null {
+  switch (id) {
+    case "cameras": return m.camerasTotal || null;
+    case "planes": return m.planes || null;
+    case "satellites": return m.satellites || null;
+    case "webcams": return m.webcams || null;
+    default: return null;
+  }
+}
+
+export function useSourceLive(id: string): SourceLive {
+  const now = useNow(1000);
+  const metrics = useMetrics();
+  const coreFresh = useFreshness();
+  const layers = useLayers();
+  const sigOn = useSignals();
+  const sigCounts = useSignalCounts();
+  const sigFresh = useSignalFreshness();
+  const source = getCatalogSource(id);
+
+  let live: SourceLive;
+  if (source && kindOf(id) === "core") {
+    const mapOn = layers[id as LayerKey] === true;
+    const rec = coreFresh.find((r) => r.id === (id as FreshSourceId));
+    const count = coreCount(id, metrics);
+    const fresh: FreshKind = !mapOn ? "off" : rec ? unifyCoreFresh(classifyFreshness(rec, now)) : "unknown";
+    live = { count, fresh, mapOn, hasData: mapOn && rec != null };
+  } else if (source) {
+    const mapOn = sigOn[id] === true;
+    const raw = sigFresh[id];
+    const count = sigCounts[id] ?? null;
+    const fresh: FreshKind = !mapOn
+      ? "off"
+      : raw
+        ? unifySignalFresh(classifySignalFreshness({ ...raw, refreshMs: source.refreshMs }, now))
+        : "unknown";
+    live = { count, fresh, mapOn, hasData: raw != null };
+  } else {
+    live = { count: null, fresh: "off", mapOn: false, hasData: false };
+  }
+
+  // Feed the history ring whenever we have a real count (drives delta + sparkline).
+  useEffect(() => {
+    if (live.count != null) countHistoryStore.record(id, live.count, now);
+  }, [id, live.count, now]);
+
+  return live;
+}
+
+export function toggleSourceMap(id: string, on: boolean): void {
+  if (kindOf(id) === "core") layersStore.set(id as LayerKey, on);
+  else signalsStore.set(id, on);
+}

--- a/lib/variants/layout.ts
+++ b/lib/variants/layout.ts
@@ -2,10 +2,11 @@
 // No RGL import — RglItem mirrors RGL's Layout item shape so this stays
 // dependency-light and node-testable. SP1b's DockableWorkspace feeds these to
 // ResponsiveGridLayout and folds onLayoutChange results back into placements.
-import type { PanelKey, PanelPlacement } from "@/lib/variants/types";
+import type { PanelPlacement } from "@/lib/variants/types";
 
 export type RglItem = {
-  i: PanelKey;
+  /** PanelKey or a dynamic widget key (`source:<id>` / `rollup:<group>`). */
+  i: string;
   x: number;
   y: number;
   w: number;

--- a/lib/variants/types.ts
+++ b/lib/variants/types.ts
@@ -11,7 +11,11 @@ export type PanelKey =
 // (transient, deep-linked via ?obj=), kept as overlay chrome.
 
 export interface PanelPlacement {
-  panel: PanelKey;
+  /**
+   * A PanelKey for a registered panel, OR a dynamic widget key
+   * (`source:<id>` / `rollup:<group>`) resolved by the dock at render time.
+   */
+  panel: string;
   /** Grid geometry — carried for SP1b (react-grid-layout); unused in SP1a. */
   grid: { x: number; y: number; w: number; h: number; minW?: number; minH?: number };
   visible: boolean;

--- a/lib/widgets/dock.ts
+++ b/lib/widgets/dock.ts
@@ -1,0 +1,47 @@
+"use client";
+// Bridge between a source/rollup widget key and the EXISTING SP1b workspace dock.
+// A source widget is "docked" iff it is a visible placement in the active variant's
+// layout — so we reuse variantStore.layoutForVariant / commitLayout (the persisted
+// `layoutOverrides` slot) rather than a second placement store. Adding a tile stacks
+// it full-width below the lowest existing tile and opens the dock; removing drops it.
+
+import { variantStore } from "@/lib/variants/store";
+import { workspaceStore } from "@/lib/shell/workspace";
+import { widgetForKey } from "@/lib/widgets/registry";
+import type { PanelPlacement } from "@/lib/variants/types";
+
+/** Is this widget key a visible tile in the active variant's dock layout? */
+export function isTileDocked(activeId: string, key: string): boolean {
+  return variantStore.layoutForVariant(activeId).some((p) => p.panel === key && p.visible);
+}
+
+/** Add a source/rollup widget tile to the active variant's layout + open the dock. */
+export function addTileToDock(activeId: string, key: string): void {
+  const cur = variantStore.layoutForVariant(activeId);
+  if (cur.some((p) => p.panel === key && p.visible)) {
+    workspaceStore.openWorkspace();
+    return;
+  }
+  const w = widgetForKey(key);
+  const h = w?.kind === "rollup" ? 6 : 4;
+  const bottom = cur.reduce((m, p) => Math.max(m, p.grid.y + p.grid.h), 0);
+  const next: PanelPlacement[] = [
+    ...cur.filter((p) => p.panel !== key),
+    { panel: key, grid: { x: 0, y: bottom, w: 12, h, minW: 3, minH: 3 }, visible: true },
+  ];
+  variantStore.commitLayout(activeId, next);
+  workspaceStore.openWorkspace();
+}
+
+/** Remove a source/rollup widget tile from the active variant's layout. */
+export function removeTileFromDock(activeId: string, key: string): void {
+  const cur = variantStore.layoutForVariant(activeId);
+  if (!cur.some((p) => p.panel === key)) return;
+  variantStore.commitLayout(activeId, cur.filter((p) => p.panel !== key));
+}
+
+/** Toggle a widget tile in/out of the active variant's dock. */
+export function toggleTileDock(activeId: string, key: string): void {
+  if (isTileDocked(activeId, key)) removeTileFromDock(activeId, key);
+  else addTileToDock(activeId, key);
+}

--- a/lib/widgets/history.ts
+++ b/lib/widgets/history.ts
@@ -1,0 +1,75 @@
+"use client";
+// A tiny per-source count history so a monitor widget can show a ▴/▾ delta and a
+// glance sparkline WITHOUT any new fetch — the live hook records the count it already
+// reads from the existing stores. Pure ring-buffer maths (node-tested) + a thin
+// module-singleton store (mirrors lib/metrics.ts).
+
+import { useSyncExternalStore } from "react";
+
+export interface CountSample {
+  t: number; // epoch ms
+  n: number; // count at t
+}
+
+const CAP = 24;
+
+/** Pure: append a sample, collapsing a same-count tail (only advancing time), capped. */
+export function pushSample(buf: CountSample[], s: CountSample, cap: number = CAP): CountSample[] {
+  const last = buf[buf.length - 1];
+  let next: CountSample[];
+  if (last && last.n === s.n) {
+    next = [...buf.slice(0, -1), { t: s.t, n: s.n }];
+  } else {
+    next = [...buf, s];
+  }
+  return next.length > cap ? next.slice(next.length - cap) : next;
+}
+
+/** Pure: latest − previous; 0 when fewer than two samples. */
+export function deltaOf(buf: CountSample[]): number {
+  if (buf.length < 2) return 0;
+  return buf[buf.length - 1].n - buf[buf.length - 2].n;
+}
+
+/** Pure: last `slots` counts normalized to 0..1 (flat 0.5 line when all equal). */
+export function trendOf(buf: CountSample[], slots: number): number[] {
+  if (slots <= 0) return [];
+  const tail = buf.slice(-slots).map((x) => x.n);
+  if (tail.length === 0) return [];
+  const min = Math.min(...tail);
+  const max = Math.max(...tail);
+  if (max === min) return tail.map(() => 0.5);
+  return tail.map((n) => (n - min) / (max - min));
+}
+
+// --- store ------------------------------------------------------------------
+let hist: Record<string, CountSample[]> = {};
+const listeners = new Set<() => void>();
+
+export const countHistoryStore = {
+  record(id: string, n: number, at: number = Date.now()) {
+    const prev = hist[id] ?? [];
+    const last = prev[prev.length - 1];
+    // Stable count → the history (count-only delta + sparkline) is visually
+    // unchanged, so skip the update entirely. This is the real anti-churn guard
+    // the dead `next === prev` check intended: the live hook calls record on every
+    // ~1s tick, so a stable source must not re-render its widgets each second.
+    if (last && last.n === n) return;
+    const next = pushSample(prev, { t: at, n });
+    hist = { ...hist, [id]: next };
+    for (const l of listeners) l();
+  },
+  get(): Record<string, CountSample[]> {
+    return hist;
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
+const EMPTY: CountSample[] = [];
+export function useCountHistory(id: string): CountSample[] {
+  const all = useSyncExternalStore(countHistoryStore.subscribe, countHistoryStore.get, countHistoryStore.get);
+  return all[id] ?? EMPTY;
+}

--- a/lib/widgets/registry.ts
+++ b/lib/widgets/registry.ts
@@ -1,0 +1,54 @@
+// Descriptors for the two Phase-1 data widget kinds: one roll-up per catalog group,
+// and a leaf per source (born from a roll-up pop-out). Stable string keys are the
+// placement + (later) layout-override identity. Utility widgets (map/video/etc.)
+// are NOT defined here in Phase 1 — they keep their existing PANEL_REGISTRY entries.
+
+import { catalogByGroup, getCatalogSource } from "@/lib/sources/catalog";
+
+export type WidgetKind = "rollup" | "source";
+
+export interface WidgetDescriptor {
+  key: string;
+  kind: WidgetKind;
+  title: string;
+  /** group name (rollup) or source id (source). */
+  ref: string;
+  defaultGrid: { w: number; h: number; minW: number; minH: number };
+}
+
+export function rollupKey(group: string): string {
+  return `rollup:${group}`;
+}
+export function sourceKey(id: string): string {
+  return `source:${id}`;
+}
+
+const ROLLUP_GRID = { w: 3, h: 3, minW: 2, minH: 2 };
+const SOURCE_GRID = { w: 3, h: 2, minW: 2, minH: 2 };
+
+export function rollupWidgets(): WidgetDescriptor[] {
+  return catalogByGroup().map((g) => ({
+    key: rollupKey(g.group),
+    kind: "rollup" as const,
+    title: g.group,
+    ref: g.group,
+    defaultGrid: { ...ROLLUP_GRID },
+  }));
+}
+
+export function sourceWidget(id: string): WidgetDescriptor | undefined {
+  const s = getCatalogSource(id);
+  if (!s) return undefined;
+  return { key: sourceKey(id), kind: "source", title: s.label, ref: id, defaultGrid: { ...SOURCE_GRID } };
+}
+
+export function widgetForKey(key: string): WidgetDescriptor | undefined {
+  if (key.startsWith("rollup:")) {
+    const group = key.slice("rollup:".length);
+    return rollupWidgets().find((w) => w.ref === group);
+  }
+  if (key.startsWith("source:")) {
+    return sourceWidget(key.slice("source:".length));
+  }
+  return undefined;
+}

--- a/lib/widgets/rollup.ts
+++ b/lib/widgets/rollup.ts
@@ -1,0 +1,29 @@
+// Pure roll-up aggregation: a category widget = the sources of one catalog `group`.
+// Count = sum of known constituent counts; freshness = worst-of (a roll-up is only
+// as fresh as its slowest source). node-tested.
+
+import { catalogByGroup } from "@/lib/sources/catalog";
+import { worseFresh, type FreshKind } from "@/lib/sources/freshKind";
+
+export function constituentIds(group: string): string[] {
+  const g = catalogByGroup().find((x) => x.group === group);
+  return g ? g.sources.map((s) => s.id) : [];
+}
+
+export function rollupCount(counts: Record<string, number | undefined>, ids: string[]): number | null {
+  let sum = 0;
+  let any = false;
+  for (const id of ids) {
+    const c = counts[id];
+    if (typeof c === "number") {
+      sum += c;
+      any = true;
+    }
+  }
+  return any ? sum : null;
+}
+
+export function rollupFresh(states: FreshKind[]): FreshKind {
+  if (states.length === 0) return "off";
+  return states.reduce((acc, s) => worseFresh(acc, s));
+}

--- a/tests/unit/sources-catalog.test.ts
+++ b/tests/unit/sources-catalog.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+import {
+  SOURCE_CATALOG, catalogByGroup, getCatalogSource, kindOf, CORE_IDS,
+} from "@/lib/sources/catalog";
+import { SIGNALS } from "@/lib/signals/registry";
+
+test("catalog contains the 4 core layers plus every signal", () => {
+  expect(SOURCE_CATALOG.length).toBe(CORE_IDS.length + SIGNALS.length);
+  for (const id of CORE_IDS) {
+    const s = getCatalogSource(id);
+    expect(s?.kind).toBe("core");
+  }
+  for (const sig of SIGNALS) {
+    expect(getCatalogSource(sig.id)?.kind).toBe("signal");
+  }
+});
+
+test("every catalog source has the required descriptor fields", () => {
+  for (const s of SOURCE_CATALOG) {
+    expect(s.id).toBeTruthy();
+    expect(s.label).toBeTruthy();
+    expect(s.group).toBeTruthy();
+    expect(s.color).toMatch(/^#/);
+    expect(s.attribution).toBeTruthy();
+    expect(s.refreshMs).toBeGreaterThan(0);
+  }
+});
+
+test("ids are unique", () => {
+  const ids = SOURCE_CATALOG.map((s) => s.id);
+  expect(new Set(ids).size).toBe(ids.length);
+});
+
+test("catalogByGroup preserves order and partitions every source exactly once", () => {
+  const groups = catalogByGroup();
+  const flat = groups.flatMap((g) => g.sources);
+  expect(flat.length).toBe(SOURCE_CATALOG.length);
+  // group labels are non-empty and unique
+  const labels = groups.map((g) => g.group);
+  expect(new Set(labels).size).toBe(labels.length);
+});
+
+test("kindOf classifies core vs signal", () => {
+  expect(kindOf("cameras")).toBe("core");
+  expect(kindOf(SIGNALS[0].id)).toBe("signal");
+});

--- a/tests/unit/sources-freshkind.test.ts
+++ b/tests/unit/sources-freshkind.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+import { unifyCoreFresh, unifySignalFresh, freshRank, worseFresh } from "@/lib/sources/freshKind";
+
+test("core states map onto the unified kind (no 'empty' for core)", () => {
+  expect(unifyCoreFresh("live")).toBe("live");
+  expect(unifyCoreFresh("lagging")).toBe("lagging");
+  expect(unifyCoreFresh("stale")).toBe("stale");
+  expect(unifyCoreFresh("down")).toBe("down");
+  expect(unifyCoreFresh("unknown")).toBe("unknown");
+});
+
+test("signal states map onto the unified kind, preserving 'empty'", () => {
+  expect(unifySignalFresh("empty")).toBe("empty");
+  expect(unifySignalFresh("live")).toBe("live");
+  expect(unifySignalFresh("down")).toBe("down");
+});
+
+test("rank orders healthy below broken so worst-of picks the broken one", () => {
+  expect(freshRank("live")).toBeLessThan(freshRank("lagging"));
+  expect(freshRank("lagging")).toBeLessThan(freshRank("stale"));
+  expect(freshRank("stale")).toBeLessThan(freshRank("down"));
+  expect(freshRank("empty")).toBe(freshRank("live")); // both healthy
+});
+
+test("worseFresh returns the higher-ranked (worse) of two states", () => {
+  expect(worseFresh("live", "stale")).toBe("stale");
+  expect(worseFresh("down", "lagging")).toBe("down");
+  expect(worseFresh("live", "empty")).toBe("live"); // tie → first; both healthy
+});

--- a/tests/unit/widgets-history.test.ts
+++ b/tests/unit/widgets-history.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import { pushSample, deltaOf, trendOf, countHistoryStore, type CountSample } from "@/lib/widgets/history";
+
+const s = (t: number, n: number): CountSample => ({ t, n });
+
+test("pushSample appends and caps to the most recent N", () => {
+  let buf: CountSample[] = [];
+  for (let i = 0; i < 30; i++) buf = pushSample(buf, s(i, i), 24);
+  expect(buf.length).toBe(24);
+  expect(buf[0].n).toBe(6); // oldest kept = 30-24
+  expect(buf[buf.length - 1].n).toBe(29);
+});
+
+test("pushSample collapses a same-count consecutive sample (only time advances)", () => {
+  let buf = pushSample([], s(1, 5));
+  buf = pushSample(buf, s(2, 5)); // unchanged count → keep one, update time
+  expect(buf.length).toBe(1);
+  expect(buf[0].t).toBe(2);
+});
+
+test("deltaOf is latest minus previous, 0 when fewer than two samples", () => {
+  expect(deltaOf([])).toBe(0);
+  expect(deltaOf([s(1, 10)])).toBe(0);
+  expect(deltaOf([s(1, 10), s(2, 13)])).toBe(3);
+  expect(deltaOf([s(1, 13), s(2, 8)])).toBe(-5);
+});
+
+test("trendOf returns the last `slots` counts normalized 0..1", () => {
+  const buf = [s(1, 0), s(2, 5), s(3, 10)];
+  expect(trendOf(buf, 3)).toEqual([0, 0.5, 1]);
+  // all-equal → flat 0.5 line, never divide-by-zero
+  expect(trendOf([s(1, 4), s(2, 4)], 2)).toEqual([0.5, 0.5]);
+});
+
+test("countHistoryStore.record skips a stable count (no subscriber churn)", () => {
+  let notifications = 0;
+  const unsub = countHistoryStore.subscribe(() => { notifications++; });
+  countHistoryStore.record("t-stable", 5, 1000);
+  countHistoryStore.record("t-stable", 5, 2000); // same count → ignored
+  countHistoryStore.record("t-stable", 7, 3000); // changed → recorded
+  unsub();
+  const buf = countHistoryStore.get()["t-stable"];
+  expect(buf.map((s) => s.n)).toEqual([5, 7]);
+  expect(notifications).toBe(2); // only the two real changes notified
+});
+
+test("trendOf returns [] for non-positive slots", () => {
+  expect(trendOf([{ t: 1, n: 5 }], 0)).toEqual([]);
+});

--- a/tests/unit/widgets-registry.test.ts
+++ b/tests/unit/widgets-registry.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { rollupWidgets, sourceWidget, widgetForKey, rollupKey, sourceKey } from "@/lib/widgets/registry";
+import { catalogByGroup } from "@/lib/sources/catalog";
+
+test("one roll-up widget per catalog group, stable keys", () => {
+  const groups = catalogByGroup();
+  const rollups = rollupWidgets();
+  expect(rollups.length).toBe(groups.length);
+  expect(rollups.every((w) => w.kind === "rollup")).toBe(true);
+  expect(rollups[0].key).toBe(rollupKey(groups[0].group));
+});
+
+test("sourceWidget builds a leaf descriptor for a known id, undefined otherwise", () => {
+  const w = sourceWidget("cameras");
+  expect(w?.kind).toBe("source");
+  expect(w?.key).toBe(sourceKey("cameras"));
+  expect(w?.title).toBe("Cameras");
+  expect(sourceWidget("nope")).toBeUndefined();
+});
+
+test("widgetForKey resolves both kinds and enforces min sizes", () => {
+  const groups = catalogByGroup();
+  const r = widgetForKey(rollupKey(groups[0].group));
+  expect(r?.kind).toBe("rollup");
+  const s = widgetForKey(sourceKey("planes"));
+  expect(s?.kind).toBe("source");
+  expect(s!.defaultGrid.minW).toBeGreaterThan(0);
+  expect(s!.defaultGrid.minH).toBeGreaterThan(0);
+  expect(widgetForKey("bogus:x")).toBeUndefined();
+});

--- a/tests/unit/widgets-rollup.test.ts
+++ b/tests/unit/widgets-rollup.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import { constituentIds, rollupCount, rollupFresh } from "@/lib/widgets/rollup";
+import { catalogByGroup } from "@/lib/sources/catalog";
+
+test("constituentIds returns the source ids of a group", () => {
+  const g = catalogByGroup()[0];
+  expect(constituentIds(g.group)).toEqual(g.sources.map((s) => s.id));
+  expect(constituentIds("no-such-group")).toEqual([]);
+});
+
+test("rollupCount sums known counts, null when no constituent has data", () => {
+  expect(rollupCount({ a: 3, b: 5 }, ["a", "b"])).toBe(8);
+  expect(rollupCount({ a: 3 }, ["a", "b"])).toBe(3); // b unknown → skipped
+  expect(rollupCount({}, ["a", "b"])).toBeNull(); // nothing known
+});
+
+test("rollupFresh is worst-of its constituents", () => {
+  expect(rollupFresh(["live", "lagging", "stale"])).toBe("stale");
+  expect(rollupFresh(["live", "empty"])).toBe("live"); // both healthy
+  expect(rollupFresh([])).toBe("off"); // nothing placed/known
+});


### PR DESCRIPTION
## Widgetize everything — Source Catalog + dockable source widgets

Reframes the left rail and the dock around a single idea: **every data source is a placeable, monitorable widget.** Builds on the existing SP1b workspace dock (react-grid-layout) and the variant layout-override persistence — no second grid, no new store.

### What's new
- **Unified source catalog** (`lib/sources/catalog.ts`) — one flat list over the 4 core layers (cameras / webcams / planes / satellites) and the 39 data signals, so the rail and the widget grid are data-driven off one source of truth.
- **Read-only live state** (`lib/sources/live.ts`) — `useSourceLive(id)` derives count + freshness + map-on by reading the **existing** metrics / freshness / signal stores. It starts **no new fetch**; a source only fetches when its layer is on, exactly as before.
- **Glance history** (`lib/widgets/history.ts`) — a tiny per-source count ring buffer feeds a ▴/▾ delta and a sparkline, recorded from the count the live hook already reads (with a same-count anti-churn guard so a stable source doesn't re-render every second).
- **Source widgets** (`components/shell/SourceWidget.tsx`) — a docked tile in two shapes: a **leaf** (hero count + delta + sparkline + map toggle) and a **roll-up** (a category's live total + a row per constituent source, each with a ⤢ pop-out that docks that single source).
- **Source Catalog rail** (`components/shell/SourceCatalog.tsx`) — replaces `LayerRail` as a **superset**: every prior control is preserved (presets, monitor bar, camera region / live-only filters, global-signal feeds, coverage / markets / watchlist entry points) and it adds source **search**, a per-source **map / ▦ widget** toggle pair, per-group roll-up toggles, and a "how many are widgeted" counter.

### How it docks
`PanelPlacement.panel` / `RglItem.i` widen from the fixed `PanelKey` union to `string`, so a dynamic `source:<id>` / `rollup:<group>` key can live in a variant's layout. `DockableWorkspace` gains a resolver: a registered `PanelKey` renders its panel component, otherwise the key renders `<SourceWidget>`. `lib/widgets/dock.ts` bridges the ▦ toggle to `variantStore.commitLayout` (the same persisted layout-override the dock editor already uses), so docked widgets save and restore per monitor.

`LayerRail` is removed — `SourceCatalog` is a strict superset and nothing else imported it.

### Verification
- `tsc --noEmit` — 0 errors
- Vitest — **427 passing** (104 files), including the brought-in catalog / freshKind / history / registry / rollup suites
- `next build` — succeeds

### Notes / follow-ups
- News-video-in-a-widget (HLS-first via `/api/hls`) is scoped as a later phase; this PR lands the catalog + monitor-widget foundation it sits on.
- Core-group roll-up toggles are currently surfaced on signal groups; core sources are added individually (each has its own ▦).
