### PR TITLE
Widget console redesign: composable monitoring shell (segments + stage + widgets)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-results/
 *.tsbuildinfo
 next-env.d.ts
 .vercel
+.superpowers/

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,26 +1,81 @@
-# SP1b · Dockable Workspace — Progress Ledger
+# Widget Console Redesign — Progress Ledger
 
-Plan: docs/superpowers/plans/2026-06-27-variant-spine-sp1b.md
-Branch: feat/sp1b-workspace (worktree, off origin/main @ 8f7c180 = merged SP1a)
-Execution: inline (executing-plans). Baseline: vitest 366 on origin/main.
+Plan: docs/superpowers/plans/2026-06-28-widget-console-redesign.md
+Spec: docs/superpowers/specs/2026-06-28-widget-console-redesign-design.md
+Branch: feat/widget-console-redesign (spec 10238b3 · plan 425e9a8)
+Execution: subagent-driven-development. BASE for Task 1 = 425e9a8.
+(Prior ground-truth-console-phase1 ledger is COMPLETE; superseded by this file. See git history for it.)
 
-## Tasks
-- [x] Task 1: pure layout mappers (lib/variants/layout.ts) — 2/2 green
-- [x] Task 2: variantStore layout methods (layoutForVariant/commitLayout/resetLayout/useLayout) — 2/2 green
-- [x] Task 3: workspaceStore (draft-commit state machine) — 4/4 green
-- [x] Task 4: dockable panels (`docked` prop) + PanelTile — tsc 0, backward-compatible
-- [x] Task 5: DockableWorkspace (RGL 2.x dock, useContainerWidth+mounted) — tsc 0
-- [x] Task 6: WorkspaceBar + ConsoleShell/palette wiring (suppress dockable slide-ins while open) — build green
-- [x] Task 7: runtime smoke + final gate
+## Status
+- [x] Task 1: layout types + defaults (lib/console/types.ts)
+- [x] Task 2: pure layout reducers
+- [x] Task 3: shellLayoutStore
+- [x] Task 4: widget registry
+- [x] Task 5: alert model
+- [x] Task 6: WidgetFrame component
+- [x] Task 8: StageHost + StageSwitch + WorldClock  (ran before 7)
+- [x] Task 7: Segment + ConsoleWorkspace  ← Phase C (shell) DONE
+- [x] Task 9: Aviation widget + rules  ← Phase D start
+- [x] Task 10: Disasters & Events widget + rules  (alerts fire on real data)
+- [x] Task 11: Cameras widget + rules  (+made loadedCamerasStore reactive)
+- [x] Task 12: Live Video News + provider catalogue  ← Phase D done
+- [x] Task 13: widget index + ⌘K catalog upgrade  ← Phase E start
+- [x] Task 14: presets + URL share
+- [x] Task 15: mount console + reconcile chrome + e2e  ← SLICE COMPLETE
 
-## Final gate (all green)
-- tsc --noEmit: 0 errors (excl. .claude/worktrees orphans)
-- vitest: 374 passing (366 baseline + 8 new: layout 2 / store-layout 2 / workspace 4)
-- npm run build: SUCCESS (/ route 74.8 kB)
-- Playwright smoke on `next start`: dock opens with markets variant tiles (Markets+Brief),
-  Edit shows 2 resize handles + 2 draggable items, Save persists layoutOverrides.markets
-  (3 placements) to localStorage tn.variant.v1 {v:1,d:{...}}, console 0 errors / 0 warnings.
+## Completed
+Task 1: complete (commit 6b5f398, review clean — spec ✅, quality Approved)
+Task 2: complete (commits 8220237..d550c65, review ✅ Approved after 1 fix: removeWidget dense reindex + upper-clamp tests)
+Task 3: complete (commit 8798caf, review ✅ Approved; Important "nextSeq missing" ADJUDICATED → vestigial spec entry, 0 consumers, dropped from plan, no code change)
+Task 4: complete (commits eaa2ac7..50f7c5e, review ✅ Approved + 1 test top-up: listWidgetTypes order + getWidgetType miss)
+Task 5: complete (commit 4117b28, review ✅ Approved, Minors only)
+Task 6: complete (commit 8c5de0c, review ✅ Approved all 12 constraints, Minors only; first UI component, e2e-gated at T15)
+NOTE: executing order swapped to 8→7 (Task 7 ConsoleWorkspace imports Task 8 StageHost; Task 8 is standalone, keeps each tsc-clean).
+Task 8: complete (commit 8f703dc, review ✅ Approved all 14 constraints, Minors only)
+Task 7: complete (commit 0227af4, review ✅ Approved; drop-index/listener-teardown/resize-signs all correct, Minors only) — PHASE C done
+Task 9: complete (commit f724d23, review ✅ Approved; rules exact+tested, body adapted to WorldObject shape; squawk/military alerts DORMANT — see Follow-ups)
+Task 10: complete (commit 7ac6378, review ✅ Approved; nested r.severity.tier + r.magnitude.value mapped right, projectEventFeed matches EventFeed.tsx; S3+/M5+ alerts LIVE)
+Task 11: complete (commits 6d166a4..69f8b1e, review ✅ Approved after 1 fix: loadedCamerasStore made reactive [subscribe], widget uses useSyncExternalStore + empty-state; offline alert LIVE)
+Task 12: complete (commits 1362eb3..f542088, review ✅ Approved after 1 fix: YT id regex {6,}→{11} + playsinline test assertion; fix self-verified via the pinning test [4/4 green] + diff inspection, no scope creep) — PHASE D done
+Task 13: complete (commit b37dd99, review ✅ Spec ✅ + quality Approved, 1 Minor; barrel registers 4 widgets + ⌘K "Add <widget>" catalog w/ open-counts + 3 stage cmds, matches brief verbatim; the LSP "unused import" diagnostics were STALE mid-edit snapshots — git diff confirms all 3 imports ARE used) — PHASE E start
+Task 14: complete (commit 837a975, review ✅ Spec ✅ + quality Approved, 4 Minors all benign/deferred; presets.ts [built-ins World/Aviation-Ops/Disaster-Response + save-your-own + listPresets] + share.ts [URL-safe base64 encode/decode, null-on-garbage] TDD'd 4/4 green, palette wired WITHOUT the duplicate shellLayoutStore import; stale red-phase "cannot find module" + mid-edit "unused import" diagnostics DISPROVEN by fresh filtered tsc [clean] + git diff)
+Task 15: complete (commit e49faf3, gates ALL GREEN — tsc clean, vitest 489 pass, `npm run build` SUCCESS [eslint clean → all removed imports verified gone], e2e 4/4 pass [Chromium ran]; ConsoleShell REWRITTEN — mounts ConsoleWorkspace + console hydrate/?c=/world-seed + inline onClose + tn-toast listener & pill, no props; page.tsx→<main><ConsoleShell/></main> [WorldMap gone, now in StageHost]; StageSwitch added to StatusBar; .tn-toast CSS; e2e spec; 1st dispatch was a 0-tool no-op, re-nudged → succeeded; self-verified final ConsoleShell + 5-file stat) — SLICE COMPLETE, next = final whole-branch review (opus)
 
-## Deferred (YAGNI, documented in plan)
-add/remove panels in edit mode, per-breakpoint responsive layouts, docking
-layerRail/tickers, userVariants editor.
+## Follow-ups (post-slice — SURFACE TO USER)
+- [DONE in Task 15, commit e49faf3] TOAST LISTENER: ConsoleShell now hosts a global tn-toast listener +
+  calm pill (3.2s auto-dismiss), so the 50-widget-cap feedback surfaces. Wiring point (alertCapacity in the
+  palette) + UI both live.
+- AVIATION ALERTS DORMANT: usePlanes()→WorldObject has no squawk/military fields, so the flagship "squawk 7700"
+  alert never fires on live data. Rules are correct+tested. To activate: extend parseAdsb() to surface squawk
+  onto WorldObject + add a military category to classifyPlane(). (Events + Cameras alerts DO fire on real data.)
+
+## Minor findings rollup (for final review)
+- T1-m1: newInstanceId exported but untested (lib/console/types.ts) — add later if reducers don't cover it.
+- T1-m2: console-reducers.test.ts asserts left/bottom but not segments.right value explicitly.
+- T2-m1: removeWidget segSorted .sort() is on a fresh filtered array (safe); a comment would make purity self-evident.
+- T2-m2: setWidgetCollapsed/setWidgetConfig/setSegmentCollapsed untested; moveWidget dest-segment order not asserted.
+- T3-m1: store.hydrate() emits even when nothing was loaded (spurious save+notify on first boot); guard `if(s){state=s;emit()}`.
+- T3-m2: store.set() and replace() are identical (both spec-listed; acceptable).
+- T5-m1: alertCount() exported but untested + likely unused (WidgetFrame uses alerts.length directly) — consider dropping later.
+- T5-m2: topSeverity tested only for info+critical; warn-only path uncovered.
+- T6-m1: WidgetFrame unmount-mid-drag pointer-listener leak (negligible; inherited from brief).
+- T6-m2: tn-cw-* CSS hardcodes hex instead of --tn-* tokens (theming drift risk; affects later widget CSS too).
+- T8-m1: WorldClock ticks every 1s but only shows HH:MM (60x excess re-renders); use 60s or show seconds.
+- T8-m2: .tn-clock-cell class used in WorldClock JSX but unstyled (cells lay out ok but not column-centered); add flex-col rule.
+- T7-m1: globals.css Task 7 block sits after Task 8 block (cosmetic ordering).
+- T7-m2: VGrip subscribes to full store redundantly (ConsoleWorkspace already does); harmless re-render churn.
+- T7-m3: Segment stays mounted+subscribed when its column is collapsed (width:0); harmless at current scale.
+- T9-m1: aviation.tsx effect dep `planes.length` redundant (lite already memoized on planes); remove.
+- T9-m2: aviation flights table has no <thead> (columns unlabeled) — UX polish.
+- T9-note: reviewer worried report() ref stability → CONFIRMED stable (Task 6 onReport is useCallback []), no loop. (Applies to all widget bodies.)
+- T10-m1: console-events.test.ts asserts S3→warn but only implicitly S4→critical; add explicit `expect(...severity).toBe("critical")`.
+- T10-m2: events.tsx freshLabel hardcoded "5m" (could reflect the active time window).
+- T10-note: config in widget effect deps is fine — instance.config ref is stable across unrelated store updates (reducers only clone on change).
+- T11-m1: cameras.tsx effect reads cams.length but only lite in deps (covered by lite memo; switch to lite.length for exhaustive-deps lint cleanliness).
+- T13-m1 (Task 15 WATCH-ITEM): CommandPalette open-counts come from useMemo(()=>buildCommands(onClose),[onClose]); counts only refresh when onClose identity changes. CURRENTLY CORRECT — ConsoleShell passes inline onClose={()=>setPaletteOpen(false)}, so it re-renders + recomputes on every open. LATENT: if Task 15 wraps onClose in useCallback the counts freeze → then add `open` to the palette useMemo deps (or subscribe the palette to shellLayoutStore). [Task 14's listPresets-staleness Minor is the SAME root cause — fixing this covers both.]
+- T14-m1: share.ts uses deprecated escape/unescape (browser path only; node test path uses Buffer). Works; decode is try/catch-safe. Modernize via TextEncoder/TextDecoder if the file is touched.
+- T14-m2: decodeLayout calls atob on padding-stripped base64 without re-padding. BENIGN — our encode never yields len%4==1, atob is forgiving of missing padding, and try/catch returns null on any failure. Node path uses lenient Buffer.
+- T14-m3: presets.ts module-level `seed` counter is shared across all build() calls (monotonic widget ids). Benign — ids are internal-only, no test asserts on them.
+- T15-m1 (FINAL-REVIEW CLEANUP): palette commands coverage / markets / toggle-workspace are now dead no-ops — their panels/dock were removed from ConsoleShell, but CommandPalette was intentionally left untouched. Prune those commands + their now-unused store imports (coverageStore/marketsStore/workspaceStore) in the final fix wave.
+- T15-m2: StatusBar still renders VariantSwitcher + WorkspaceBar, now partly orphaned (variant-driven PanelHost + DockableWorkspace were removed). Harmless; consider removing in cleanup.
+- T15-note: implementer left a stray `next start` on :3000 — kill it before any local `npm run dev`.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1063,3 +1063,24 @@ a { color: var(--tn-accent); }
 }
 .tn-scope-result:hover { background: var(--tn-surface-2); }
 .tn-scope-note { font-size: 11px; color: var(--tn-text-muted); margin: 6px 4px 2px; }
+
+/* ── Console top bar (floating cluster) ────────────────────────────────────── */
+.tn-console-topbar {
+  position: fixed; top: calc(var(--tn-topbar-h) + 8px); left: 12px; z-index: 26;
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+}
+.tn-console-explore {
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+  font-size: 13px; font-weight: 600; padding: 6px 12px; border-radius: 8px;
+  background: var(--tn-surface); color: var(--tn-text);
+  border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
+}
+.tn-console-explore:hover { border-color: var(--tn-border-strong); }
+/* A small "← Console" affordance lives in the existing globe chrome (Explore). */
+.tn-explore-return {
+  position: fixed; top: calc(var(--tn-topbar-h) + 8px); left: 12px; z-index: 26;
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+  font-size: 13px; font-weight: 600; padding: 6px 12px; border-radius: 8px;
+  background: var(--tn-surface); color: var(--tn-text);
+  border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1084,3 +1084,21 @@ a { color: var(--tn-accent); }
   background: var(--tn-surface); color: var(--tn-text);
   border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
 }
+
+/* ===========================================================================
+   WidgetFrame chrome — Task 6
+   =========================================================================== */
+.tn-cw{display:flex;flex-direction:column;background:#fff;border:1px solid var(--tn-border,#dbe2ea);border-radius:8px;overflow:hidden}
+.tn-cw-head{display:flex;align-items:center;gap:6px;padding:6px 8px;border-bottom:1px solid #f1f5f9;cursor:grab;font-size:12px}
+.tn-cw-title{font-weight:700;color:#2b3640}.tn-cw-count{font-size:11px;color:#8a97a6}.tn-cw-sp{flex:1}
+.tn-cw-badge{font-size:10px;font-weight:800;color:#fff;border-radius:8px;padding:0 5px;background:#8a97a6}
+.tn-cw-badge.tn-sev-critical{background:#d9534f}.tn-cw-badge.tn-sev-warn{background:#d9882f}.tn-cw-badge.tn-sev-info{background:#4a78c9}
+.tn-cw-fresh{font-size:10px;color:#3f8f5c}.tn-cw-menu{border:0;background:none;cursor:pointer;color:#b3bdc8;font-size:14px}
+.tn-cw-menu-pop{display:flex;flex-direction:column;border-bottom:1px solid #eef2f6}
+.tn-cw-menu-pop button{text-align:left;border:0;background:none;padding:7px 10px;font-size:12px;cursor:pointer}
+.tn-cw-menu-pop button:hover{background:#f6f9fb}.tn-cw-danger{color:#d9534f}
+.tn-cw-attn{border-bottom:1px solid #f1f5f9}.tn-cw-attn-h{font-size:9px;text-transform:uppercase;letter-spacing:.8px;color:#a9b4bf;padding:5px 8px 2px}
+.tn-cw-alert{font-size:11px;padding:4px 8px;border-left:3px solid #d9534f;background:#fdf3f2}
+.tn-cw-alert.tn-sev-warn{border-left-color:#d9882f;background:#fdf7ee}.tn-cw-alert.tn-sev-info{border-left-color:#4a78c9;background:#f1f5fc}
+.tn-cw-body{flex:1;overflow:auto;min-height:0}
+.tn-cw-resize{height:6px;cursor:row-resize;background:linear-gradient(#f1f5f9,#fff)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1168,3 +1168,9 @@ a { color: var(--tn-accent); }
 .tn-news-picker{display:flex;flex-direction:column;border-top:1px solid #eef2f6;max-height:160px;overflow:auto}
 .tn-news-picker button{text-align:left;border:0;background:none;padding:5px 9px;font-size:11px;cursor:pointer}
 .tn-news-cat{color:#9aa6b2;font-size:9px;float:right}.tn-news-custom{margin:6px 9px;padding:4px;font-size:11px;border:1px solid #e1e8ef;border-radius:5px}
+
+/* ===========================================================================
+   Global capacity toast (Task 15) — calm bottom-centre pill, auto-dismisses
+   =========================================================================== */
+.tn-toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%);z-index:1200;max-width:90vw;background:#2b3640;color:#fff;font:13px/1.4 -apple-system,"Segoe UI",Roboto,sans-serif;padding:9px 16px;border-radius:999px;box-shadow:0 6px 24px rgba(20,28,38,.28);animation:tn-toast-in .18s ease-out}
+@keyframes tn-toast-in{from{opacity:0;transform:translate(-50%,8px)}to{opacity:1;transform:translate(-50%,0)}}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1101,6 +1101,8 @@ a { color: var(--tn-accent); }
 .tn-cw-alert{font-size:11px;padding:4px 8px;border-left:3px solid #d9534f;background:#fdf3f2}
 .tn-cw-alert.tn-sev-warn{border-left-color:#d9882f;background:#fdf7ee}.tn-cw-alert.tn-sev-info{border-left-color:#4a78c9;background:#f1f5fc}
 .tn-cw-body{flex:1;overflow:auto;min-height:0}
+.tn-cw-attn-feed{display:flex;flex-direction:column;gap:2px;margin-bottom:6px}
+.tn-cw-failed{padding:12px 10px;font-size:11px;color:#a9b4bf}
 .tn-cw-resize{height:6px;cursor:row-resize;background:linear-gradient(#f1f5f9,#fff)}
 
 /* ===========================================================================

--- a/app/globals.css
+++ b/app/globals.css
@@ -1145,3 +1145,10 @@ a { color: var(--tn-accent); }
 .tn-w-kind{flex:none;font-size:11px;color:var(--tn-text-muted);font-weight:500}
 .tn-w-place{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--tn-text)}
 .tn-w-mag{flex:none;font-family:var(--tn-mono);font-size:11px;color:var(--tn-text-muted)}
+
+/* ===========================================================================
+   Widget body — camera grid (Task 11 Cameras widget)
+   =========================================================================== */
+.tn-cam-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:6px;padding:6px}
+.tn-cam-cell{display:flex;flex-direction:column;gap:3px;background:var(--tn-surface-2);border:1px solid var(--tn-border);border-radius:8px;overflow:hidden}
+.tn-cam-label{font-size:10px;color:var(--tn-text-muted);padding:3px 6px 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1134,3 +1134,14 @@ a { color: var(--tn-accent); }
 .tn-w-strong{font-weight:600;color:var(--tn-text)}
 .tn-w-muted{color:var(--tn-text-muted)}
 .tn-w-num{font-family:var(--tn-mono);text-align:right;color:var(--tn-text-muted)}
+.tn-w-empty{padding:12px 8px;font-size:12px;color:var(--tn-text-muted);text-align:center}
+
+/* ===========================================================================
+   Widget body — list primitives (Task 10 Disasters & Events widget)
+   =========================================================================== */
+.tn-w-list{list-style:none;margin:0;padding:0;font-size:12px}
+.tn-w-list li{display:flex;align-items:baseline;gap:4px;padding:4px 6px;border-bottom:1px solid var(--tn-border);line-height:1.4}
+.tn-w-sev{flex:none;font-size:10px;font-weight:700;padding:1px 4px;border-radius:3px;letter-spacing:.03em;background:var(--tn-border);color:var(--tn-text-muted)}
+.tn-w-kind{flex:none;font-size:11px;color:var(--tn-text-muted);font-weight:500}
+.tn-w-place{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--tn-text)}
+.tn-w-mag{flex:none;font-family:var(--tn-mono);font-size:11px;color:var(--tn-text-muted)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1152,3 +1152,5 @@ a { color: var(--tn-accent); }
 .tn-cam-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:6px;padding:6px}
 .tn-cam-cell{display:flex;flex-direction:column;gap:3px;background:var(--tn-surface-2);border:1px solid var(--tn-border);border-radius:8px;overflow:hidden}
 .tn-cam-label{font-size:10px;color:var(--tn-text-muted);padding:3px 6px 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+.tn-cam-empty{font-size:11px;color:#9aa6b2;text-align:center;padding:14px}

--- a/app/globals.css
+++ b/app/globals.css
@@ -75,7 +75,7 @@ a { color: var(--tn-accent); }
 /* ---- Stage ---- */
 .tn-shell-main { width: 100vw; height: 100vh; overflow: hidden; }
 .tn-shell { position: relative; width: 100vw; height: 100vh; }
-.world-map { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
+.world-map { position: absolute; inset: 0; width: 100%; height: 100%; overflow: hidden; }
 .map-canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
 
 /* MapLibre chrome: light, and lifted clear of the bottom ticker. */
@@ -1159,17 +1159,20 @@ a { color: var(--tn-accent); }
 
 /* ===========================================================================
    Widget body — Live Video News (Task 12)
+   NOTE: prefix is `tn-newsw` (news-WIDGET), NOT `tn-news` — the bottom news
+   TICKER already owns `.tn-news` with position:fixed + backdrop-blur, so reusing
+   it made this in-segment widget escape to a full-viewport blurred overlay.
    =========================================================================== */
-.tn-news{display:flex;flex-direction:column;height:100%}
-.tn-news-screen{position:relative;aspect-ratio:16/9;background:#15212b}
-.tn-news-video{position:absolute;inset:0;width:100%;height:100%;border:0}
-.tn-news-ch{position:absolute;left:6px;bottom:6px;color:#fff;font-size:10px;font-weight:700;text-shadow:0 1px 2px rgba(0,0,0,.6)}
-.tn-news-tabs{display:flex;gap:4px;padding:6px;flex-wrap:wrap}
-.tn-news-tabs button{font-size:9px;border:1px solid #e1e8ef;border-radius:10px;padding:2px 7px;background:#fff;cursor:pointer}
-.tn-news-tabs button.is-on{background:#27313b;color:#fff;border-color:#27313b}.tn-news-more{color:#3f8f5c;border-style:dashed!important}
-.tn-news-picker{display:flex;flex-direction:column;border-top:1px solid #eef2f6;max-height:160px;overflow:auto}
-.tn-news-picker button{text-align:left;border:0;background:none;padding:5px 9px;font-size:11px;cursor:pointer}
-.tn-news-cat{color:#9aa6b2;font-size:9px;float:right}.tn-news-custom{margin:6px 9px;padding:4px;font-size:11px;border:1px solid #e1e8ef;border-radius:5px}
+.tn-newsw{display:flex;flex-direction:column;height:100%}
+.tn-newsw-screen{position:relative;aspect-ratio:16/9;background:#15212b}
+.tn-newsw-video{position:absolute;inset:0;width:100%;height:100%;border:0}
+.tn-newsw-ch{position:absolute;left:6px;bottom:6px;color:#fff;font-size:10px;font-weight:700;text-shadow:0 1px 2px rgba(0,0,0,.6)}
+.tn-newsw-tabs{display:flex;gap:4px;padding:6px;flex-wrap:wrap}
+.tn-newsw-tabs button{font-size:9px;border:1px solid #e1e8ef;border-radius:10px;padding:2px 7px;background:#fff;cursor:pointer}
+.tn-newsw-tabs button.is-on{background:#27313b;color:#fff;border-color:#27313b}.tn-newsw-more{color:#3f8f5c;border-style:dashed!important}
+.tn-newsw-picker{display:flex;flex-direction:column;border-top:1px solid #eef2f6;max-height:160px;overflow:auto}
+.tn-newsw-picker button{text-align:left;border:0;background:none;padding:5px 9px;font-size:11px;cursor:pointer}
+.tn-newsw-cat{color:#9aa6b2;font-size:9px;float:right}.tn-newsw-custom{margin:6px 9px;padding:4px;font-size:11px;border:1px solid #e1e8ef;border-radius:5px}
 
 /* ===========================================================================
    Global capacity toast (Task 15) — calm bottom-centre pill, auto-dismisses

--- a/app/globals.css
+++ b/app/globals.css
@@ -1111,3 +1111,16 @@ a { color: var(--tn-accent); }
 .tn-stage-switch{display:inline-flex;gap:2px;background:#fff;border:1px solid #d7dee6;border-radius:7px;padding:2px}
 .tn-stage-switch button{border:0;background:none;font-size:11px;font-weight:700;color:#5a6470;padding:2px 8px;border-radius:5px;cursor:pointer}
 .tn-stage-switch button.is-on{background:#27313b;color:#fff}
+
+/* ===========================================================================
+   ConsoleWorkspace + Segment — Task 7
+   =========================================================================== */
+.tn-cw-shell{position:absolute;inset:0;display:flex;min-height:0}
+.tn-cw-col{flex:none;overflow:hidden;display:flex}
+.tn-cw-center{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0}
+.tn-cw-stage{flex:1;position:relative;min-height:0}
+.tn-cw-bottom{flex:none;overflow:hidden;display:flex}
+.tn-seg{flex:1;overflow-y:auto;overflow-x:hidden;display:flex;flex-direction:column;gap:8px;padding:8px;background:#eef2f6}
+.tn-seg-slot{flex:none}.tn-seg-empty{font-size:11px;color:#9aa6b2;text-align:center;margin:auto;padding:16px}
+.tn-grip{width:6px;flex:none;cursor:col-resize;background:#cdd6e0}
+.tn-grip:hover{background:#aebac6}.tn-grip-h{width:auto;height:6px;cursor:row-resize}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1014,7 +1014,7 @@ a { color: var(--tn-accent); }
 .tn-feed-item:hover { background: var(--tn-surface-2); }
 .tn-feed-sev {
   flex: none; align-self: flex-start; font-family: var(--tn-mono);
-  font-size: 11px; font-weight: 700; color: #fff; padding: 1px 6px; border-radius: 5px;
+  font-size: 11px; font-weight: 700; padding: 1px 6px; border-radius: 5px;
 }
 .tn-feed-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .tn-feed-item-title { font-size: 13px; line-height: 1.3; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1006,18 +1006,18 @@ a { color: var(--tn-accent); }
 }
 .tn-feed-type.on { background: var(--tn-accent-soft); color: var(--tn-accent-strong); border-color: var(--tn-accent); }
 .tn-feed-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; }
-.tn-feed-row {
+.tn-feed-item {
   display: flex; gap: 10px; width: 100%; text-align: left; cursor: pointer;
   padding: 9px 12px; background: transparent; border: 0; border-bottom: 1px solid var(--tn-border);
   color: inherit;
 }
-.tn-feed-row:hover { background: var(--tn-surface-2); }
+.tn-feed-item:hover { background: var(--tn-surface-2); }
 .tn-feed-sev {
   flex: none; align-self: flex-start; font-family: var(--tn-mono);
   font-size: 11px; font-weight: 700; color: #fff; padding: 1px 6px; border-radius: 5px;
 }
 .tn-feed-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.tn-feed-row-title { font-size: 13px; line-height: 1.3; }
+.tn-feed-item-title { font-size: 13px; line-height: 1.3; }
 .tn-feed-kind { color: var(--tn-text-muted); text-transform: capitalize; font-weight: 600; }
 .tn-feed-meta { font-size: 11px; color: var(--tn-text-faint); }
 .tn-feed-prec { font-variant: small-caps; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1154,3 +1154,17 @@ a { color: var(--tn-accent); }
 .tn-cam-label{font-size:10px;color:var(--tn-text-muted);padding:3px 6px 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 
 .tn-cam-empty{font-size:11px;color:#9aa6b2;text-align:center;padding:14px}
+
+/* ===========================================================================
+   Widget body — Live Video News (Task 12)
+   =========================================================================== */
+.tn-news{display:flex;flex-direction:column;height:100%}
+.tn-news-screen{position:relative;aspect-ratio:16/9;background:#15212b}
+.tn-news-video{position:absolute;inset:0;width:100%;height:100%;border:0}
+.tn-news-ch{position:absolute;left:6px;bottom:6px;color:#fff;font-size:10px;font-weight:700;text-shadow:0 1px 2px rgba(0,0,0,.6)}
+.tn-news-tabs{display:flex;gap:4px;padding:6px;flex-wrap:wrap}
+.tn-news-tabs button{font-size:9px;border:1px solid #e1e8ef;border-radius:10px;padding:2px 7px;background:#fff;cursor:pointer}
+.tn-news-tabs button.is-on{background:#27313b;color:#fff;border-color:#27313b}.tn-news-more{color:#3f8f5c;border-style:dashed!important}
+.tn-news-picker{display:flex;flex-direction:column;border-top:1px solid #eef2f6;max-height:160px;overflow:auto}
+.tn-news-picker button{text-align:left;border:0;background:none;padding:5px 9px;font-size:11px;cursor:pointer}
+.tn-news-cat{color:#9aa6b2;font-size:9px;float:right}.tn-news-custom{margin:6px 9px;padding:4px;font-size:11px;border:1px solid #e1e8ef;border-radius:5px}

--- a/app/globals.css
+++ b/app/globals.css
@@ -964,3 +964,68 @@ a { color: var(--tn-accent); }
 @media (prefers-reduced-motion: reduce) {
   .tn-thumb { transition: none; }
 }
+
+/* ── Event Feed (console hero) ─────────────────────────────────────────────── */
+.tn-feed {
+  position: fixed;
+  top: var(--tn-topbar-h);
+  right: 0;
+  bottom: var(--tn-ticker-h);
+  width: 360px;
+  max-width: 92vw;
+  z-index: 25;
+  display: flex;
+  flex-direction: column;
+  background: var(--tn-surface);
+  backdrop-filter: blur(12px);
+  border-left: 1px solid var(--tn-border);
+  box-shadow: var(--tn-shadow);
+  color: var(--tn-text);
+  font-family: var(--tn-sans);
+}
+.tn-feed-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 12px 14px 8px; border-bottom: 1px solid var(--tn-border);
+}
+.tn-feed-title { font-size: 14px; font-weight: 650; margin: 0; letter-spacing: 0.01em; }
+.tn-feed-count { font-size: 12px; color: var(--tn-text-muted); }
+.tn-feed-controls {
+  display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  padding: 8px 12px; border-bottom: 1px solid var(--tn-border);
+}
+.tn-feed-controls select {
+  font: inherit; font-size: 12px; padding: 3px 6px;
+  background: var(--tn-surface-2); color: var(--tn-text);
+  border: 1px solid var(--tn-border); border-radius: 6px;
+}
+.tn-feed-types { display: flex; flex-wrap: wrap; gap: 4px; }
+.tn-feed-type {
+  font-size: 11px; padding: 2px 8px; border-radius: 999px; cursor: pointer;
+  background: var(--tn-chip-bg); color: var(--tn-text-muted);
+  border: 1px solid transparent; text-transform: capitalize;
+}
+.tn-feed-type.on { background: var(--tn-accent-soft); color: var(--tn-accent-strong); border-color: var(--tn-accent); }
+.tn-feed-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; }
+.tn-feed-row {
+  display: flex; gap: 10px; width: 100%; text-align: left; cursor: pointer;
+  padding: 9px 12px; background: transparent; border: 0; border-bottom: 1px solid var(--tn-border);
+  color: inherit;
+}
+.tn-feed-row:hover { background: var(--tn-surface-2); }
+.tn-feed-sev {
+  flex: none; align-self: flex-start; font-family: var(--tn-mono);
+  font-size: 11px; font-weight: 700; color: #fff; padding: 1px 6px; border-radius: 5px;
+}
+.tn-feed-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.tn-feed-row-title { font-size: 13px; line-height: 1.3; }
+.tn-feed-kind { color: var(--tn-text-muted); text-transform: capitalize; font-weight: 600; }
+.tn-feed-meta { font-size: 11px; color: var(--tn-text-faint); }
+.tn-feed-prec { font-variant: small-caps; }
+.tn-feed-empty { padding: 18px 14px; font-size: 13px; color: var(--tn-text-muted); }
+.tn-feed-foot {
+  padding: 8px 12px; font-size: 11px; color: var(--tn-text-faint);
+  border-top: 1px solid var(--tn-border);
+}
+@media (max-width: 640px) {
+  .tn-feed { width: 100%; top: auto; height: 52vh; border-left: 0; border-top: 1px solid var(--tn-border); }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1102,3 +1102,12 @@ a { color: var(--tn-accent); }
 .tn-cw-alert.tn-sev-warn{border-left-color:#d9882f;background:#fdf7ee}.tn-cw-alert.tn-sev-info{border-left-color:#4a78c9;background:#f1f5fc}
 .tn-cw-body{flex:1;overflow:auto;min-height:0}
 .tn-cw-resize{height:6px;cursor:row-resize;background:linear-gradient(#f1f5f9,#fff)}
+
+/* ===========================================================================
+   StageHost + WorldClock + StageSwitch — Task 8
+   =========================================================================== */
+.tn-clock{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:32px;background:radial-gradient(circle at 50% 40%,#26323d,#141c24)}
+.tn-clock-time{font-size:34px;font-weight:800;color:#fff;letter-spacing:1px}.tn-clock-zone{font-size:11px;color:#9fb0bf;letter-spacing:1px;text-align:center}
+.tn-stage-switch{display:inline-flex;gap:2px;background:#fff;border:1px solid #d7dee6;border-radius:7px;padding:2px}
+.tn-stage-switch button{border:0;background:none;font-size:11px;font-weight:700;color:#5a6470;padding:2px 8px;border-radius:5px;cursor:pointer}
+.tn-stage-switch button.is-on{background:#27313b;color:#fff}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1029,3 +1029,37 @@ a { color: var(--tn-accent); }
 @media (max-width: 640px) {
   .tn-feed { width: 100%; top: auto; height: 52vh; border-left: 0; border-top: 1px solid var(--tn-border); }
 }
+
+/* ── Scope control (console top bar) ───────────────────────────────────────── */
+.tn-scope { position: relative; font-family: var(--tn-sans); }
+.tn-scope-btn {
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+  font-size: 13px; font-weight: 600; padding: 6px 12px; border-radius: 8px;
+  background: var(--tn-surface); color: var(--tn-text);
+  border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
+}
+.tn-scope-caret { color: var(--tn-text-faint); font-size: 10px; }
+.tn-scope-menu {
+  position: absolute; top: calc(100% + 6px); left: 0; width: 280px; z-index: 40;
+  display: flex; flex-direction: column; gap: 4px; padding: 8px;
+  background: var(--tn-surface-solid); border: 1px solid var(--tn-border);
+  border-radius: 10px; box-shadow: var(--tn-shadow);
+}
+.tn-scope-item {
+  text-align: left; cursor: pointer; font-size: 13px; padding: 7px 10px; border-radius: 7px;
+  background: transparent; color: var(--tn-text); border: 0;
+}
+.tn-scope-item:hover { background: var(--tn-surface-2); }
+.tn-scope-region { border-top: 1px solid var(--tn-border); padding-top: 6px; margin-top: 2px; }
+.tn-scope-input {
+  width: 100%; font: inherit; font-size: 13px; padding: 7px 10px;
+  background: var(--tn-surface-2); color: var(--tn-text);
+  border: 1px solid var(--tn-border); border-radius: 7px;
+}
+.tn-scope-results { display: flex; flex-direction: column; margin-top: 4px; max-height: 220px; overflow-y: auto; }
+.tn-scope-result {
+  text-align: left; cursor: pointer; font-size: 12px; padding: 6px 10px; border-radius: 6px;
+  background: transparent; color: var(--tn-text); border: 0;
+}
+.tn-scope-result:hover { background: var(--tn-surface-2); }
+.tn-scope-note { font-size: 11px; color: var(--tn-text-muted); margin: 6px 4px 2px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1124,3 +1124,13 @@ a { color: var(--tn-accent); }
 .tn-seg-slot{flex:none}.tn-seg-empty{font-size:11px;color:#9aa6b2;text-align:center;margin:auto;padding:16px}
 .tn-grip{width:6px;flex:none;cursor:col-resize;background:#cdd6e0}
 .tn-grip:hover{background:#aebac6}.tn-grip-h{width:auto;height:6px;cursor:row-resize}
+
+/* ===========================================================================
+   Widget body — shared table primitives (Task 9 Aviation widget)
+   =========================================================================== */
+.tn-w-table{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed}
+.tn-w-table tr{border-bottom:1px solid var(--tn-border)}
+.tn-w-table td{padding:4px 6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;vertical-align:middle}
+.tn-w-strong{font-weight:600;color:var(--tn-text)}
+.tn-w-muted{color:var(--tn-text-muted)}
+.tn-w-num{font-family:var(--tn-mono);text-align:right;color:var(--tn-text-muted)}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,12 @@
 "use client";
-import dynamic from "next/dynamic";
 import ConsoleShell from "@/components/shell/ConsoleShell";
 
-// The map is a heavy client-only canvas (MapLibre + globe projection); keep it
-// out of SSR. The calm shell chrome around it renders server-side fine.
-const WorldMap = dynamic(() => import("@/components/WorldMap"), { ssr: false });
-
+// The map now lives in the console's centre stage (StageHost), so the page just
+// mounts the shell; the heavy client-only canvas is dynamically imported there.
 export default function Home() {
   return (
     <main className="tn-shell-main">
-      <ConsoleShell>
-        <WorldMap />
-      </ConsoleShell>
+      <ConsoleShell />
     </main>
   );
 }

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -38,6 +38,7 @@ import { useSignals, signalCountsStore } from "@/lib/signals/store";
 import { signalFreshnessStore } from "@/lib/signals/freshness";
 import type { SignalFeature, SignalSource } from "@/lib/signals/types";
 import { useTimeWindow, windowMsFor, withinWindow } from "@/lib/shell/timeWindow";
+import { viewModeStore } from "@/lib/shell/viewMode";
 import { useNow } from "@/lib/shell/useNow";
 import {
   readInitialViewState,
@@ -304,9 +305,10 @@ export default function WorldMap() {
   // safely on the first load AND after each basemap swap (setStyle wipes them).
   const addAppLayers = useCallback(
     async (map: maplibregl.Map) => {
-      // Force globe projection (a freshly-set style may reset to mercator).
+      // Projection follows the view mode: flat (console, default) vs globe (Explore).
+      const wantProjection = viewModeStore.get() === "explore" ? "globe" : "mercator";
       try {
-        map.setProjection({ type: "globe" });
+        map.setProjection({ type: wantProjection });
       } catch {
         /* older styles ignore this */
       }
@@ -983,6 +985,16 @@ export default function WorldMap() {
     mapViewStore.registerFlyToPoint(flyToPoint);
     return () => mapViewStore.registerFlyToPoint(null);
   }, [flyToPoint]);
+
+  // Re-project live when the user toggles Console ⇄ Explore.
+  useEffect(() => {
+    return viewModeStore.subscribe(() => {
+      const map = mapRef.current;
+      if (!map) return;
+      const want = viewModeStore.get() === "explore" ? "globe" : "mercator";
+      if (map.getProjection?.()?.type !== want) map.setProjection({ type: want });
+    });
+  }, []);
 
   // Cinematic dive (SP6): a pitched flyTo to a single camera; on arrival, promote
   // the dive store to "landed" so <CinematicDive> materialises the hero feed.

--- a/components/console/ConsoleWorkspace.tsx
+++ b/components/console/ConsoleWorkspace.tsx
@@ -1,0 +1,45 @@
+// components/console/ConsoleWorkspace.tsx
+"use client";
+import { useShellLayout, shellLayoutStore } from "@/lib/console/store";
+import type { SegmentId } from "@/lib/console/types";
+import Segment from "@/components/console/Segment";
+import StageHost from "@/components/console/StageHost";
+
+function VGrip({ seg, dir }: { seg: SegmentId; dir: 1 | -1 }) {
+  const layout = useShellLayout();
+  const onDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const startX = e.clientX, startSize = layout.segments[seg].size;
+    const move = (ev: PointerEvent) => shellLayoutStore.setSegment(seg, startSize + dir * (ev.clientX - startX));
+    const up = () => { window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", up); };
+    window.addEventListener("pointermove", move); window.addEventListener("pointerup", up);
+  };
+  return <div className="tn-grip" onPointerDown={onDown} role="separator" aria-orientation="vertical" />;
+}
+
+export default function ConsoleWorkspace() {
+  const layout = useShellLayout();
+  const w = (s: SegmentId) => (layout.segments[s].collapsed ? 0 : layout.segments[s].size);
+  return (
+    <div className="tn-cw-shell">
+      <div className="tn-cw-col" style={{ width: w("left") }}><Segment id="left" /></div>
+      <VGrip seg="left" dir={1} />
+      <div className="tn-cw-center">
+        <div className="tn-cw-stage"><StageHost stage={layout.stage} /></div>
+        <div className="tn-grip tn-grip-h"
+             onPointerDown={(e) => {
+               e.preventDefault();
+               const startY = e.clientY, start = layout.segments.bottom.size;
+               const move = (ev: PointerEvent) => shellLayoutStore.setSegment("bottom", start - (ev.clientY - startY));
+               const up = () => { window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", up); };
+               window.addEventListener("pointermove", move); window.addEventListener("pointerup", up);
+             }} role="separator" aria-orientation="horizontal" />
+        <div className="tn-cw-bottom" style={{ height: layout.segments.bottom.collapsed ? 0 : layout.segments.bottom.size }}>
+          <Segment id="bottom" />
+        </div>
+      </div>
+      <VGrip seg="right" dir={-1} />
+      <div className="tn-cw-col" style={{ width: w("right") }}><Segment id="right" /></div>
+    </div>
+  );
+}

--- a/components/console/Segment.tsx
+++ b/components/console/Segment.tsx
@@ -1,0 +1,34 @@
+// components/console/Segment.tsx
+"use client";
+import type { SegmentId } from "@/lib/console/types";
+import { useShellLayout, shellLayoutStore } from "@/lib/console/store";
+import { widgetsInSegment } from "@/lib/console/reducers";
+import WidgetFrame from "@/components/console/WidgetFrame";
+
+export default function Segment({ id }: { id: SegmentId }) {
+  const layout = useShellLayout();
+  const widgets = widgetsInSegment(layout, id);
+  const onDrop = (e: React.DragEvent) => {
+    const wid = e.dataTransfer.getData("text/tn-widget");
+    if (!wid) return;
+    e.preventDefault();
+    // index = position of the card the pointer is over, else append
+    const cards = [...e.currentTarget.querySelectorAll("[data-widget-id]")] as HTMLElement[];
+    let idx = cards.length;
+    for (let i = 0; i < cards.length; i++) {
+      const r = cards[i].getBoundingClientRect();
+      if (e.clientY < r.top + r.height / 2) { idx = i; break; }
+    }
+    shellLayoutStore.move(wid, id, idx);
+  };
+  return (
+    <div className="tn-seg" data-segment={id}
+         onDragOver={(e) => { if (e.dataTransfer.types.includes("text/tn-widget")) e.preventDefault(); }}
+         onDrop={onDrop}>
+      {widgets.length === 0 && <p className="tn-seg-empty">Drop a widget here, or add one with ⌘K</p>}
+      {widgets.map((w) => (
+        <div key={w.id} data-widget-id={w.id} className="tn-seg-slot"><WidgetFrame instance={w} /></div>
+      ))}
+    </div>
+  );
+}

--- a/components/console/StageHost.tsx
+++ b/components/console/StageHost.tsx
@@ -1,0 +1,18 @@
+"use client";
+import dynamic from "next/dynamic";
+import { useEffect } from "react";
+import type { StageId } from "@/lib/console/types";
+import { viewModeStore } from "@/lib/shell/viewMode";
+import WorldClock from "@/components/console/WorldClock";
+
+const WorldMap = dynamic(() => import("@/components/WorldMap"), { ssr: false });
+
+export default function StageHost({ stage }: { stage: StageId }) {
+  // The map reads viewModeStore for its MapLibre projection: 3D=globe(explore), 2D=flat(console).
+  useEffect(() => {
+    if (stage === "map3d") viewModeStore.set("explore");
+    else if (stage === "map2d") viewModeStore.set("console");
+  }, [stage]);
+  if (stage === "clock") return <WorldClock />;
+  return <WorldMap />;
+}

--- a/components/console/StageSwitch.tsx
+++ b/components/console/StageSwitch.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useShellLayout, shellLayoutStore } from "@/lib/console/store";
+import type { StageId } from "@/lib/console/types";
+
+const OPTS: { id: StageId; label: string }[] = [
+  { id: "map3d", label: "3D" },
+  { id: "map2d", label: "2D" },
+  { id: "clock", label: "🕐" },
+];
+
+export default function StageSwitch() {
+  const { stage } = useShellLayout();
+  return (
+    <div className="tn-stage-switch" role="group" aria-label="Centre stage">
+      {OPTS.map((o) => (
+        <button
+          key={o.id}
+          className={stage === o.id ? "is-on" : ""}
+          aria-pressed={stage === o.id}
+          onClick={() => shellLayoutStore.stage(o.id)}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/console/WidgetErrorBoundary.tsx
+++ b/components/console/WidgetErrorBoundary.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+
+export class WidgetErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError() { return { failed: true }; }
+  componentDidCatch() { /* swallow — the frame stays alive */ }
+  render() {
+    return this.state.failed
+      ? <div className="tn-cw-failed">This widget hit an error.</div>
+      : this.props.children;
+  }
+}

--- a/components/console/WidgetFrame.tsx
+++ b/components/console/WidgetFrame.tsx
@@ -5,6 +5,7 @@ import type { WidgetInstance } from "@/lib/console/types";
 import { shellLayoutStore } from "@/lib/console/store";
 import { getWidgetType } from "@/lib/console/registry";
 import { topSeverity, type Alert } from "@/lib/console/alerts";
+import { WidgetErrorBoundary } from "@/components/console/WidgetErrorBoundary";
 
 interface Report { alerts: Alert[]; count?: number; freshLabel?: string }
 const ReportCtx = createContext<(r: Report) => void>(() => {});
@@ -18,7 +19,8 @@ export default function WidgetFrame({ instance }: { instance: WidgetInstance }) 
   if (!type) return null;
   const Body = type.component;
   const sev = topSeverity(report.alerts);
-  const alertStyle = (instance.config.alertStyle as string) ?? "top"; // "top" | "feed"
+  const cfg = instance.config ?? {};
+  const alertStyle = (cfg.alertStyle as string) ?? "top"; // "top" | "feed"
 
   const onDragStart = (e: React.DragEvent) => {
     e.dataTransfer.setData("text/tn-widget", instance.id);
@@ -46,7 +48,7 @@ export default function WidgetFrame({ instance }: { instance: WidgetInstance }) 
 
       {menuOpen && (
         <div className="tn-cw-menu-pop" role="menu">
-          <button onClick={() => { shellLayoutStore.add(instance.type, { config: { ...instance.config } }); setMenuOpen(false); }}>⧉ Duplicate</button>
+          <button onClick={() => { const r = shellLayoutStore.add(instance.type, { config: { ...cfg } }); if (!r.ok) window.dispatchEvent(new CustomEvent("tn-toast", { detail: "50-widget limit — remove one to add another" })); setMenuOpen(false); }}>⧉ Duplicate</button>
           <button onClick={() => { shellLayoutStore.configure(instance.id, { alertStyle: alertStyle === "top" ? "feed" : "top" }); setMenuOpen(false); }}>
             ⚡ Alerts: {alertStyle === "top" ? "on top" : "in feed"}
           </button>
@@ -65,7 +67,16 @@ export default function WidgetFrame({ instance }: { instance: WidgetInstance }) 
             </div>
           )}
           <div className="tn-cw-body">
-            <ReportCtx.Provider value={onReport}><Body instanceId={instance.id} config={instance.config} /></ReportCtx.Provider>
+            {alertStyle === "feed" && report.alerts.length > 0 && (
+              <div className="tn-cw-attn-feed">
+                {report.alerts.slice(0, 4).map((a) => (
+                  <div key={a.id} className={`tn-cw-alert tn-sev-${a.severity}`}>{a.text}</div>
+                ))}
+              </div>
+            )}
+            <WidgetErrorBoundary>
+              <ReportCtx.Provider value={onReport}><Body instanceId={instance.id} config={cfg} /></ReportCtx.Provider>
+            </WidgetErrorBoundary>
           </div>
           <div className="tn-cw-resize" onPointerDown={onResizePointerDown} title="Drag to resize" />
         </>

--- a/components/console/WidgetFrame.tsx
+++ b/components/console/WidgetFrame.tsx
@@ -1,0 +1,75 @@
+// components/console/WidgetFrame.tsx
+"use client";
+import { createContext, useContext, useState, useCallback } from "react";
+import type { WidgetInstance } from "@/lib/console/types";
+import { shellLayoutStore } from "@/lib/console/store";
+import { getWidgetType } from "@/lib/console/registry";
+import { topSeverity, type Alert } from "@/lib/console/alerts";
+
+interface Report { alerts: Alert[]; count?: number; freshLabel?: string }
+const ReportCtx = createContext<(r: Report) => void>(() => {});
+export function useWidgetReport() { return useContext(ReportCtx); }
+
+export default function WidgetFrame({ instance }: { instance: WidgetInstance }) {
+  const type = getWidgetType(instance.type);
+  const [report, setReport] = useState<Report>({ alerts: [] });
+  const [menuOpen, setMenuOpen] = useState(false);
+  const onReport = useCallback((r: Report) => setReport(r), []);
+  if (!type) return null;
+  const Body = type.component;
+  const sev = topSeverity(report.alerts);
+  const alertStyle = (instance.config.alertStyle as string) ?? "top"; // "top" | "feed"
+
+  const onDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.setData("text/tn-widget", instance.id);
+    e.dataTransfer.effectAllowed = "move";
+  };
+  const onResizePointerDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const startY = e.clientY, startH = instance.height;
+    const move = (ev: PointerEvent) => shellLayoutStore.resizeWidget(instance.id, startH + (ev.clientY - startY));
+    const up = () => { window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", up); };
+    window.addEventListener("pointermove", move); window.addEventListener("pointerup", up);
+  };
+
+  return (
+    <div className="tn-cw" data-widget-type={instance.type} style={{ height: instance.collapsed ? undefined : instance.height }}>
+      <header className="tn-cw-head" draggable onDragStart={onDragStart}>
+        <span className="tn-cw-icon">{type.icon}</span>
+        <span className="tn-cw-title">{type.title}</span>
+        {report.count != null && <span className="tn-cw-count">{report.count}</span>}
+        <span className="tn-cw-sp" />
+        {report.alerts.length > 0 && <span className={`tn-cw-badge tn-sev-${sev}`}>{report.alerts.length}</span>}
+        {report.freshLabel && <span className="tn-cw-fresh">{report.freshLabel}</span>}
+        <button className="tn-cw-menu" aria-label="Widget menu" onClick={() => setMenuOpen((o) => !o)}>⋯</button>
+      </header>
+
+      {menuOpen && (
+        <div className="tn-cw-menu-pop" role="menu">
+          <button onClick={() => { shellLayoutStore.add(instance.type, { config: { ...instance.config } }); setMenuOpen(false); }}>⧉ Duplicate</button>
+          <button onClick={() => { shellLayoutStore.configure(instance.id, { alertStyle: alertStyle === "top" ? "feed" : "top" }); setMenuOpen(false); }}>
+            ⚡ Alerts: {alertStyle === "top" ? "on top" : "in feed"}
+          </button>
+          <button className="tn-cw-danger" onClick={() => shellLayoutStore.remove(instance.id)}>✕ Remove</button>
+        </div>
+      )}
+
+      {!instance.collapsed && (
+        <>
+          {alertStyle === "top" && report.alerts.length > 0 && (
+            <div className="tn-cw-attn">
+              <div className="tn-cw-attn-h">Needs attention · {report.alerts.length}</div>
+              {report.alerts.slice(0, 4).map((a) => (
+                <div key={a.id} className={`tn-cw-alert tn-sev-${a.severity}`}>{a.text}</div>
+              ))}
+            </div>
+          )}
+          <div className="tn-cw-body">
+            <ReportCtx.Provider value={onReport}><Body instanceId={instance.id} config={instance.config} /></ReportCtx.Provider>
+          </div>
+          <div className="tn-cw-resize" onPointerDown={onResizePointerDown} title="Drag to resize" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/console/WorldClock.tsx
+++ b/components/console/WorldClock.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const ZONES = [
+  { zone: "Europe/London", label: "LONDON" },
+  { zone: "America/New_York", label: "NEW YORK" },
+  { zone: "Asia/Tokyo", label: "TOKYO" },
+  { zone: "UTC", label: "UTC" },
+];
+
+export default function WorldClock() {
+  const [now, setNow] = useState<Date | null>(null);
+  useEffect(() => {
+    setNow(new Date());
+    const t = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(t);
+  }, []);
+  return (
+    <div className="tn-clock">
+      {ZONES.map((z) => (
+        <div key={z.zone} className="tn-clock-cell">
+          <div className="tn-clock-time">
+            {now
+              ? now.toLocaleTimeString("en-GB", {
+                  timeZone: z.zone,
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })
+              : "--:--"}
+          </div>
+          <div className="tn-clock-zone">{z.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -7,9 +7,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { layersStore, LAYER_PRESETS, ACTIVE_LAYERS, type LayerKey } from "@/lib/layers";
 import { mapViewStore } from "@/lib/mapView";
 import { BASEMAPS, type BasemapKey } from "@/lib/basemaps";
-import { coverageStore } from "@/lib/shell/coverage";
-import { marketsStore } from "@/lib/shell/markets";
-import { workspaceStore } from "@/lib/shell/workspace";
 import { CAMERA_REGIONS } from "@/lib/icons/svg";
 import { cinematic } from "@/lib/cinematic/store";
 import { pickLiveCamera } from "@/lib/cinematic/livePick";
@@ -93,38 +90,6 @@ function buildCommands(close: () => void): Command[] {
       },
     });
   }
-
-  cmds.push({
-    id: "coverage",
-    label: "Coverage details",
-    hint: "info",
-    run: () => {
-      coverageStore.open();
-      close();
-    },
-  });
-
-  cmds.push({
-    id: "markets",
-    label: "Markets — crypto prices",
-    hint: "panel",
-    run: () => {
-      marketsStore.open();
-      close();
-    },
-  });
-
-  cmds.push({
-    id: "toggle-workspace",
-    label: "Toggle workspace dock",
-    hint: "layout",
-    run: () => {
-      const ws = workspaceStore.get();
-      if (ws.open) workspaceStore.closeWorkspace();
-      else workspaceStore.openWorkspace();
-      close();
-    },
-  });
 
   cmds.push({
     id: "dive-live",

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -14,6 +14,10 @@ import { CAMERA_REGIONS } from "@/lib/icons/svg";
 import { cinematic } from "@/lib/cinematic/store";
 import { pickLiveCamera } from "@/lib/cinematic/livePick";
 import { loadedCamerasStore } from "@/lib/cameras/loaded";
+import "@/lib/console/widgets";
+import { widgetsByCategory } from "@/lib/console/registry";
+import { shellLayoutStore } from "@/lib/console/store";
+import type { StageId } from "@/lib/console/types";
 
 interface Command {
   id: string;
@@ -30,6 +34,10 @@ const LAYER_NAMES: Record<LayerKey, string> = {
   webcams: "Webcams",
   weather: "Weather",
 };
+
+function alertCapacity() {
+  if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent("tn-toast", { detail: "50-widget limit — remove one to add another" }));
+}
 
 function buildCommands(close: () => void): Command[] {
   const cmds: Command[] = [];
@@ -135,6 +143,21 @@ function buildCommands(close: () => void): Command[] {
       close();
     },
   });
+
+  for (const group of widgetsByCategory()) {
+    for (const t of group.types) {
+      const openCount = shellLayoutStore.get().widgets.filter((w) => w.type === t.id).length;
+      cmds.push({
+        id: `add-${t.id}`,
+        label: `Add ${t.title}${openCount ? ` (${openCount} open)` : ""}`,
+        hint: group.category.toLowerCase(),
+        run: () => { const r = shellLayoutStore.add(t.id, { config: { ...t.defaultConfig }, height: t.defaultHeight }); if (!r.ok) alertCapacity(); close(); },
+      });
+    }
+  }
+
+  const STAGES: { id: StageId; label: string }[] = [{ id: "map3d", label: "3D map" }, { id: "map2d", label: "2D map" }, { id: "clock", label: "World clock" }];
+  for (const s of STAGES) cmds.push({ id: `stage-${s.id}`, label: `Stage → ${s.label}`, hint: "stage", run: () => { shellLayoutStore.stage(s.id); close(); } });
 
   return cmds;
 }

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -18,6 +18,8 @@ import "@/lib/console/widgets";
 import { widgetsByCategory } from "@/lib/console/registry";
 import { shellLayoutStore } from "@/lib/console/store";
 import type { StageId } from "@/lib/console/types";
+import { listPresets, applyPreset, saveCustomPreset } from "@/lib/console/presets";
+import { encodeLayout } from "@/lib/console/share";
 
 interface Command {
   id: string;
@@ -158,6 +160,10 @@ function buildCommands(close: () => void): Command[] {
 
   const STAGES: { id: StageId; label: string }[] = [{ id: "map3d", label: "3D map" }, { id: "map2d", label: "2D map" }, { id: "clock", label: "World clock" }];
   for (const s of STAGES) cmds.push({ id: `stage-${s.id}`, label: `Stage → ${s.label}`, hint: "stage", run: () => { shellLayoutStore.stage(s.id); close(); } });
+
+  for (const p of listPresets()) cmds.push({ id: `cpreset-${p.id}`, label: `Preset: ${p.title}`, hint: "preset", run: () => { applyPreset(p.id); close(); } });
+  cmds.push({ id: "save-preset", label: "Save layout as preset…", hint: "preset", run: () => { const t = window.prompt("Preset name?"); if (t) saveCustomPreset(t); close(); } });
+  cmds.push({ id: "share-layout", label: "Copy shareable link", hint: "share", run: () => { const url = `${location.origin}${location.pathname}?c=${encodeLayout(shellLayoutStore.get())}`; navigator.clipboard?.writeText(url); close(); } });
 
   return cmds;
 }

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -25,10 +25,16 @@ import { CinematicDive } from "@/components/CinematicDive";
 import PanelHost from "@/components/shell/PanelHost";
 import DockableWorkspace from "@/components/shell/DockableWorkspace";
 import IntelColumn from "@/components/shell/IntelColumn";
+import { scopeStore } from "@/lib/shell/scope";
+import { viewModeStore, useViewMode } from "@/lib/shell/viewMode";
+import EventFeed from "@/components/shell/EventFeed";
+import ConsoleTopBar from "@/components/shell/ConsoleTopBar";
 
 export default function ConsoleShell({ children }: { children: React.ReactNode }) {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const ws = useWorkspace();
+  const view = useViewMode();
+  const isConsole = view === "console";
 
   // Re-hydrate persisted view state once, client-side (render defaults on the
   // server, reconcile after mount → no hydration mismatch).
@@ -41,6 +47,8 @@ export default function ConsoleShell({ children }: { children: React.ReactNode }
     timeWindowStore.hydrate();
     alertStore.hydrate();
     langStore.hydrate();
+    scopeStore.hydrate();
+    viewModeStore.hydrate();
     registerServiceWorker(); // production-only; a no-op under `next dev`
   }, []);
 
@@ -61,15 +69,33 @@ export default function ConsoleShell({ children }: { children: React.ReactNode }
       {children}
       <StatusBar onOpenPalette={() => setPaletteOpen(true)} />
       <BreakingBanner />
-      <PlaceSearch />
       <PanelHost />
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
-      {/* Dockable slide-ins are suppressed while the workspace dock owns them. */}
-      {!ws.open && <CoveragePanel />}
-      {!ws.open && <MarketsPanel />}
-      {!ws.open && <WatchlistPanel />}
-      <DockableWorkspace />
-      <IntelColumn />
+
+      {isConsole ? (
+        <>
+          <ConsoleTopBar />
+          <EventFeed />
+        </>
+      ) : (
+        <>
+          <button
+            type="button"
+            className="tn-explore-return"
+            onClick={() => viewModeStore.set("console")}
+            title="Back to the console"
+          >
+            <span aria-hidden>←</span> Console
+          </button>
+          <PlaceSearch />
+          {!ws.open && <CoveragePanel />}
+          {!ws.open && <MarketsPanel />}
+          {!ws.open && <WatchlistPanel />}
+          <DockableWorkspace />
+          <IntelColumn />
+        </>
+      )}
+
       <FeedOverlay />
       <CinematicDive />
     </div>

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -1,8 +1,10 @@
 "use client";
-// The calm light console shell. Wraps the full-bleed WorldMap (children) with the
-// thin chrome that recedes around it: a thin top status bar + variant switcher,
-// the variant-driven PanelHost, the ⌘K palette, and the right slide-in dossiers.
-// Owns the global ⌘K shortcut and the one-time client hydration of the persisted stores.
+// The calm light console shell. Hosts the widget workspace (3 resizable segments
+// around a fixed centre stage) with the thin chrome that recedes around it: a thin
+// top status bar, the ⌘K palette, the breaking banner, and the cinematic/feed
+// overlays. Owns the global ⌘K shortcut, the one-time client hydration of the
+// persisted stores (including the console layout + ?c= shared-layout / first-run
+// seed), and the global capacity toast.
 
 import { useEffect, useState } from "react";
 import { uiStore } from "@/lib/shell/ui";
@@ -12,29 +14,22 @@ import { watchlistStore } from "@/lib/shell/watchlist";
 import { timeWindowStore } from "@/lib/shell/timeWindow";
 import { registerServiceWorker } from "@/lib/pwa/register";
 import { variantStore } from "@/lib/variants/store";
-import { useWorkspace } from "@/lib/shell/workspace";
 import StatusBar from "@/components/shell/StatusBar";
 import CommandPalette from "@/components/shell/CommandPalette";
-import PlaceSearch from "@/components/shell/PlaceSearch";
-import CoveragePanel from "@/components/shell/CoveragePanel";
-import MarketsPanel from "@/components/shell/MarketsPanel";
-import WatchlistPanel from "@/components/shell/WatchlistPanel";
 import BreakingBanner from "@/components/shell/BreakingBanner";
 import { FeedOverlay } from "@/components/FeedOverlay";
 import { CinematicDive } from "@/components/CinematicDive";
-import PanelHost from "@/components/shell/PanelHost";
-import DockableWorkspace from "@/components/shell/DockableWorkspace";
-import IntelColumn from "@/components/shell/IntelColumn";
 import { scopeStore } from "@/lib/shell/scope";
-import { viewModeStore, useViewMode } from "@/lib/shell/viewMode";
-import EventFeed from "@/components/shell/EventFeed";
-import ConsoleTopBar from "@/components/shell/ConsoleTopBar";
+import { viewModeStore } from "@/lib/shell/viewMode";
+import ConsoleWorkspace from "@/components/console/ConsoleWorkspace";
+import { shellLayoutStore } from "@/lib/console/store";
+import { applyPreset } from "@/lib/console/presets";
+import { decodeLayout } from "@/lib/console/share";
+import "@/lib/console/widgets";
 
-export default function ConsoleShell({ children }: { children: React.ReactNode }) {
+export default function ConsoleShell() {
   const [paletteOpen, setPaletteOpen] = useState(false);
-  const ws = useWorkspace();
-  const view = useViewMode();
-  const isConsole = view === "console";
+  const [toast, setToast] = useState<string | null>(null);
 
   // Re-hydrate persisted view state once, client-side (render defaults on the
   // server, reconcile after mount → no hydration mismatch).
@@ -49,6 +44,10 @@ export default function ConsoleShell({ children }: { children: React.ReactNode }
     langStore.hydrate();
     scopeStore.hydrate();
     viewModeStore.hydrate();
+    shellLayoutStore.hydrate();
+    const c = new URLSearchParams(window.location.search).get("c");
+    if (c) { const l = decodeLayout(c); if (l) shellLayoutStore.replace(l); }
+    else if (shellLayoutStore.get().widgets.length === 0) applyPreset("world"); // first-run seed
     registerServiceWorker(); // production-only; a no-op under `next dev`
   }, []);
 
@@ -64,40 +63,30 @@ export default function ConsoleShell({ children }: { children: React.ReactNode }
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // The ⌘K palette dispatches a `tn-toast` CustomEvent (e.g. the 50-widget cap).
+  // This always-mounted shell is the host that surfaces it as a calm pill.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const onToast = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      if (typeof detail !== "string") return;
+      setToast(detail);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setToast(null), 3200);
+    };
+    window.addEventListener("tn-toast", onToast as EventListener);
+    return () => { window.removeEventListener("tn-toast", onToast as EventListener); if (timer) clearTimeout(timer); };
+  }, []);
+
   return (
     <div className="tn-shell">
-      {children}
       <StatusBar onOpenPalette={() => setPaletteOpen(true)} />
       <BreakingBanner />
-      <PanelHost />
+      <ConsoleWorkspace />
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
-
-      {isConsole ? (
-        <>
-          <ConsoleTopBar />
-          <EventFeed />
-        </>
-      ) : (
-        <>
-          <button
-            type="button"
-            className="tn-explore-return"
-            onClick={() => viewModeStore.set("console")}
-            title="Back to the console"
-          >
-            <span aria-hidden>←</span> Console
-          </button>
-          <PlaceSearch />
-          {!ws.open && <CoveragePanel />}
-          {!ws.open && <MarketsPanel />}
-          {!ws.open && <WatchlistPanel />}
-          <DockableWorkspace />
-          <IntelColumn />
-        </>
-      )}
-
       <FeedOverlay />
       <CinematicDive />
+      {toast && <div className="tn-toast" role="status" aria-live="polite">{toast}</div>}
     </div>
   );
 }

--- a/components/shell/ConsoleTopBar.tsx
+++ b/components/shell/ConsoleTopBar.tsx
@@ -1,0 +1,26 @@
+// components/shell/ConsoleTopBar.tsx
+"use client";
+// The console's floating control cluster, under the status bar (the established
+// "floating chrome over a full-bleed map" idiom — cf. PlaceSearch). Holds the
+// global Scope control, the shared time-window, and the Console⇄Explore toggle.
+
+import ScopeControl from "@/components/shell/ScopeControl";
+import TimeWindowControl from "@/components/shell/TimeWindowControl";
+import { viewModeStore } from "@/lib/shell/viewMode";
+
+export default function ConsoleTopBar() {
+  return (
+    <div className="tn-console-topbar">
+      <ScopeControl />
+      <TimeWindowControl />
+      <button
+        type="button"
+        className="tn-console-explore"
+        onClick={() => viewModeStore.set("explore")}
+        title="Switch to the 3D globe"
+      >
+        <span aria-hidden>🌐</span> Explore
+      </button>
+    </div>
+  );
+}

--- a/components/shell/EventFeed.tsx
+++ b/components/shell/EventFeed.tsx
@@ -1,0 +1,158 @@
+// components/shell/EventFeed.tsx
+"use client";
+// The Event Feed — the console hero. Ranked, scoped, sourced rows built by the
+// pure projectEventFeed from the live EVENT_SOURCES feeds. Click a row → fly +
+// open its dossier (reusing openSignalFeature, exactly like the old Top Events
+// panel). Honest empty state echoes the active scope + window.
+
+import { useMemo, useState } from "react";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import type { EventType, SeverityTier } from "@/lib/events/model";
+import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
+import { projectEventFeed, type FeedSort, type FeedInput } from "@/lib/widgets/eventFeed";
+import { useScope } from "@/lib/shell/scope";
+import { useTimeWindow, windowMsFor, TIME_WINDOWS } from "@/lib/shell/timeWindow";
+import { useNow, formatAge } from "@/lib/shell/useNow";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+
+const TIERS: SeverityTier[] = ["S0", "S1", "S2", "S3", "S4"];
+const TYPES: EventType[] = Array.from(new Set(EVENT_SOURCES.map((s) => s.type)));
+const SORTS: { key: FeedSort; label: string }[] = [
+  { key: "severity", label: "Severity" },
+  { key: "recent", label: "Recent" },
+  { key: "nearest", label: "Nearest" },
+];
+
+export default function EventFeed() {
+  const scope = useScope();
+  const win = useTimeWindow();
+  const now = useNow(1000);
+  const { bySource, status, updatedAt } = useEventFeeds();
+
+  const [minTier, setMinTier] = useState<SeverityTier>("S0");
+  const [sort, setSort] = useState<FeedSort>("severity");
+  const [type, setType] = useState<EventType | null>(null);
+
+  // Keep the original SignalFeature for each event id so a row click can reuse the
+  // exact map-fly + dossier behaviour.
+  const featureById = useMemo(() => {
+    const m = new Map<string, { feature: SignalFeature; label: string }>();
+    for (const s of EVENT_SOURCES) {
+      for (const f of bySource[s.id] ?? []) m.set(f.id, { feature: f, label: s.label });
+    }
+    return m;
+  }, [bySource]);
+
+  const inputs: FeedInput[] = useMemo(
+    () => EVENT_SOURCES.map((source) => ({ source, features: bySource[source.id] ?? [] })),
+    [bySource],
+  );
+
+  const projected = useMemo(
+    () =>
+      projectEventFeed(inputs, scope, windowMsFor(win), now, {
+        types: type ? new Set([type]) : null,
+        minTier,
+        sort: sort === "nearest" && !scope.center ? "severity" : sort,
+      }),
+    [inputs, scope, win, now, type, minTier, sort],
+  );
+
+  const winLabel = TIME_WINDOWS.find((w) => w.key === win)?.label ?? win;
+  const open = (id: string) => {
+    const hit = featureById.get(id);
+    if (hit) openSignalFeature(hit.feature, hit.label, 7);
+  };
+
+  return (
+    <aside className="tn-feed" role="region" aria-label="Event feed">
+      <header className="tn-feed-head">
+        <h2 className="tn-feed-title">Events</h2>
+        <span className="tn-feed-count tn-num">
+          {projected.shown}
+          {projected.shown !== projected.total ? ` / ${projected.total}` : ""}
+        </span>
+      </header>
+
+      <div className="tn-feed-controls">
+        <select
+          aria-label="Minimum severity"
+          value={minTier}
+          onChange={(e) => setMinTier(e.target.value as SeverityTier)}
+        >
+          {TIERS.map((t) => (
+            <option key={t} value={t}>
+              {t}+
+            </option>
+          ))}
+        </select>
+        <select aria-label="Sort" value={sort} onChange={(e) => setSort(e.target.value as FeedSort)}>
+          {SORTS.map((s) => (
+            <option key={s.key} value={s.key} disabled={s.key === "nearest" && !scope.center}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+        <div className="tn-feed-types">
+          <button
+            type="button"
+            className={`tn-feed-type${type === null ? " on" : ""}`}
+            onClick={() => setType(null)}
+          >
+            All
+          </button>
+          {TYPES.map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`tn-feed-type${type === t ? " on" : ""}`}
+              onClick={() => setType(type === t ? null : t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {projected.shown === 0 ? (
+        <p className="tn-feed-empty">
+          {status === "loading"
+            ? "Loading events…"
+            : status === "error"
+              ? "Event sources are unavailable right now."
+              : `No events above ${minTier} in ${scope.label} · last ${winLabel}.`}
+        </p>
+      ) : (
+        <ol className="tn-feed-list">
+          {projected.rows.map((e) => (
+            <li key={e.id}>
+              <button type="button" className="tn-feed-row" onClick={() => open(e.id)}>
+                <span className="tn-feed-sev" style={{ background: e.color }}>
+                  {e.severity.tier}
+                </span>
+                <span className="tn-feed-main">
+                  <span className="tn-feed-row-title">
+                    <span className="tn-feed-kind">{e.type}</span> {e.place.name}
+                  </span>
+                  <span className="tn-feed-meta">
+                    {e.occurredAt ? `${formatAge(now - Date.parse(e.occurredAt))} · ` : ""}
+                    {e.source.attribution}
+                    {e.magnitude ? ` · ${e.magnitude.value} ${e.magnitude.unit}` : ""}
+                    {" · "}
+                    <span className="tn-feed-prec">{e.geo.precision.toLowerCase()}</span>
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <footer className="tn-feed-foot">
+        {updatedAt != null ? `Updated ${formatAge(now - updatedAt)} ago` : "—"} ·{" "}
+        {EVENT_SOURCES.length} sources
+      </footer>
+    </aside>
+  );
+}

--- a/components/shell/EventFeed.tsx
+++ b/components/shell/EventFeed.tsx
@@ -30,7 +30,7 @@ export default function EventFeed() {
   const now = useNow(1000);
   const { bySource, status, updatedAt } = useEventFeeds();
 
-  const [minTier, setMinTier] = useState<SeverityTier>("S0");
+  const [minTier, setMinTier] = useState<SeverityTier>("S1");
   const [sort, setSort] = useState<FeedSort>("severity");
   const [type, setType] = useState<EventType | null>(null);
 

--- a/components/shell/EventFeed.tsx
+++ b/components/shell/EventFeed.tsx
@@ -127,12 +127,12 @@ export default function EventFeed() {
         <ol className="tn-feed-list">
           {projected.rows.map((e) => (
             <li key={e.id}>
-              <button type="button" className="tn-feed-row" onClick={() => open(e.id)}>
+              <button type="button" className="tn-feed-item" onClick={() => open(e.id)}>
                 <span className="tn-feed-sev" style={{ background: e.color }}>
                   {e.severity.tier}
                 </span>
                 <span className="tn-feed-main">
-                  <span className="tn-feed-row-title">
+                  <span className="tn-feed-item-title">
                     <span className="tn-feed-kind">{e.type}</span> {e.place.name}
                   </span>
                   <span className="tn-feed-meta">

--- a/components/shell/EventFeed.tsx
+++ b/components/shell/EventFeed.tsx
@@ -128,7 +128,7 @@ export default function EventFeed() {
           {projected.rows.map((e) => (
             <li key={e.id}>
               <button type="button" className="tn-feed-item" onClick={() => open(e.id)}>
-                <span className="tn-feed-sev" style={{ background: e.color }}>
+                <span className="tn-feed-sev" style={{ background: e.color, color: e.severity.tier === "S3" || e.severity.tier === "S4" ? "#fff" : "#111827" }}>
                   {e.severity.tier}
                 </span>
                 <span className="tn-feed-main">

--- a/components/shell/ScopeControl.tsx
+++ b/components/shell/ScopeControl.tsx
@@ -1,0 +1,151 @@
+// components/shell/ScopeControl.tsx
+"use client";
+// The global Scope control. World / Near-me / Region — drives scopeStore (the feed
+// + map relevance) and flies the map to the chosen centre. Geolocation is requested
+// ONLY on an explicit "Near me" click (never on load); denial falls back to World
+// with a calm note. Region reuses the keyless /api/geocode used by PlaceSearch.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { scopeStore, useScope, WORLD_SCOPE, DEFAULT_RADIUS_KM, radiusFromBbox } from "@/lib/shell/scope";
+import { mapViewStore } from "@/lib/mapView";
+import type { GeocodeResult } from "@/lib/geo/geocode";
+
+export default function ScopeControl() {
+  const scope = useScope();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<GeocodeResult[]>([]);
+  const [note, setNote] = useState<string | null>(null);
+  const reqRef = useRef(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setNote(null);
+    setQuery("");
+    setResults([]);
+  }, []);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) close();
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [close]);
+
+  // Debounced region search.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      return;
+    }
+    const t = setTimeout(() => {
+      const myReq = ++reqRef.current;
+      fetch(`/api/geocode?q=${encodeURIComponent(q)}`)
+        .then((r) => r.json())
+        .then((d) => {
+          if (myReq !== reqRef.current) return;
+          setResults((d.results as GeocodeResult[]) ?? []);
+        })
+        .catch(() => {
+          if (myReq === reqRef.current) setResults([]);
+        });
+    }, 350);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const setWorld = () => {
+    scopeStore.set(WORLD_SCOPE);
+    close();
+  };
+
+  const setRegion = (r: GeocodeResult) => {
+    const radiusKm = r.bbox ? radiusFromBbox(r.bbox) : DEFAULT_RADIUS_KM;
+    scopeStore.set({ mode: "region", center: { lat: r.lat, lon: r.lon }, radiusKm, label: r.name });
+    mapViewStore.flyToPoint({ lat: r.lat, lon: r.lon, zoom: 8 });
+    close();
+  };
+
+  const setNearMe = () => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      setNote("Location isn't available in this browser.");
+      return;
+    }
+    setNote("Finding your location…");
+    const myReq = ++reqRef.current;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (myReq !== reqRef.current) return;
+        const { latitude, longitude } = pos.coords;
+        scopeStore.set({
+          mode: "near-me",
+          center: { lat: latitude, lon: longitude },
+          radiusKm: DEFAULT_RADIUS_KM,
+          label: "Near me",
+        });
+        mapViewStore.flyToPoint({ lat: latitude, lon: longitude, zoom: 8 });
+        close();
+      },
+      () => {
+        if (myReq !== reqRef.current) return;
+        setNote("Location denied — still showing World. Search a region instead.");
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
+    );
+  };
+
+  return (
+    <div className="tn-scope" ref={rootRef}>
+      <button
+        type="button"
+        className="tn-scope-btn"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        <span aria-hidden>◎</span> {scope.label}
+        <span className="tn-scope-caret" aria-hidden>▾</span>
+      </button>
+
+      {open && (
+        <div className="tn-scope-menu" role="menu">
+          <button type="button" className="tn-scope-item" role="menuitem" onClick={setNearMe}>
+            Near me
+          </button>
+          <button type="button" className="tn-scope-item" role="menuitem" onClick={setWorld}>
+            World
+          </button>
+          <div className="tn-scope-region">
+            <input
+              className="tn-scope-input"
+              type="search"
+              placeholder="Region — search a place…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Scope to a region"
+            />
+            {results.length > 0 && (
+              <div className="tn-scope-results" role="listbox">
+                {results.map((r) => (
+                  <button
+                    key={`${r.name}:${r.lat},${r.lon}`}
+                    type="button"
+                    role="option"
+                    aria-selected={false}
+                    className="tn-scope-result"
+                    onClick={() => setRegion(r)}
+                  >
+                    {r.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {note && <p className="tn-scope-note">{note}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/shell/ScopeControl.tsx
+++ b/components/shell/ScopeControl.tsx
@@ -17,6 +17,7 @@ export default function ScopeControl() {
   const [results, setResults] = useState<GeocodeResult[]>([]);
   const [note, setNote] = useState<string | null>(null);
   const reqRef = useRef(0);
+  const geoReqRef = useRef(0);
   const rootRef = useRef<HTMLDivElement>(null);
 
   const close = useCallback(() => {
@@ -30,8 +31,13 @@ export default function ScopeControl() {
     const onDown = (e: MouseEvent) => {
       if (rootRef.current && !rootRef.current.contains(e.target as Node)) close();
     };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") close(); };
     document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
   }, [close]);
 
   // Debounced region search.
@@ -74,10 +80,10 @@ export default function ScopeControl() {
       return;
     }
     setNote("Finding your location…");
-    const myReq = ++reqRef.current;
+    const myReq = ++geoReqRef.current;
     navigator.geolocation.getCurrentPosition(
       (pos) => {
-        if (myReq !== reqRef.current) return;
+        if (myReq !== geoReqRef.current) return;
         const { latitude, longitude } = pos.coords;
         scopeStore.set({
           mode: "near-me",
@@ -89,7 +95,7 @@ export default function ScopeControl() {
         close();
       },
       () => {
-        if (myReq !== reqRef.current) return;
+        if (myReq !== geoReqRef.current) return;
         setNote("Location denied — still showing World. Search a region instead.");
       },
       { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
@@ -102,7 +108,7 @@ export default function ScopeControl() {
         type="button"
         className="tn-scope-btn"
         onClick={() => setOpen((o) => !o)}
-        aria-haspopup="true"
+        aria-haspopup="menu"
         aria-expanded={open}
       >
         <span aria-hidden>◎</span> {scope.label}
@@ -133,7 +139,7 @@ export default function ScopeControl() {
                     key={`${r.name}:${r.lat},${r.lon}`}
                     type="button"
                     role="option"
-                    aria-selected={false}
+                    aria-selected={scope.mode === "region" && scope.label === r.name}
                     className="tn-scope-result"
                     onClick={() => setRegion(r)}
                   >

--- a/components/shell/StatusBar.tsx
+++ b/components/shell/StatusBar.tsx
@@ -16,7 +16,6 @@ import { useT } from "@/lib/i18n/store";
 import type { StringKey } from "@/lib/i18n/catalog";
 import LangSwitcher from "@/components/shell/LangSwitcher";
 import VariantSwitcher from "@/components/shell/VariantSwitcher";
-import WorkspaceBar from "@/components/shell/WorkspaceBar";
 import StageSwitch from "@/components/console/StageSwitch";
 
 type Health = { labelKey: StringKey; tone: "live" | "degraded" | "down" | "connecting" };
@@ -82,7 +81,6 @@ export default function StatusBar({ onOpenPalette }: { onOpenPalette: () => void
         <span className="tn-tagline">{t("appTagline")}</span>
         <div className="tn-topbar-variant">
           <VariantSwitcher />
-          <WorkspaceBar />
         </div>
       </div>
 

--- a/components/shell/StatusBar.tsx
+++ b/components/shell/StatusBar.tsx
@@ -17,6 +17,7 @@ import type { StringKey } from "@/lib/i18n/catalog";
 import LangSwitcher from "@/components/shell/LangSwitcher";
 import VariantSwitcher from "@/components/shell/VariantSwitcher";
 import WorkspaceBar from "@/components/shell/WorkspaceBar";
+import StageSwitch from "@/components/console/StageSwitch";
 
 type Health = { labelKey: StringKey; tone: "live" | "degraded" | "down" | "connecting" };
 
@@ -102,6 +103,8 @@ export default function StatusBar({ onOpenPalette }: { onOpenPalette: () => void
       </div>
 
       <div className="tn-topbar-right">
+        <StageSwitch />
+
         <div className="tn-basemap" role="group" aria-label="Basemap">
           {(Object.keys(BASEMAPS) as BasemapKey[]).map((k) => (
             <button

--- a/docs/superpowers/plans/2026-06-28-ground-truth-console-phase1.md
+++ b/docs/superpowers/plans/2026-06-28-ground-truth-console-phase1.md
@@ -1,0 +1,1711 @@
+# Ground-Truth Console — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the failed widget dashboard with a console-first surface: normalize every hazard signal into one ranked `NormalizedEvent`, render it in a scoped, sourced **Event Feed** (the hero), drive relevance with a global **Scope** control, and default the map to flat 2D (globe demoted to an Explore toggle).
+
+**Architecture:** One pure data spine (`SignalFeature[] → NormalizedEvent[]`, ranked) feeds a thin React shell. All logic lives in pure, unit-tested functions (mirroring `lib/signals/*` + `lib/widgets/topEvents.ts`); hooks/components are dumb impure shells (the repo has no React Testing Library — do not add it). New global state uses the established `useSyncExternalStore` + `lib/shell/persist` store idiom (see `lib/shell/timeWindow.ts`). The console reuses the existing "floating chrome over a full-bleed MapLibre map" architecture — no CSS-grid re-architecture.
+
+**Tech Stack:** Next.js 15.5.19 (App Router) · React 19 · TypeScript 5.7.3 · MapLibre GL 5 · Vitest 2.1.8 · `@/` path alias.
+
+## Global Constraints
+
+- **Commits are SOLO-attributed.** Plain `git commit -m "…"`. **Never** append a `Co-Authored-By: Claude` trailer — this is a job-facing `011-sam-110` repo. (Overrides the default harness trailer instruction.)
+- **Branch:** `feat/ground-truth-console-redesign` (already checked out; spec committed at `ef7c2be`).
+- **Never run `next build` concurrently with `next dev`** — it corrupts `.next`. Stop the dev server before any `npm run build`.
+- **Add only the specific files each commit names** — never `git add -A` (parallel terminals share this working dir).
+- **Pure-function discipline:** every non-trivial transform is an exported pure function with a Vitest unit test in `tests/unit/`. Hooks/components stay thin and are verified by `npm run build` + manual smoke, not unit tests.
+- **Signal/feed fetchers MUST resolve, never reject** — a failing source yields `[]` (the existing `SignalSource.fetch` contract).
+- **Honesty rules (the brand):** never render a fake "0"; empty states echo the active scope + window ("No events above S1 in *Near me · last 1h*"); never imply "all live"; label normalized/derived values for what they are (the Round-1 "MW" mislabel is the anti-pattern).
+- **Calm light identity:** use the `--tn-*` CSS tokens in `app/globals.css`; default basemap `positron`.
+- **Test command:** `npm run test` (= `vitest run`). Single file: `npx vitest run tests/unit/<file> -t "<name>"`. Type-check: `npx tsc --noEmit`.
+
+## Scope of Phase 1 (and what defers)
+
+Phase 1 ships **World / Near-me / Region** scope. The `Scope` model also carries an `aoi` bbox variant (so `withinScope` is forward-compatible), but the **draw-AOI map interaction defers to P4** (Scope deepening) — it needs a MapLibre draw layer that would bloat this phase. The feed is seeded with the **4 proven event source ids** the current Top Events panel already fetches successfully (`earthquakes`, `fire-active`, `gdacs`, `tropical-cyclones`); more sources (floods, severe-storms, volcanoes, conflict) join in P2/P3 once their normalized magnitude scale is confirmed. Per-source health bar, full provenance object, and per-domain severity are **P3** — P1 carries a lightweight `source` credit + a single transparent magnitude ramp, both explicitly labelled as interim.
+
+**Resolved open questions (spec §15):** Q1 → default scope is **World** (the codebase rule "never geolocate on load" wins; Near-me is one explicit click, and a persisted Near-me rehydrates to World). Q4 → Explore is a **top-bar peer toggle** (`viewMode` store).
+
+---
+
+## File Structure
+
+**New — pure (unit-tested):**
+- `lib/events/model.ts` — `NormalizedEvent` + enums + `severityTier`/`severityRank`/`placeName`/`SEVERITY_COLOR`. *(Named `NormalizedEvent`, not `Event`, to avoid shadowing the DOM `Event` global.)*
+- `lib/events/sources.ts` — `EventSource` type + `EVENT_SOURCES` constant (which signal ids are events).
+- `lib/events/adapter.ts` — `toEvent(feature, source)` + `rankEvents(events)`.
+- `lib/shell/scope.ts` — `Scope` type, pure `withinScope` + `coerceSavedScope` + `radiusFromBbox`, plus the persisted store + `useScope`.
+- `lib/shell/viewMode.ts` — `console | explore` persisted store + `useViewMode`.
+- `lib/widgets/eventFeed.ts` — pure `projectEventFeed(inputs, scope, windowMs, now, filters)`.
+
+**New — impure shells / UI (build + manual verified):**
+- `lib/widgets/useEventFeeds.ts` — polls every `EVENT_SOURCES` feed → features-by-source.
+- `components/shell/EventFeed.tsx` — the ranked, scoped, sourced feed (the hero).
+- `components/shell/ScopeControl.tsx` — top-bar World / Near-me / Region control.
+- `components/shell/ConsoleTopBar.tsx` — floating cluster: ScopeControl + TimeWindowControl + Explore toggle.
+
+**Modified:**
+- `components/WorldMap.tsx` — projection follows `viewMode` (flat default, globe in Explore).
+- `components/shell/ConsoleShell.tsx` — hydrate new stores; mount top bar + feed in console mode; gate the legacy panels to Explore.
+- `app/globals.css` — feed / scope / topbar / severity-chip styles.
+
+**New tests:** `tests/unit/events-model.test.ts`, `tests/unit/events-adapter.test.ts`, `tests/unit/scope.test.ts`, `tests/unit/eventFeed.test.ts`, `tests/unit/viewMode.test.ts`.
+
+---
+
+## Task 1: Event model + severity (pure spine)
+
+**Files:**
+- Create: `lib/events/model.ts`
+- Test: `tests/unit/events-model.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf module).
+- Produces:
+  - `type EventType = "quake"|"fire"|"disaster"|"cyclone"|"flood"|"storm"|"volcano"|"conflict"|"other"`
+  - `type SeverityTier = "S0"|"S1"|"S2"|"S3"|"S4"`
+  - `type GeoPrecision = "EXACT"|"CITY"|"ADMIN"|"COUNTRY_CENTROID"`
+  - `interface NormalizedEvent { id; type:EventType; title; place:{name:string}; geo:{lat;lon;precision:GeoPrecision}; occurredAt:string|null; severity:{tier:SeverityTier;raw:number}; magnitude?:{value:number;unit:string}; source:{id;label;attribution}; link?:string; color:string }`
+  - `severityTier(magnitude:number):SeverityTier`
+  - `severityRank(tier:SeverityTier):number`
+  - `placeName(title:string, props?:Record<string,unknown>):string`
+  - `SEVERITY_COLOR: Record<SeverityTier,string>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/events-model.test.ts
+import { describe, it, expect } from "vitest";
+import { severityTier, severityRank, placeName, SEVERITY_COLOR } from "@/lib/events/model";
+
+describe("severityTier (interim 0–10 ramp)", () => {
+  it("maps the normalized magnitude band to a tier", () => {
+    expect(severityTier(9)).toBe("S4");
+    expect(severityTier(8)).toBe("S4");
+    expect(severityTier(6)).toBe("S3");
+    expect(severityTier(4)).toBe("S2");
+    expect(severityTier(2)).toBe("S1");
+    expect(severityTier(1.9)).toBe("S0");
+    expect(severityTier(0)).toBe("S0");
+  });
+  it("treats a non-finite magnitude as S0 (never throws)", () => {
+    expect(severityTier(NaN)).toBe("S0");
+    expect(severityTier(Infinity)).toBe("S4"); // >=8 branch; finite-guard only catches NaN
+  });
+});
+
+describe("severityRank", () => {
+  it("orders tiers low→high", () => {
+    expect(severityRank("S0")).toBeLessThan(severityRank("S4"));
+    expect(severityRank("S3")).toBe(3);
+  });
+});
+
+describe("placeName", () => {
+  it("prefers an explicit props.place", () => {
+    expect(placeName("M0.7 - 9 km N of Anza, CA", { place: "Anza, CA" })).toBe("Anza, CA");
+  });
+  it("falls back to the title tail after a dash", () => {
+    expect(placeName("M5.8 - 9 km N of Anza, CA")).toBe("9 km N of Anza, CA");
+    expect(placeName("Active fire — Sonoma County")).toBe("Sonoma County");
+  });
+  it("uses the whole title when there is no delimiter", () => {
+    expect(placeName("Tropical Storm Bret")).toBe("Tropical Storm Bret");
+  });
+});
+
+describe("SEVERITY_COLOR", () => {
+  it("has a colour for every tier", () => {
+    for (const t of ["S0", "S1", "S2", "S3", "S4"] as const) {
+      expect(SEVERITY_COLOR[t]).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/events-model.test.ts`
+Expected: FAIL — "Failed to resolve import @/lib/events/model".
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// lib/events/model.ts
+// The Event spine. Every hazard signal normalizes to ONE NormalizedEvent — the
+// unit the feed, the map and the dossier all read. (Named NormalizedEvent, not
+// `Event`, to avoid shadowing the DOM `Event` global.)
+//
+// P1 severity uses ONE transparent 0–10 magnitude ramp (the shared SignalFeature
+// `props.magnitude` convention). P3 (§10.3) replaces this with a per-domain,
+// exposure-weighted basis — until then `severity.raw` is surfaced honestly.
+
+export type EventType =
+  | "quake" | "fire" | "disaster" | "cyclone"
+  | "flood" | "storm" | "volcano" | "conflict" | "other";
+
+export type SeverityTier = "S0" | "S1" | "S2" | "S3" | "S4";
+
+export type GeoPrecision = "EXACT" | "CITY" | "ADMIN" | "COUNTRY_CENTROID";
+
+export interface NormalizedEvent {
+  /** Stable id (the source feature id). */
+  id: string;
+  type: EventType;
+  /** Human, specific — reused verbatim from the source feature title. */
+  title: string;
+  place: { name: string };
+  geo: { lat: number; lon: number; precision: GeoPrecision };
+  /** ISO UTC event time; null when the source carries none (never faked). */
+  occurredAt: string | null;
+  /** Display tier + the raw normalized magnitude it derives from (shown, not hidden). */
+  severity: { tier: SeverityTier; raw: number };
+  /** Native magnitude — populated only where the unit is known-safe (P1: quakes). */
+  magnitude?: { value: number; unit: string };
+  /** Lightweight source credit (P1). The full Provenance object lands in P3. */
+  source: { id: string; label: string; attribution: string };
+  link?: string;
+  /** Marker/chip colour, from the severity ramp. */
+  color: string;
+}
+
+const TIER_RANK: Record<SeverityTier, number> = { S0: 0, S1: 1, S2: 2, S3: 3, S4: 4 };
+
+export const SEVERITY_COLOR: Record<SeverityTier, string> = {
+  S0: "#94a3b8",
+  S1: "#eab308",
+  S2: "#f97316",
+  S3: "#ef4444",
+  S4: "#b91c1c",
+};
+
+/** Map the shared 0–10 normalized magnitude to a display tier (interim — see header). */
+export function severityTier(magnitude: number): SeverityTier {
+  if (Number.isNaN(magnitude)) return "S0";
+  if (magnitude >= 8) return "S4";
+  if (magnitude >= 6) return "S3";
+  if (magnitude >= 4) return "S2";
+  if (magnitude >= 2) return "S1";
+  return "S0";
+}
+
+export function severityRank(tier: SeverityTier): number {
+  return TIER_RANK[tier];
+}
+
+/** Best-effort row place (P1-honest): explicit props.place → the title tail after
+ *  a dash/em-dash → the whole title. Country/admin enrichment is P3. */
+export function placeName(title: string, props?: Record<string, unknown>): string {
+  const explicit = props?.place;
+  if (typeof explicit === "string" && explicit.trim()) return explicit.trim();
+  const m = title.match(/\s[—-]\s(.+)$/);
+  return (m ? m[1] : title).trim();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/events-model.test.ts`
+Expected: PASS (all assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/events/model.ts tests/unit/events-model.test.ts
+git commit -m "feat(events): add NormalizedEvent model + severity ramp"
+```
+
+---
+
+## Task 2: Event sources + adapter (SignalFeature → NormalizedEvent)
+
+**Files:**
+- Create: `lib/events/sources.ts`, `lib/events/adapter.ts`
+- Test: `tests/unit/events-adapter.test.ts`
+
+**Interfaces:**
+- Consumes: `NormalizedEvent`, `severityTier`, `severityRank`, `placeName`, `SEVERITY_COLOR` (Task 1); `SignalFeature` (`lib/signals/types.ts`).
+- Produces:
+  - `interface EventSource { id:string; type:EventType; label:string; attribution:string; precision:GeoPrecision; magnitudeUnit?:string }`
+  - `EVENT_SOURCES: EventSource[]`
+  - `toEvent(f:SignalFeature, src:EventSource):NormalizedEvent`
+  - `rankEvents(events:NormalizedEvent[]):NormalizedEvent[]` — severity tier desc, then newest-first (undated last).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/events-adapter.test.ts
+import { describe, it, expect } from "vitest";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import { toEvent, rankEvents } from "@/lib/events/adapter";
+
+const QUAKE = EVENT_SOURCES.find((s) => s.id === "earthquakes")!;
+const FIRE = EVENT_SOURCES.find((s) => s.id === "fire-active")!;
+
+const sf = (over: Partial<SignalFeature>): SignalFeature => ({
+  id: "x", lat: 1, lon: 2, title: "T", signalId: "s", ...over,
+});
+
+describe("EVENT_SOURCES", () => {
+  it("seeds the 4 proven event ids", () => {
+    expect(EVENT_SOURCES.map((s) => s.id)).toEqual([
+      "earthquakes", "fire-active", "gdacs", "tropical-cyclones",
+    ]);
+  });
+});
+
+describe("toEvent", () => {
+  it("maps a quake feature into a NormalizedEvent with native M magnitude", () => {
+    const e = toEvent(
+      sf({ id: "usgs:1", title: "M5.8 - 9 km N of Anza, CA", lat: 33.6, lon: -116.7,
+           ts: "2026-06-28T00:00:00Z", props: { magnitude: 5.8, place: "9 km N of Anza, CA" } }),
+      QUAKE,
+    );
+    expect(e.type).toBe("quake");
+    expect(e.place.name).toBe("9 km N of Anza, CA");
+    expect(e.geo).toEqual({ lat: 33.6, lon: -116.7, precision: "EXACT" });
+    expect(e.occurredAt).toBe("2026-06-28T00:00:00Z");
+    expect(e.severity.tier).toBe("S2");      // 5.8 → S2
+    expect(e.severity.raw).toBe(5.8);
+    expect(e.magnitude).toEqual({ value: 5.8, unit: "M" });
+    expect(e.source.attribution).toBe("USGS");
+  });
+
+  it("omits native magnitude for a source with no known unit (no MW mislabel)", () => {
+    const e = toEvent(sf({ title: "Active fire — Sonoma", props: { magnitude: 7 } }), FIRE);
+    expect(e.type).toBe("fire");
+    expect(e.magnitude).toBeUndefined();     // FIRE has no magnitudeUnit
+    expect(e.severity.tier).toBe("S3");      // 7 → S3
+  });
+
+  it("treats a missing magnitude as 0 / S0 and a missing ts as null", () => {
+    const e = toEvent(sf({ title: "Quiet" }), QUAKE);
+    expect(e.severity.raw).toBe(0);
+    expect(e.severity.tier).toBe("S0");
+    expect(e.occurredAt).toBeNull();
+  });
+});
+
+describe("rankEvents", () => {
+  it("sorts by severity tier desc, then newest-first", () => {
+    const rows = rankEvents([
+      toEvent(sf({ id: "a", ts: "2026-06-27T00:00:00Z", props: { magnitude: 5 } }), QUAKE),
+      toEvent(sf({ id: "b", ts: "2026-06-26T00:00:00Z", props: { magnitude: 8 } }), QUAKE),
+      toEvent(sf({ id: "c", ts: "2026-06-28T00:00:00Z", props: { magnitude: 8 } }), QUAKE),
+    ]);
+    expect(rows.map((r) => r.id)).toEqual(["c", "b", "a"]); // S4 newest, S4 older, then S2
+  });
+  it("orders undated events after dated ones of the same tier", () => {
+    const rows = rankEvents([
+      toEvent(sf({ id: "undated", props: { magnitude: 5 } }), QUAKE),
+      toEvent(sf({ id: "dated", ts: "2026-06-28T00:00:00Z", props: { magnitude: 5 } }), QUAKE),
+    ]);
+    expect(rows.map((r) => r.id)).toEqual(["dated", "undated"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/events-adapter.test.ts`
+Expected: FAIL — cannot resolve `@/lib/events/sources` / `@/lib/events/adapter`.
+
+- [ ] **Step 3: Write `lib/events/sources.ts`**
+
+```ts
+// lib/events/sources.ts
+// The curated set of signal sources that emit discrete, time/place-stamped EVENTS
+// for the feed. Seeded with the proven ids the Top Events panel already fetches
+// successfully (components/shell/TopEventsPanel.tsx). Add more (floods, severe-
+// storms, volcanoes, conflict) as each one's normalized magnitude scale is
+// confirmed — see the registry in lib/signals/registry.ts.
+//
+// magnitudeUnit is set ONLY where props.magnitude genuinely IS that unit, so the
+// row can show a native value without the Round-1 "MW" mislabel. Leave it unset
+// and the row leans on the source's own title for the human magnitude.
+
+import type { EventType, GeoPrecision } from "@/lib/events/model";
+
+export interface EventSource {
+  /** Signal source id — the /api/signals/<id> route segment + store key. */
+  id: string;
+  type: EventType;
+  /** Human source label for the row's source credit. */
+  label: string;
+  attribution: string;
+  /** Default geo-precision for this source's points (per-feature precision is P3). */
+  precision: GeoPrecision;
+  /** Native magnitude unit, only when props.magnitude IS that unit. */
+  magnitudeUnit?: string;
+}
+
+export const EVENT_SOURCES: EventSource[] = [
+  { id: "earthquakes", type: "quake", label: "Earthquakes (USGS)", attribution: "USGS", precision: "EXACT", magnitudeUnit: "M" },
+  { id: "fire-active", type: "fire", label: "Active fire (FIRMS)", attribution: "NASA FIRMS", precision: "EXACT" },
+  { id: "gdacs", type: "disaster", label: "Disasters (GDACS)", attribution: "GDACS", precision: "ADMIN" },
+  { id: "tropical-cyclones", type: "cyclone", label: "Cyclones (NOAA NHC)", attribution: "NOAA NHC", precision: "ADMIN" },
+];
+```
+
+- [ ] **Step 4: Write `lib/events/adapter.ts`**
+
+```ts
+// lib/events/adapter.ts
+// SignalFeature → NormalizedEvent, plus the severity×recency ranking. The general
+// form of lib/widgets/topEvents.ts (which this supersedes): the magnitude/place/
+// time the rows need already ride in each feature — this surfaces them.
+
+import type { SignalFeature } from "@/lib/signals/types";
+import type { EventSource } from "@/lib/events/sources";
+import {
+  type NormalizedEvent,
+  severityTier,
+  severityRank,
+  placeName,
+  SEVERITY_COLOR,
+} from "@/lib/events/model";
+
+export function toEvent(f: SignalFeature, src: EventSource): NormalizedEvent {
+  const raw = Number(f.props?.magnitude ?? 0);
+  const tier = severityTier(raw);
+  const event: NormalizedEvent = {
+    id: f.id,
+    type: src.type,
+    title: f.title,
+    place: { name: placeName(f.title, f.props) },
+    geo: { lat: f.lat, lon: f.lon, precision: src.precision },
+    occurredAt: f.ts ?? null,
+    severity: { tier, raw },
+    source: { id: src.id, label: src.label, attribution: src.attribution },
+    link: f.link,
+    color: SEVERITY_COLOR[tier],
+  };
+  if (src.magnitudeUnit && Number.isFinite(raw) && raw > 0) {
+    event.magnitude = { value: raw, unit: src.magnitudeUnit };
+  }
+  return event;
+}
+
+/** Severity tier desc, then newest-first (undated sorts last). Mirrors topEventsRows. */
+export function rankEvents(events: NormalizedEvent[]): NormalizedEvent[] {
+  return [...events].sort((a, b) => {
+    const sev = severityRank(b.severity.tier) - severityRank(a.severity.tier);
+    if (sev !== 0) return sev;
+    const at = a.occurredAt ?? "";
+    const bt = b.occurredAt ?? "";
+    if (at < bt) return 1;
+    if (at > bt) return -1;
+    return 0;
+  });
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/events-adapter.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/events/sources.ts lib/events/adapter.ts tests/unit/events-adapter.test.ts
+git commit -m "feat(events): curated event sources + SignalFeature→Event adapter"
+```
+
+---
+
+## Task 3: Scope store + `withinScope`
+
+**Files:**
+- Create: `lib/shell/scope.ts`
+- Test: `tests/unit/scope.test.ts`
+
+**Interfaces:**
+- Consumes: `haversineKm` (`lib/geo/haversine.ts`); `loadPersisted`/`savePersisted` (`lib/shell/persist.ts`).
+- Produces:
+  - `type ScopeMode = "world"|"near-me"|"region"|"aoi"`
+  - `interface Scope { mode:ScopeMode; center?:{lat:number;lon:number}; radiusKm?:number; bbox?:[number,number,number,number]; label:string }`
+  - `WORLD_SCOPE:Scope`, `DEFAULT_RADIUS_KM:number`
+  - `withinScope(lat:number, lon:number, scope:Scope):boolean`
+  - `radiusFromBbox(bbox:[number,number,number,number]):number`
+  - `coerceSavedScope(saved:unknown):Scope`
+  - `scopeStore` (`set`/`get`/`reset`/`hydrate`/`subscribe`), `useScope():Scope`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/scope.test.ts
+import { describe, it, expect } from "vitest";
+import { withinScope, radiusFromBbox, coerceSavedScope, WORLD_SCOPE, type Scope } from "@/lib/shell/scope";
+
+describe("withinScope", () => {
+  it("world admits everything", () => {
+    expect(withinScope(80, 170, WORLD_SCOPE)).toBe(true);
+  });
+  it("near-me / region admit points inside the radius and reject those outside", () => {
+    const s: Scope = { mode: "near-me", center: { lat: 51.5, lon: -0.12 }, radiusKm: 50, label: "Near me" };
+    expect(withinScope(51.51, -0.13, s)).toBe(true);   // ~1 km away
+    expect(withinScope(48.85, 2.35, s)).toBe(false);   // Paris, far outside
+  });
+  it("aoi admits points inside the bbox [west,south,east,north]", () => {
+    const s: Scope = { mode: "aoi", bbox: [-1, 50, 1, 52], label: "AOI" };
+    expect(withinScope(51, 0, s)).toBe(true);
+    expect(withinScope(60, 0, s)).toBe(false);
+  });
+  it("falls back to admit-all on a malformed scope (never hide untestable data)", () => {
+    expect(withinScope(0, 0, { mode: "near-me", label: "x" })).toBe(true);
+    expect(withinScope(0, 0, { mode: "aoi", label: "x" })).toBe(true);
+  });
+});
+
+describe("radiusFromBbox", () => {
+  it("derives a sensible radius (km) from a place extent", () => {
+    expect(radiusFromBbox([-0.5, 51.2, 0.3, 51.7])).toBeGreaterThan(20);
+    expect(radiusFromBbox([-0.001, 51.5, 0.001, 51.501])).toBeGreaterThanOrEqual(10); // floor
+  });
+});
+
+describe("coerceSavedScope", () => {
+  it("rehydrates a persisted near-me back to World (never auto-geolocates)", () => {
+    expect(coerceSavedScope({ mode: "near-me", center: { lat: 1, lon: 2 }, radiusKm: 50, label: "Near me" }))
+      .toEqual(WORLD_SCOPE);
+  });
+  it("keeps a region scope", () => {
+    const r: Scope = { mode: "region", center: { lat: 1, lon: 2 }, radiusKm: 100, label: "Berlin" };
+    expect(coerceSavedScope(r)).toEqual(r);
+  });
+  it("returns World for junk", () => {
+    expect(coerceSavedScope(null)).toEqual(WORLD_SCOPE);
+    expect(coerceSavedScope({ nope: true })).toEqual(WORLD_SCOPE);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/scope.test.ts`
+Expected: FAIL — cannot resolve `@/lib/shell/scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// lib/shell/scope.ts
+"use client";
+// The global Scope — the relevance spine. A single persisted store (the lib/shell
+// idiom) the feed, the map and (later) the alerts all read: World (firehose) /
+// Near-me / Region / AOI. Pure withinScope is unit-tested; the store is a thin
+// useSyncExternalStore shell. AOI's bbox is modelled now; the draw interaction is
+// P4 — withinScope already handles it so nothing changes when the UI arrives.
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { haversineKm } from "@/lib/geo/haversine";
+
+export type ScopeMode = "world" | "near-me" | "region" | "aoi";
+
+export interface Scope {
+  mode: ScopeMode;
+  /** Centre for near-me / region. */
+  center?: { lat: number; lon: number };
+  /** Radius (km) for centre-based scopes. */
+  radiusKm?: number;
+  /** [west, south, east, north] for aoi. */
+  bbox?: [number, number, number, number];
+  /** Human label for the top bar + the feed's honest empty state. */
+  label: string;
+}
+
+export const WORLD_SCOPE: Scope = { mode: "world", label: "World" };
+export const DEFAULT_RADIUS_KM = 250;
+const MIN_RADIUS_KM = 10;
+
+/** Pure: is a point inside the scope? Malformed centre/aoi scopes admit
+ *  everything — we never silently hide data we cannot test. */
+export function withinScope(lat: number, lon: number, scope: Scope): boolean {
+  switch (scope.mode) {
+    case "near-me":
+    case "region":
+      if (!scope.center || scope.radiusKm == null) return true;
+      return haversineKm(scope.center.lat, scope.center.lon, lat, lon) <= scope.radiusKm;
+    case "aoi": {
+      if (!scope.bbox) return true;
+      const [w, s, e, n] = scope.bbox;
+      return lon >= w && lon <= e && lat >= s && lat <= n;
+    }
+    case "world":
+    default:
+      return true;
+  }
+}
+
+/** Radius (km) covering a geocoder extent [west,south,east,north], floored. */
+export function radiusFromBbox(bbox: [number, number, number, number]): number {
+  const [w, s, e, n] = bbox;
+  const midLat = (s + n) / 2;
+  const halfDiag = haversineKm(s, w, n, e) / 2;
+  void midLat;
+  return Math.max(MIN_RADIUS_KM, Math.round(halfDiag));
+}
+
+/** A persisted near-me rehydrates to World (we never auto-geolocate on load);
+ *  region/aoi/world survive; junk → World. */
+export function coerceSavedScope(saved: unknown): Scope {
+  const s = saved as Scope | null;
+  if (!s || typeof s !== "object" || typeof s.mode !== "string") return WORLD_SCOPE;
+  if (s.mode === "near-me") return WORLD_SCOPE;
+  if (s.mode === "region" || s.mode === "aoi" || s.mode === "world") return s;
+  return WORLD_SCOPE;
+}
+
+const PERSIST_KEY = "tn.scope.v1";
+const PERSIST_VERSION = 1;
+
+let state: Scope = WORLD_SCOPE;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+}
+
+export const scopeStore = {
+  set(scope: Scope) {
+    state = scope;
+    emit();
+  },
+  get(): Scope {
+    return state;
+  },
+  reset() {
+    state = WORLD_SCOPE;
+    emit();
+  },
+  hydrate() {
+    state = coerceSavedScope(loadPersisted<Scope>(PERSIST_KEY, PERSIST_VERSION));
+    emit();
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export function useScope(): Scope {
+  return useSyncExternalStore(scopeStore.subscribe, scopeStore.get, scopeStore.get);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/scope.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/shell/scope.ts tests/unit/scope.test.ts
+git commit -m "feat(scope): global Scope store + pure withinScope"
+```
+
+---
+
+## Task 4: Feed projection (pure) + the fetch hook
+
+**Files:**
+- Create: `lib/widgets/eventFeed.ts` (pure), `lib/widgets/useEventFeeds.ts` (impure shell)
+- Test: `tests/unit/eventFeed.test.ts`
+
+**Interfaces:**
+- Consumes: `toEvent`/`rankEvents` (Task 2), `EVENT_SOURCES`/`EventSource` (Task 2), `withinScope`/`Scope` (Task 3), `withinWindow` (`lib/shell/timeWindow.ts`), `haversineKm`, `severityRank`/`SeverityTier`/`EventType`/`NormalizedEvent` (Task 1), `SignalFeature`.
+- Produces:
+  - `type FeedSort = "severity"|"recent"|"nearest"`
+  - `interface FeedFilters { types:Set<EventType>|null; minTier:SeverityTier; sort:FeedSort }`
+  - `interface FeedInput { source:EventSource; features:SignalFeature[] }`
+  - `interface ProjectedFeed { rows:NormalizedEvent[]; total:number; shown:number }`
+  - `projectEventFeed(inputs:FeedInput[], scope:Scope, windowMs:number|null, now:number, filters:FeedFilters):ProjectedFeed`
+  - `interface RawFeeds { bySource:Record<string,SignalFeature[]>; status:"idle"|"loading"|"error"; updatedAt:number|null }`
+  - `useEventFeeds():RawFeeds`
+
+- [ ] **Step 1: Write the failing test (pure projection only)**
+
+```ts
+// tests/unit/eventFeed.test.ts
+import { describe, it, expect } from "vitest";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import { projectEventFeed, type FeedFilters, type FeedInput } from "@/lib/widgets/eventFeed";
+import { WORLD_SCOPE, type Scope } from "@/lib/shell/scope";
+
+const QUAKE = EVENT_SOURCES.find((s) => s.id === "earthquakes")!;
+const sf = (over: Partial<SignalFeature>): SignalFeature => ({
+  id: "x", lat: 1, lon: 2, title: "T", signalId: "s", ...over,
+});
+const NOW = Date.parse("2026-06-28T12:00:00Z");
+const base: FeedFilters = { types: null, minTier: "S0", sort: "severity" };
+
+const inputs = (feats: SignalFeature[]): FeedInput[] => [{ source: QUAKE, features: feats }];
+
+describe("projectEventFeed", () => {
+  it("ranks by severity×recency and reports total vs shown", () => {
+    const r = projectEventFeed(inputs([
+      sf({ id: "a", props: { magnitude: 5 }, ts: "2026-06-28T10:00:00Z" }),
+      sf({ id: "b", props: { magnitude: 8 }, ts: "2026-06-28T09:00:00Z" }),
+    ]), WORLD_SCOPE, null, NOW, base);
+    expect(r.rows.map((x) => x.id)).toEqual(["b", "a"]);
+    expect(r.total).toBe(2);
+    expect(r.shown).toBe(2);
+  });
+
+  it("applies the severity floor", () => {
+    const r = projectEventFeed(inputs([
+      sf({ id: "lo", props: { magnitude: 1 } }),
+      sf({ id: "hi", props: { magnitude: 9 } }),
+    ]), WORLD_SCOPE, null, NOW, { ...base, minTier: "S3" });
+    expect(r.rows.map((x) => x.id)).toEqual(["hi"]);
+    expect(r.total).toBe(2);
+    expect(r.shown).toBe(1);
+  });
+
+  it("filters by type", () => {
+    const r = projectEventFeed(inputs([sf({ id: "q", props: { magnitude: 5 } })]),
+      WORLD_SCOPE, null, NOW, { ...base, types: new Set(["fire"]) });
+    expect(r.shown).toBe(0);
+  });
+
+  it("trims by scope radius", () => {
+    const near: Scope = { mode: "region", center: { lat: 51.5, lon: -0.12 }, radiusKm: 50, label: "London" };
+    const r = projectEventFeed(inputs([
+      sf({ id: "in", lat: 51.51, lon: -0.13, props: { magnitude: 5 } }),
+      sf({ id: "out", lat: 35, lon: 139, props: { magnitude: 5 } }),
+    ]), near, null, NOW, base);
+    expect(r.rows.map((x) => x.id)).toEqual(["in"]);
+  });
+
+  it("trims by the time window (old events drop, undated stay)", () => {
+    const r = projectEventFeed(inputs([
+      sf({ id: "fresh", props: { magnitude: 5 }, ts: "2026-06-28T11:30:00Z" }),
+      sf({ id: "old", props: { magnitude: 5 }, ts: "2026-06-01T00:00:00Z" }),
+      sf({ id: "undated", props: { magnitude: 5 } }),
+    ]), WORLD_SCOPE, 60 * 60 * 1000, NOW, base);
+    expect(r.rows.map((x) => x.id).sort()).toEqual(["fresh", "undated"]);
+  });
+
+  it("sort=nearest orders by distance to the scope centre", () => {
+    const near: Scope = { mode: "region", center: { lat: 0, lon: 0 }, radiusKm: 100000, label: "x" };
+    const r = projectEventFeed(inputs([
+      sf({ id: "far", lat: 10, lon: 10, props: { magnitude: 9 } }),
+      sf({ id: "close", lat: 1, lon: 1, props: { magnitude: 1 } }),
+    ]), near, null, NOW, { ...base, sort: "nearest" });
+    expect(r.rows.map((x) => x.id)).toEqual(["close", "far"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/eventFeed.test.ts`
+Expected: FAIL — cannot resolve `@/lib/widgets/eventFeed`.
+
+- [ ] **Step 3: Write `lib/widgets/eventFeed.ts`**
+
+```ts
+// lib/widgets/eventFeed.ts
+// PURE feed projection: SignalFeature[] (by source) → scoped, windowed, filtered,
+// ranked NormalizedEvent[] + honest counts. The single place the feed's logic
+// lives; the component and the hook are dumb shells around this.
+
+import type { SignalFeature } from "@/lib/signals/types";
+import type { EventSource } from "@/lib/events/sources";
+import { type NormalizedEvent, type SeverityTier, type EventType, severityRank } from "@/lib/events/model";
+import { toEvent, rankEvents } from "@/lib/events/adapter";
+import { withinWindow } from "@/lib/shell/timeWindow";
+import { withinScope, type Scope } from "@/lib/shell/scope";
+import { haversineKm } from "@/lib/geo/haversine";
+
+export type FeedSort = "severity" | "recent" | "nearest";
+
+export interface FeedFilters {
+  /** null = all types; otherwise the set to keep. */
+  types: Set<EventType> | null;
+  minTier: SeverityTier;
+  sort: FeedSort;
+}
+
+export interface FeedInput {
+  source: EventSource;
+  features: SignalFeature[];
+}
+
+export interface ProjectedFeed {
+  rows: NormalizedEvent[];
+  /** Events emitted before scope/window/filter trimming (for the "N of M" honesty). */
+  total: number;
+  /** rows.length after trimming. */
+  shown: number;
+}
+
+export function projectEventFeed(
+  inputs: FeedInput[],
+  scope: Scope,
+  windowMs: number | null,
+  now: number,
+  filters: FeedFilters,
+): ProjectedFeed {
+  const all: NormalizedEvent[] = [];
+  for (const { source, features } of inputs) {
+    for (const f of features) all.push(toEvent(f, source));
+  }
+  const total = all.length;
+  const floor = severityRank(filters.minTier);
+
+  let rows = all.filter(
+    (e) =>
+      withinScope(e.geo.lat, e.geo.lon, scope) &&
+      withinWindow(e.occurredAt, windowMs, now) &&
+      severityRank(e.severity.tier) >= floor &&
+      (filters.types == null || filters.types.has(e.type)),
+  );
+
+  if (filters.sort === "nearest" && scope.center) {
+    const c = scope.center;
+    rows = [...rows].sort(
+      (a, b) =>
+        haversineKm(c.lat, c.lon, a.geo.lat, a.geo.lon) -
+        haversineKm(c.lat, c.lon, b.geo.lat, b.geo.lon),
+    );
+  } else if (filters.sort === "recent") {
+    rows = [...rows].sort((a, b) => {
+      const at = a.occurredAt ?? "";
+      const bt = b.occurredAt ?? "";
+      return at < bt ? 1 : at > bt ? -1 : 0;
+    });
+  } else {
+    rows = rankEvents(rows);
+  }
+
+  return { rows, total, shown: rows.length };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/eventFeed.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the impure fetch hook `lib/widgets/useEventFeeds.ts`**
+
+```ts
+// lib/widgets/useEventFeeds.ts
+"use client";
+// Fetch every EVENT_SOURCES feed through the generic /api/signals/<id> proxy on a
+// cadence, accumulating the latest features per source. A thin impure shell (no
+// unit test — the logic it feeds lives in lib/widgets/eventFeed.ts). Dormant-safe:
+// a failed source keeps its last features; status is "error" only if ALL fail.
+
+import { useEffect, useState } from "react";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+
+export interface RawFeeds {
+  bySource: Record<string, SignalFeature[]>;
+  status: "idle" | "loading" | "error";
+  updatedAt: number | null;
+}
+
+const POLL_MS = 5 * 60_000;
+
+export function useEventFeeds(): RawFeeds {
+  const [bySource, setBySource] = useState<Record<string, SignalFeature[]>>({});
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const load = () => {
+      setStatus("loading");
+      Promise.all(
+        EVENT_SOURCES.map((s) =>
+          fetch(`/api/signals/${encodeURIComponent(s.id)}`)
+            .then((r) => r.json())
+            .then((d) => ({ id: s.id, features: (d.features as SignalFeature[]) ?? [], ok: true }))
+            .catch(() => ({ id: s.id, features: [] as SignalFeature[], ok: false })),
+        ),
+      ).then((results) => {
+        if (!alive) return;
+        setBySource((prev) => {
+          const next = { ...prev };
+          for (const r of results) if (r.ok) next[r.id] = r.features;
+          return next;
+        });
+        setStatus(results.every((r) => !r.ok) ? "error" : "idle");
+        setUpdatedAt(Date.now());
+      });
+    };
+    load();
+    const t = setInterval(load, POLL_MS);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, []);
+
+  return { bySource, status, updatedAt };
+}
+```
+
+- [ ] **Step 6: Type-check + commit**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+```bash
+git add lib/widgets/eventFeed.ts lib/widgets/useEventFeeds.ts tests/unit/eventFeed.test.ts
+git commit -m "feat(feed): pure event-feed projection + multi-source fetch hook"
+```
+
+---
+
+## Task 5: The Event Feed component (the hero)
+
+**Files:**
+- Create: `components/shell/EventFeed.tsx`
+- Modify: `app/globals.css` (append the feed styles below)
+
+**Interfaces:**
+- Consumes: `useEventFeeds` (Task 4), `projectEventFeed`/`FeedFilters`/`FeedSort` (Task 4), `EVENT_SOURCES` (Task 2), `useScope` (Task 3), `useTimeWindow`/`windowMsFor`/`TIME_WINDOWS` (`lib/shell/timeWindow.ts`), `useNow`/`formatAge` (`lib/shell/useNow.ts`), `openSignalFeature` (`lib/widgets/openSignal.ts`), `EventType`/`SeverityTier`/`SEVERITY_COLOR` (Task 1), `SignalFeature`.
+- Produces: `export default function EventFeed()` — the right-docked feed panel.
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/shell/EventFeed.tsx
+"use client";
+// The Event Feed — the console hero. Ranked, scoped, sourced rows built by the
+// pure projectEventFeed from the live EVENT_SOURCES feeds. Click a row → fly +
+// open its dossier (reusing openSignalFeature, exactly like the old Top Events
+// panel). Honest empty state echoes the active scope + window.
+
+import { useMemo, useState } from "react";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import type { EventType, SeverityTier } from "@/lib/events/model";
+import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
+import { projectEventFeed, type FeedSort, type FeedInput } from "@/lib/widgets/eventFeed";
+import { useScope } from "@/lib/shell/scope";
+import { useTimeWindow, windowMsFor, TIME_WINDOWS } from "@/lib/shell/timeWindow";
+import { useNow, formatAge } from "@/lib/shell/useNow";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+
+const TIERS: SeverityTier[] = ["S0", "S1", "S2", "S3", "S4"];
+const TYPES: EventType[] = Array.from(new Set(EVENT_SOURCES.map((s) => s.type)));
+const SORTS: { key: FeedSort; label: string }[] = [
+  { key: "severity", label: "Severity" },
+  { key: "recent", label: "Recent" },
+  { key: "nearest", label: "Nearest" },
+];
+
+export default function EventFeed() {
+  const scope = useScope();
+  const win = useTimeWindow();
+  const now = useNow(1000);
+  const { bySource, status, updatedAt } = useEventFeeds();
+
+  const [minTier, setMinTier] = useState<SeverityTier>("S0");
+  const [sort, setSort] = useState<FeedSort>("severity");
+  const [type, setType] = useState<EventType | null>(null);
+
+  // Keep the original SignalFeature for each event id so a row click can reuse the
+  // exact map-fly + dossier behaviour.
+  const featureById = useMemo(() => {
+    const m = new Map<string, { feature: SignalFeature; label: string }>();
+    for (const s of EVENT_SOURCES) {
+      for (const f of bySource[s.id] ?? []) m.set(f.id, { feature: f, label: s.label });
+    }
+    return m;
+  }, [bySource]);
+
+  const inputs: FeedInput[] = useMemo(
+    () => EVENT_SOURCES.map((source) => ({ source, features: bySource[source.id] ?? [] })),
+    [bySource],
+  );
+
+  const projected = useMemo(
+    () =>
+      projectEventFeed(inputs, scope, windowMsFor(win), now, {
+        types: type ? new Set([type]) : null,
+        minTier,
+        sort: sort === "nearest" && !scope.center ? "severity" : sort,
+      }),
+    [inputs, scope, win, now, type, minTier, sort],
+  );
+
+  const winLabel = TIME_WINDOWS.find((w) => w.key === win)?.label ?? win;
+  const open = (id: string) => {
+    const hit = featureById.get(id);
+    if (hit) openSignalFeature(hit.feature, hit.label, 7);
+  };
+
+  return (
+    <aside className="tn-feed" role="region" aria-label="Event feed">
+      <header className="tn-feed-head">
+        <h2 className="tn-feed-title">Events</h2>
+        <span className="tn-feed-count tn-num">
+          {projected.shown}
+          {projected.shown !== projected.total ? ` / ${projected.total}` : ""}
+        </span>
+      </header>
+
+      <div className="tn-feed-controls">
+        <select
+          aria-label="Minimum severity"
+          value={minTier}
+          onChange={(e) => setMinTier(e.target.value as SeverityTier)}
+        >
+          {TIERS.map((t) => (
+            <option key={t} value={t}>
+              {t}+
+            </option>
+          ))}
+        </select>
+        <select aria-label="Sort" value={sort} onChange={(e) => setSort(e.target.value as FeedSort)}>
+          {SORTS.map((s) => (
+            <option key={s.key} value={s.key} disabled={s.key === "nearest" && !scope.center}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+        <div className="tn-feed-types">
+          <button
+            type="button"
+            className={`tn-feed-type${type === null ? " on" : ""}`}
+            onClick={() => setType(null)}
+          >
+            All
+          </button>
+          {TYPES.map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`tn-feed-type${type === t ? " on" : ""}`}
+              onClick={() => setType(type === t ? null : t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {projected.shown === 0 ? (
+        <p className="tn-feed-empty">
+          {status === "loading"
+            ? "Loading events…"
+            : status === "error"
+              ? "Event sources are unavailable right now."
+              : `No events above ${minTier} in ${scope.label} · last ${winLabel}.`}
+        </p>
+      ) : (
+        <ol className="tn-feed-list">
+          {projected.rows.map((e) => (
+            <li key={e.id}>
+              <button type="button" className="tn-feed-row" onClick={() => open(e.id)}>
+                <span className="tn-feed-sev" style={{ background: e.color }}>
+                  {e.severity.tier}
+                </span>
+                <span className="tn-feed-main">
+                  <span className="tn-feed-row-title">
+                    <span className="tn-feed-kind">{e.type}</span> {e.place.name}
+                  </span>
+                  <span className="tn-feed-meta">
+                    {e.occurredAt ? `${formatAge(now - Date.parse(e.occurredAt))} · ` : ""}
+                    {e.source.attribution}
+                    {e.magnitude ? ` · ${e.magnitude.value} ${e.magnitude.unit}` : ""}
+                    {" · "}
+                    <span className="tn-feed-prec">{e.geo.precision.toLowerCase()}</span>
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <footer className="tn-feed-foot">
+        {updatedAt != null ? `Updated ${formatAge(now - updatedAt)} ago` : "—"} ·{" "}
+        {EVENT_SOURCES.length} sources
+      </footer>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 2: Append the feed styles to `app/globals.css`**
+
+```css
+/* ── Event Feed (console hero) ─────────────────────────────────────────────── */
+.tn-feed {
+  position: fixed;
+  top: var(--tn-topbar-h);
+  right: 0;
+  bottom: var(--tn-ticker-h);
+  width: 360px;
+  max-width: 92vw;
+  z-index: 25;
+  display: flex;
+  flex-direction: column;
+  background: var(--tn-surface);
+  backdrop-filter: blur(12px);
+  border-left: 1px solid var(--tn-border);
+  box-shadow: var(--tn-shadow);
+  color: var(--tn-text);
+  font-family: var(--tn-sans);
+}
+.tn-feed-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 12px 14px 8px; border-bottom: 1px solid var(--tn-border);
+}
+.tn-feed-title { font-size: 14px; font-weight: 650; margin: 0; letter-spacing: 0.01em; }
+.tn-feed-count { font-size: 12px; color: var(--tn-text-muted); }
+.tn-feed-controls {
+  display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+  padding: 8px 12px; border-bottom: 1px solid var(--tn-border);
+}
+.tn-feed-controls select {
+  font: inherit; font-size: 12px; padding: 3px 6px;
+  background: var(--tn-surface-2); color: var(--tn-text);
+  border: 1px solid var(--tn-border); border-radius: 6px;
+}
+.tn-feed-types { display: flex; flex-wrap: wrap; gap: 4px; }
+.tn-feed-type {
+  font-size: 11px; padding: 2px 8px; border-radius: 999px; cursor: pointer;
+  background: var(--tn-chip-bg); color: var(--tn-text-muted);
+  border: 1px solid transparent; text-transform: capitalize;
+}
+.tn-feed-type.on { background: var(--tn-accent-soft); color: var(--tn-accent-strong); border-color: var(--tn-accent); }
+.tn-feed-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1; }
+.tn-feed-row {
+  display: flex; gap: 10px; width: 100%; text-align: left; cursor: pointer;
+  padding: 9px 12px; background: transparent; border: 0; border-bottom: 1px solid var(--tn-border);
+  color: inherit;
+}
+.tn-feed-row:hover { background: var(--tn-surface-2); }
+.tn-feed-sev {
+  flex: none; align-self: flex-start; font-family: var(--tn-mono);
+  font-size: 11px; font-weight: 700; color: #fff; padding: 1px 6px; border-radius: 5px;
+}
+.tn-feed-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.tn-feed-row-title { font-size: 13px; line-height: 1.3; }
+.tn-feed-kind { color: var(--tn-text-muted); text-transform: capitalize; font-weight: 600; }
+.tn-feed-meta { font-size: 11px; color: var(--tn-text-faint); }
+.tn-feed-prec { font-variant: small-caps; }
+.tn-feed-empty { padding: 18px 14px; font-size: 13px; color: var(--tn-text-muted); }
+.tn-feed-foot {
+  padding: 8px 12px; font-size: 11px; color: var(--tn-text-faint);
+  border-top: 1px solid var(--tn-border);
+}
+@media (max-width: 640px) {
+  .tn-feed { width: 100%; top: auto; height: 52vh; border-left: 0; border-top: 1px solid var(--tn-border); }
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. (The component is not yet mounted — Task 8 mounts it. This step only proves it compiles.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/shell/EventFeed.tsx app/globals.css
+git commit -m "feat(feed): Event Feed component + styles"
+```
+
+---
+
+## Task 6: The Scope control (top bar)
+
+**Files:**
+- Create: `components/shell/ScopeControl.tsx`
+- Modify: `app/globals.css` (append the scope styles below)
+
+**Interfaces:**
+- Consumes: `scopeStore`/`useScope`/`WORLD_SCOPE`/`DEFAULT_RADIUS_KM`/`radiusFromBbox`/`Scope` (Task 3); `mapViewStore` (`lib/mapView.ts`); `GeocodeResult` (`lib/geo/geocode.ts`).
+- Produces: `export default function ScopeControl()`.
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// components/shell/ScopeControl.tsx
+"use client";
+// The global Scope control. World / Near-me / Region — drives scopeStore (the feed
+// + map relevance) and flies the map to the chosen centre. Geolocation is requested
+// ONLY on an explicit "Near me" click (never on load); denial falls back to World
+// with a calm note. Region reuses the keyless /api/geocode used by PlaceSearch.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { scopeStore, useScope, WORLD_SCOPE, DEFAULT_RADIUS_KM, radiusFromBbox } from "@/lib/shell/scope";
+import { mapViewStore } from "@/lib/mapView";
+import type { GeocodeResult } from "@/lib/geo/geocode";
+
+export default function ScopeControl() {
+  const scope = useScope();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<GeocodeResult[]>([]);
+  const [note, setNote] = useState<string | null>(null);
+  const reqRef = useRef(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setNote(null);
+    setQuery("");
+    setResults([]);
+  }, []);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) close();
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [close]);
+
+  // Debounced region search.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      return;
+    }
+    const t = setTimeout(() => {
+      const myReq = ++reqRef.current;
+      fetch(`/api/geocode?q=${encodeURIComponent(q)}`)
+        .then((r) => r.json())
+        .then((d) => {
+          if (myReq !== reqRef.current) return;
+          setResults((d.results as GeocodeResult[]) ?? []);
+        })
+        .catch(() => {
+          if (myReq === reqRef.current) setResults([]);
+        });
+    }, 350);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const setWorld = () => {
+    scopeStore.set(WORLD_SCOPE);
+    close();
+  };
+
+  const setRegion = (r: GeocodeResult) => {
+    const radiusKm = r.bbox ? radiusFromBbox(r.bbox) : DEFAULT_RADIUS_KM;
+    scopeStore.set({ mode: "region", center: { lat: r.lat, lon: r.lon }, radiusKm, label: r.name });
+    mapViewStore.flyToPoint({ lat: r.lat, lon: r.lon, zoom: 8 });
+    close();
+  };
+
+  const setNearMe = () => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      setNote("Location isn't available in this browser.");
+      return;
+    }
+    setNote("Finding your location…");
+    const myReq = ++reqRef.current;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (myReq !== reqRef.current) return;
+        const { latitude, longitude } = pos.coords;
+        scopeStore.set({
+          mode: "near-me",
+          center: { lat: latitude, lon: longitude },
+          radiusKm: DEFAULT_RADIUS_KM,
+          label: "Near me",
+        });
+        mapViewStore.flyToPoint({ lat: latitude, lon: longitude, zoom: 8 });
+        close();
+      },
+      () => {
+        if (myReq !== reqRef.current) return;
+        setNote("Location denied — still showing World. Search a region instead.");
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
+    );
+  };
+
+  return (
+    <div className="tn-scope" ref={rootRef}>
+      <button
+        type="button"
+        className="tn-scope-btn"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        <span aria-hidden>◎</span> {scope.label}
+        <span className="tn-scope-caret" aria-hidden>▾</span>
+      </button>
+
+      {open && (
+        <div className="tn-scope-menu" role="menu">
+          <button type="button" className="tn-scope-item" role="menuitem" onClick={setNearMe}>
+            Near me
+          </button>
+          <button type="button" className="tn-scope-item" role="menuitem" onClick={setWorld}>
+            World
+          </button>
+          <div className="tn-scope-region">
+            <input
+              className="tn-scope-input"
+              type="search"
+              placeholder="Region — search a place…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Scope to a region"
+            />
+            {results.length > 0 && (
+              <div className="tn-scope-results" role="listbox">
+                {results.map((r) => (
+                  <button
+                    key={`${r.name}:${r.lat},${r.lon}`}
+                    type="button"
+                    role="option"
+                    aria-selected={false}
+                    className="tn-scope-result"
+                    onClick={() => setRegion(r)}
+                  >
+                    {r.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {note && <p className="tn-scope-note">{note}</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Append the scope styles to `app/globals.css`**
+
+```css
+/* ── Scope control (console top bar) ───────────────────────────────────────── */
+.tn-scope { position: relative; font-family: var(--tn-sans); }
+.tn-scope-btn {
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+  font-size: 13px; font-weight: 600; padding: 6px 12px; border-radius: 8px;
+  background: var(--tn-surface); color: var(--tn-text);
+  border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
+}
+.tn-scope-caret { color: var(--tn-text-faint); font-size: 10px; }
+.tn-scope-menu {
+  position: absolute; top: calc(100% + 6px); left: 0; width: 280px; z-index: 40;
+  display: flex; flex-direction: column; gap: 4px; padding: 8px;
+  background: var(--tn-surface-solid); border: 1px solid var(--tn-border);
+  border-radius: 10px; box-shadow: var(--tn-shadow);
+}
+.tn-scope-item {
+  text-align: left; cursor: pointer; font-size: 13px; padding: 7px 10px; border-radius: 7px;
+  background: transparent; color: var(--tn-text); border: 0;
+}
+.tn-scope-item:hover { background: var(--tn-surface-2); }
+.tn-scope-region { border-top: 1px solid var(--tn-border); padding-top: 6px; margin-top: 2px; }
+.tn-scope-input {
+  width: 100%; font: inherit; font-size: 13px; padding: 7px 10px;
+  background: var(--tn-surface-2); color: var(--tn-text);
+  border: 1px solid var(--tn-border); border-radius: 7px;
+}
+.tn-scope-results { display: flex; flex-direction: column; margin-top: 4px; max-height: 220px; overflow-y: auto; }
+.tn-scope-result {
+  text-align: left; cursor: pointer; font-size: 12px; padding: 6px 10px; border-radius: 6px;
+  background: transparent; color: var(--tn-text); border: 0;
+}
+.tn-scope-result:hover { background: var(--tn-surface-2); }
+.tn-scope-note { font-size: 11px; color: var(--tn-text-muted); margin: 6px 4px 2px; }
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/shell/ScopeControl.tsx app/globals.css
+git commit -m "feat(scope): top-bar Scope control (World/Near-me/Region)"
+```
+
+---
+
+## Task 7: View-mode store + flat-map default
+
+**Files:**
+- Create: `lib/shell/viewMode.ts`
+- Modify: `components/WorldMap.tsx`
+- Test: `tests/unit/viewMode.test.ts`
+
+**Interfaces:**
+- Consumes: `loadPersisted`/`savePersisted` (`lib/shell/persist.ts`).
+- Produces:
+  - `type ViewMode = "console"|"explore"`, `DEFAULT_VIEW_MODE`
+  - `coerceViewMode(saved:unknown):ViewMode`
+  - `viewModeStore` (`set`/`toggle`/`get`/`hydrate`/`subscribe`), `useViewMode():ViewMode`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/viewMode.test.ts
+import { describe, it, expect } from "vitest";
+import { coerceViewMode, DEFAULT_VIEW_MODE } from "@/lib/shell/viewMode";
+
+describe("coerceViewMode", () => {
+  it("defaults to console", () => {
+    expect(DEFAULT_VIEW_MODE).toBe("console");
+    expect(coerceViewMode(null)).toBe("console");
+    expect(coerceViewMode("nonsense")).toBe("console");
+  });
+  it("keeps a valid saved mode", () => {
+    expect(coerceViewMode("explore")).toBe("explore");
+    expect(coerceViewMode("console")).toBe("console");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/viewMode.test.ts`
+Expected: FAIL — cannot resolve `@/lib/shell/viewMode`.
+
+- [ ] **Step 3: Write `lib/shell/viewMode.ts`**
+
+```ts
+// lib/shell/viewMode.ts
+"use client";
+// Console (default, flat 2D map) vs Explore (the 3D globe + cinematic dive). One
+// persisted store the shell reads to choose chrome, and WorldMap reads to choose
+// its MapLibre projection. The redesign flips the default from globe-as-hero to
+// console-as-hero (spec §4, §11).
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export type ViewMode = "console" | "explore";
+export const DEFAULT_VIEW_MODE: ViewMode = "console";
+
+export function coerceViewMode(saved: unknown): ViewMode {
+  return saved === "explore" || saved === "console" ? saved : DEFAULT_VIEW_MODE;
+}
+
+const PERSIST_KEY = "tn.viewmode.v1";
+const PERSIST_VERSION = 1;
+
+let state: ViewMode = DEFAULT_VIEW_MODE;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+}
+
+export const viewModeStore = {
+  set(m: ViewMode) {
+    if (state === m) return;
+    state = m;
+    emit();
+  },
+  toggle() {
+    state = state === "console" ? "explore" : "console";
+    emit();
+  },
+  get(): ViewMode {
+    return state;
+  },
+  hydrate() {
+    state = coerceViewMode(loadPersisted<ViewMode>(PERSIST_KEY, PERSIST_VERSION));
+    emit();
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export function useViewMode(): ViewMode {
+  return useSyncExternalStore(viewModeStore.subscribe, viewModeStore.get, viewModeStore.get);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/viewMode.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the projection in `components/WorldMap.tsx`**
+
+WorldMap currently **forces** globe projection. Make projection follow `viewMode`: flat (`mercator`) in console, `globe` in Explore.
+
+5a. Add the import near the other `lib/` imports (the file already imports from `@/lib/mapView` — add this beneath it):
+
+```tsx
+import { viewModeStore } from "@/lib/shell/viewMode";
+```
+
+5b. Find the forced-globe projection (around `components/WorldMap.tsx:307-309`):
+
+```tsx
+      // Force globe projection (a freshly-set style may reset to mercator).
+      if (map.getProjection?.()?.type !== "globe") {
+        map.setProjection({ type: "globe" });
+```
+
+Replace that `setProjection` call so it honours the current view mode. Define a tiny helper and use it both here and on view-mode change:
+
+```tsx
+      // Projection follows the view mode: flat (console, default) vs globe (Explore).
+      const wantProjection = viewModeStore.get() === "explore" ? "globe" : "mercator";
+      if (map.getProjection?.()?.type !== wantProjection) {
+        map.setProjection({ type: wantProjection });
+```
+
+(Keep the surrounding `if`/closing braces; only the projection *value* changes from a hard-coded `"globe"` to `wantProjection`.)
+
+5c. Add an effect that re-applies projection when the view mode changes, modelled on the existing `registerFlyToPoint` effect (around `components/WorldMap.tsx:983`). Place it next to those `useEffect`s:
+
+```tsx
+  // Re-project live when the user toggles Console ⇄ Explore.
+  useEffect(() => {
+    return viewModeStore.subscribe(() => {
+      const map = mapRef.current;
+      if (!map) return;
+      const want = viewModeStore.get() === "explore" ? "globe" : "mercator";
+      if (map.getProjection?.()?.type !== want) map.setProjection({ type: want });
+    });
+  }, []);
+```
+
+> If the map handle in this file is not named `mapRef.current`, use whatever the surrounding effects use to reach the live `maplibregl.Map` (grep the file for `.setProjection(` and `registerFlyToPoint` to confirm the handle name). Do **not** introduce a new ref.
+
+- [ ] **Step 6: Manual verification (build, not dev — never concurrent)**
+
+```bash
+npm run build && npm run start
+```
+
+Visit `http://localhost:3000` → the map must render **flat** (mercator), not a globe. Then in the browser console:
+
+```js
+__map && __map.setProjection({ type: "globe" }); // sanity: the handle still projects
+```
+
+Stop the server (Ctrl-C) when done.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/shell/viewMode.ts components/WorldMap.tsx tests/unit/viewMode.test.ts
+git commit -m "feat(view): viewMode store + flat-map default (globe → Explore)"
+```
+
+---
+
+## Task 8: Console layout integration (capstone)
+
+**Files:**
+- Create: `components/shell/ConsoleTopBar.tsx`
+- Modify: `components/shell/ConsoleShell.tsx`, `app/globals.css` (append the topbar styles)
+
+**Interfaces:**
+- Consumes: `ScopeControl` (Task 6), `TimeWindowControl` (`components/shell/TimeWindowControl.tsx`), `viewModeStore`/`useViewMode` (Task 7), `EventFeed` (Task 5), `scopeStore` (Task 3).
+- Produces: `export default function ConsoleTopBar()`; an updated `ConsoleShell` that mounts the console chrome in `console` mode and the legacy globe chrome in `explore` mode.
+
+- [ ] **Step 1: Write `components/shell/ConsoleTopBar.tsx`**
+
+```tsx
+// components/shell/ConsoleTopBar.tsx
+"use client";
+// The console's floating control cluster, under the status bar (the established
+// "floating chrome over a full-bleed map" idiom — cf. PlaceSearch). Holds the
+// global Scope control, the shared time-window, and the Console⇄Explore toggle.
+
+import ScopeControl from "@/components/shell/ScopeControl";
+import TimeWindowControl from "@/components/shell/TimeWindowControl";
+import { viewModeStore } from "@/lib/shell/viewMode";
+
+export default function ConsoleTopBar() {
+  return (
+    <div className="tn-console-topbar">
+      <ScopeControl />
+      <TimeWindowControl />
+      <button
+        type="button"
+        className="tn-console-explore"
+        onClick={() => viewModeStore.set("explore")}
+        title="Switch to the 3D globe"
+      >
+        <span aria-hidden>🌐</span> Explore
+      </button>
+    </div>
+  );
+}
+```
+
+> Confirm `components/shell/TimeWindowControl.tsx` has a default export. If it is a **named** export, import it as `{ TimeWindowControl }` instead — grep the file's `export` line before writing this import.
+
+- [ ] **Step 2: Append the topbar styles to `app/globals.css`**
+
+```css
+/* ── Console top bar (floating cluster) ────────────────────────────────────── */
+.tn-console-topbar {
+  position: fixed; top: calc(var(--tn-topbar-h) + 8px); left: 12px; z-index: 26;
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+}
+.tn-console-explore {
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+  font-size: 13px; font-weight: 600; padding: 6px 12px; border-radius: 8px;
+  background: var(--tn-surface); color: var(--tn-text);
+  border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
+}
+.tn-console-explore:hover { border-color: var(--tn-border-strong); }
+/* A small "← Console" affordance lives in the existing globe chrome (Explore). */
+.tn-explore-return {
+  position: fixed; top: calc(var(--tn-topbar-h) + 8px); left: 12px; z-index: 26;
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+  font-size: 13px; font-weight: 600; padding: 6px 12px; border-radius: 8px;
+  background: var(--tn-surface); color: var(--tn-text);
+  border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
+}
+```
+
+- [ ] **Step 3: Rewire `components/shell/ConsoleShell.tsx`**
+
+Replace the imports + the hydration effect + the returned JSX so the new stores hydrate and the chrome splits by `viewMode`. Concretely:
+
+3a. Add these imports beside the existing shell imports (after the `IntelColumn` import line):
+
+```tsx
+import { scopeStore } from "@/lib/shell/scope";
+import { viewModeStore, useViewMode } from "@/lib/shell/viewMode";
+import EventFeed from "@/components/shell/EventFeed";
+import ConsoleTopBar from "@/components/shell/ConsoleTopBar";
+```
+
+3b. In the hydration `useEffect`, add the two new stores (alongside `watchlistStore.hydrate()` etc.):
+
+```tsx
+    scopeStore.hydrate();
+    viewModeStore.hydrate();
+```
+
+3c. Read the mode in the component body (next to `const ws = useWorkspace();`):
+
+```tsx
+  const view = useViewMode();
+  const isConsole = view === "console";
+```
+
+3d. Replace the returned JSX block (currently `components/shell/ConsoleShell.tsx:59-76`) with the mode-split layout. Keep StatusBar / BreakingBanner / PanelHost / CommandPalette / FeedOverlay / CinematicDive mounted in BOTH modes; the globe-era panels (CoveragePanel, MarketsPanel, WatchlistPanel, DockableWorkspace, IntelColumn, PlaceSearch) render only in Explore; the console chrome (ConsoleTopBar, EventFeed) only in Console:
+
+```tsx
+  return (
+    <div className="tn-shell">
+      {children}
+      <StatusBar onOpenPalette={() => setPaletteOpen(true)} />
+      <BreakingBanner />
+      <PanelHost />
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+
+      {isConsole ? (
+        <>
+          <ConsoleTopBar />
+          <EventFeed />
+        </>
+      ) : (
+        <>
+          <button
+            type="button"
+            className="tn-explore-return"
+            onClick={() => viewModeStore.set("console")}
+            title="Back to the console"
+          >
+            <span aria-hidden>←</span> Console
+          </button>
+          <PlaceSearch />
+          {!ws.open && <CoveragePanel />}
+          {!ws.open && <MarketsPanel />}
+          {!ws.open && <WatchlistPanel />}
+          <DockableWorkspace />
+          <IntelColumn />
+        </>
+      )}
+
+      <FeedOverlay />
+      <CinematicDive />
+    </div>
+  );
+```
+
+> Note: `PlaceSearch` moves from always-on into the Explore branch (in Console, the Scope control owns place search). Leave every existing import in place — they are all still referenced across the two branches.
+
+- [ ] **Step 4: Full test suite**
+
+Run: `npm run test`
+Expected: all unit tests PASS (the 5 new files + the pre-existing suite — `widgets-mappers.test.ts` still green; nothing was removed).
+
+- [ ] **Step 5: Build + manual smoke (build, never concurrent with dev)**
+
+```bash
+npm run build && npm run start
+```
+
+Verify at `http://localhost:3000`:
+1. **Console is the default** — flat map, a right-hand **Events** feed, a top-left cluster (Scope ▾ · time window · Explore 🌐). No globe, no dock, no IntelColumn.
+2. **Feed populates** — within ~10s rows appear (earthquakes at least), each: `Sx` chip · type · place · age · source · precision. Click a row → map flies + the dossier opens.
+3. **Scope works** — open Scope ▾ → type a city → pick it → the feed trims to that region and the header shows `N / M`; the empty state (raise "min severity" to S4) reads e.g. *"No events above S4 in <city> · last All."* "Near me" prompts for location once; denial shows the calm note and stays World.
+4. **Time window works** — switching 1h/6h/24h trims the feed.
+5. **Explore toggle** — click Explore 🌐 → the globe returns with the old chrome + a "← Console" button that returns. Reload → it reopens in Console (persisted default).
+
+Stop the server when done.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/shell/ConsoleTopBar.tsx components/shell/ConsoleShell.tsx app/globals.css
+git commit -m "feat(console): mount Event Feed + Scope top bar; demote globe to Explore"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§-by-§):**
+- §3 Event model → Tasks 1–2 (`NormalizedEvent` + adapter). *Interim vs spec:* the full `provenance`/`exposure`/`baseline`/`footprint` fields are explicitly P3/P4; P1 ships `source` + a labelled magnitude ramp. ✔ (boundary stated)
+- §4 Console layout → Task 8 (top bar + right feed; floating-chrome variant of the wireframe, not CSS grid — noted). ✔
+- §5 Event Feed → Task 5 (ranked, scoped, sourced rows; sort severity/recent/nearest; filter type + severity floor; click→fly+dossier; honest empty state). *Dedup disclosure ("▸ 3 reports") is P3.* ✔ (boundary stated)
+- §6 Scope & time → Tasks 3 + 6 (World/Near-me/Region wired to feed + map; time-window reused). *Draw-AOI UI is P4* (bbox modelled). ✔ (boundary stated)
+- §11 Explore demotion → Task 7 (flat default) + Task 8 (toggle). ✔
+- §15 Q1/Q4 → resolved in "Scope of Phase 1". ✔
+
+**Placeholder scan:** no "TBD"/"handle edge cases"/uncoded steps — every code step carries complete code. The two "confirm the export/handle name" notes (Tasks 7, 8) are guardrails against a wrong-symbol guess, not deferred work; the code to write is fully shown.
+
+**Type consistency:** `NormalizedEvent`, `EventSource`, `Scope`, `FeedFilters`, `FeedInput`, `ProjectedFeed`, `ViewMode` names + signatures match across producing/consuming tasks. `severityTier`/`severityRank`/`placeName`/`withinScope`/`withinWindow`/`projectEventFeed`/`coerceSavedScope`/`coerceViewMode`/`radiusFromBbox` are each defined once and referenced with the same arity. `useEventFeeds` (Task 4) is the name imported in Task 5. Row click reuses `openSignalFeature(feature, label, zoom)` — the existing 3-arg signature.
+
+**Out-of-scope guardrails honored:** no React Testing Library added (shells verified by build); no `git add -A`; commits carry no Claude trailer; `next build` only run after stopping any dev server.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-28-ground-truth-console-phase1.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-28-widget-console-redesign.md
+++ b/docs/superpowers/plans/2026-06-28-widget-console-redesign.md
@@ -335,7 +335,7 @@ git commit -m "feat(console): pure layout reducers (add/move/resize/stage, 50-ca
 
 **Interfaces:**
 - Consumes: reducers from Task 2; `createDefaultLayout`, `ShellLayout` from Task 1; `loadPersisted`/`savePersisted` from `@/lib/shell/persist`.
-- Produces: `shellLayoutStore` with `{ get(): ShellLayout; set(l): void; subscribe(fn): ()=>void; hydrate(): void; replace(l): void; add(type, opts?): {ok:boolean; id?:string}; remove(id); move(id, seg, idx); resizeWidget(id, h); setSegment(seg, size); collapseSegment(seg, c); stage(s): void; configure(id, patch); nextSeq(): number }`; hook `useShellLayout(): ShellLayout`.
+- Produces: `shellLayoutStore` with `{ get(): ShellLayout; set(l): void; subscribe(fn): ()=>void; hydrate(): void; replace(l): void; add(type, opts?): {ok:boolean; id?:string}; remove(id); move(id, seg, idx); resizeWidget(id, h); setSegment(seg, size); collapseSegment(seg, c); stage(s): void; configure(id, patch) }`; hook `useShellLayout(): ShellLayout` (ids minted internally).
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/superpowers/plans/2026-06-28-widget-console-redesign.md
+++ b/docs/superpowers/plans/2026-06-28-widget-console-redesign.md
@@ -1,0 +1,1890 @@
+# Widget Console Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the TrafficNerd UI as a composable monitoring console — a fixed centre stage (3D/2D map · world clock) surrounded by three resizable, collapsible, scrollable segments holding multi-instance category-card widgets, added via ⌘K, swapped wholesale by presets.
+
+**Architecture:** A new `lib/console/` owns pure logic (layout types + reducers + a `useSyncExternalStore` store + widget registry + alert model + presets + URL codec). A new `components/console/` owns the shell (segments, stage host, widget frame) and the four widgets. Pure logic is TDD'd in vitest (node). UI is gated by Playwright e2e + a real `next dev` run. Existing pieces are reused, not rewritten: `usePlanes`, `useEventFeeds`/`projectEventFeed`, `loadedCamerasStore`/`CameraVideo`, `WorldMap` (its projection already follows `viewModeStore`), the ⌘K palette, `CinematicDive`/`FeedOverlay`.
+
+**Tech Stack:** Next 15.5 (App Router), React 19, TypeScript 5.7, MapLibre GL 5, hls.js, vitest 2.1 (node), Playwright. **Zero new runtime dependencies** — widget drag uses native HTML5 DnD, segment/widget resize uses pointer events.
+
+**Spec:** `docs/superpowers/specs/2026-06-28-widget-console-redesign-design.md`
+
+## Global Constraints
+
+- React 19.0.0 / Next 15.5.19 — no version changes.
+- **Zero new runtime dependencies.** Reuse hls.js, maplibre-gl; native DnD + pointer-event resize.
+- **Hard cap: 50 widget instances total** across all segments (`MAX_WIDGETS = 50`).
+- Stores follow the existing pattern: framework-light `useSyncExternalStore` singletons with `get/subscribe/emit`, persisted via `@/lib/shell/persist` (`loadPersisted`/`savePersisted`, both window-guarded — no-op in node).
+- Persistence keys: `tn.console.v1` (layout), `tn.console.presets.v1` (custom presets). Bump version ints on shape changes.
+- CSS classes are namespaced `tn-…`; calm light theme (CSS vars already in `app/globals.css`).
+- Video widgets **muted by default**; click to unmute.
+- Widget config is **per-instance** (filter/sort, channel, alert style live in `WidgetInstance.config`).
+- Presets **replace** the whole arrangement.
+- Every task ends green: `npx tsc --noEmit` clean, `npm test` green, and (for UI tasks) `npm run e2e` for the new spec green.
+- Pure logic lives in `.ts` files with **no React imports** so vitest (node env) can test it.
+
+---
+
+## File Structure
+
+**New — pure logic (`lib/console/`)**
+- `types.ts` — `SegmentId`, `StageId`, `WidgetTypeId`, `WidgetInstance`, `ShellLayout`, `MAX_WIDGETS`, `createDefaultLayout()`.
+- `reducers.ts` — pure layout transforms (add/remove/move/reorder/resize/collapse/segment ops/stage/config).
+- `store.ts` — `shellLayoutStore` (persist `tn.console.v1`) + `useShellLayout()`.
+- `registry.ts` — `WidgetType`, `registerWidget`, `getWidgetType`, `listWidgetTypes`, `widgetsByCategory`.
+- `alerts.ts` — `Alert`, `AlertRule`, `runAlertRule`.
+- `presets.ts` — `ConsolePreset`, built-ins, `applyPreset`, custom-preset store.
+- `share.ts` — `encodeLayout`/`decodeLayout` (URL param `c=`).
+- `news/providers.ts` — provider catalogue + `parseCustomStream` + `resolvePlayable`.
+- `widgets/aviation.tsx`, `widgets/events.tsx`, `widgets/cameras.tsx`, `widgets/news.tsx` — descriptor + alert rules (pure, in sibling `*.rules.ts`) + body component + self-registration.
+
+**New — components (`components/console/`)**
+- `WidgetFrame.tsx` — shared card chrome.
+- `Segment.tsx` — one droppable scrollable segment.
+- `ConsoleWorkspace.tsx` — the three segments + centre column + grips/resize/collapse.
+- `StageHost.tsx` — renders map (3D/2D) or clock per `stage`.
+- `WorldClock.tsx` — clock stage widget.
+- `StageSwitch.tsx` — the 3D/2D/🕐 top-bar control.
+
+**Modified**
+- `components/shell/CommandPalette.tsx` — add widget-catalog + stage + preset commands.
+- `components/shell/ConsoleShell.tsx` — render `<ConsoleWorkspace/>` as the body; keep hydration, ⌘K, overlays; drop the console/explore split.
+- `app/page.tsx` — mount the new shell (map import moves into `StageHost`).
+- `lib/console/widgets/index.ts` — import all four widgets so they self-register.
+
+**Tests**
+- `tests/unit/console-reducers.test.ts`, `console-store.test.ts`, `console-registry.test.ts`, `console-alerts.test.ts`, `console-aviation.test.ts`, `console-events.test.ts`, `console-cameras.test.ts`, `console-news-providers.test.ts`, `console-presets.test.ts`, `console-share.test.ts`.
+- `tests/e2e/console.spec.ts` — shell resize/collapse/scroll, add/move/remove widget, stage swap, preset apply.
+
+---
+
+## Phase A — Core model & store (pure logic)
+
+### Task 1: Layout types + defaults
+
+**Files:**
+- Create: `lib/console/types.ts`
+- Test: `tests/unit/console-reducers.test.ts` (shared file, starts here)
+
+**Interfaces:**
+- Produces: `SegmentId = "left"|"right"|"bottom"`; `StageId = "map3d"|"map2d"|"clock"`; `WidgetTypeId = string`; `WidgetInstance { id:string; type:WidgetTypeId; segment:SegmentId; order:number; height:number; collapsed:boolean; config:Record<string,unknown> }`; `ShellLayout { segments:Record<SegmentId,{size:number;collapsed:boolean}>; stage:StageId; widgets:WidgetInstance[] }`; `MAX_WIDGETS = 50`; `createDefaultLayout(): ShellLayout`; `newInstanceId(seq:number): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/console-reducers.test.ts
+import { expect, test } from "vitest";
+import { createDefaultLayout, MAX_WIDGETS } from "@/lib/console/types";
+
+test("default layout has three segments, a 2D stage, and no widgets", () => {
+  const l = createDefaultLayout();
+  expect(Object.keys(l.segments).sort()).toEqual(["bottom", "left", "right"]);
+  expect(l.segments.left).toEqual({ size: 320, collapsed: false });
+  expect(l.segments.bottom).toEqual({ size: 240, collapsed: false });
+  expect(l.stage).toBe("map2d");
+  expect(l.widgets).toEqual([]);
+  expect(MAX_WIDGETS).toBe(50);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- console-reducers`
+Expected: FAIL — cannot find module `@/lib/console/types`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// lib/console/types.ts
+export type SegmentId = "left" | "right" | "bottom";
+export type StageId = "map3d" | "map2d" | "clock";
+export type WidgetTypeId = string;
+
+export interface WidgetInstance {
+  id: string;
+  type: WidgetTypeId;
+  segment: SegmentId;
+  order: number;
+  height: number;       // px; user-resizable
+  collapsed: boolean;   // header-only
+  config: Record<string, unknown>;
+}
+
+export interface SegmentState { size: number; collapsed: boolean }
+
+export interface ShellLayout {
+  segments: Record<SegmentId, SegmentState>;
+  stage: StageId;
+  widgets: WidgetInstance[];
+}
+
+export const MAX_WIDGETS = 50;
+
+export function createDefaultLayout(): ShellLayout {
+  return {
+    segments: {
+      left: { size: 320, collapsed: false },
+      right: { size: 320, collapsed: false },
+      bottom: { size: 240, collapsed: false },
+    },
+    stage: "map2d",
+    widgets: [],
+  };
+}
+
+/** Deterministic id (no Math.random — keeps reducers pure/testable). */
+export function newInstanceId(seq: number): string {
+  return `w${seq.toString(36)}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- console-reducers`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/console/types.ts tests/unit/console-reducers.test.ts
+git commit -m "feat(console): shell layout types + default layout"
+```
+
+---
+
+### Task 2: Pure layout reducers
+
+**Files:**
+- Create: `lib/console/reducers.ts`
+- Test: `tests/unit/console-reducers.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `ShellLayout`, `WidgetInstance`, `SegmentId`, `StageId`, `MAX_WIDGETS`, `newInstanceId` from `types.ts`.
+- Produces (all `(layout, …) => ShellLayout`, pure, never mutate input):
+  - `addWidget(l, type, instanceId, opts?:{segment?:SegmentId; config?:Record<string,unknown>; height?:number}): ShellLayout` — appends to the chosen segment (default = segment with fewest widgets, tie → "left"); **no-op (returns same `l`) when `l.widgets.length >= MAX_WIDGETS`**.
+  - `removeWidget(l, id): ShellLayout`
+  - `moveWidget(l, id, toSegment, toIndex): ShellLayout` — reindexes `order` densely in both segments.
+  - `setWidgetHeight(l, id, height): ShellLayout` — clamps `height` to `[120, 1200]`.
+  - `setWidgetCollapsed(l, id, collapsed): ShellLayout`
+  - `setWidgetConfig(l, id, patch): ShellLayout` — shallow-merges into `config`.
+  - `setSegmentSize(l, seg, size): ShellLayout` — clamps `[0, 900]`.
+  - `setSegmentCollapsed(l, seg, collapsed): ShellLayout`
+  - `setStage(l, stage): ShellLayout`
+  - `widgetsInSegment(l, seg): WidgetInstance[]` — sorted by `order`.
+  - `isAtCapacity(l): boolean`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// append to tests/unit/console-reducers.test.ts
+import {
+  addWidget, removeWidget, moveWidget, setWidgetHeight, setSegmentSize,
+  setStage, widgetsInSegment, isAtCapacity,
+} from "@/lib/console/reducers";
+import { newInstanceId } from "@/lib/console/types";
+
+test("addWidget appends to the emptiest segment and assigns dense order", () => {
+  let l = createDefaultLayout();
+  l = addWidget(l, "aviation", "a");
+  l = addWidget(l, "events", "b", { segment: "left" });
+  expect(widgetsInSegment(l, "left").map((w) => w.id)).toEqual(["a", "b"]);
+  expect(widgetsInSegment(l, "left").map((w) => w.order)).toEqual([0, 1]);
+});
+
+test("addWidget is a no-op at capacity", () => {
+  let l = createDefaultLayout();
+  for (let i = 0; i < 50; i++) l = addWidget(l, "aviation", newInstanceId(i));
+  expect(l.widgets.length).toBe(50);
+  expect(isAtCapacity(l)).toBe(true);
+  const same = addWidget(l, "aviation", "overflow");
+  expect(same).toBe(l); // identity — caller can detect rejection
+});
+
+test("moveWidget re-segments and densely reindexes order", () => {
+  let l = createDefaultLayout();
+  l = addWidget(l, "aviation", "a", { segment: "left" });
+  l = addWidget(l, "events", "b", { segment: "left" });
+  l = moveWidget(l, "a", "right", 0);
+  expect(widgetsInSegment(l, "left").map((w) => w.id)).toEqual(["b"]);
+  expect(widgetsInSegment(l, "right").map((w) => w.id)).toEqual(["a"]);
+  expect(widgetsInSegment(l, "left")[0].order).toBe(0);
+});
+
+test("setWidgetHeight clamps; setSegmentSize clamps; setStage swaps", () => {
+  let l = addWidget(createDefaultLayout(), "aviation", "a");
+  l = setWidgetHeight(l, "a", 5);
+  expect(l.widgets[0].height).toBe(120);
+  l = setSegmentSize(l, "left", -10);
+  expect(l.segments.left.size).toBe(0);
+  l = setStage(l, "clock");
+  expect(l.stage).toBe("clock");
+});
+
+test("removeWidget drops the instance and leaves others intact", () => {
+  let l = addWidget(addWidget(createDefaultLayout(), "aviation", "a"), "events", "b");
+  l = removeWidget(l, "a");
+  expect(l.widgets.map((w) => w.id)).toEqual(["b"]);
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-reducers`
+Expected: FAIL — cannot find module `@/lib/console/reducers`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/console/reducers.ts
+import type { ShellLayout, WidgetInstance, SegmentId, StageId } from "@/lib/console/types";
+import { MAX_WIDGETS } from "@/lib/console/types";
+
+const SEGMENTS: SegmentId[] = ["left", "right", "bottom"];
+const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
+
+export function widgetsInSegment(l: ShellLayout, seg: SegmentId): WidgetInstance[] {
+  return l.widgets.filter((w) => w.segment === seg).sort((a, b) => a.order - b.order);
+}
+export function isAtCapacity(l: ShellLayout): boolean {
+  return l.widgets.length >= MAX_WIDGETS;
+}
+
+function emptiestSegment(l: ShellLayout): SegmentId {
+  let best: SegmentId = "left";
+  let min = Infinity;
+  for (const s of SEGMENTS) {
+    const n = l.widgets.filter((w) => w.segment === s).length;
+    if (n < min) { min = n; best = s; }
+  }
+  return best;
+}
+
+export function addWidget(
+  l: ShellLayout, type: string, instanceId: string,
+  opts: { segment?: SegmentId; config?: Record<string, unknown>; height?: number } = {},
+): ShellLayout {
+  if (isAtCapacity(l)) return l;
+  const segment = opts.segment ?? emptiestSegment(l);
+  const order = l.widgets.filter((w) => w.segment === segment).length;
+  const inst: WidgetInstance = {
+    id: instanceId, type, segment, order,
+    height: opts.height ?? 260, collapsed: false, config: opts.config ?? {},
+  };
+  return { ...l, widgets: [...l.widgets, inst] };
+}
+
+export function removeWidget(l: ShellLayout, id: string): ShellLayout {
+  return { ...l, widgets: l.widgets.filter((w) => w.id !== id) };
+}
+
+export function moveWidget(l: ShellLayout, id: string, toSegment: SegmentId, toIndex: number): ShellLayout {
+  const moving = l.widgets.find((w) => w.id === id);
+  if (!moving) return l;
+  const from = widgetsInSegment(l, moving.segment).filter((w) => w.id !== id);
+  const to = toSegment === moving.segment ? from : widgetsInSegment(l, toSegment);
+  const idx = clamp(toIndex, 0, to.length);
+  const nextTo = [...to.slice(0, idx), { ...moving, segment: toSegment }, ...to.slice(idx)];
+  const reindex = (arr: WidgetInstance[], seg: SegmentId) => arr.map((w, i) => ({ ...w, segment: seg, order: i }));
+  const untouched = l.widgets.filter((w) => w.segment !== moving.segment && w.segment !== toSegment);
+  const rebuilt = toSegment === moving.segment
+    ? reindex(nextTo, toSegment)
+    : [...reindex(from, moving.segment), ...reindex(nextTo, toSegment)];
+  return { ...l, widgets: [...untouched, ...rebuilt] };
+}
+
+export function setWidgetHeight(l: ShellLayout, id: string, height: number): ShellLayout {
+  return { ...l, widgets: l.widgets.map((w) => w.id === id ? { ...w, height: clamp(height, 120, 1200) } : w) };
+}
+export function setWidgetCollapsed(l: ShellLayout, id: string, collapsed: boolean): ShellLayout {
+  return { ...l, widgets: l.widgets.map((w) => w.id === id ? { ...w, collapsed } : w) };
+}
+export function setWidgetConfig(l: ShellLayout, id: string, patch: Record<string, unknown>): ShellLayout {
+  return { ...l, widgets: l.widgets.map((w) => w.id === id ? { ...w, config: { ...w.config, ...patch } } : w) };
+}
+export function setSegmentSize(l: ShellLayout, seg: SegmentId, size: number): ShellLayout {
+  return { ...l, segments: { ...l.segments, [seg]: { ...l.segments[seg], size: clamp(size, 0, 900) } } };
+}
+export function setSegmentCollapsed(l: ShellLayout, seg: SegmentId, collapsed: boolean): ShellLayout {
+  return { ...l, segments: { ...l.segments, [seg]: { ...l.segments[seg], collapsed } } };
+}
+export function setStage(l: ShellLayout, stage: StageId): ShellLayout {
+  return { ...l, stage };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-reducers`
+Expected: PASS (all reducer tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/console/reducers.ts tests/unit/console-reducers.test.ts
+git commit -m "feat(console): pure layout reducers (add/move/resize/stage, 50-cap)"
+```
+
+---
+
+### Task 3: shellLayoutStore
+
+**Files:**
+- Create: `lib/console/store.ts`
+- Test: `tests/unit/console-store.test.ts`
+
+**Interfaces:**
+- Consumes: reducers from Task 2; `createDefaultLayout`, `ShellLayout` from Task 1; `loadPersisted`/`savePersisted` from `@/lib/shell/persist`.
+- Produces: `shellLayoutStore` with `{ get(): ShellLayout; set(l): void; subscribe(fn): ()=>void; hydrate(): void; replace(l): void; add(type, opts?): {ok:boolean; id?:string}; remove(id); move(id, seg, idx); resizeWidget(id, h); setSegment(seg, size); collapseSegment(seg, c); stage(s): void; configure(id, patch); nextSeq(): number }`; hook `useShellLayout(): ShellLayout`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/console-store.test.ts
+import { afterEach, expect, test } from "vitest";
+import { shellLayoutStore } from "@/lib/console/store";
+import { createDefaultLayout } from "@/lib/console/types";
+
+afterEach(() => shellLayoutStore.replace(createDefaultLayout()));
+
+test("add returns the new id and lands the widget", () => {
+  const r = shellLayoutStore.add("aviation", { segment: "left" });
+  expect(r.ok).toBe(true);
+  expect(shellLayoutStore.get().widgets.find((w) => w.id === r.id)?.type).toBe("aviation");
+});
+
+test("add past 50 is rejected with ok:false", () => {
+  for (let i = 0; i < 50; i++) shellLayoutStore.add("aviation");
+  const r = shellLayoutStore.add("aviation");
+  expect(r.ok).toBe(false);
+  expect(shellLayoutStore.get().widgets.length).toBe(50);
+});
+
+test("subscribers fire on mutation", () => {
+  let n = 0;
+  const unsub = shellLayoutStore.subscribe(() => n++);
+  shellLayoutStore.add("events");
+  shellLayoutStore.stage("clock");
+  unsub();
+  shellLayoutStore.add("events"); // not counted
+  expect(n).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-store`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/console/store.ts
+"use client";
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { createDefaultLayout, type ShellLayout, type SegmentId, type StageId } from "@/lib/console/types";
+import * as R from "@/lib/console/reducers";
+
+const KEY = "tn.console.v1";
+const VERSION = 1;
+
+let state: ShellLayout = createDefaultLayout();
+let seq = 0;
+const listeners = new Set<() => void>();
+function emit() { for (const l of listeners) l(); savePersisted(KEY, VERSION, state); }
+function nextId(): string { seq += 1; return `w${Date.now().toString(36)}${seq.toString(36)}`; }
+
+export const shellLayoutStore = {
+  get(): ShellLayout { return state; },
+  set(l: ShellLayout) { state = l; emit(); },
+  replace(l: ShellLayout) { state = l; emit(); },
+  subscribe(fn: () => void) { listeners.add(fn); return () => { listeners.delete(fn); }; },
+  hydrate() { const s = loadPersisted<ShellLayout>(KEY, VERSION); if (s) state = s; emit(); },
+  add(type: string, opts: { segment?: SegmentId; config?: Record<string, unknown>; height?: number } = {}) {
+    if (R.isAtCapacity(state)) return { ok: false as const };
+    const id = nextId();
+    state = R.addWidget(state, type, id, opts); emit();
+    return { ok: true as const, id };
+  },
+  remove(id: string) { state = R.removeWidget(state, id); emit(); },
+  move(id: string, seg: SegmentId, idx: number) { state = R.moveWidget(state, id, seg, idx); emit(); },
+  resizeWidget(id: string, h: number) { state = R.setWidgetHeight(state, id, h); emit(); },
+  collapseWidget(id: string, c: boolean) { state = R.setWidgetCollapsed(state, id, c); emit(); },
+  configure(id: string, patch: Record<string, unknown>) { state = R.setWidgetConfig(state, id, patch); emit(); },
+  setSegment(seg: SegmentId, size: number) { state = R.setSegmentSize(state, seg, size); emit(); },
+  collapseSegment(seg: SegmentId, c: boolean) { state = R.setSegmentCollapsed(state, seg, c); emit(); },
+  stage(s: StageId) { state = R.setStage(state, s); emit(); },
+};
+
+export function useShellLayout(): ShellLayout {
+  return useSyncExternalStore(shellLayoutStore.subscribe, shellLayoutStore.get, shellLayoutStore.get);
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-store`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/console/store.ts tests/unit/console-store.test.ts
+git commit -m "feat(console): shellLayoutStore (persist + capacity-aware add)"
+```
+
+---
+
+## Phase B — Widget framework
+
+### Task 4: Widget type registry
+
+**Files:**
+- Create: `lib/console/registry.ts`
+- Test: `tests/unit/console-registry.test.ts`
+
+**Interfaces:**
+- Consumes: `Alert`, `AlertRule` (forward ref to Task 5 — `registry.ts` imports the types only).
+- Produces: `WidgetType { id; title; icon:string; category:string; defaultHeight:number; defaultConfig:Record<string,unknown>; component: ComponentType<WidgetBodyProps>; capabilities?:{filter?:boolean;sort?:boolean} }`; `WidgetBodyProps { instanceId:string; config:Record<string,unknown> }`; `registerWidget(t)`, `getWidgetType(id)`, `listWidgetTypes()`, `widgetsByCategory(): {category:string; types:WidgetType[]}[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/console-registry.test.ts
+import { expect, test, beforeEach } from "vitest";
+import { registerWidget, getWidgetType, listWidgetTypes, widgetsByCategory, __resetRegistry } from "@/lib/console/registry";
+
+const stub = (id: string, category: string) =>
+  ({ id, title: id, icon: "■", category, defaultHeight: 200, defaultConfig: {}, component: (() => null) as never });
+
+beforeEach(() => __resetRegistry());
+
+test("register + get + list", () => {
+  registerWidget(stub("aviation", "Aviation"));
+  expect(getWidgetType("aviation")?.title).toBe("aviation");
+  expect(listWidgetTypes().map((t) => t.id)).toEqual(["aviation"]);
+});
+
+test("widgetsByCategory groups and preserves insertion order", () => {
+  registerWidget(stub("aviation", "Aviation"));
+  registerWidget(stub("news", "News"));
+  registerWidget(stub("emerg", "Aviation"));
+  const groups = widgetsByCategory();
+  expect(groups.map((g) => g.category)).toEqual(["Aviation", "News"]);
+  expect(groups[0].types.map((t) => t.id)).toEqual(["aviation", "emerg"]);
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-registry`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/console/registry.ts
+import type { ComponentType } from "react";
+
+export interface WidgetBodyProps { instanceId: string; config: Record<string, unknown> }
+
+export interface WidgetType {
+  id: string;
+  title: string;
+  icon: string;
+  category: string;
+  defaultHeight: number;
+  defaultConfig: Record<string, unknown>;
+  component: ComponentType<WidgetBodyProps>;
+  capabilities?: { filter?: boolean; sort?: boolean };
+}
+
+const reg = new Map<string, WidgetType>();
+
+export function registerWidget(t: WidgetType): void { reg.set(t.id, t); }
+export function getWidgetType(id: string): WidgetType | undefined { return reg.get(id); }
+export function listWidgetTypes(): WidgetType[] { return [...reg.values()]; }
+export function widgetsByCategory(): { category: string; types: WidgetType[] }[] {
+  const order: string[] = [];
+  const byCat = new Map<string, WidgetType[]>();
+  for (const t of reg.values()) {
+    if (!byCat.has(t.category)) { byCat.set(t.category, []); order.push(t.category); }
+    byCat.get(t.category)!.push(t);
+  }
+  return order.map((category) => ({ category, types: byCat.get(category)! }));
+}
+/** Test-only: clear the singleton registry between tests. */
+export function __resetRegistry(): void { reg.clear(); }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-registry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/console/registry.ts tests/unit/console-registry.test.ts
+git commit -m "feat(console): widget type registry + category grouping"
+```
+
+---
+
+### Task 5: Alert model
+
+**Files:**
+- Create: `lib/console/alerts.ts`
+- Test: `tests/unit/console-alerts.test.ts`
+
+**Interfaces:**
+- Produces: `AlertSeverity = "info"|"warn"|"critical"`; `Alert { id:string; severity:AlertSeverity; text:string; ts?:number; ref?:string }`; `AlertRule<T> = (items:T[], config:Record<string,unknown>) => Alert[]`; `runAlertRule<T>(rule, items, config): Alert[]` (returns `[]` if rule throws — a widget's data hiccup must never crash the frame); `alertCount(alerts): number`; `topSeverity(alerts): AlertSeverity|null`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/console-alerts.test.ts
+import { expect, test } from "vitest";
+import { runAlertRule, topSeverity, type Alert } from "@/lib/console/alerts";
+
+test("runAlertRule passes through results", () => {
+  const rule = (xs: number[]): Alert[] => xs.filter((n) => n > 5).map((n) => ({ id: `a${n}`, severity: "warn", text: `${n}` }));
+  expect(runAlertRule(rule, [1, 9], {}).map((a) => a.id)).toEqual(["a9"]);
+});
+
+test("runAlertRule swallows rule errors", () => {
+  const boom = () => { throw new Error("bad data"); };
+  expect(runAlertRule(boom, [], {})).toEqual([]);
+});
+
+test("topSeverity ranks critical > warn > info", () => {
+  expect(topSeverity([{ id: "1", severity: "info", text: "" }, { id: "2", severity: "critical", text: "" }])).toBe("critical");
+  expect(topSeverity([])).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-alerts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/console/alerts.ts
+export type AlertSeverity = "info" | "warn" | "critical";
+export interface Alert { id: string; severity: AlertSeverity; text: string; ts?: number; ref?: string }
+export type AlertRule<T> = (items: T[], config: Record<string, unknown>) => Alert[];
+
+const RANK: Record<AlertSeverity, number> = { info: 0, warn: 1, critical: 2 };
+
+export function runAlertRule<T>(rule: AlertRule<T>, items: T[], config: Record<string, unknown>): Alert[] {
+  try { return rule(items, config); } catch { return []; }
+}
+export function alertCount(alerts: Alert[]): number { return alerts.length; }
+export function topSeverity(alerts: Alert[]): AlertSeverity | null {
+  if (alerts.length === 0) return null;
+  return alerts.reduce((top, a) => (RANK[a.severity] > RANK[top] ? a.severity : top), "info" as AlertSeverity);
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-alerts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/console/alerts.ts tests/unit/console-alerts.test.ts
+git commit -m "feat(console): alert model (rules, error-safe runner, severity rank)"
+```
+
+---
+
+### Task 6: WidgetFrame component
+
+**Files:**
+- Create: `components/console/WidgetFrame.tsx`
+- Test: `tests/e2e/console.spec.ts` (started; full shell e2e completes in Task 15)
+
+**Interfaces:**
+- Consumes: `shellLayoutStore` (Task 3), `Alert`/`topSeverity` (Task 5), `getWidgetType` (Task 4).
+- Produces: default export `WidgetFrame({ instance }: { instance: WidgetInstance })` rendering the type's component; props for body via `WidgetBodyProps`. Body widgets report alerts/count/freshness up through a context: `useWidgetReport(): (r:{ alerts:Alert[]; count?:number; freshLabel?:string })=>void` — the frame provides it; bodies call it in an effect.
+
+- [ ] **Step 1: Implement the frame (UI — gated by e2e + tsc)**
+
+```tsx
+// components/console/WidgetFrame.tsx
+"use client";
+import { createContext, useContext, useState, useCallback } from "react";
+import type { WidgetInstance } from "@/lib/console/types";
+import { shellLayoutStore } from "@/lib/console/store";
+import { getWidgetType } from "@/lib/console/registry";
+import { topSeverity, type Alert } from "@/lib/console/alerts";
+
+interface Report { alerts: Alert[]; count?: number; freshLabel?: string }
+const ReportCtx = createContext<(r: Report) => void>(() => {});
+export function useWidgetReport() { return useContext(ReportCtx); }
+
+export default function WidgetFrame({ instance }: { instance: WidgetInstance }) {
+  const type = getWidgetType(instance.type);
+  const [report, setReport] = useState<Report>({ alerts: [] });
+  const [menuOpen, setMenuOpen] = useState(false);
+  const onReport = useCallback((r: Report) => setReport(r), []);
+  if (!type) return null;
+  const Body = type.component;
+  const sev = topSeverity(report.alerts);
+  const alertStyle = (instance.config.alertStyle as string) ?? "top"; // "top" | "feed"
+
+  const onDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.setData("text/tn-widget", instance.id);
+    e.dataTransfer.effectAllowed = "move";
+  };
+  const onResizePointerDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const startY = e.clientY, startH = instance.height;
+    const move = (ev: PointerEvent) => shellLayoutStore.resizeWidget(instance.id, startH + (ev.clientY - startY));
+    const up = () => { window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", up); };
+    window.addEventListener("pointermove", move); window.addEventListener("pointerup", up);
+  };
+
+  return (
+    <div className="tn-cw" data-widget-type={instance.type} style={{ height: instance.collapsed ? undefined : instance.height }}>
+      <header className="tn-cw-head" draggable onDragStart={onDragStart}>
+        <span className="tn-cw-icon">{type.icon}</span>
+        <span className="tn-cw-title">{type.title}</span>
+        {report.count != null && <span className="tn-cw-count">{report.count}</span>}
+        <span className="tn-cw-sp" />
+        {report.alerts.length > 0 && <span className={`tn-cw-badge tn-sev-${sev}`}>{report.alerts.length}</span>}
+        {report.freshLabel && <span className="tn-cw-fresh">{report.freshLabel}</span>}
+        <button className="tn-cw-menu" aria-label="Widget menu" onClick={() => setMenuOpen((o) => !o)}>⋯</button>
+      </header>
+
+      {menuOpen && (
+        <div className="tn-cw-menu-pop" role="menu">
+          <button onClick={() => { shellLayoutStore.add(instance.type, { config: { ...instance.config } }); setMenuOpen(false); }}>⧉ Duplicate</button>
+          <button onClick={() => { shellLayoutStore.configure(instance.id, { alertStyle: alertStyle === "top" ? "feed" : "top" }); setMenuOpen(false); }}>
+            ⚡ Alerts: {alertStyle === "top" ? "on top" : "in feed"}
+          </button>
+          <button className="tn-cw-danger" onClick={() => shellLayoutStore.remove(instance.id)}>✕ Remove</button>
+        </div>
+      )}
+
+      {!instance.collapsed && (
+        <>
+          {alertStyle === "top" && report.alerts.length > 0 && (
+            <div className="tn-cw-attn">
+              <div className="tn-cw-attn-h">Needs attention · {report.alerts.length}</div>
+              {report.alerts.slice(0, 4).map((a) => (
+                <div key={a.id} className={`tn-cw-alert tn-sev-${a.severity}`}>{a.text}</div>
+              ))}
+            </div>
+          )}
+          <div className="tn-cw-body">
+            <ReportCtx.Provider value={onReport}><Body instanceId={instance.id} config={instance.config} /></ReportCtx.Provider>
+          </div>
+          <div className="tn-cw-resize" onPointerDown={onResizePointerDown} title="Drag to resize" />
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add the namespaced styles**
+
+Append to `app/globals.css` (calm light; mirror existing `.tn-…` vars):
+
+```css
+.tn-cw{display:flex;flex-direction:column;background:#fff;border:1px solid var(--tn-border,#dbe2ea);border-radius:8px;overflow:hidden}
+.tn-cw-head{display:flex;align-items:center;gap:6px;padding:6px 8px;border-bottom:1px solid #f1f5f9;cursor:grab;font-size:12px}
+.tn-cw-title{font-weight:700;color:#2b3640}.tn-cw-count{font-size:11px;color:#8a97a6}.tn-cw-sp{flex:1}
+.tn-cw-badge{font-size:10px;font-weight:800;color:#fff;border-radius:8px;padding:0 5px;background:#8a97a6}
+.tn-cw-badge.tn-sev-critical{background:#d9534f}.tn-cw-badge.tn-sev-warn{background:#d9882f}.tn-cw-badge.tn-sev-info{background:#4a78c9}
+.tn-cw-fresh{font-size:10px;color:#3f8f5c}.tn-cw-menu{border:0;background:none;cursor:pointer;color:#b3bdc8;font-size:14px}
+.tn-cw-menu-pop{display:flex;flex-direction:column;border-bottom:1px solid #eef2f6}
+.tn-cw-menu-pop button{text-align:left;border:0;background:none;padding:7px 10px;font-size:12px;cursor:pointer}
+.tn-cw-menu-pop button:hover{background:#f6f9fb}.tn-cw-danger{color:#d9534f}
+.tn-cw-attn{border-bottom:1px solid #f1f5f9}.tn-cw-attn-h{font-size:9px;text-transform:uppercase;letter-spacing:.8px;color:#a9b4bf;padding:5px 8px 2px}
+.tn-cw-alert{font-size:11px;padding:4px 8px;border-left:3px solid #d9534f;background:#fdf3f2}
+.tn-cw-alert.tn-sev-warn{border-left-color:#d9882f;background:#fdf7ee}.tn-cw-alert.tn-sev-info{border-left-color:#4a78c9;background:#f1f5fc}
+.tn-cw-body{flex:1;overflow:auto;min-height:0}
+.tn-cw-resize{height:6px;cursor:row-resize;background:linear-gradient(#f1f5f9,#fff)}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: no errors in `components/console/WidgetFrame.tsx` (a "no widgets registered" runtime is fine; e2e covers behavior after Task 15).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/console/WidgetFrame.tsx app/globals.css
+git commit -m "feat(console): WidgetFrame chrome (header, alerts strip, menu, resize, drag)"
+```
+
+---
+
+## Phase C — Shell
+
+### Task 7: Segment + ConsoleWorkspace
+
+**Files:**
+- Create: `components/console/Segment.tsx`, `components/console/ConsoleWorkspace.tsx`
+- Test: `tests/e2e/console.spec.ts` (extend in Task 15)
+
+**Interfaces:**
+- Consumes: `useShellLayout`, `shellLayoutStore`, `widgetsInSegment` (import from reducers), `WidgetFrame`, `StageHost` (Task 8).
+- Produces: `Segment({ id }: { id: SegmentId })` — a scrollable drop zone rendering its widgets; `ConsoleWorkspace()` — the flex shell wiring the three segments + centre column + pointer-drag grips.
+
+- [ ] **Step 1: Implement Segment (native DnD drop zone)**
+
+```tsx
+// components/console/Segment.tsx
+"use client";
+import type { SegmentId } from "@/lib/console/types";
+import { useShellLayout, shellLayoutStore } from "@/lib/console/store";
+import { widgetsInSegment } from "@/lib/console/reducers";
+import WidgetFrame from "@/components/console/WidgetFrame";
+
+export default function Segment({ id }: { id: SegmentId }) {
+  const layout = useShellLayout();
+  const widgets = widgetsInSegment(layout, id);
+  const onDrop = (e: React.DragEvent) => {
+    const wid = e.dataTransfer.getData("text/tn-widget");
+    if (!wid) return;
+    e.preventDefault();
+    // index = position of the card the pointer is over, else append
+    const cards = [...e.currentTarget.querySelectorAll("[data-widget-id]")] as HTMLElement[];
+    let idx = cards.length;
+    for (let i = 0; i < cards.length; i++) {
+      const r = cards[i].getBoundingClientRect();
+      if (e.clientY < r.top + r.height / 2) { idx = i; break; }
+    }
+    shellLayoutStore.move(wid, id, idx);
+  };
+  return (
+    <div className="tn-seg" data-segment={id}
+         onDragOver={(e) => { if (e.dataTransfer.types.includes("text/tn-widget")) e.preventDefault(); }}
+         onDrop={onDrop}>
+      {widgets.length === 0 && <p className="tn-seg-empty">Drop a widget here, or add one with ⌘K</p>}
+      {widgets.map((w) => (
+        <div key={w.id} data-widget-id={w.id} className="tn-seg-slot"><WidgetFrame instance={w} /></div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement ConsoleWorkspace (grips + resize + collapse)**
+
+```tsx
+// components/console/ConsoleWorkspace.tsx
+"use client";
+import { useShellLayout, shellLayoutStore } from "@/lib/console/store";
+import type { SegmentId } from "@/lib/console/types";
+import Segment from "@/components/console/Segment";
+import StageHost from "@/components/console/StageHost";
+
+function VGrip({ seg, dir }: { seg: SegmentId; dir: 1 | -1 }) {
+  const layout = useShellLayout();
+  const onDown = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const startX = e.clientX, startSize = layout.segments[seg].size;
+    const move = (ev: PointerEvent) => shellLayoutStore.setSegment(seg, startSize + dir * (ev.clientX - startX));
+    const up = () => { window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", up); };
+    window.addEventListener("pointermove", move); window.addEventListener("pointerup", up);
+  };
+  return <div className="tn-grip" onPointerDown={onDown} role="separator" aria-orientation="vertical" />;
+}
+
+export default function ConsoleWorkspace() {
+  const layout = useShellLayout();
+  const w = (s: SegmentId) => (layout.segments[s].collapsed ? 0 : layout.segments[s].size);
+  return (
+    <div className="tn-cw-shell">
+      <div className="tn-cw-col" style={{ width: w("left") }}><Segment id="left" /></div>
+      <VGrip seg="left" dir={1} />
+      <div className="tn-cw-center">
+        <div className="tn-cw-stage"><StageHost stage={layout.stage} /></div>
+        <div className="tn-grip tn-grip-h"
+             onPointerDown={(e) => {
+               e.preventDefault();
+               const startY = e.clientY, start = layout.segments.bottom.size;
+               const move = (ev: PointerEvent) => shellLayoutStore.setSegment("bottom", start - (ev.clientY - startY));
+               const up = () => { window.removeEventListener("pointermove", move); window.removeEventListener("pointerup", up); };
+               window.addEventListener("pointermove", move); window.addEventListener("pointerup", up);
+             }} role="separator" aria-orientation="horizontal" />
+        <div className="tn-cw-bottom" style={{ height: layout.segments.bottom.collapsed ? 0 : layout.segments.bottom.size }}>
+          <Segment id="bottom" />
+        </div>
+      </div>
+      <VGrip seg="right" dir={-1} />
+      <div className="tn-cw-col" style={{ width: w("right") }}><Segment id="right" /></div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Styles** — append to `app/globals.css`:
+
+```css
+.tn-cw-shell{position:absolute;inset:0;display:flex;min-height:0}
+.tn-cw-col{flex:none;overflow:hidden;display:flex}
+.tn-cw-center{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0}
+.tn-cw-stage{flex:1;position:relative;min-height:0}
+.tn-cw-bottom{flex:none;overflow:hidden;display:flex}
+.tn-seg{flex:1;overflow-y:auto;overflow-x:hidden;display:flex;flex-direction:column;gap:8px;padding:8px;background:#eef2f6}
+.tn-seg-slot{flex:none}.tn-seg-empty{font-size:11px;color:#9aa6b2;text-align:center;margin:auto;padding:16px}
+.tn-grip{width:6px;flex:none;cursor:col-resize;background:#cdd6e0}
+.tn-grip:hover{background:#aebac6}.tn-grip-h{width:auto;height:6px;cursor:row-resize}
+```
+
+- [ ] **Step 4: Verify compile**
+
+Run: `npx tsc --noEmit`
+Expected: clean (StageHost resolves after Task 8 — implement Task 8 before running e2e; tsc may flag the missing import until then, so commit Tasks 7-8 together if needed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/console/Segment.tsx components/console/ConsoleWorkspace.tsx app/globals.css
+git commit -m "feat(console): segments + workspace shell (resize, collapse, scroll, drag-drop)"
+```
+
+---
+
+### Task 8: StageHost + StageSwitch + WorldClock
+
+**Files:**
+- Create: `components/console/StageHost.tsx`, `components/console/StageSwitch.tsx`, `components/console/WorldClock.tsx`
+- Modify: none yet (StageSwitch mounted in Task 15)
+
+**Interfaces:**
+- Consumes: `shellLayoutStore.stage`, `viewModeStore` (sets map projection: `explore`=globe/3D, `console`=mercator/2D).
+- Produces: `StageHost({ stage }: { stage: StageId })` — renders `<WorldMap/>` (dynamic, ssr:false) for `map2d`/`map3d` and `<WorldClock/>` for `clock`, and syncs `viewModeStore` to the projection; `StageSwitch()` — the 3D/2D/🕐 buttons; `WorldClock()` — multi-timezone clock.
+
+- [ ] **Step 1: Implement StageHost (reuse viewMode → projection)**
+
+```tsx
+// components/console/StageHost.tsx
+"use client";
+import dynamic from "next/dynamic";
+import { useEffect } from "react";
+import type { StageId } from "@/lib/console/types";
+import { viewModeStore } from "@/lib/shell/viewMode";
+import WorldClock from "@/components/console/WorldClock";
+
+const WorldMap = dynamic(() => import("@/components/WorldMap"), { ssr: false });
+
+export default function StageHost({ stage }: { stage: StageId }) {
+  // The map reads viewModeStore for its MapLibre projection: 3D=globe(explore), 2D=flat(console).
+  useEffect(() => {
+    if (stage === "map3d") viewModeStore.set("explore");
+    else if (stage === "map2d") viewModeStore.set("console");
+  }, [stage]);
+  if (stage === "clock") return <WorldClock />;
+  return <WorldMap />;
+}
+```
+
+- [ ] **Step 2: Implement WorldClock**
+
+```tsx
+// components/console/WorldClock.tsx
+"use client";
+import { useEffect, useState } from "react";
+const ZONES = [
+  { zone: "Europe/London", label: "LONDON" },
+  { zone: "America/New_York", label: "NEW YORK" },
+  { zone: "Asia/Tokyo", label: "TOKYO" },
+  { zone: "UTC", label: "UTC" },
+];
+export default function WorldClock() {
+  const [now, setNow] = useState<Date | null>(null);
+  useEffect(() => { setNow(new Date()); const t = setInterval(() => setNow(new Date()), 1000); return () => clearInterval(t); }, []);
+  return (
+    <div className="tn-clock">
+      {ZONES.map((z) => (
+        <div key={z.zone} className="tn-clock-cell">
+          <div className="tn-clock-time">{now ? now.toLocaleTimeString("en-GB", { timeZone: z.zone, hour: "2-digit", minute: "2-digit" }) : "--:--"}</div>
+          <div className="tn-clock-zone">{z.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Implement StageSwitch**
+
+```tsx
+// components/console/StageSwitch.tsx
+"use client";
+import { useShellLayout, shellLayoutStore } from "@/lib/console/store";
+import type { StageId } from "@/lib/console/types";
+const OPTS: { id: StageId; label: string }[] = [
+  { id: "map3d", label: "3D" }, { id: "map2d", label: "2D" }, { id: "clock", label: "🕐" },
+];
+export default function StageSwitch() {
+  const { stage } = useShellLayout();
+  return (
+    <div className="tn-stage-switch" role="group" aria-label="Centre stage">
+      {OPTS.map((o) => (
+        <button key={o.id} className={stage === o.id ? "is-on" : ""} aria-pressed={stage === o.id}
+                onClick={() => shellLayoutStore.stage(o.id)}>{o.label}</button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Styles** — append to `app/globals.css`:
+
+```css
+.tn-clock{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:32px;background:radial-gradient(circle at 50% 40%,#26323d,#141c24)}
+.tn-clock-time{font-size:34px;font-weight:800;color:#fff;letter-spacing:1px}.tn-clock-zone{font-size:11px;color:#9fb0bf;letter-spacing:1px;text-align:center}
+.tn-stage-switch{display:inline-flex;gap:2px;background:#fff;border:1px solid #d7dee6;border-radius:7px;padding:2px}
+.tn-stage-switch button{border:0;background:none;font-size:11px;font-weight:700;color:#5a6470;padding:2px 8px;border-radius:5px;cursor:pointer}
+.tn-stage-switch button.is-on{background:#27313b;color:#fff}
+```
+
+- [ ] **Step 5: Verify compile + commit**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+```bash
+git add components/console/StageHost.tsx components/console/WorldClock.tsx components/console/StageSwitch.tsx app/globals.css
+git commit -m "feat(console): stage host (map 3D/2D · world clock) + stage switch"
+```
+
+---
+
+## Phase D — Widgets
+
+### Task 9: Aviation widget + alert rules
+
+**Files:**
+- Create: `lib/console/widgets/aviation.rules.ts`, `lib/console/widgets/aviation.tsx`
+- Test: `tests/unit/console-aviation.test.ts`
+
+**Interfaces:**
+- Consumes: `usePlanes` from `@/lib/planes/usePlanes` (the data feeding the planes map layer), `WidgetBodyProps`, `useWidgetReport`, `AlertRule`/`Alert`.
+- Produces: `aviationAlerts: AlertRule<PlaneLite>` where `PlaneLite = { callsign:string; squawk?:string; isMilitary?:boolean }`; `AVIATION_WIDGET: WidgetType` (self-registers on import).
+
+- [ ] **Step 1: Write the failing test (pure rules only)**
+
+```ts
+// tests/unit/console-aviation.test.ts
+import { expect, test } from "vitest";
+import { aviationAlerts, type PlaneLite } from "@/lib/console/widgets/aviation.rules";
+
+const planes: PlaneLite[] = [
+  { callsign: "AF23", squawk: "7700" },
+  { callsign: "BA117", squawk: "2200" },
+  { callsign: "RCH804", squawk: "1234", isMilitary: true },
+  { callsign: "UA90", squawk: "7600" },
+];
+
+test("flags emergency squawks 7500/7600/7700 as critical", () => {
+  const a = aviationAlerts(planes, {});
+  const crit = a.filter((x) => x.severity === "critical").map((x) => x.ref);
+  expect(crit.sort()).toEqual(["AF23", "UA90"]);
+});
+
+test("flags military entry as info", () => {
+  const a = aviationAlerts(planes, {});
+  expect(a.find((x) => x.ref === "RCH804")?.severity).toBe("info");
+});
+
+test("clean traffic produces no alerts", () => {
+  expect(aviationAlerts([{ callsign: "X", squawk: "1000" }], {})).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-aviation`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the rules**
+
+```ts
+// lib/console/widgets/aviation.rules.ts
+import type { AlertRule, Alert } from "@/lib/console/alerts";
+export interface PlaneLite { callsign: string; squawk?: string; isMilitary?: boolean }
+const EMERGENCY = new Set(["7500", "7600", "7700"]);
+const REASON: Record<string, string> = { "7500": "hijack", "7600": "radio failure", "7700": "emergency" };
+
+export const aviationAlerts: AlertRule<PlaneLite> = (planes) => {
+  const out: Alert[] = [];
+  for (const p of planes) {
+    if (p.squawk && EMERGENCY.has(p.squawk)) {
+      out.push({ id: `sq-${p.callsign}`, severity: "critical", text: `${p.callsign} squawk ${p.squawk} — ${REASON[p.squawk]}`, ref: p.callsign });
+    } else if (p.isMilitary) {
+      out.push({ id: `mil-${p.callsign}`, severity: "info", text: `Military ${p.callsign} in region`, ref: p.callsign });
+    }
+  }
+  return out;
+};
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-aviation`
+Expected: PASS.
+
+- [ ] **Step 5: Implement the widget body + register (UI)**
+
+```tsx
+// lib/console/widgets/aviation.tsx
+"use client";
+import { useEffect, useMemo } from "react";
+import { usePlanes } from "@/lib/planes/usePlanes";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { runAlertRule } from "@/lib/console/alerts";
+import { aviationAlerts, type PlaneLite } from "@/lib/console/widgets/aviation.rules";
+
+function AviationBody({ config }: WidgetBodyProps) {
+  const planes = usePlanes(); // existing hook → array of live planes
+  const lite: PlaneLite[] = useMemo(
+    () => planes.map((p) => ({ callsign: p.callsign ?? p.hex ?? "?", squawk: p.squawk, isMilitary: p.isMilitary })),
+    [planes],
+  );
+  const sortKey = (config.sort as string) ?? "alt";
+  const rows = useMemo(() => {
+    const r = [...planes];
+    r.sort((a, b) => (sortKey === "alt" ? (b.altitude ?? 0) - (a.altitude ?? 0) : (a.callsign ?? "").localeCompare(b.callsign ?? "")));
+    return r.slice(0, 200);
+  }, [planes, sortKey]);
+  const report = useWidgetReport();
+  useEffect(() => {
+    report({ alerts: runAlertRule(aviationAlerts, lite, config), count: planes.length, freshLabel: "live" });
+  }, [lite, planes.length, report, config]);
+
+  return (
+    <table className="tn-w-table"><tbody>
+      {rows.map((p) => (
+        <tr key={p.id ?? p.hex}><td className="tn-w-strong">{p.callsign ?? p.hex}</td>
+          <td>{p.origin ?? ""}{p.destination ? `→${p.destination}` : ""}</td>
+          <td className="tn-w-num">{p.altitude != null ? `${Math.round(p.altitude / 1000)}k` : ""}</td></tr>
+      ))}
+    </tbody></table>
+  );
+}
+
+export const AVIATION_WIDGET = {
+  id: "aviation", title: "Aviation", icon: "✈", category: "Aviation",
+  defaultHeight: 280, defaultConfig: { sort: "alt" }, component: AviationBody,
+  capabilities: { filter: true, sort: true },
+};
+registerWidget(AVIATION_WIDGET);
+```
+
+> Note: `usePlanes()`'s element shape is the existing plane type. If a referenced field (`squawk`, `isMilitary`, `altitude`, `origin`) is named differently, adapt the `.map` in `AviationBody` only — the rules test fixes the rule contract.
+
+- [ ] **Step 6: tsc + commit**
+
+Run: `npx tsc --noEmit`
+
+```bash
+git add lib/console/widgets/aviation.rules.ts lib/console/widgets/aviation.tsx tests/unit/console-aviation.test.ts
+git commit -m "feat(console): Aviation widget + emergency-squawk/military alert rules"
+```
+
+---
+
+### Task 10: Disasters & Events widget + alert rules
+
+**Files:**
+- Create: `lib/console/widgets/events.rules.ts`, `lib/console/widgets/events.tsx`
+- Test: `tests/unit/console-events.test.ts`
+
+**Interfaces:**
+- Consumes: `useEventFeeds` + `projectEventFeed` + `FeedInput`/`FeedSort` from `@/lib/widgets/eventFeed`/`useEventFeeds`; `SeverityTier`/`EventType` from `@/lib/events/model`; `useScope`.
+- Produces: `eventAlerts: AlertRule<EventLite>` where `EventLite = { id:string; type:EventType; tier:SeverityTier; title:string; magnitude?:number }` — flags `tier ∈ {S3,S4}` (severity by tier) and quakes `magnitude>=5`; `EVENTS_WIDGET: WidgetType`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/console-events.test.ts
+import { expect, test } from "vitest";
+import { eventAlerts, type EventLite } from "@/lib/console/widgets/events.rules";
+
+const evs: EventLite[] = [
+  { id: "1", type: "quake", tier: "S2", title: "M4.7 quake", magnitude: 4.7 },
+  { id: "2", type: "quake", tier: "S2", title: "M5.2 quake", magnitude: 5.2 },
+  { id: "3", type: "disaster", tier: "S4", title: "Earthquake Venezuela" },
+  { id: "4", type: "cyclone", tier: "S1", title: "Storm" },
+];
+
+test("flags S3/S4 tiers and M5+ quakes; ignores routine", () => {
+  const ids = eventAlerts(evs, {}).map((a) => a.ref).sort();
+  expect(ids).toEqual(["2", "3"]);
+});
+
+test("S4 is critical, S3 is warn", () => {
+  const a = eventAlerts([{ id: "x", type: "disaster", tier: "S3", title: "Drought" }], {});
+  expect(a[0].severity).toBe("warn");
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-events`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement rules**
+
+```ts
+// lib/console/widgets/events.rules.ts
+import type { AlertRule, Alert } from "@/lib/console/alerts";
+import type { EventType, SeverityTier } from "@/lib/events/model";
+export interface EventLite { id: string; type: EventType; tier: SeverityTier; title: string; magnitude?: number }
+
+export const eventAlerts: AlertRule<EventLite> = (events) => {
+  const out: Alert[] = [];
+  for (const e of events) {
+    const bigTier = e.tier === "S4" || e.tier === "S3";
+    const bigQuake = e.type === "quake" && (e.magnitude ?? 0) >= 5;
+    if (bigTier || bigQuake) {
+      const severity = e.tier === "S4" ? "critical" : e.tier === "S3" ? "warn" : "warn";
+      out.push({ id: `ev-${e.id}`, severity, text: e.title, ref: e.id });
+    }
+  }
+  return out;
+};
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-events`
+Expected: PASS.
+
+- [ ] **Step 5: Implement widget body + register**
+
+```tsx
+// lib/console/widgets/events.tsx
+"use client";
+import { useEffect, useMemo } from "react";
+import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
+import { projectEventFeed, type FeedInput } from "@/lib/widgets/eventFeed";
+import { useScope } from "@/lib/shell/scope";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { runAlertRule } from "@/lib/console/alerts";
+import { eventAlerts, type EventLite } from "@/lib/console/widgets/events.rules";
+
+function EventsBody({ config }: WidgetBodyProps) {
+  const scope = useScope();
+  const { bySource } = useEventFeeds();
+  const input: FeedInput = { bySource, scope, minTier: (config.minTier as never) ?? "S1", sort: (config.sort as never) ?? "severity" };
+  const rows = useMemo(() => projectEventFeed(input), [bySource, scope, config.minTier, config.sort]);
+  const lite: EventLite[] = useMemo(
+    () => rows.map((r) => ({ id: r.id, type: r.type, tier: r.tier, title: r.title, magnitude: r.magnitude })),
+    [rows],
+  );
+  const report = useWidgetReport();
+  useEffect(() => { report({ alerts: runAlertRule(eventAlerts, lite, config), count: rows.length, freshLabel: "2m" }); }, [lite, rows.length, report, config]);
+
+  return (
+    <ul className="tn-w-list">
+      {rows.slice(0, 100).map((r) => (
+        <li key={r.id}><span className={`tn-w-sev tn-${r.tier}`}>{r.tier}</span> <b>{r.type}</b> {r.title}</li>
+      ))}
+    </ul>
+  );
+}
+
+export const EVENTS_WIDGET = {
+  id: "events", title: "Disasters & Events", icon: "🌎", category: "Events",
+  defaultHeight: 320, defaultConfig: { minTier: "S1", sort: "severity" }, component: EventsBody,
+  capabilities: { filter: true, sort: true },
+};
+registerWidget(EVENTS_WIDGET);
+```
+
+> Note: align the `projectEventFeed` `FeedInput` field names and the row shape with `components/shell/EventFeed.tsx` (it already calls `useEventFeeds()` + `projectEventFeed`); copy its exact usage. Only the `EventLite` mapping needs to match `events.rules.ts`.
+
+- [ ] **Step 6: tsc + commit**
+
+Run: `npx tsc --noEmit`
+
+```bash
+git add lib/console/widgets/events.rules.ts lib/console/widgets/events.tsx tests/unit/console-events.test.ts
+git commit -m "feat(console): Disasters & Events widget + S3+/M5+ alert rules"
+```
+
+---
+
+### Task 11: Cameras widget + alert rules
+
+**Files:**
+- Create: `lib/console/widgets/cameras.rules.ts`, `lib/console/widgets/cameras.tsx`
+- Test: `tests/unit/console-cameras.test.ts`
+
+**Interfaces:**
+- Consumes: `loadedCamerasStore` from `@/lib/cameras/loaded`; `CameraVideo` from `@/components/CameraVideo`; `cinematic` dive (optional, for click).
+- Produces: `cameraAlerts: AlertRule<CameraLite>` where `CameraLite = { id:string; name:string; available:boolean }` — flags `available===false` as `warn`; `CAMERAS_WIDGET: WidgetType`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/console-cameras.test.ts
+import { expect, test } from "vitest";
+import { cameraAlerts, type CameraLite } from "@/lib/console/widgets/cameras.rules";
+
+const cams: CameraLite[] = [
+  { id: "a", name: "LHR A4", available: true },
+  { id: "b", name: "I-95 MM12", available: false },
+];
+
+test("flags offline cameras as warn", () => {
+  const a = cameraAlerts(cams, {});
+  expect(a.length).toBe(1);
+  expect(a[0].severity).toBe("warn");
+  expect(a[0].ref).toBe("b");
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-cameras`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement rules**
+
+```ts
+// lib/console/widgets/cameras.rules.ts
+import type { AlertRule, Alert } from "@/lib/console/alerts";
+export interface CameraLite { id: string; name: string; available: boolean }
+export const cameraAlerts: AlertRule<CameraLite> = (cams) => {
+  const out: Alert[] = [];
+  for (const c of cams) if (!c.available) out.push({ id: `cam-${c.id}`, severity: "warn", text: `${c.name} went offline`, ref: c.id });
+  return out;
+};
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-cameras`
+Expected: PASS.
+
+- [ ] **Step 5: Implement widget body + register**
+
+```tsx
+// lib/console/widgets/cameras.tsx
+"use client";
+import { useEffect, useMemo } from "react";
+import { loadedCamerasStore } from "@/lib/cameras/loaded";
+import { useSyncExternalStore } from "react";
+import { CameraVideo } from "@/components/CameraVideo";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { runAlertRule } from "@/lib/console/alerts";
+import { cameraAlerts, type CameraLite } from "@/lib/console/widgets/cameras.rules";
+
+function CamerasBody({ config }: WidgetBodyProps) {
+  const cams = useSyncExternalStore(loadedCamerasStore.subscribe, loadedCamerasStore.get, loadedCamerasStore.get);
+  const lite: CameraLite[] = useMemo(() => cams.map((c) => ({ id: c.id, name: c.name, available: c.available !== false })), [cams]);
+  const report = useWidgetReport();
+  useEffect(() => { report({ alerts: runAlertRule(cameraAlerts, lite, config), count: cams.length, freshLabel: "live" }); }, [lite, cams.length, report, config]);
+  return (
+    <div className="tn-cam-grid">
+      {cams.slice(0, 6).map((c) => (
+        <div key={c.id} className="tn-cam-cell">
+          <CameraVideo id={c.id} alt={c.name} attribution={c.attribution ?? ""} license={c.license ?? ""} refreshSeconds={c.refreshSeconds ?? 30} />
+          <span className="tn-cam-label">{c.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const CAMERAS_WIDGET = {
+  id: "cameras", title: "Cameras", icon: "📷", category: "Cameras",
+  defaultHeight: 260, defaultConfig: {}, component: CamerasBody,
+};
+registerWidget(CAMERAS_WIDGET);
+```
+
+> Note: match the loaded-camera element shape from `lib/cameras/loaded` (fields `id/name/available/attribution/license/refreshSeconds`); adapt the `.map` only.
+
+- [ ] **Step 6: tsc + commit**
+
+Run: `npx tsc --noEmit`
+
+```bash
+git add lib/console/widgets/cameras.rules.ts lib/console/widgets/cameras.tsx tests/unit/console-cameras.test.ts
+git commit -m "feat(console): Cameras widget + offline alert rule"
+```
+
+---
+
+### Task 12: Live Video News — provider catalogue + widget
+
+**Files:**
+- Create: `lib/console/news/providers.ts`, `lib/console/widgets/news.tsx`
+- Test: `tests/unit/console-news-providers.test.ts`
+
+**Interfaces:**
+- Produces: `NewsProvider { id:string; name:string; category:string; kind:"youtube"|"hls"; ref:string; favorite?:boolean }`; `NEWS_PROVIDERS: NewsProvider[]` (~12 seeded); `parseCustomStream(url:string): NewsProvider|null` (accepts a YouTube watch/live URL → `kind:"youtube"`, or a `.m3u8` URL → `kind:"hls"`); `resolveEmbed(p): { kind:"youtube"|"hls"; src:string }`; `NEWS_WIDGET: WidgetType`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/console-news-providers.test.ts
+import { expect, test } from "vitest";
+import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed } from "@/lib/console/news/providers";
+
+test("seeds at least 10 free providers with valid kinds", () => {
+  expect(NEWS_PROVIDERS.length).toBeGreaterThanOrEqual(10);
+  for (const p of NEWS_PROVIDERS) expect(["youtube", "hls"]).toContain(p.kind);
+});
+
+test("parseCustomStream reads a YouTube live URL", () => {
+  const p = parseCustomStream("https://www.youtube.com/watch?v=abc123XYZ");
+  expect(p?.kind).toBe("youtube");
+  expect(p?.ref).toBe("abc123XYZ");
+});
+
+test("parseCustomStream reads an HLS url and rejects junk", () => {
+  expect(parseCustomStream("https://x.com/live/stream.m3u8")?.kind).toBe("hls");
+  expect(parseCustomStream("not a url")).toBeNull();
+});
+
+test("resolveEmbed builds a youtube embed src", () => {
+  const e = resolveEmbed({ id: "x", name: "X", category: "World", kind: "youtube", ref: "abc123XYZ" });
+  expect(e.kind).toBe("youtube");
+  expect(e.src).toContain("youtube.com/embed/abc123XYZ");
+  expect(e.src).toContain("autoplay=1");
+  expect(e.src).toContain("mute=1");
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-news-providers`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement providers**
+
+```ts
+// lib/console/news/providers.ts
+export interface NewsProvider { id: string; name: string; category: string; kind: "youtube" | "hls"; ref: string; favorite?: boolean }
+
+// YouTube live video ids for free 24/7 news channels. ids are tunable — they
+// occasionally rotate; the picker's add-custom-stream covers breakage.
+export const NEWS_PROVIDERS: NewsProvider[] = [
+  { id: "aljazeera", name: "Al Jazeera English", category: "World", kind: "youtube", ref: "gCNeDWCI0vo", favorite: true },
+  { id: "dw", name: "DW News", category: "World", kind: "youtube", ref: "tQwQfNuvb1A", favorite: true },
+  { id: "france24", name: "France 24", category: "World", kind: "youtube", ref: "h3MuIUNCCzI", favorite: true },
+  { id: "sky", name: "Sky News", category: "World", kind: "youtube", ref: "9Auq9mYxFEE" },
+  { id: "euronews", name: "Euronews", category: "World", kind: "youtube", ref: "pykpO5kQJ98" },
+  { id: "cna", name: "CNA", category: "World", kind: "youtube", ref: "XWq5kBlakcQ" },
+  { id: "trt", name: "TRT World", category: "World", kind: "youtube", ref: "Wp0_Dk0nJOk" },
+  { id: "nhk", name: "NHK World", category: "World", kind: "youtube", ref: "f0lYkdg2DZw" },
+  { id: "abcau", name: "ABC News (AU)", category: "World", kind: "youtube", ref: "vOTiJkg1voo" },
+  { id: "bloomberg", name: "Bloomberg TV", category: "Business", kind: "youtube", ref: "iEpJwprxDdk" },
+  { id: "nasa", name: "NASA TV", category: "Space", kind: "youtube", ref: "21X5lGlDOfg" },
+  { id: "iss", name: "ISS Live", category: "Space", kind: "youtube", ref: "DIgkvm2nmHc" },
+];
+
+const YT_ID = /(?:v=|youtu\.be\/|\/live\/|\/embed\/)([A-Za-z0-9_-]{6,})/;
+
+export function parseCustomStream(url: string): NewsProvider | null {
+  const u = url.trim();
+  const yt = u.match(YT_ID);
+  if (yt) return { id: `custom-${yt[1]}`, name: "Custom (YouTube)", category: "Custom", kind: "youtube", ref: yt[1] };
+  if (/^https?:\/\/\S+\.m3u8(\?\S*)?$/i.test(u)) return { id: `custom-hls`, name: "Custom (HLS)", category: "Custom", kind: "hls", ref: u };
+  return null;
+}
+
+export function resolveEmbed(p: NewsProvider): { kind: "youtube" | "hls"; src: string } {
+  if (p.kind === "youtube") return { kind: "youtube", src: `https://www.youtube.com/embed/${p.ref}?autoplay=1&mute=1&playsinline=1` };
+  return { kind: "hls", src: p.ref };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- console-news-providers`
+Expected: PASS.
+
+- [ ] **Step 5: Implement the widget (YouTube iframe / HLS video) + register**
+
+```tsx
+// lib/console/widgets/news.tsx
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+
+function NewsBody({ instanceId, config }: WidgetBodyProps) {
+  const report = useWidgetReport();
+  const activeId = (config.providerId as string) ?? NEWS_PROVIDERS[0].id;
+  const custom = config.customProvider as NewsProvider | undefined;
+  const active = custom?.id === activeId ? custom : NEWS_PROVIDERS.find((p) => p.id === activeId) ?? NEWS_PROVIDERS[0];
+  const embed = resolveEmbed(active);
+  const favorites = NEWS_PROVIDERS.filter((p) => p.favorite).slice(0, 4);
+  const [picker, setPicker] = useState(false);
+  useEffect(() => { report({ alerts: [], freshLabel: "live" }); }, [report]);
+
+  const choose = (id: string) => { import("@/lib/console/store").then((m) => m.shellLayoutStore.configure(instanceId, { providerId: id })); };
+  const videoRef = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (embed.kind !== "hls" || !videoRef.current) return;
+    const v = videoRef.current; let hls: { destroy(): void } | null = null; let cancelled = false;
+    if (v.canPlayType("application/vnd.apple.mpegurl")) { v.src = embed.src; return; }
+    (async () => { const Hls = (await import("hls.js")).default; if (cancelled || !Hls.isSupported()) return; const h = new Hls(); hls = h; h.loadSource(embed.src); h.attachMedia(v); })();
+    return () => { cancelled = true; hls?.destroy(); };
+  }, [embed.kind, embed.src]);
+
+  return (
+    <div className="tn-news">
+      <div className="tn-news-screen">
+        {embed.kind === "youtube"
+          ? <iframe className="tn-news-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
+          : <video ref={videoRef} className="tn-news-video" muted autoPlay playsInline controls />}
+        <span className="tn-news-ch">{active.name}</span>
+      </div>
+      <div className="tn-news-tabs">
+        {favorites.map((p) => (
+          <button key={p.id} className={p.id === activeId ? "is-on" : ""} onClick={() => choose(p.id)}>{p.name.split(" ")[0]}</button>
+        ))}
+        <button className="tn-news-more" onClick={() => setPicker((o) => !o)}>＋ More…</button>
+      </div>
+      {picker && (
+        <div className="tn-news-picker">
+          {NEWS_PROVIDERS.map((p) => (
+            <button key={p.id} onClick={() => { choose(p.id); setPicker(false); }}>{p.id === activeId ? "✓ " : ""}{p.name} <span className="tn-news-cat">{p.category}</span></button>
+          ))}
+          <input className="tn-news-custom" placeholder="Add stream URL (YouTube / .m3u8)…"
+                 onKeyDown={(e) => {
+                   if (e.key !== "Enter") return;
+                   const p = parseCustomStream((e.target as HTMLInputElement).value);
+                   if (p) import("@/lib/console/store").then((m) => m.shellLayoutStore.configure(instanceId, { providerId: p.id, customProvider: p }));
+                 }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const NEWS_WIDGET = {
+  id: "news", title: "Live News", icon: "📺", category: "News",
+  defaultHeight: 240, defaultConfig: { providerId: "aljazeera" }, component: NewsBody,
+};
+registerWidget(NEWS_WIDGET);
+```
+
+- [ ] **Step 6: Styles** — append to `app/globals.css`:
+
+```css
+.tn-news{display:flex;flex-direction:column;height:100%}
+.tn-news-screen{position:relative;aspect-ratio:16/9;background:#15212b}
+.tn-news-video{position:absolute;inset:0;width:100%;height:100%;border:0}
+.tn-news-ch{position:absolute;left:6px;bottom:6px;color:#fff;font-size:10px;font-weight:700;text-shadow:0 1px 2px rgba(0,0,0,.6)}
+.tn-news-tabs{display:flex;gap:4px;padding:6px;flex-wrap:wrap}
+.tn-news-tabs button{font-size:9px;border:1px solid #e1e8ef;border-radius:10px;padding:2px 7px;background:#fff;cursor:pointer}
+.tn-news-tabs button.is-on{background:#27313b;color:#fff;border-color:#27313b}.tn-news-more{color:#3f8f5c;border-style:dashed!important}
+.tn-news-picker{display:flex;flex-direction:column;border-top:1px solid #eef2f6;max-height:160px;overflow:auto}
+.tn-news-picker button{text-align:left;border:0;background:none;padding:5px 9px;font-size:11px;cursor:pointer}
+.tn-news-cat{color:#9aa6b2;font-size:9px;float:right}.tn-news-custom{margin:6px 9px;padding:4px;font-size:11px;border:1px solid #e1e8ef;border-radius:5px}
+```
+
+- [ ] **Step 7: tsc + commit**
+
+Run: `npx tsc --noEmit`
+
+```bash
+git add lib/console/news/providers.ts lib/console/widgets/news.tsx tests/unit/console-news-providers.test.ts app/globals.css
+git commit -m "feat(console): Live Video News widget + provider catalogue (favourites/picker/custom)"
+```
+
+---
+
+## Phase E — Catalog, presets, share, mount
+
+### Task 13: Widget index + ⌘K catalog upgrade
+
+**Files:**
+- Create: `lib/console/widgets/index.ts`
+- Modify: `components/shell/CommandPalette.tsx`
+
+**Interfaces:**
+- Consumes: `widgetsByCategory`/`listWidgetTypes` (registry), `shellLayoutStore`, `STAGES`.
+- Produces: side-effect import that registers all four widgets; new palette commands `Add <widget>` (per type), `Stage → 3D/2D/Clock`.
+
+- [ ] **Step 1: Create the registration barrel**
+
+```ts
+// lib/console/widgets/index.ts
+// Importing this file registers every console widget exactly once.
+import "@/lib/console/widgets/aviation";
+import "@/lib/console/widgets/events";
+import "@/lib/console/widgets/cameras";
+import "@/lib/console/widgets/news";
+```
+
+- [ ] **Step 2: Add catalog commands to the palette**
+
+In `components/shell/CommandPalette.tsx`, inside `buildCommands(close)`, after the existing layer/preset loops, append:
+
+```ts
+import "@/lib/console/widgets"; // ensure registry populated
+import { widgetsByCategory } from "@/lib/console/registry";
+import { shellLayoutStore } from "@/lib/console/store";
+import type { StageId } from "@/lib/console/types";
+
+// …inside buildCommands(), append:
+for (const group of widgetsByCategory()) {
+  for (const t of group.types) {
+    const openCount = shellLayoutStore.get().widgets.filter((w) => w.type === t.id).length;
+    cmds.push({
+      id: `add-${t.id}`,
+      label: `Add ${t.title}${openCount ? ` (${openCount} open)` : ""}`,
+      hint: group.category.toLowerCase(),
+      run: () => { const r = shellLayoutStore.add(t.id, { config: { ...t.defaultConfig }, height: t.defaultHeight }); if (!r.ok) alertCapacity(); close(); },
+    });
+  }
+}
+const STAGES: { id: StageId; label: string }[] = [{ id: "map3d", label: "3D map" }, { id: "map2d", label: "2D map" }, { id: "clock", label: "World clock" }];
+for (const s of STAGES) cmds.push({ id: `stage-${s.id}`, label: `Stage → ${s.label}`, hint: "stage", run: () => { shellLayoutStore.stage(s.id); close(); } });
+```
+
+Add a tiny capacity helper at module scope (above `buildCommands`):
+
+```ts
+function alertCapacity() {
+  if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent("tn-toast", { detail: "50-widget limit — remove one to add another" }));
+}
+```
+
+- [ ] **Step 3: Verify compile + manual run**
+
+Run: `npx tsc --noEmit` (clean), then `npm run dev`, press ⌘K, type "Add" → the four widgets appear with open-counts; "Stage" → three stage commands.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/console/widgets/index.ts components/shell/CommandPalette.tsx
+git commit -m "feat(console): ⌘K widget catalog (add instances + open counts) + stage commands"
+```
+
+---
+
+### Task 14: Presets + URL share
+
+**Files:**
+- Create: `lib/console/presets.ts`, `lib/console/share.ts`
+- Test: `tests/unit/console-presets.test.ts`, `tests/unit/console-share.test.ts`
+
+**Interfaces:**
+- Consumes: `ShellLayout`, reducers’ `addWidget`, `createDefaultLayout`, `loadPersisted`/`savePersisted`.
+- Produces: `ConsolePreset { id:string; title:string; icon:string; build(): ShellLayout }`; `BUILTIN_PRESETS: ConsolePreset[]` (World, Aviation Ops, Disaster Response); `applyPreset(id): void` (replaces the store layout); `saveCustomPreset(title): void`; `listPresets(): {id;title;icon}[]`. `encodeLayout(l): string` / `decodeLayout(s): ShellLayout|null` (compact, URL-safe).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/unit/console-presets.test.ts
+import { expect, test } from "vitest";
+import { BUILTIN_PRESETS } from "@/lib/console/presets";
+
+test("built-ins are non-empty and within the cap", () => {
+  const ids = BUILTIN_PRESETS.map((p) => p.id);
+  expect(ids).toContain("world");
+  expect(ids).toContain("aviation-ops");
+  expect(ids).toContain("disaster-response");
+  for (const p of BUILTIN_PRESETS) {
+    const l = p.build();
+    expect(l.widgets.length).toBeGreaterThan(0);
+    expect(l.widgets.length).toBeLessThanOrEqual(50);
+  }
+});
+
+test("aviation-ops puts an aviation widget on the canvas with a stage", () => {
+  const l = BUILTIN_PRESETS.find((p) => p.id === "aviation-ops")!.build();
+  expect(l.widgets.some((w) => w.type === "aviation")).toBe(true);
+  expect(["map2d", "map3d", "clock"]).toContain(l.stage);
+});
+```
+
+```ts
+// tests/unit/console-share.test.ts
+import { expect, test } from "vitest";
+import { encodeLayout, decodeLayout } from "@/lib/console/share";
+import { BUILTIN_PRESETS } from "@/lib/console/presets";
+
+test("encode→decode round-trips a layout", () => {
+  const l = BUILTIN_PRESETS.find((p) => p.id === "disaster-response")!.build();
+  const round = decodeLayout(encodeLayout(l));
+  expect(round?.stage).toBe(l.stage);
+  expect(round?.widgets.map((w) => w.type)).toEqual(l.widgets.map((w) => w.type));
+});
+
+test("decode returns null on garbage", () => {
+  expect(decodeLayout("@@@notjson@@@")).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npm test -- console-presets console-share`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Implement presets**
+
+```ts
+// lib/console/presets.ts
+"use client";
+import { createDefaultLayout, type ShellLayout, type SegmentId } from "@/lib/console/types";
+import { addWidget, setStage } from "@/lib/console/reducers";
+import { shellLayoutStore } from "@/lib/console/store";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export interface ConsolePreset { id: string; title: string; icon: string; build(): ShellLayout }
+
+let seed = 0;
+const id = () => `p${(seed += 1).toString(36)}`;
+function compose(stage: ShellLayout["stage"], specs: { type: string; segment: SegmentId }[]): ShellLayout {
+  let l = setStage(createDefaultLayout(), stage);
+  for (const s of specs) l = addWidget(l, s.type, id(), { segment: s.segment });
+  return l;
+}
+
+export const BUILTIN_PRESETS: ConsolePreset[] = [
+  { id: "world", title: "World", icon: "🌐", build: () => compose("map2d", [
+      { type: "events", segment: "left" }, { type: "news", segment: "bottom" },
+      { type: "cameras", segment: "right" }, { type: "aviation", segment: "left" },
+  ]) },
+  { id: "aviation-ops", title: "Aviation Ops", icon: "✈", build: () => compose("map2d", [
+      { type: "aviation", segment: "left" }, { type: "events", segment: "left" },
+      { type: "cameras", segment: "right" }, { type: "news", segment: "bottom" },
+  ]) },
+  { id: "disaster-response", title: "Disaster Response", icon: "🆘", build: () => compose("map2d", [
+      { type: "events", segment: "left" }, { type: "cameras", segment: "right" },
+      { type: "news", segment: "bottom" },
+  ]) },
+];
+
+const KEY = "tn.console.presets.v1";
+const VERSION = 1;
+interface CustomPreset { id: string; title: string; layout: ShellLayout }
+
+function loadCustom(): CustomPreset[] { return loadPersisted<CustomPreset[]>(KEY, VERSION) ?? []; }
+
+export function applyPreset(presetId: string): void {
+  const built = BUILTIN_PRESETS.find((p) => p.id === presetId);
+  if (built) { shellLayoutStore.replace(built.build()); return; }
+  const custom = loadCustom().find((p) => p.id === presetId);
+  if (custom) shellLayoutStore.replace(custom.layout);
+}
+
+export function saveCustomPreset(title: string): void {
+  const list = loadCustom();
+  list.push({ id: `custom-${Date.now().toString(36)}`, title, layout: shellLayoutStore.get() });
+  savePersisted(KEY, VERSION, list);
+}
+
+export function listPresets(): { id: string; title: string; icon: string }[] {
+  return [...BUILTIN_PRESETS.map((p) => ({ id: p.id, title: p.title, icon: p.icon })),
+          ...loadCustom().map((p) => ({ id: p.id, title: p.title, icon: "★" }))];
+}
+```
+
+- [ ] **Step 4: Implement share**
+
+```ts
+// lib/console/share.ts
+import type { ShellLayout } from "@/lib/console/types";
+
+/** Compact, URL-safe encoding of a layout (base64 of JSON). */
+export function encodeLayout(l: ShellLayout): string {
+  const json = JSON.stringify(l);
+  const b64 = typeof window === "undefined" ? Buffer.from(json, "utf8").toString("base64") : btoa(unescape(encodeURIComponent(json)));
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function decodeLayout(s: string): ShellLayout | null {
+  try {
+    const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
+    const json = typeof window === "undefined" ? Buffer.from(b64, "base64").toString("utf8") : decodeURIComponent(escape(atob(b64)));
+    const l = JSON.parse(json) as ShellLayout;
+    if (!l || typeof l !== "object" || !Array.isArray(l.widgets) || !l.segments || !l.stage) return null;
+    return l;
+  } catch { return null; }
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `npm test -- console-presets console-share`
+Expected: PASS.
+
+- [ ] **Step 6: Wire presets + share into the palette (extend Task 13)**
+
+In `components/shell/CommandPalette.tsx`, append after the stage commands:
+
+```ts
+import { listPresets, applyPreset, saveCustomPreset } from "@/lib/console/presets";
+import { encodeLayout } from "@/lib/console/share";
+import { shellLayoutStore } from "@/lib/console/store";
+
+for (const p of listPresets()) cmds.push({ id: `cpreset-${p.id}`, label: `Preset: ${p.title}`, hint: "preset", run: () => { applyPreset(p.id); close(); } });
+cmds.push({ id: "save-preset", label: "Save layout as preset…", hint: "preset", run: () => { const t = window.prompt("Preset name?"); if (t) saveCustomPreset(t); close(); } });
+cmds.push({ id: "share-layout", label: "Copy shareable link", hint: "share", run: () => { const url = `${location.origin}${location.pathname}?c=${encodeLayout(shellLayoutStore.get())}`; navigator.clipboard?.writeText(url); close(); } });
+```
+
+- [ ] **Step 7: tsc + commit**
+
+Run: `npx tsc --noEmit`
+
+```bash
+git add lib/console/presets.ts lib/console/share.ts components/shell/CommandPalette.tsx tests/unit/console-presets.test.ts tests/unit/console-share.test.ts
+git commit -m "feat(console): presets (built-ins + save-your-own) + URL share"
+```
+
+---
+
+### Task 15: Mount the console + reconcile chrome + e2e
+
+**Files:**
+- Modify: `components/shell/ConsoleShell.tsx`, `app/page.tsx`
+- Create: `tests/e2e/console.spec.ts`
+
+**Interfaces:**
+- Consumes: `ConsoleWorkspace`, `StageSwitch`, `shellLayoutStore.hydrate`, `applyPreset`, `decodeLayout`, the widget registry barrel.
+
+- [ ] **Step 1: Mount the workspace in ConsoleShell**
+
+In `components/shell/ConsoleShell.tsx`:
+1. Add imports: `import ConsoleWorkspace from "@/components/console/ConsoleWorkspace";`, `import StageSwitch from "@/components/console/StageSwitch";`, `import { shellLayoutStore } from "@/lib/console/store";`, `import { applyPreset } from "@/lib/console/presets";`, `import { decodeLayout } from "@/lib/console/share";`, `import "@/lib/console/widgets";`.
+2. In the hydrate `useEffect`, after `viewModeStore.hydrate();` add:
+
+```ts
+shellLayoutStore.hydrate();
+const c = new URLSearchParams(window.location.search).get("c");
+if (c) { const l = decodeLayout(c); if (l) shellLayoutStore.replace(l); }
+else if (shellLayoutStore.get().widgets.length === 0) applyPreset("world"); // first-run seed
+```
+
+3. Replace the `isConsole ? (…) : (…)` body block with the single workspace, keeping the chrome and overlays:
+
+```tsx
+return (
+  <div className="tn-shell">
+    <StatusBar onOpenPalette={() => setPaletteOpen(true)} />
+    <BreakingBanner />
+    <ConsoleWorkspace />
+    <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+    <FeedOverlay />
+    <CinematicDive />
+  </div>
+);
+```
+
+(Remove the now-unused `children`, `view`, `isConsole`, `ws`, PanelHost/EventFeed/ConsoleTopBar/DockableWorkspace/IntelColumn/PlaceSearch/Coverage/Markets/Watchlist imports. Mount `<StageSwitch/>` inside `StatusBar` or as a top-bar element — add it to `StatusBar`'s right cluster.)
+
+- [ ] **Step 2: Simplify page.tsx**
+
+```tsx
+// app/page.tsx
+import ConsoleShell from "@/components/shell/ConsoleShell";
+export default function Home() {
+  return <main className="tn-shell-main"><ConsoleShell /></main>;
+}
+```
+
+(`ConsoleShell` no longer takes children; the map now lives in `StageHost`.)
+
+- [ ] **Step 3: Add StageSwitch to the top bar**
+
+In `components/shell/StatusBar.tsx`, import and render `<StageSwitch/>` in the bar's control cluster.
+
+- [ ] **Step 4: Write the e2e spec**
+
+```ts
+// tests/e2e/console.spec.ts
+import { test, expect } from "@playwright/test";
+
+test("first-run seeds the World preset with widgets in segments", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".tn-cw").first()).toBeVisible();
+  await expect(page.locator('[data-segment="left"] .tn-cw')).not.toHaveCount(0);
+});
+
+test("⌘K adds a widget instance", async ({ page }) => {
+  await page.goto("/");
+  const before = await page.locator(".tn-cw").count();
+  await page.keyboard.press("Control+k");
+  await page.getByPlaceholder(/Search/).fill("Add Aviation");
+  await page.keyboard.press("Enter");
+  await expect(page.locator(".tn-cw")).toHaveCount(before + 1);
+});
+
+test("stage switch swaps to the world clock", async ({ page }) => {
+  await page.goto("/");
+  await page.locator(".tn-stage-switch button", { hasText: "🕐" }).click();
+  await expect(page.locator(".tn-clock")).toBeVisible();
+});
+
+test("collapsing the left segment hides its widgets", async ({ page }) => {
+  await page.goto("/");
+  // drag the left grip fully left
+  const grip = page.locator(".tn-grip").first();
+  const box = await grip.boundingBox();
+  if (box) { await page.mouse.move(box.x + 2, box.y + 20); await page.mouse.down(); await page.mouse.move(0, box.y + 20); await page.mouse.up(); }
+  await expect(page.locator('[data-segment="left"]')).toHaveCSS("width", /0px|(\d|10|20)px/);
+});
+```
+
+- [ ] **Step 5: Run everything**
+
+Run: `npx tsc --noEmit` → clean.
+Run: `npm test` → all `console-*` unit suites green.
+Run: `npm run build` → succeeds.
+Run: `npm run e2e -- console` → the four console e2e tests pass (start `npm run dev` if the Playwright config doesn't auto-start a server).
+
+- [ ] **Step 6: Manual smoke**
+
+`npm run dev` → load `/`: three segments with widgets, map on stage; ⌘K add/remove; drag a widget between segments; resize a segment to zero; switch to 3D/clock; apply "Aviation Ops" preset; copy shareable link, open in a new tab → same layout.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/shell/ConsoleShell.tsx app/page.tsx components/shell/StatusBar.tsx tests/e2e/console.spec.ts
+git commit -m "feat(console): mount widget console shell; reconcile chrome; e2e"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Shell: 3 segments + fixed stage, resize/collapse/scroll → Tasks 1-3, 7, 8 ✓
+- Center stage 3D/2D/clock → Task 8 (reuses `viewModeStore` projection) ✓
+- Widgets: multi-instance + 50 cap → Tasks 1-3 (cap), 6 (frame, duplicate/remove) ✓
+- Curated alerts + strip + badge + A/B style → Tasks 5, 6, 9-11 ✓
+- ⌘K catalog (add + counts) → Task 13 ✓
+- Presets replace + built-ins + save-your-own + URL share → Task 14 ✓
+- First-slice widgets (News video w/ provider picker, Aviation, Cameras, Events) → Tasks 9-12 ✓
+- Reconcile chrome (keep CinematicDive/FeedOverlay; drop viewMode split) → Task 15 ✓
+- Persistence (`tn.console.v1`) → Task 3 ✓
+
+**Deferred (per spec §10), intentionally absent:** more widgets, configurable/correlated alerts, notify-when-away, mobile. ✓
+
+**Placeholder scan:** No TBD/TODO; the three "Note" callouts point to a real sibling file to copy exact field names (allowed — they name the file and the exact adaptation point), not vague guidance.
+
+**Type consistency:** `WidgetInstance`/`ShellLayout` fields used identically across reducers, store, frame, segment, presets, share. `AlertRule<T>`/`Alert` consistent across alerts + all `*.rules.ts`. `shellLayoutStore` method names (`add/remove/move/resizeWidget/configure/setSegment/collapseSegment/stage/replace/hydrate`) consistent across store, frame, palette, presets, shell. `resolveEmbed`/`parseCustomStream`/`NEWS_PROVIDERS` consistent across providers + news widget + tests.
+
+**Known integration risks (flagged for the implementer, not blockers):**
+- `usePlanes`/`loadedCamerasStore`/`projectEventFeed` element shapes: adapt the `.map` in the widget body to the real field names; the pure rules tests pin the rule contracts regardless.
+- YouTube live video ids rotate; `add-custom-stream` is the escape hatch, and the ids are one-line edits.
+- Playwright base URL / dev-server auto-start: confirm `playwright.config.ts` `webServer` is set; if not, run `npm run dev` alongside `npm run e2e`.

--- a/docs/superpowers/specs/2026-06-28-ground-truth-console-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-28-ground-truth-console-redesign-design.md
@@ -1,0 +1,392 @@
+# TrafficNerd V2 — Ground-Truth Console Redesign — Design Spec
+
+> Date: 2026-06-28 · Status: Draft (awaiting review) · Owner: Sampo
+> Supersedes the direction of `2026-06-27-widgetize-everything-redesign-design.md` (the worldmonitor-style
+> widget console) after a 2-round, 6-persona blind-critique exercise showed that console was overwhelming,
+> low-signal, and "not a substitute" for anyone's real tool. This spec keeps the *good bones* that shipped on
+> `main` (the cinematic globe, the dossiers, the source catalog, freshness/attribution, watchlist/time-window
+> scaffolding) and restructures the product around a **console-first, trust-first, ground-truth** thesis.
+
+---
+
+## 0. How we got here (the evidence base)
+
+We ran each of 6 real user personas as a **blind critic**: given the live UI (screenshots of `main`) + the
+data, told only their job and their real alternatives, asked to tear it apart and say whether it beats their
+tools. Then we redesigned and re-critiqued the *proposed* design. Two rounds:
+
+| Persona | Round 1 | Round 2 | Round-2 stance |
+|---|---|---|---|
+| OSINT / geopolitics analyst | 2/5 | **3/5** | "Architecture finally right; data *trust* isn't." |
+| Commodities / macro trader | 1/5 | **3/5** | "Side scanner, never a trigger — until numbers are provenanced." |
+| Emergency / disaster manager | 2/5 | **3.5/5** | "First-look triage screen yes; system-of-record no." |
+| Logistics / supply-chain ops | 2/5 | **3.5/5** | "Pilot *alongside* project44, never instead." |
+| Newsroom / verification journalist | 2/5 | **3/5** | "Discovery + capture layer yes; verification *source* not yet." |
+| Everyday road-conditions driver | 2/5 | **3/5** (4 as cameras) | "Cameras are the real value; route/jams = a worse Waze." |
+
+**Round-1 universal failures (all 6):** the "Top Events" panel was nine near-identical `Active fire — 168 MW
+(nominal)` rows with no place/time/dedup; no event time or location on rows; no severity ranking/filter;
+the map was dot-soup / label-soup / crime-soup with layers on; no scoping to "what's relevant to me"; no
+alerting; trust-breaking contradictions ("Armed Conflict — no data" *during* a US-Iran strike banner; "all
+sources live" while feeds paused; an M0.7 quake dossier; mislabeled "MW").
+
+**Round-2 lesson (the strategic one):** the console-first direction is right (everyone moved up), but every
+pro independently said TrafficNerd is a **complement, not a replacement**, and named the incumbent *moat* it
+cannot cross (Bloomberg/Kpler's quant+desk, project44's live shipment integration, Waze's nav+crowd reports,
+Bellingcat's forensic chain). They also all pointed at the *same gap no incumbent fills*: **live, cross-domain,
+scoped ground-truth + disruption awareness, with honest provenance — and the live camera as proof.** That is
+the wedge this spec commits to.
+
+---
+
+## 1. Product thesis & positioning
+
+**TrafficNerd is the live, cross-domain, ground-truth situational layer** — the one place that fuses live
+cameras + flights + ships + hazards + infrastructure/conflict signals into a single *scoped, ranked, sourced*
+view, and lets you see the real thing (a live camera, a flight track, a satellite frame) as proof. It is the
+**honest complement** that sits next to your primary tool and answers "what is actually happening, right now,
+where I care — and can I see it?"
+
+**The signature mechanic** (from the original differentiation research, re-validated by the critics): the
+**live camera as ground-truth proof**, reachable in one move from any event, and visible at a glance (working
+thumbnails) rather than buried behind clicks.
+
+**Three pillars (everything in this spec serves one of them):**
+1. **Scoped relevance** — never the whole firehose; always *near me / this region / this AOI / my watchlist*.
+2. **Ranked, sourced events** — a real event feed with time, place, severity, magnitude-in-native-units, and
+   provenance; not counts, not spam.
+3. **Trust as the product** — honest-empty over full-but-wrong; source independence not "corroboration
+   counts"; official-vs-derived badging; visible freshness/latency; transparent severity & baselines.
+
+### 1.1 Explicit non-goals (what we will NOT chase — confirmed by the persona exercise)
+
+- **Turn-by-turn navigation / routing-as-guidance** (Waze/Google own it; the driver said the route/jam layer
+  is "a worse Waze"). We do "see your road right now," not "drive me there."
+- **Shipment-level ETA / carrier integration** (project44's moat: live ELD/EDI/AWB keyed to *your* loads). We
+  do disruption + camera ground-truth on a corridor, not "where is container ABCD."
+- **Terminal-grade quant / tradable numbers** (Bloomberg/Kpler). We surface awareness + provenance; we do not
+  invent capacity-at-risk numbers anyone would trade on without confirming elsewhere.
+- **Forensic chain-of-custody verification** as a legal product (Bellingcat-grade). We give *better* evidence
+  capture than a screenshot, clearly labelled for what it is — not a courtroom artifact.
+- **Crowd-sourced incident reporting** (Waze's community moat). We use authoritative/official feeds.
+
+Saying these out loud is itself a feature: it keeps us honest and focused, and it's the brand the research
+demanded ("everything here is a real, live, attributable feed").
+
+---
+
+## 2. Architecture overview (console-first)
+
+The product flips from "a globe with chrome" to "a **console** with a globe available."
+
+```
+ConsoleShell (hydration, ⌘K, dossier overlay, alerts)
+ ├─ TopBar          Scope ▾ · Time-window · ⌘K universal search · Alerts🔔 · Explore🌐 switch
+ ├─ SourceRail      (left, collapsible) layers/sources + presets ("lenses")
+ ├─ MapSurface      the 2D flat MapLibre map (default) — severity-graded, decluttered, layer-priority
+ │     └─ (Explore mode swaps this surface to the 3D globe + cinematic dive)
+ ├─ EventFeed       (right, the HERO) ranked + scoped + sourced event list  → click row → fly + dossier
+ ├─ FeedOverlay     the right-side dossier (camera/plane/sat/signal) — kept + extended
+ └─ StatusBar       per-source live/stale/paused health (honest)
+```
+
+**One data engine, two surfaces.** The Console (2D, default) and Explore (3D globe, secondary) read the same
+normalized **Event store** and the same live layers. Switching modes never changes the data — only the
+presentation and the chrome density.
+
+**Reuse, don't rewrite.** `main` already has most of the substrate; this spec evolves it:
+
+| Need | Already on `main` (reuse/evolve) | New work |
+|---|---|---|
+| Map engine, globe↔flat, clustering, basemaps | `components/WorldMap.tsx`, `lib/map/{features,icons,cluster}.ts` | default to flat; severity encoding; footprint geometry; layer-priority |
+| Event aggregation/ranking | `lib/widgets/topEvents.ts`, `useSignalFeatures`, `openSignalFeature` | promote to the full **Event model** + feed |
+| Dossiers (the good part) | `components/{Camera,Plane,Satellite,Signal,Webcam}Detail.tsx`, `lib/overlay*` | capture-UTC, evidence-export, camera bearing/FOV/DVR, exposure, track playback |
+| Scope: saved places | `lib/shell/watchlist.ts` (pure ops + recall) | extend to AOI/lanes/assets + scope-everything |
+| Time window | `lib/shell/timeWindow.ts`, `TimeWindowControl` | wire to feed + map + alerts |
+| Source catalog | `lib/sources/catalog.ts`, `lib/signals/*` | add provenance/severity/baseline metadata per source |
+| Freshness / source health | `lib/freshness.ts`, `lib/signals/freshness.ts` | per-source latency badge + honest-empty + last-update heartbeat |
+| Cinematic dive + thumbnails | `lib/cinematic/*`, `CinematicDive.tsx`, `lib/map/liveThumbnails.ts` | → the Explore mode; **fix thumbnail loading** (most don't render today) |
+| Alerts | `lib/shell/alert.ts` (banner dismissal only) | **net-new** relevance-scored threshold alerting |
+| Universal search | `components/shell/CommandPalette.tsx` (command-only) | index places + events + entities + sources |
+
+**Retired / folded:** the `DockableWorkspace` + `SourceWidget` count-tiles + the separate
+`IntelColumn`/`TopEventsPanel`/`InstabilityPanel`/`RiskPanel`/`ConflictPanel` panels are **replaced by the one
+Event Feed** (their data flows into it). `react-grid-layout` drag-the-tiles is dropped — the critics never
+wanted a configurable tile wall; they wanted one good ranked feed.
+
+---
+
+## 3. The Event model (the spine)
+
+Every signal — quake, fire, flood, cyclone, conflict event, protest, outage, port-congestion, military
+flight of note — normalizes to ONE `Event`:
+
+```ts
+interface Event {
+  id: string;                       // stable; dedupe key derives from (type, geo-cell, time-bucket)
+  type: EventType;                  // 'quake' | 'fire' | 'flood' | 'cyclone' | 'conflict' | 'outage' | ...
+  title: string;                    // human, specific ("M5.8 — 9 km N of Anza, CA")
+  place: { name: string; admin?: string; country?: string };
+  geo: { lat: number; lon: number; precision: GeoPrecision }; // EXACT|CITY|ADMIN|COUNTRY_CENTROID
+  footprint?: GeoJSON.Geometry;     // perimeter / flood polygon / cyclone cone / shake contour (not a dot)
+  occurredAt: string;               // ISO UTC — EVENT time, never poll time
+  severity: { tier: 'S0'|'S1'|'S2'|'S3'|'S4'; basis: SeverityBasis }; // see §10.3
+  magnitude?: { value: number; unit: string };  // native unit, correctly labelled (M, MW-FRP, m/s, …)
+  exposure?: { people?: number; assets?: AssetCount; method: string; asOf: string }; // §9.4
+  baseline?: { deltaPct: number; horizon: '7d'|'30d'|'365d'|'season'; note?: string }; // §10.4
+  provenance: Provenance;           // §10.1 — the trust object
+  links: { label: string; url: string }[];
+}
+```
+
+The `Event` is the unit the **feed**, the **map**, the **alerts**, and the **dossier** all read. Adding a
+source means "one adapter that emits `Event[]` with provenance" — the existing `lib/signals` registry
+contract, plus the provenance/severity fields.
+
+> Evolves `lib/widgets/topEvents.ts` (which already merges quakes/fires/disasters/cyclones and ranks by
+> severity-then-recency) into the general model; the data the rows need (magnitude, place, time) already
+> rides in each feature's `props` — it simply isn't surfaced today.
+
+---
+
+## 4. The Console layout (default surface)
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ TrafficNerd  [Scope ▾ Near me·Region·Draw AOI·Watchlist·World]  [15m 1h 6h 24h 7d] │
+│              [⌘K search places/events/entities]        [Alerts 🔔]  [Explore 🌐]   │
+├───────────┬───────────────────────────────────────────┬──────────────────────────┤
+│ SOURCES   │              2D FLAT MAP                   │  EVENT FEED  (the hero)    │
+│ /lenses   │  • severity-graded markers (S0–S4)         │  [type ▾ severity ▾ sort ▾]│
+│ (rail,    │  • signals clustered like cameras          │  ───────────────────────── │
+│ collapse) │  • label-collision avoidance + legend      │  S3 ● Quake  M5.8          │
+│           │  • LAYER PRIORITY: cameras+incidents on top │     9km N Anza CA · 12m    │
+│           │  • footprint geometry (perimeters/cones)   │     USGS ↗ · exact         │
+│           │  • live vs aggregate never same weight     │  S2 ● Wildfire  420 km²    │
+│           │  • basemaps: Light / Satellite / Topo      │     Sonoma · 1h · +growth  │
+│           │  feed row → fly + pulse marker             │  S2 ● Port congestion      │
+│           │  marker → dossier                          │     LA/LB · +18% vs 30d    │
+├───────────┴───────────────────────────────────────────┴──────────────────────────┤
+│ per-source health: ● live  ◐ stale 14m  ○ paused  ⊘ needs key      (honest, never "all live") │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Three zones, each independently understandable: **left** = what's on (sources/lenses), **centre** = where
+(map), **right** = what's happening (feed). The dossier slides over the centre on click.
+
+---
+
+## 5. The Event Feed (the hero)
+
+A reverse-chron, **de-duplicated**, **scoped**, sortable/filterable list. The single most important surface.
+
+**Row anatomy:** `severity chip (S0–S4) · type · title (place + magnitude) · age · Δ-vs-baseline · source↗ ·
+geo-precision marker`. Example: `S3 ● Quake M5.8 · 9 km N of Anza, CA · 12m · USGS ↗ · exact`.
+
+- **Sort:** severity×recency (default) · time · magnitude · distance-to-scope.
+- **Filter:** type · severity floor · time window (shared control) · source.
+- **Interactions:** click row → map flies + marker pulses + dossier opens; hover row → marker highlights
+  (two-way selection sync, reusing `lib/overlay`).
+- **De-dup is conservative + reversible** (§10.5): merged rows show a "▸ 3 reports" disclosure listing the
+  distinct members; we never silently collapse two genuinely distinct events.
+- **Empty state is explicit and honest:** "No events above S1 in *Near me · last 1h*" with the scope echoed —
+  never a blank panel, never a fake "0".
+
+**Per-role projection:** the feed has named **lenses** (presets) that set default type-filters + columns:
+*Hazards* (severity→exposure→recency, shows exposure col), *Intel* (conflict/protests/outages, shows
+source-independence), *Logistics* (incidents/ports on my lanes, shows ETA-Δ-estimate *labelled as estimate*),
+*Markets-watch* (asset-proximity events, shows Δ-vs-baseline), *Roads/near-me* (cameras + road incidents,
+shows thumbnails). Same engine, different default projection.
+
+---
+
+## 6. Scope & time-window (the relevance spine)
+
+A single global **Scope** control (top bar) drives the map extent, the feed contents, the counts, and the
+alert rules:
+
+- **Near me** — geolocate (reuses `/api/geolocate`, `/api/near`). Default for the road/near-me lens.
+- **Region** — place search (reuses `/api/geocode` + `PlaceSearch` + `flyToPoint`).
+- **Draw AOI** — box/polygon; "everything in this box, last N hours."
+- **Watchlist** — pinned places, drawn lanes/corridors, imported assets. **Evolves `lib/shell/watchlist.ts`**
+  (already persists saved places + recalls them) to also hold lanes (polylines) and assets (points with a
+  type), and to *filter* the feed/alerts to events intersecting them, not just bookmark a camera.
+- **World** — the firehose, explicitly opt-in.
+
+**Time window** (`lib/shell/timeWindow.ts`, already built) is wired to feed + map + alerts so "last 15m / 1h /
+6h / 24h / 7d" trims everything consistently. A map time-slider scrubs within the window.
+
+---
+
+## 7. The 2D map (legibility)
+
+The fixes for "the data on the map is horrific":
+
+- **Severity encoding:** marker size/colour = `severity.tier` (one ramp, shared with the feed chips).
+- **Cluster signals** the way cameras already cluster (`lib/map/cluster.ts`), so dense event regions collapse
+  to counts, not soup.
+- **Label-collision avoidance** + a **legend**; labels appear only at zoom and never stack.
+- **Layer priority:** cameras + road incidents always render above ambient signals (the things you act on
+  win the z-order).
+- **Footprint geometry:** render `Event.footprint` — fire perimeters, flood polygons, cyclone cones, shake
+  contours — instead of a lone dot (extends `lib/map/features.ts`, which already handles line/area signal
+  geometry for cables/jamming).
+- **Live vs aggregate are visually distinct and never share weight.** Monthly aggregates (UK street crime) are
+  labelled "monthly," styled flatter, and off by default — they must never read as live (the crime-soup of
+  Round 1).
+- Basemaps unchanged (Light / Satellite / Topographic), all camera-ground-truth-friendly.
+
+---
+
+## 8. Dossiers + the camera ground-truth system (the signature)
+
+The dossiers are the part the critics liked ("the right bones"). Keep them; extend for ground-truth + trust.
+The **camera** dossier is the signature surface and the sleeper win every persona valued:
+
+- **Camera metadata** (new): bearing/azimuth, FOV, fixed-vs-PTZ, range, last-move time — so you know *what it
+  is looking at* (journalist geolocation; driver "is this my junction"; emergency evac-route framing).
+- **Capture-UTC** burned into the frame + **DVR/scrub-back** of a short buffer (verification happens *after*
+  the moment; live-only loses it).
+- **Working thumbnails:** fix `lib/map/liveThumbnails.ts` so available cameras actually show their live frame
+  at zoom (today most stay icons because the proxied images are slow/failing — see §15 P2). This is the
+  "see the feed at a glance" promise.
+- **Evidence export** (labelled honestly, *not* forensic): frozen frame + burned-in capture-UTC + source +
+  coords + URL as one file. We note what time is stamped (fetch vs source-emit) and that streams lag.
+- **Event → nearest cameras** (relevance, not just radius): from any event, surface cameras whose
+  bearing/FOV plausibly see the footprint, labelled "nearby — viewpoint unverified" (never auto-assert that a
+  camera shows the event; the journalist flagged false-confirmation as the single most dangerous feature).
+
+Other dossiers: **plane** gains track playback + position-age + squawk display (with the caveat that
+7500/7600/7700 are *emergency* squawks, frequently spurious — not a "military" indicator); **event** gains
+occurredAt(UTC) + exposure (§9.4) + footprint + provenance + "nearest live cameras."
+
+### 8.4 Exposure (events)
+
+`Event.exposure` relays authoritative exposure where it exists (e.g. USGS **PAGER** order-of-magnitude
+population-by-intensity with its stated uncertainty) rather than recomputing it, and labels everything with
+`method` + `asOf`. Asset counts (hospitals/schools in footprint) come from OSM/HIFLD with a freshness date.
+We show ranges + uncertainty, never false-precise single numbers.
+
+---
+
+## 9. Alerts (relevance-scored, entity-keyed)
+
+Net-new (today's `lib/shell/alert.ts` is only banner-dismissal). A rule = `{ scope|asset, type[], severityFloor,
+window }` → in-app + (opt-in) push. Built to *not* cry wolf:
+
+- **Relevance, not radius:** an alert fires on `event-type × asset-type` relevance, not mere distance (a brush
+  fire on a refinery fence-line shouldn't page the energy desk). Entity-keyed (this lane / this asset / this
+  AOI), deduped against the feed's dedup.
+- **Official vs derived badging:** alerts relayed from official CAP/NWS/NHC are marked authoritative; alerts
+  *we* derive (a FIRMS fire-growth threshold) are badged "UNOFFICIAL — not for dispatch." (Emergency manager:
+  this distinction is the whole game.)
+- The existing anti-"crying-wolf" dismissal idiom (remember the dismissed key) carries over per-rule.
+
+---
+
+## 10. Trust & provenance (the brand, made into a system)
+
+This is the layer Round 2 said is missing, and it *is* the differentiation. Cross-cutting requirements:
+
+**10.1 Provenance object** on every Event/datum: `{ sources: {name, tier, firstSeenAt, role:'primary'|'echo',
+url}[], latencyMs, derivation?: string }`. Surfaced in the row (source↗ + a tier marker) and the dossier.
+
+**10.2 Source independence, not "corroboration counts."** We show *distinct primary sources* (GDELT copying
+one wire 200× is one source, not 200). Echoes are collapsed and labelled. No bare count ever implies
+confidence.
+
+**10.3 Severity is per-domain + transparent.** A single S0–S4 *display* ramp, but the *basis* is
+domain-specific and shown (`SeverityBasis`): quakes by magnitude+depth+exposure, fires **exposure-weighted**
+(a 20 MW WUI fire outranks a 168 MW wilderness fire), conflict by fatalities+confidence — never one naive
+global number. FIRMS confidence (`nominal/high`) is **never** shown as severity.
+
+**10.4 Baselines are multi-horizon + seasonal.** `Δ-vs-baseline` offers 7d/30d/365d/same-season, guards
+against baseline-poisoning (a 60-day Suez closure must not become "normal"), and for media-derived sources
+(GDELT) is labelled "media-volume Δ, not event Δ." Chronic state (a country sitting at instability 49
+forever) is suppressed; only *change* surfaces.
+
+**10.5 Honest-empty + source-health over full-but-wrong.** Every source carries a live/stale/paused/needs-key
+state + last-update heartbeat + latency badge (extends `lib/freshness.ts`). A lagging curated source (ACLED is
+days behind) shows **honestly empty** during a live event rather than being back-filled with noisy real-time
+proxies presented at equal weight. The status bar can never say "all live" while a feed is paused. A clean map
+during a data gap must read as "no data," not "all clear."
+
+**10.6 Geo-precision is explicit.** `GeoPrecision` (EXACT/CITY/ADMIN/COUNTRY_CENTROID) is rendered — centroid-
+geocoded events (GDELT "Iran" → a mid-country dot) are drawn with an uncertainty halo, never a precise pin.
+
+**10.7 Dedup is conservative + reversible** (see §5) — undercounting two real events or flattening a
+fore/aftershock sequence is treated as a worse failure than a near-dup slipping through.
+
+---
+
+## 11. Explore mode (the demoted globe)
+
+The 3D globe + cinematic dive (`lib/cinematic/*`, `CinematicDive.tsx`) becomes the secondary **Explore 🌐**
+mode behind the top-bar switch: calm, decluttered, severity-scaled, "wander the planet," with working live
+thumbnails on descent. Same Event engine; lower chrome density. It keeps the wonder/marketing appeal the
+research valued, without being the default work surface.
+
+---
+
+## 12. Per-role payoff & honest boundary
+
+| Persona | What now serves them | The boundary we accept (non-goal) |
+|---|---|---|
+| OSINT analyst | scoped event feed w/ UTC+coords+source-tier+geo-precision; AOI+time; mil-air *of note*; export; honest-empty conflict | not a correlation/causal engine; ACLED lag shown, not faked |
+| Trader | asset-proximity feed, Δ-vs-baseline, live AIS chokepoint deltas, alerts; magnitude in native units w/ provenance | no tradable capacity-at-risk numbers; "awareness then confirm in Kpler" |
+| Emergency | severity (exposure-weighted) + footprint + exposure + **official CAP relayed**, one-tap evac cameras, push | derived alerts badged UNOFFICIAL; not a system-of-record |
+| Logistics | scope-to-my-lanes, road-incident layer + camera-as-proof, port-dwell, lane alerts/export | not shipment-level ETA (project44's moat); ETA-Δ labelled "estimate" |
+| Journalist | UTC+dedup wire, evidence export, camera bearing/FOV/DVR, event→camera (labelled unverified), ⌘K over data | not forensic chain-of-custody; fusion never auto-asserts |
+| Driver | near-me/route lens: working camera thumbnails, "updated 2m ago," road incidents, fixed mobile | not navigation; "see your road now," not "drive me there" |
+
+---
+
+## 13. Phased delivery
+
+Each phase is independently shippable, build-green, solo-attributed (repo convention). Phase 1 delivers the
+visible payoff (the feed + console + scope); trust depth and per-role lenses layer on.
+
+- **P1 — Console + Event model + Event Feed.** Normalize signals → `Event[]` (evolve `topEvents.ts`); the
+  console layout (default flat map + right feed); rows with type/place/UTC/severity/source; click→fly+dossier;
+  the **Scope** control (near-me/region/AOI/world) + time-window wired through; retire the dock/IntelColumn
+  panels into the feed. *This alone fixes the Round-1 "Top Events" disaster.*
+- **P2 — Map legibility + camera ground-truth.** Severity encoding, signal clustering, label-collision,
+  layer-priority, footprint geometry, live-vs-aggregate split; **fix live thumbnails**; camera dossier
+  metadata (bearing/FOV/PTZ) + capture-UTC + DVR + evidence-export.
+- **P3 — Trust & provenance system.** Provenance object + source-independence display; geo-precision rendering;
+  honest-empty + per-source latency/health; transparent per-domain severity; multi-horizon baselines;
+  conservative reversible dedup.
+- **P4 — Scope deepening + Alerts.** Watchlist → lanes + imported assets (CSV) + scope-everything;
+  relevance-scored, entity-keyed alerts with official-vs-derived badging + push; universal ⌘K (places/events/
+  entities). Exposure (PAGER relay) + footprint sources.
+- **P5 — Lenses + new live data + Explore polish.** Per-role lenses (Hazards/Intel/Logistics/Markets/Roads);
+  live AIS + weather radar (unblock trader/logistics); road-incident layer; Explore mode polish; mobile
+  feed-first.
+
+(Phases 2–4 can reorder; P1 ships the feed-first console first.)
+
+---
+
+## 14. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Provenance/severity/baseline shipped naively → re-introduces the distrust we're fixing | §10 is first-class, not a footnote; each lands with its source-independence/precision/honest-empty rules + tests |
+| "One Event model" flattens native fields pros triage on (AIS draught, ADS-B climb) | Event carries a typed `raw` payload; the dossier renders native fields per type |
+| Alert fatigue kills the feature (first false 3am push → muted forever) | relevance (type×asset) not radius; entity-keyed; deduped; official-vs-derived; per-rule dismissal |
+| Camera ground-truth over-promises (thumbnails fail today; "nearest camera" mis-associates) | P2 fixes thumbnail loading w/ a verified budget; event→camera is bearing/FOV-aware + labelled "unverified" |
+| Scope creep back toward the incumbent moats | §1.1 non-goals are binding; lenses *project* the same engine, they don't fork it |
+| Big restructure destabilizes a working `main` | reuse map (§2) — evolve existing stores/components; phased; build+vitest green per phase |
+
+## 15. Open questions (for review)
+
+1. **Default scope on first load:** Near-me (driver-friendly, needs geolocation permission) vs World (no
+   prompt, but firehose)? Lean: **Near-me with a graceful World fallback** if permission denied.
+2. **Lens vs scope coupling:** does choosing the "Hazards" lens also set a sensible default scope/time, or are
+   they fully orthogonal? Lean: lens sets *defaults* the user can override.
+3. **How much of P5's new live data (AIS, weather radar) is in-scope now** vs a follow-on — they unblock 2
+   personas but add real ingestion/cost.
+4. **Explore mode prominence:** a top-bar peer toggle, or a softer "globe" affordance? (Marketing wants the
+   globe visible; the work surface is the console.)
+5. **Name/Framing:** "TrafficNerd" undersells a cross-domain ground-truth layer — revisit, or lean into the
+   transport/observation identity?

--- a/docs/superpowers/specs/2026-06-28-widget-console-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-28-widget-console-redesign-design.md
@@ -149,7 +149,7 @@ Each reuses data the app already fetches.
 
 | Widget | Body | Curated alert rules (examples) | Reuses |
 |--------|------|--------------------------------|--------|
-| **Live Video News** | Live **video** player + channel lower-third + `● LIVE`; tabs switch channel (Al Jazeera, DW, France 24, Sky News, Bloomberg, NASA TV — free 24/7 YouTube-live/HLS). Muted by default, click to unmute, `⛶` expand. | (none in v1 — a "breaking" hook can come later) | `CameraVideo`/HLS player; news source list |
+| **Live Video News** | Live **video** player + channel lower-third + `● LIVE`; **favourite tabs** for quick-switch + a **"More…" provider catalogue** (search + categories, ★ favourites) + **add-custom-stream** (HLS `.m3u8` / YouTube-live). Provider is **per-instance**. ~12 free 24/7 channels seeded (Al Jazeera, DW, France 24, Sky, Euronews, CNA, TRT, NHK, Bloomberg, NASA…). Muted by default, click to unmute, `⛶` expand. | (none in v1 — a "breaking" hook can come later) | `CameraVideo`/HLS player; news source list |
 | **Aviation** | Filter/sort flights board (callsign, route, alt, speed, status). Filter by airline/region; sort by alt/speed. | squawk **7700/7600/7500**; rapid descent; new **military** callsign in region; airport traffic surge | `adsb.lol` plane layer (already live) |
 | **Cameras** | Grid/list of live camera thumbnails/streams for the active region; click → dive. | camera went **offline**; new incident camera in region | existing HLS camera feeds + `CinematicDive` |
 | **Disasters & Events** | The ranked event feed (filter by type/severity, sort by severity/time). | **M5+** quake; new **S3+** GDACS disaster; FIRMS cluster spike | the `EventFeed` projection you already built |
@@ -239,8 +239,9 @@ from MapLibre's globe/flat projection (the app already renders the globe) — an
 - **Assumption:** widget placement on add = "segment with most room, else Left." Loose by design; user
   confirmed they'll rearrange.
 - **Assumption:** 50-instance cap is global (not per-type).
-- **Assumption:** Live News channels are free public livestreams (YouTube-live/HLS); exact channel list and
-  default audio (muted) are tunable.
+- **Assumption:** Live News = free public livestreams (YouTube-live/HLS). v1 seeds ~12 channels with
+  favourite-tabs + a searchable provider catalogue + **add-custom-stream**; provider is per-instance; audio
+  muted by default. Channel list is tunable.
 - **Open:** intra-segment widget sizing — confirm height-only resize (vs. also a 2-col option in the wide
   Bottom segment). Default: height-only everywhere for v1.
 - **Open:** does the Bottom segment span the **full width** (under the rails too) or only under the stage?

--- a/docs/superpowers/specs/2026-06-28-widget-console-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-28-widget-console-redesign-design.md
@@ -1,0 +1,260 @@
+# TrafficNerd — Segmented Widget Console (redesign)
+
+**Date:** 2026-06-28
+**Status:** Design — approved in brainstorm, pending spec review
+**Builds on:** branch `feat/ground-truth-console-redesign` (the console-first work). Supersedes the
+console/explore split with a single segmented widget shell.
+**Visual mockups:** `.superpowers/brainstorm/2120-1782679303/content/*.html` (layout-v2, category-card,
+full-shell, palette-catalog, video-news).
+
+---
+
+## 1. Vision
+
+TrafficNerd becomes a **composable live-monitoring console**. The screen is a fixed map/stage in the
+centre, flanked by three resizable, collapsible, scrollable **segments**. Each segment holds **widgets** —
+rich, self-contained category cards (Aviation, Live Video News, Cameras, Disasters…). Every widget is a
+**monitoring surface**: it shows plenty of detail *and* auto-surfaces "something important to my job just
+happened." A user picks a **preset** for their field and the segments fill with the widgets relevant to
+them; they add more from the **command palette**, drag widgets between segments, run several at once, and
+save their own arrangement.
+
+The north star: a professional (an aviation ops controller, a journalist, a disaster-response coordinator)
+opens their preset and, at a glance, sees their world — and is pulled to whatever just changed.
+
+---
+
+## 2. Vocabulary
+
+| Term | Meaning |
+|------|---------|
+| **Shell** | The whole app frame: top bar + centre stage + three segments + overlays. |
+| **Segment** | One of three resizable / collapsible / **scrollable** regions: **Left**, **Right**, **Bottom**. Each is a vertical scrolling stack of widgets. |
+| **Centre stage** | The fixed middle region. Holds exactly one **stage widget**, swappable: **3D map / 2D map / World clock**. Position-locked; grows as segments collapse. |
+| **Widget** | A category card (a `WidgetType` instance). Rich, detailed, monitorable. |
+| **Widget instance** | A specific live card with its own config. Widgets are **multi-instance** (e.g. two Live News cards on different channels). Hard cap **50** instances total. |
+| **Preset** | A named bundle that *replaces* the current arrangement: which widgets exist, in which segments, segment sizes, stage choice, map layers/scope/theme. Built-in or user-saved. (Extends today's `Variant`.) |
+| **Alert** | A notable-change item a widget detects via its curated rules, shown in the card's "Needs attention" strip + badge. |
+
+---
+
+## 3. The shell layout
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ TrafficNerd   [✈ Aviation Ops ▾]      [3D|2D|🕐]   Satellite ◎World ⌘K Share EN ☾ │  top bar
+├──────────┬──────────────────────────────────────────────┬───────────┤
+│  LEFT    │                                              │  RIGHT     │
+│ segment  │              CENTRE STAGE                    │  segment   │
+│ (scroll) │          (3D / 2D map · or clock)            │ (scroll)   │
+│ [widget] │                                              │ [widget]   │
+│ [widget] ├──────────────────────────────────────────────┤ [widget]   │
+│   ⇕      │              BOTTOM segment (scroll)          │   ⇕        │
+│          │              [widget] [widget]                │            │
+└──────────┴──────────────────────────────────────────────┴───────────┘
+```
+
+- **Three segments: Left, Right, Bottom.** Left & Right are full-height columns; Bottom sits under the
+  stage, between the rails (the stage is "surrounded" — chosen layout **Y**).
+- **Resize** by dragging the divider between a segment and the stage. **Collapse** a segment to zero
+  (drag the divider all the way, or a collapse caret) → the stage reclaims the space. Collapse all three
+  → the stage is full-screen.
+- Each segment **scrolls** vertically; stack as many widgets as you like.
+- **Centre stage** is never a segment — it's fixed and always present; only its *content* swaps
+  (3D map ↔ 2D map ↔ world clock) via the top-bar switch or the palette.
+- Segment sizes + collapsed state are **persisted** and **part of a preset**.
+
+---
+
+## 4. Widgets (category cards)
+
+### 4.1 Shared frame (`<WidgetFrame>`)
+
+Every widget renders inside one frame so the chrome is consistent:
+
+- **Header:** icon · title · live count · freshness dot (e.g. "1m") · **alert badge** (count, red) ·
+  `⋯` menu.
+- **`⋯` menu:** Duplicate · Alert style (toggle A/B, see 4.3) · Resize-to-fit · **Remove**.
+- **Toolbar (optional):** filter chips + sort control, per the widget's capabilities. Filter/sort is
+  **per-instance** (two Aviation cards can filter to different regions).
+- **"Needs attention" strip:** the widget's current alerts (4.3).
+- **Body:** the widget-type's own content.
+- **Drag handle** (the header): drag to reorder within a segment or move to another segment.
+- **Resize handle** (bottom edge): adjust the widget's **height** (segments are 1-D scrolling stacks, so
+  width = the segment's width; only height is user-set). A collapse caret shows header-only.
+
+### 4.2 Multi-instance + per-instance config
+
+- A widget is a `WidgetType`; the canvas holds `WidgetInstance`s. Adding the same type again creates a new
+  instance with its own `config`. Example: Live News ×2 (Al Jazeera + Bloomberg); Aviation ×2 (Europe + US).
+- Cap: **50 instances total.** Adding past 50 is blocked with a gentle inline nudge ("50-widget limit —
+  remove one to add another").
+
+### 4.3 The monitoring / alert model (v1 = curated rules)
+
+Each `WidgetType` ships a pure **`alertRules(data, config) → Alert[]`** function — a handful of built-in
+notable-change detectors. No user setup in v1.
+
+- **Alert** = `{ id, severity: "info"|"warn"|"critical", text, ts, ref? }`.
+- **Two display styles, per-card toggle (default A):**
+  - **A — Alerts pinned on top:** a "Needs attention · N" strip above the live body.
+  - **B — Priority feed:** one body stream sorted by importance; alerts float to the top with a priority dot.
+- **Badge:** header shows the count of current alerts; the **segment** shows an aggregate badge so a
+  collapsed/scrolled-away widget can still shout.
+- **Deferred to later passes:** user-configurable thresholds, cross-widget correlation, and
+  notify-when-not-looking (desktop / sound / tab-title). Captured in §10.
+
+---
+
+## 5. Command palette = the widget catalog
+
+⌘K / Ctrl-K (already wired in `ConsoleShell`) becomes the catalog of everything addable:
+
+- **Search** across widget types, presets, places, and commands.
+- **Widget types grouped by category** (Aviation, News & Markets, Cameras, Events, Space, Maritime…).
+  Each row: icon · name · short description · **Add** (creates an instance) · a small **count** of how many
+  of that type are currently open.
+- **Adding lands the widget in a segment automatically** (no segment picker — placement is loose by
+  design); the user drags it wherever afterward. Default target: the segment with the most room / fewest
+  widgets, falling back to Left.
+- **Commands** (existing behaviour preserved): apply preset, switch stage (3D/2D/clock), switch basemap,
+  fly to a region, open share.
+- Respects the **50-instance cap**.
+
+---
+
+## 6. Presets
+
+Presets *are* today's `Variant`, extended to carry the widget arrangement. Applying one **replaces** the
+current arrangement.
+
+- **Applying a preset sets:** the open widget instances + their segments/order/size, the segment
+  sizes/collapsed state, the centre-stage choice, and (as today) map layers / signals / scope / theme /
+  view.
+- **Built-in presets (ship in slice):** `World` (all four widgets), `Aviation Ops` (Aviation + News +
+  Cameras + Events), `Disaster Response` (Events + Cameras + News). More presets (e.g. Maritime Watch)
+  arrive with their widgets in later passes — no empty presets in the slice.
+- **Save your own:** "Save layout as preset…" snapshots the current arrangement into `userVariants`
+  (already supported by `variantStore`), persisted to localStorage.
+- **Unsaved-changes guard:** switching presets with unsaved edits prompts (the store already tracks an
+  `edited`/override delta).
+- **Share via URL:** extend the existing `share/url` encoder so a link restores the full arrangement
+  (`?v=` preset + layout payload). Already have `?v=`/`?sig=` plumbing.
+
+---
+
+## 7. First-slice widgets (the 4)
+
+Each reuses data the app already fetches.
+
+| Widget | Body | Curated alert rules (examples) | Reuses |
+|--------|------|--------------------------------|--------|
+| **Live Video News** | Live **video** player + channel lower-third + `● LIVE`; tabs switch channel (Al Jazeera, DW, France 24, Sky News, Bloomberg, NASA TV — free 24/7 YouTube-live/HLS). Muted by default, click to unmute, `⛶` expand. | (none in v1 — a "breaking" hook can come later) | `CameraVideo`/HLS player; news source list |
+| **Aviation** | Filter/sort flights board (callsign, route, alt, speed, status). Filter by airline/region; sort by alt/speed. | squawk **7700/7600/7500**; rapid descent; new **military** callsign in region; airport traffic surge | `adsb.lol` plane layer (already live) |
+| **Cameras** | Grid/list of live camera thumbnails/streams for the active region; click → dive. | camera went **offline**; new incident camera in region | existing HLS camera feeds + `CinematicDive` |
+| **Disasters & Events** | The ranked event feed (filter by type/severity, sort by severity/time). | **M5+** quake; new **S3+** GDACS disaster; FIRMS cluster spike | the `EventFeed` projection you already built |
+
+Stage widgets in slice: **3D map** (globe projection) and **2D map** (flat projection) — both available
+from MapLibre's globe/flat projection (the app already renders the globe) — and a new **World Clock**
+(multi-timezone).
+
+---
+
+## 8. Architecture (how it maps to existing code)
+
+**Reused largely as-is**
+- `variantStore` — presets, persistence (`tn.variant.v1`), URL share, `userVariants`, override deltas,
+  `setActive`, `commitLayout`. Extend its persisted state with the widget arrangement.
+- `layersStore` / `signalsStore` / `mapViewStore` / `scopeStore` / `uiStore` — preset application already
+  flows through these.
+- MapLibre `WorldMap` — 3D = globe projection, 2D = flat (existing). Becomes the stage's map widget.
+- HLS player (`CameraVideo`) — basis for Live Video News + Cameras.
+- `EventFeed` projection — wrapped as the Disasters & Events widget body.
+- ⌘K `CommandPalette` shell + global shortcut.
+
+**New / changed**
+1. **Data model — `WidgetInstance` replaces one-per-key `PanelPlacement`.** This is the core change.
+   ```ts
+   type SegmentId = "left" | "right" | "bottom";
+   type StageId = "map3d" | "map2d" | "clock";
+   interface WidgetInstance {
+     id: string;            // unique (nanoid)
+     type: WidgetTypeId;    // "video-news" | "aviation" | "cameras" | "events" | …
+     segment: SegmentId;
+     order: number;         // position within the segment's scroll stack
+     height: number;        // user-resizable; width = segment width
+     collapsed?: boolean;
+     config: Record<string, unknown>; // filter/sort, channel, region, alertStyle…
+   }
+   interface ShellLayout {
+     segments: Record<SegmentId, { size: number; collapsed: boolean }>;
+     stage: StageId;
+     widgets: WidgetInstance[]; // ≤ 50
+   }
+   ```
+   The current grid `PanelPlacement.grid{x,y,w,h}` is retired for this view in favour of
+   segment + order + height (segments are 1-D scroll stacks, not a 2-D grid).
+2. **`WidgetType` registry** — `{ id, title, icon, category, defaultConfig, defaultHeight, component,
+   alertRules?, capabilities:{filter?,sort?,channels?} }`. Generalises today's `widgets/registry`
+   (`rollup:`/`source:`) and the intel `PANEL_REGISTRY` into one typed registry that the palette and the
+   segments both read.
+3. **Shell stores** — `shellLayoutStore` (segment sizes/collapsed, stage, widget instances; persisted) and
+   the drag/resize interactions. Segment dividers: a resizable-panels approach; intra/inter-segment widget
+   drag: a vertical multi-container sortable (dnd-kit or equivalent). RGL is not needed for 1-D stacks.
+4. **`<WidgetFrame>`** + the four widget bodies + the alert-rule functions.
+5. **Live Video News** widget (channel list + player).
+6. **World Clock** stage widget.
+7. **Palette upgrade** — catalog rows with Add + instance counts + cap.
+
+---
+
+## 9. Reconciling existing chrome
+
+- **Top bar:** keep; show active preset pill + stage switch + basemap + Scope + ⌘K + Share + lang + theme.
+- **`viewMode` console/explore split:** retired — the segmented shell is the one view. "Explore the globe"
+  becomes "collapse the segments / switch stage to 3D."
+- **Old left Monitors (`SourceCatalog`) & right Events (`EventFeed`):** become widgets (Sources widget
+  later; Events ships in slice).
+- **`CinematicDive`** (fly-to-feed) and **`FeedOverlay`** dossier (`?obj=`): kept as drill-in overlays —
+  clicking a row/camera dives or opens the dossier.
+- **`BreakingBanner`:** kept for now (could fold into a widget later).
+- **Bottom sources/paused bar:** folded into a slim status line or dropped (superseded by per-widget
+  freshness).
+
+---
+
+## 10. Out of scope / later passes
+
+- More widgets/categories: Maritime/Ships, Satellites/Space, Weather, Markets, Webcams, Sources, NOTAMs,
+  Airports, Delays, Aviation-Wx, Helicopters, Military.
+- **Smarter alerts:** user-configurable thresholds; cross-widget correlation; **notify-when-not-looking**
+  (desktop notification / sound / tab-title badge).
+- Mobile / small-screen layout (slice targets desktop console).
+- Per-widget deep settings panels beyond filter/sort.
+
+---
+
+## 11. Assumptions & open questions
+
+- **Assumption:** widget placement on add = "segment with most room, else Left." Loose by design; user
+  confirmed they'll rearrange.
+- **Assumption:** 50-instance cap is global (not per-type).
+- **Assumption:** Live News channels are free public livestreams (YouTube-live/HLS); exact channel list and
+  default audio (muted) are tunable.
+- **Open:** intra-segment widget sizing — confirm height-only resize (vs. also a 2-col option in the wide
+  Bottom segment). Default: height-only everywhere for v1.
+- **Open:** does the Bottom segment span the **full width** (under the rails too) or only under the stage?
+  Default: under the stage only (layout Y). Easy to switch.
+
+---
+
+## 12. Success criteria (slice)
+
+1. Three segments resize, collapse to zero, and scroll; centre stage swaps 3D/2D/clock.
+2. Add any of the 4 widgets from ⌘K; it appears in a segment; drag it to another segment; reorder; resize
+   height; remove. Multi-instance works; 50-cap enforced.
+3. Each widget shows live data + a working filter/sort and surfaces ≥1 curated alert in its strip/badge.
+4. Live Video News plays a real livestream and switches channel.
+5. Apply each built-in preset → the arrangement (widgets + segments + stage + layers) swaps wholesale.
+6. Save a custom preset, reload → it persists; share a URL → it restores the arrangement.
+7. `tsc` clean, unit tests for the pure pieces (layout reducers, alert rules, preset apply) green, build green.

--- a/lib/cameras/loaded.ts
+++ b/lib/cameras/loaded.ts
@@ -2,7 +2,7 @@
 // A lightweight snapshot of the cameras currently loaded on the map, so the ⌘K
 // "Dive to a live feed" command can pick a known-live one without re-fetching the
 // full /api/cameras payload. WorldMap publishes here whenever CamerasFeed lands.
-// Not reactive on purpose — the command reads it on demand.
+// Now reactive: subscribe() lets widgets (e.g. Cameras widget) rerender on updates.
 
 export interface LoadedCamera {
   id: string;
@@ -14,12 +14,18 @@ export interface LoadedCamera {
 }
 
 let cams: LoadedCamera[] = [];
+const listeners = new Set<() => void>();
 
 export const loadedCamerasStore = {
   set(next: LoadedCamera[]) {
     cams = next;
+    for (const fn of listeners) fn();
   },
   get(): LoadedCamera[] {
     return cams;
+  },
+  subscribe(cb: () => void): () => void {
+    listeners.add(cb);
+    return () => { listeners.delete(cb); };
   },
 };

--- a/lib/console/alerts.ts
+++ b/lib/console/alerts.ts
@@ -1,0 +1,14 @@
+export type AlertSeverity = "info" | "warn" | "critical";
+export interface Alert { id: string; severity: AlertSeverity; text: string; ts?: number; ref?: string }
+export type AlertRule<T> = (items: T[], config: Record<string, unknown>) => Alert[];
+
+const RANK: Record<AlertSeverity, number> = { info: 0, warn: 1, critical: 2 };
+
+export function runAlertRule<T>(rule: AlertRule<T>, items: T[], config: Record<string, unknown>): Alert[] {
+  try { return rule(items, config); } catch { return []; }
+}
+export function alertCount(alerts: Alert[]): number { return alerts.length; }
+export function topSeverity(alerts: Alert[]): AlertSeverity | null {
+  if (alerts.length === 0) return null;
+  return alerts.reduce((top, a) => (RANK[a.severity] > RANK[top] ? a.severity : top), "info" as AlertSeverity);
+}

--- a/lib/console/news/providers.ts
+++ b/lib/console/news/providers.ts
@@ -38,5 +38,5 @@ export function parseCustomStream(url: string): NewsProvider | null {
 
 export function resolveEmbed(p: NewsProvider): { kind: "youtube" | "hls"; src: string } {
   if (p.kind === "youtube") return { kind: "youtube", src: `https://www.youtube.com/embed/${p.ref}?autoplay=1&mute=1&playsinline=1` };
-  return { kind: "hls", src: p.ref };
+  return { kind: "hls", src: /^https?:\/\//i.test(p.ref) ? p.ref : "" };
 }

--- a/lib/console/news/providers.ts
+++ b/lib/console/news/providers.ts
@@ -1,0 +1,42 @@
+export interface NewsProvider {
+  id: string;
+  name: string;
+  category: string;
+  kind: "youtube" | "hls";
+  ref: string;
+  favorite?: boolean;
+}
+
+// YouTube live video ids for free 24/7 news channels. ids are tunable — they
+// occasionally rotate; the picker's add-custom-stream covers breakage.
+export const NEWS_PROVIDERS: NewsProvider[] = [
+  { id: "aljazeera", name: "Al Jazeera English", category: "World", kind: "youtube", ref: "gCNeDWCI0vo", favorite: true },
+  { id: "dw", name: "DW News", category: "World", kind: "youtube", ref: "tQwQfNuvb1A", favorite: true },
+  { id: "france24", name: "France 24", category: "World", kind: "youtube", ref: "h3MuIUNCCzI", favorite: true },
+  { id: "sky", name: "Sky News", category: "World", kind: "youtube", ref: "9Auq9mYxFEE" },
+  { id: "euronews", name: "Euronews", category: "World", kind: "youtube", ref: "pykpO5kQJ98" },
+  { id: "cna", name: "CNA", category: "World", kind: "youtube", ref: "XWq5kBlakcQ" },
+  { id: "trt", name: "TRT World", category: "World", kind: "youtube", ref: "Wp0_Dk0nJOk" },
+  { id: "nhk", name: "NHK World", category: "World", kind: "youtube", ref: "f0lYkdg2DZw" },
+  { id: "abcau", name: "ABC News (AU)", category: "World", kind: "youtube", ref: "vOTiJkg1voo" },
+  { id: "bloomberg", name: "Bloomberg TV", category: "Business", kind: "youtube", ref: "iEpJwprxDdk" },
+  { id: "nasa", name: "NASA TV", category: "Space", kind: "youtube", ref: "21X5lGlDOfg" },
+  { id: "iss", name: "ISS Live", category: "Space", kind: "youtube", ref: "DIgkvm2nmHc" },
+];
+
+const YT_ID = /(?:v=|youtu\.be\/|\/live\/|\/embed\/)([A-Za-z0-9_-]{6,})/;
+
+export function parseCustomStream(url: string): NewsProvider | null {
+  const u = url.trim();
+  // Check HLS first — a .m3u8 URL may contain /live/ in its path which would
+  // otherwise trip the YouTube regex below.
+  if (/^https?:\/\/\S+\.m3u8(\?\S*)?$/i.test(u)) return { id: `custom-hls`, name: "Custom (HLS)", category: "Custom", kind: "hls", ref: u };
+  const yt = u.match(YT_ID);
+  if (yt) return { id: `custom-${yt[1]}`, name: "Custom (YouTube)", category: "Custom", kind: "youtube", ref: yt[1] };
+  return null;
+}
+
+export function resolveEmbed(p: NewsProvider): { kind: "youtube" | "hls"; src: string } {
+  if (p.kind === "youtube") return { kind: "youtube", src: `https://www.youtube.com/embed/${p.ref}?autoplay=1&mute=1&playsinline=1` };
+  return { kind: "hls", src: p.ref };
+}

--- a/lib/console/news/providers.ts
+++ b/lib/console/news/providers.ts
@@ -24,7 +24,7 @@ export const NEWS_PROVIDERS: NewsProvider[] = [
   { id: "iss", name: "ISS Live", category: "Space", kind: "youtube", ref: "DIgkvm2nmHc" },
 ];
 
-const YT_ID = /(?:v=|youtu\.be\/|\/live\/|\/embed\/)([A-Za-z0-9_-]{6,})/;
+const YT_ID = /(?:v=|youtu\.be\/|\/live\/|\/embed\/)([A-Za-z0-9_-]{11})/;
 
 export function parseCustomStream(url: string): NewsProvider | null {
   const u = url.trim();

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -1,0 +1,54 @@
+"use client";
+import { createDefaultLayout, type ShellLayout, type SegmentId } from "@/lib/console/types";
+import { addWidget, setStage } from "@/lib/console/reducers";
+import { shellLayoutStore } from "@/lib/console/store";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export interface ConsolePreset { id: string; title: string; icon: string; build(): ShellLayout }
+
+let seed = 0;
+const id = () => `p${(seed += 1).toString(36)}`;
+function compose(stage: ShellLayout["stage"], specs: { type: string; segment: SegmentId }[]): ShellLayout {
+  let l = setStage(createDefaultLayout(), stage);
+  for (const s of specs) l = addWidget(l, s.type, id(), { segment: s.segment });
+  return l;
+}
+
+export const BUILTIN_PRESETS: ConsolePreset[] = [
+  { id: "world", title: "World", icon: "🌐", build: () => compose("map2d", [
+      { type: "events", segment: "left" }, { type: "news", segment: "bottom" },
+      { type: "cameras", segment: "right" }, { type: "aviation", segment: "left" },
+  ]) },
+  { id: "aviation-ops", title: "Aviation Ops", icon: "✈", build: () => compose("map2d", [
+      { type: "aviation", segment: "left" }, { type: "events", segment: "left" },
+      { type: "cameras", segment: "right" }, { type: "news", segment: "bottom" },
+  ]) },
+  { id: "disaster-response", title: "Disaster Response", icon: "🆘", build: () => compose("map2d", [
+      { type: "events", segment: "left" }, { type: "cameras", segment: "right" },
+      { type: "news", segment: "bottom" },
+  ]) },
+];
+
+const KEY = "tn.console.presets.v1";
+const VERSION = 1;
+interface CustomPreset { id: string; title: string; layout: ShellLayout }
+
+function loadCustom(): CustomPreset[] { return loadPersisted<CustomPreset[]>(KEY, VERSION) ?? []; }
+
+export function applyPreset(presetId: string): void {
+  const built = BUILTIN_PRESETS.find((p) => p.id === presetId);
+  if (built) { shellLayoutStore.replace(built.build()); return; }
+  const custom = loadCustom().find((p) => p.id === presetId);
+  if (custom) shellLayoutStore.replace(custom.layout);
+}
+
+export function saveCustomPreset(title: string): void {
+  const list = loadCustom();
+  list.push({ id: `custom-${Date.now().toString(36)}`, title, layout: shellLayoutStore.get() });
+  savePersisted(KEY, VERSION, list);
+}
+
+export function listPresets(): { id: string; title: string; icon: string }[] {
+  return [...BUILTIN_PRESETS.map((p) => ({ id: p.id, title: p.title, icon: p.icon })),
+          ...loadCustom().map((p) => ({ id: p.id, title: p.title, icon: "★" }))];
+}

--- a/lib/console/reducers.ts
+++ b/lib/console/reducers.ts
@@ -36,7 +36,12 @@ export function addWidget(
 }
 
 export function removeWidget(l: ShellLayout, id: string): ShellLayout {
-  return { ...l, widgets: l.widgets.filter((w) => w.id !== id) };
+  const removed = l.widgets.find((w) => w.id === id);
+  if (!removed) return l;
+  const kept = l.widgets.filter((w) => w.id !== id);
+  const segSorted = kept.filter((w) => w.segment === removed.segment).sort((a, b) => a.order - b.order);
+  const orderMap = new Map(segSorted.map((w, i) => [w.id, i] as const));
+  return { ...l, widgets: kept.map((w) => (orderMap.has(w.id) ? { ...w, order: orderMap.get(w.id)! } : w)) };
 }
 
 export function moveWidget(l: ShellLayout, id: string, toSegment: SegmentId, toIndex: number): ShellLayout {

--- a/lib/console/reducers.ts
+++ b/lib/console/reducers.ts
@@ -1,0 +1,74 @@
+import type { ShellLayout, WidgetInstance, SegmentId, StageId } from "@/lib/console/types";
+import { MAX_WIDGETS } from "@/lib/console/types";
+
+const SEGMENTS: SegmentId[] = ["left", "right", "bottom"];
+const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
+
+export function widgetsInSegment(l: ShellLayout, seg: SegmentId): WidgetInstance[] {
+  return l.widgets.filter((w) => w.segment === seg).sort((a, b) => a.order - b.order);
+}
+export function isAtCapacity(l: ShellLayout): boolean {
+  return l.widgets.length >= MAX_WIDGETS;
+}
+
+function emptiestSegment(l: ShellLayout): SegmentId {
+  let best: SegmentId = "left";
+  let min = Infinity;
+  for (const s of SEGMENTS) {
+    const n = l.widgets.filter((w) => w.segment === s).length;
+    if (n < min) { min = n; best = s; }
+  }
+  return best;
+}
+
+export function addWidget(
+  l: ShellLayout, type: string, instanceId: string,
+  opts: { segment?: SegmentId; config?: Record<string, unknown>; height?: number } = {},
+): ShellLayout {
+  if (isAtCapacity(l)) return l;
+  const segment = opts.segment ?? emptiestSegment(l);
+  const order = l.widgets.filter((w) => w.segment === segment).length;
+  const inst: WidgetInstance = {
+    id: instanceId, type, segment, order,
+    height: opts.height ?? 260, collapsed: false, config: opts.config ?? {},
+  };
+  return { ...l, widgets: [...l.widgets, inst] };
+}
+
+export function removeWidget(l: ShellLayout, id: string): ShellLayout {
+  return { ...l, widgets: l.widgets.filter((w) => w.id !== id) };
+}
+
+export function moveWidget(l: ShellLayout, id: string, toSegment: SegmentId, toIndex: number): ShellLayout {
+  const moving = l.widgets.find((w) => w.id === id);
+  if (!moving) return l;
+  const from = widgetsInSegment(l, moving.segment).filter((w) => w.id !== id);
+  const to = toSegment === moving.segment ? from : widgetsInSegment(l, toSegment);
+  const idx = clamp(toIndex, 0, to.length);
+  const nextTo = [...to.slice(0, idx), { ...moving, segment: toSegment }, ...to.slice(idx)];
+  const reindex = (arr: WidgetInstance[], seg: SegmentId) => arr.map((w, i) => ({ ...w, segment: seg, order: i }));
+  const untouched = l.widgets.filter((w) => w.segment !== moving.segment && w.segment !== toSegment);
+  const rebuilt = toSegment === moving.segment
+    ? reindex(nextTo, toSegment)
+    : [...reindex(from, moving.segment), ...reindex(nextTo, toSegment)];
+  return { ...l, widgets: [...untouched, ...rebuilt] };
+}
+
+export function setWidgetHeight(l: ShellLayout, id: string, height: number): ShellLayout {
+  return { ...l, widgets: l.widgets.map((w) => w.id === id ? { ...w, height: clamp(height, 120, 1200) } : w) };
+}
+export function setWidgetCollapsed(l: ShellLayout, id: string, collapsed: boolean): ShellLayout {
+  return { ...l, widgets: l.widgets.map((w) => w.id === id ? { ...w, collapsed } : w) };
+}
+export function setWidgetConfig(l: ShellLayout, id: string, patch: Record<string, unknown>): ShellLayout {
+  return { ...l, widgets: l.widgets.map((w) => w.id === id ? { ...w, config: { ...w.config, ...patch } } : w) };
+}
+export function setSegmentSize(l: ShellLayout, seg: SegmentId, size: number): ShellLayout {
+  return { ...l, segments: { ...l.segments, [seg]: { ...l.segments[seg], size: clamp(size, 0, 900) } } };
+}
+export function setSegmentCollapsed(l: ShellLayout, seg: SegmentId, collapsed: boolean): ShellLayout {
+  return { ...l, segments: { ...l.segments, [seg]: { ...l.segments[seg], collapsed } } };
+}
+export function setStage(l: ShellLayout, stage: StageId): ShellLayout {
+  return { ...l, stage };
+}

--- a/lib/console/registry.ts
+++ b/lib/console/registry.ts
@@ -1,0 +1,31 @@
+import type { ComponentType } from "react";
+
+export interface WidgetBodyProps { instanceId: string; config: Record<string, unknown> }
+
+export interface WidgetType {
+  id: string;
+  title: string;
+  icon: string;
+  category: string;
+  defaultHeight: number;
+  defaultConfig: Record<string, unknown>;
+  component: ComponentType<WidgetBodyProps>;
+  capabilities?: { filter?: boolean; sort?: boolean };
+}
+
+const reg = new Map<string, WidgetType>();
+
+export function registerWidget(t: WidgetType): void { reg.set(t.id, t); }
+export function getWidgetType(id: string): WidgetType | undefined { return reg.get(id); }
+export function listWidgetTypes(): WidgetType[] { return [...reg.values()]; }
+export function widgetsByCategory(): { category: string; types: WidgetType[] }[] {
+  const order: string[] = [];
+  const byCat = new Map<string, WidgetType[]>();
+  for (const t of reg.values()) {
+    if (!byCat.has(t.category)) { byCat.set(t.category, []); order.push(t.category); }
+    byCat.get(t.category)!.push(t);
+  }
+  return order.map((category) => ({ category, types: byCat.get(category)! }));
+}
+/** Test-only: clear the singleton registry between tests. */
+export function __resetRegistry(): void { reg.clear(); }

--- a/lib/console/sanitize.ts
+++ b/lib/console/sanitize.ts
@@ -1,0 +1,49 @@
+import {
+  createDefaultLayout, MAX_WIDGETS,
+  type ShellLayout, type SegmentId, type StageId, type WidgetInstance,
+} from "@/lib/console/types";
+
+const SEGMENTS: SegmentId[] = ["left", "right", "bottom"];
+const STAGES: StageId[] = ["map3d", "map2d", "clock"];
+const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
+const num = (v: unknown, fallback: number) => (typeof v === "number" && Number.isFinite(v) ? v : fallback);
+
+/** Coerce arbitrary/untrusted input into a valid ShellLayout, or null if unrecoverable.
+ *  Guarantees: all three segment keys present; sizes clamped [0,900]; each widget has a
+ *  valid segment, clamped height [120,1200], object config; total widgets <= MAX_WIDGETS. */
+export function sanitizeLayout(raw: unknown): ShellLayout | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (!Array.isArray(r.widgets)) return null;
+  if (typeof r.stage !== "string" || !STAGES.includes(r.stage as StageId)) return null;
+  if (!r.segments || typeof r.segments !== "object") return null;
+
+  const base = createDefaultLayout();
+  const segsIn = r.segments as Record<string, unknown>;
+  const segments = {} as ShellLayout["segments"];
+  for (const id of SEGMENTS) {
+    const s = segsIn[id] && typeof segsIn[id] === "object" ? (segsIn[id] as Record<string, unknown>) : {};
+    segments[id] = {
+      size: clamp(num(s.size, base.segments[id].size), 0, 900),
+      collapsed: s.collapsed === true,
+    };
+  }
+
+  const widgets: WidgetInstance[] = [];
+  for (const w of r.widgets as unknown[]) {
+    if (widgets.length >= MAX_WIDGETS) break;
+    if (!w || typeof w !== "object") continue;
+    const o = w as Record<string, unknown>;
+    if (typeof o.id !== "string" || typeof o.type !== "string") continue;
+    widgets.push({
+      id: o.id,
+      type: o.type,
+      segment: SEGMENTS.includes(o.segment as SegmentId) ? (o.segment as SegmentId) : "left",
+      order: num(o.order, widgets.length),
+      height: clamp(num(o.height, 240), 120, 1200),
+      collapsed: o.collapsed === true,
+      config: o.config && typeof o.config === "object" ? (o.config as Record<string, unknown>) : {},
+    });
+  }
+  return { segments, stage: r.stage as StageId, widgets };
+}

--- a/lib/console/share.ts
+++ b/lib/console/share.ts
@@ -1,4 +1,5 @@
 import type { ShellLayout } from "@/lib/console/types";
+import { sanitizeLayout } from "@/lib/console/sanitize";
 
 /** Compact, URL-safe encoding of a layout (base64 of JSON). */
 export function encodeLayout(l: ShellLayout): string {
@@ -11,8 +12,7 @@ export function decodeLayout(s: string): ShellLayout | null {
   try {
     const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
     const json = typeof window === "undefined" ? Buffer.from(b64, "base64").toString("utf8") : decodeURIComponent(escape(atob(b64)));
-    const l = JSON.parse(json) as ShellLayout;
-    if (!l || typeof l !== "object" || !Array.isArray(l.widgets) || !l.segments || !l.stage) return null;
-    return l;
+    const l = JSON.parse(json);
+    return sanitizeLayout(l);
   } catch { return null; }
 }

--- a/lib/console/share.ts
+++ b/lib/console/share.ts
@@ -1,0 +1,18 @@
+import type { ShellLayout } from "@/lib/console/types";
+
+/** Compact, URL-safe encoding of a layout (base64 of JSON). */
+export function encodeLayout(l: ShellLayout): string {
+  const json = JSON.stringify(l);
+  const b64 = typeof window === "undefined" ? Buffer.from(json, "utf8").toString("base64") : btoa(unescape(encodeURIComponent(json)));
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function decodeLayout(s: string): ShellLayout | null {
+  try {
+    const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
+    const json = typeof window === "undefined" ? Buffer.from(b64, "base64").toString("utf8") : decodeURIComponent(escape(atob(b64)));
+    const l = JSON.parse(json) as ShellLayout;
+    if (!l || typeof l !== "object" || !Array.isArray(l.widgets) || !l.segments || !l.stage) return null;
+    return l;
+  } catch { return null; }
+}

--- a/lib/console/store.ts
+++ b/lib/console/store.ts
@@ -1,0 +1,40 @@
+"use client";
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { createDefaultLayout, type ShellLayout, type SegmentId, type StageId } from "@/lib/console/types";
+import * as R from "@/lib/console/reducers";
+
+const KEY = "tn.console.v1";
+const VERSION = 1;
+
+let state: ShellLayout = createDefaultLayout();
+let seq = 0;
+const listeners = new Set<() => void>();
+function emit() { for (const l of listeners) l(); savePersisted(KEY, VERSION, state); }
+function nextId(): string { seq += 1; return `w${Date.now().toString(36)}${seq.toString(36)}`; }
+
+export const shellLayoutStore = {
+  get(): ShellLayout { return state; },
+  set(l: ShellLayout) { state = l; emit(); },
+  replace(l: ShellLayout) { state = l; emit(); },
+  subscribe(fn: () => void) { listeners.add(fn); return () => { listeners.delete(fn); }; },
+  hydrate() { const s = loadPersisted<ShellLayout>(KEY, VERSION); if (s) state = s; emit(); },
+  add(type: string, opts: { segment?: SegmentId; config?: Record<string, unknown>; height?: number } = {}) {
+    if (R.isAtCapacity(state)) return { ok: false as const };
+    const id = nextId();
+    state = R.addWidget(state, type, id, opts); emit();
+    return { ok: true as const, id };
+  },
+  remove(id: string) { state = R.removeWidget(state, id); emit(); },
+  move(id: string, seg: SegmentId, idx: number) { state = R.moveWidget(state, id, seg, idx); emit(); },
+  resizeWidget(id: string, h: number) { state = R.setWidgetHeight(state, id, h); emit(); },
+  collapseWidget(id: string, c: boolean) { state = R.setWidgetCollapsed(state, id, c); emit(); },
+  configure(id: string, patch: Record<string, unknown>) { state = R.setWidgetConfig(state, id, patch); emit(); },
+  setSegment(seg: SegmentId, size: number) { state = R.setSegmentSize(state, seg, size); emit(); },
+  collapseSegment(seg: SegmentId, c: boolean) { state = R.setSegmentCollapsed(state, seg, c); emit(); },
+  stage(s: StageId) { state = R.setStage(state, s); emit(); },
+};
+
+export function useShellLayout(): ShellLayout {
+  return useSyncExternalStore(shellLayoutStore.subscribe, shellLayoutStore.get, shellLayoutStore.get);
+}

--- a/lib/console/store.ts
+++ b/lib/console/store.ts
@@ -2,6 +2,7 @@
 import { useSyncExternalStore } from "react";
 import { loadPersisted, savePersisted } from "@/lib/shell/persist";
 import { createDefaultLayout, type ShellLayout, type SegmentId, type StageId } from "@/lib/console/types";
+import { sanitizeLayout } from "@/lib/console/sanitize";
 import * as R from "@/lib/console/reducers";
 
 const KEY = "tn.console.v1";
@@ -16,9 +17,9 @@ function nextId(): string { seq += 1; return `w${Date.now().toString(36)}${seq.t
 export const shellLayoutStore = {
   get(): ShellLayout { return state; },
   set(l: ShellLayout) { state = l; emit(); },
-  replace(l: ShellLayout) { state = l; emit(); },
+  replace(l: ShellLayout) { const clean = sanitizeLayout(l); if (clean) { state = clean; emit(); } },
   subscribe(fn: () => void) { listeners.add(fn); return () => { listeners.delete(fn); }; },
-  hydrate() { const s = loadPersisted<ShellLayout>(KEY, VERSION); if (s) state = s; emit(); },
+  hydrate() { const s = loadPersisted<ShellLayout>(KEY, VERSION); const clean = s ? sanitizeLayout(s) : null; if (clean) { state = clean; emit(); } },
   add(type: string, opts: { segment?: SegmentId; config?: Record<string, unknown>; height?: number } = {}) {
     if (R.isAtCapacity(state)) return { ok: false as const };
     const id = nextId();

--- a/lib/console/types.ts
+++ b/lib/console/types.ts
@@ -1,0 +1,40 @@
+export type SegmentId = "left" | "right" | "bottom";
+export type StageId = "map3d" | "map2d" | "clock";
+export type WidgetTypeId = string;
+
+export interface WidgetInstance {
+  id: string;
+  type: WidgetTypeId;
+  segment: SegmentId;
+  order: number;
+  height: number;       // px; user-resizable
+  collapsed: boolean;   // header-only
+  config: Record<string, unknown>;
+}
+
+export interface SegmentState { size: number; collapsed: boolean }
+
+export interface ShellLayout {
+  segments: Record<SegmentId, SegmentState>;
+  stage: StageId;
+  widgets: WidgetInstance[];
+}
+
+export const MAX_WIDGETS = 50;
+
+export function createDefaultLayout(): ShellLayout {
+  return {
+    segments: {
+      left: { size: 320, collapsed: false },
+      right: { size: 320, collapsed: false },
+      bottom: { size: 240, collapsed: false },
+    },
+    stage: "map2d",
+    widgets: [],
+  };
+}
+
+/** Deterministic id (no Math.random — keeps reducers pure/testable). */
+export function newInstanceId(seq: number): string {
+  return `w${seq.toString(36)}`;
+}

--- a/lib/console/widgets/aviation.rules.ts
+++ b/lib/console/widgets/aviation.rules.ts
@@ -1,0 +1,36 @@
+import type { AlertRule, Alert } from "@/lib/console/alerts";
+
+export interface PlaneLite {
+  callsign: string;
+  squawk?: string;
+  isMilitary?: boolean;
+}
+
+const EMERGENCY = new Set(["7500", "7600", "7700"]);
+const REASON: Record<string, string> = {
+  "7500": "hijack",
+  "7600": "radio failure",
+  "7700": "emergency",
+};
+
+export const aviationAlerts: AlertRule<PlaneLite> = (planes) => {
+  const out: Alert[] = [];
+  for (const p of planes) {
+    if (p.squawk && EMERGENCY.has(p.squawk)) {
+      out.push({
+        id: `sq-${p.callsign}`,
+        severity: "critical",
+        text: `${p.callsign} squawk ${p.squawk} — ${REASON[p.squawk]}`,
+        ref: p.callsign,
+      });
+    } else if (p.isMilitary) {
+      out.push({
+        id: `mil-${p.callsign}`,
+        severity: "info",
+        text: `Military ${p.callsign} in region`,
+        ref: p.callsign,
+      });
+    }
+  }
+  return out;
+};

--- a/lib/console/widgets/aviation.tsx
+++ b/lib/console/widgets/aviation.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useEffect, useMemo } from "react";
+import { usePlanes } from "@/lib/planes/usePlanes";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { runAlertRule } from "@/lib/console/alerts";
+import { aviationAlerts, type PlaneLite } from "@/lib/console/widgets/aviation.rules";
+
+/**
+ * Aviation widget body.
+ *
+ * Field-mapping notes (real usePlanes() shape vs brief's assumed fields):
+ * - usePlanes() returns PlanesLayer { objects: WorldObject[], trails: PlaneTrail[] }
+ *   → we use .objects (not the top-level array the brief assumed).
+ * - WorldObject.label  → callsign (adsb.ts sets label = a.callsign ?? a.hex)
+ * - WorldObject.altKm  → altitude in km (NOT feet; brief used p.altitude)
+ * - WorldObject.typeLabel → human type ("Airliner", "Regional / jet", etc.)
+ * - NO squawk field   — adsb.lol's raw data does include squawk but parseAdsb()
+ *   does not extract it; squawk will be undefined for all planes until the
+ *   upstream parser is extended. Emergency alerts are spec-correct but dormant.
+ * - NO isMilitary     — classifyPlane() has no military category; the ADS-B A6
+ *   "heavy military" code exists but is not mapped. isMilitary is always undefined.
+ * - NO origin/destination — not present in the WorldObject/Aircraft schema.
+ */
+function AviationBody({ config }: WidgetBodyProps) {
+  const layer = usePlanes();
+  const planes = layer.objects;
+
+  // Map to PlaneLite for alert rules. squawk + isMilitary are unavailable in
+  // the current pipeline (see notes above).
+  const lite: PlaneLite[] = useMemo(
+    () => planes.map((p) => ({ callsign: p.label })),
+    [planes],
+  );
+
+  const sortKey = (config.sort as string) ?? "alt";
+  const rows = useMemo(() => {
+    const r = [...planes];
+    r.sort((a, b) =>
+      sortKey === "alt"
+        ? (b.altKm ?? 0) - (a.altKm ?? 0)
+        : a.label.localeCompare(b.label),
+    );
+    return r.slice(0, 200);
+  }, [planes, sortKey]);
+
+  const report = useWidgetReport();
+  useEffect(() => {
+    report({
+      alerts: runAlertRule(aviationAlerts, lite, config),
+      count: planes.length,
+      freshLabel: "live",
+    });
+  }, [lite, planes.length, report, config]);
+
+  return (
+    <table className="tn-w-table">
+      <tbody>
+        {rows.map((p) => (
+          <tr key={p.id}>
+            <td className="tn-w-strong">{p.label}</td>
+            <td className="tn-w-muted">{p.typeLabel ?? ""}</td>
+            <td className="tn-w-num">
+              {p.altKm != null ? `${p.altKm.toFixed(1)}k` : ""}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export const AVIATION_WIDGET = {
+  id: "aviation",
+  title: "Aviation",
+  icon: "✈",
+  category: "Aviation",
+  defaultHeight: 280,
+  defaultConfig: { sort: "alt" },
+  component: AviationBody,
+  capabilities: { filter: true, sort: true },
+};
+registerWidget(AVIATION_WIDGET);

--- a/lib/console/widgets/cameras.rules.ts
+++ b/lib/console/widgets/cameras.rules.ts
@@ -1,0 +1,13 @@
+import type { AlertRule, Alert } from "@/lib/console/alerts";
+
+export interface CameraLite { id: string; name: string; available: boolean }
+
+export const cameraAlerts: AlertRule<CameraLite> = (cams) => {
+  const out: Alert[] = [];
+  for (const c of cams) {
+    if (!c.available) {
+      out.push({ id: `cam-${c.id}`, severity: "warn", text: `${c.name} went offline`, ref: c.id });
+    }
+  }
+  return out;
+};

--- a/lib/console/widgets/cameras.tsx
+++ b/lib/console/widgets/cameras.tsx
@@ -1,0 +1,72 @@
+"use client";
+/**
+ * Cameras widget — shows a live thumbnail grid of the cameras currently
+ * loaded on the map and alerts on any that go offline.
+ *
+ * Field-mapping notes (real LoadedCamera shape vs brief assumed fields):
+ * - LoadedCamera: { id, name, lat, lon, available, live }
+ * - `available` is a REAL field → CameraLite.available = c.available (direct).
+ * - `attribution` is NOT a field → falls back to "".
+ * - `license` is NOT a field → falls back to "".
+ * - `refreshSeconds` is NOT a field → falls back to 30.
+ * - loadedCamerasStore has only set()/get(); NO subscribe method (intentionally
+ *   "not reactive"). We use useState with an initial snapshot instead of
+ *   useSyncExternalStore to avoid calling undefined .subscribe.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { loadedCamerasStore } from "@/lib/cameras/loaded";
+import { CameraVideo } from "@/components/CameraVideo";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { runAlertRule } from "@/lib/console/alerts";
+import { cameraAlerts, type CameraLite } from "@/lib/console/widgets/cameras.rules";
+
+function CamerasBody({ config }: WidgetBodyProps) {
+  // loadedCamerasStore is a non-reactive snapshot store (set/get only, no subscribe).
+  // Read once on mount; the store is refreshed by WorldMap whenever CamerasFeed lands.
+  const [cams] = useState(() => loadedCamerasStore.get());
+
+  // Map to CameraLite for the alert rule.
+  // available is a real field on LoadedCamera; attribution/license/refreshSeconds are not.
+  const lite: CameraLite[] = useMemo(
+    () => cams.map((c) => ({ id: c.id, name: c.name, available: c.available })),
+    [cams],
+  );
+
+  const report = useWidgetReport();
+  useEffect(() => {
+    report({
+      alerts: runAlertRule(cameraAlerts, lite, config),
+      count: cams.length,
+      freshLabel: "live",
+    });
+  }, [lite, cams.length, report, config]);
+
+  return (
+    <div className="tn-cam-grid">
+      {cams.slice(0, 6).map((c) => (
+        <div key={c.id} className="tn-cam-cell">
+          <CameraVideo
+            id={c.id}
+            alt={c.name}
+            attribution=""
+            license=""
+            refreshSeconds={30}
+          />
+          <span className="tn-cam-label">{c.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const CAMERAS_WIDGET = {
+  id: "cameras",
+  title: "Cameras",
+  icon: "📷",
+  category: "Cameras",
+  defaultHeight: 260,
+  defaultConfig: {},
+  component: CamerasBody,
+};
+registerWidget(CAMERAS_WIDGET);

--- a/lib/console/widgets/cameras.tsx
+++ b/lib/console/widgets/cameras.tsx
@@ -9,11 +9,11 @@
  * - `attribution` is NOT a field → falls back to "".
  * - `license` is NOT a field → falls back to "".
  * - `refreshSeconds` is NOT a field → falls back to 30.
- * - loadedCamerasStore has only set()/get(); NO subscribe method (intentionally
- *   "not reactive"). We use useState with an initial snapshot instead of
- *   useSyncExternalStore to avoid calling undefined .subscribe.
+ * - loadedCamerasStore now has subscribe(); we use useSyncExternalStore so the
+ *   widget rerenders whenever WorldMap publishes cameras (instead of reading once
+ *   on mount and showing an empty grid forever if it mounts first).
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { loadedCamerasStore } from "@/lib/cameras/loaded";
 import { CameraVideo } from "@/components/CameraVideo";
 import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
@@ -22,9 +22,8 @@ import { runAlertRule } from "@/lib/console/alerts";
 import { cameraAlerts, type CameraLite } from "@/lib/console/widgets/cameras.rules";
 
 function CamerasBody({ config }: WidgetBodyProps) {
-  // loadedCamerasStore is a non-reactive snapshot store (set/get only, no subscribe).
-  // Read once on mount; the store is refreshed by WorldMap whenever CamerasFeed lands.
-  const [cams] = useState(() => loadedCamerasStore.get());
+  // Reactive: rerenders whenever WorldMap calls loadedCamerasStore.set().
+  const cams = useSyncExternalStore(loadedCamerasStore.subscribe, loadedCamerasStore.get, loadedCamerasStore.get);
 
   // Map to CameraLite for the alert rule.
   // available is a real field on LoadedCamera; attribution/license/refreshSeconds are not.
@@ -40,10 +39,11 @@ function CamerasBody({ config }: WidgetBodyProps) {
       count: cams.length,
       freshLabel: "live",
     });
-  }, [lite, cams.length, report, config]);
+  }, [lite, report, config]);
 
   return (
     <div className="tn-cam-grid">
+      {cams.length === 0 && <p className="tn-cam-empty">No cameras loaded yet…</p>}
       {cams.slice(0, 6).map((c) => (
         <div key={c.id} className="tn-cam-cell">
           <CameraVideo

--- a/lib/console/widgets/events.rules.ts
+++ b/lib/console/widgets/events.rules.ts
@@ -1,0 +1,23 @@
+import type { AlertRule, Alert } from "@/lib/console/alerts";
+import type { EventType, SeverityTier } from "@/lib/events/model";
+
+export interface EventLite {
+  id: string;
+  type: EventType;
+  tier: SeverityTier;
+  title: string;
+  magnitude?: number;
+}
+
+export const eventAlerts: AlertRule<EventLite> = (events) => {
+  const out: Alert[] = [];
+  for (const e of events) {
+    const bigTier = e.tier === "S4" || e.tier === "S3";
+    const bigQuake = e.type === "quake" && (e.magnitude ?? 0) >= 5;
+    if (bigTier || bigQuake) {
+      const severity = e.tier === "S4" ? "critical" : e.tier === "S3" ? "warn" : "warn";
+      out.push({ id: `ev-${e.id}`, severity, text: e.title, ref: e.id });
+    }
+  }
+  return out;
+};

--- a/lib/console/widgets/events.tsx
+++ b/lib/console/widgets/events.tsx
@@ -1,0 +1,117 @@
+// lib/console/widgets/events.tsx
+// Disasters & Events widget.
+//
+// Integration notes — real projectEventFeed API (differs from task brief template):
+//   FeedInput is { source: EventSource; features: SignalFeature[] } per source.
+//   projectEventFeed(inputs, scope, windowMs, now, filters) returns ProjectedFeed.
+//   Row (NormalizedEvent) → EventLite mapping:
+//     r.id              → EventLite.id
+//     r.type            → EventLite.type
+//     r.severity.tier   → EventLite.tier   (NESTED in severity object, not r.tier)
+//     r.title           → EventLite.title
+//     r.magnitude?.value → EventLite.magnitude  (NESTED, optional number)
+//   Display uses r.place.name for the human location label.
+"use client";
+import { useEffect, useMemo } from "react";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
+import { projectEventFeed, type FeedInput, type FeedSort } from "@/lib/widgets/eventFeed";
+import { useScope } from "@/lib/shell/scope";
+import { useTimeWindow, windowMsFor } from "@/lib/shell/timeWindow";
+import { useNow } from "@/lib/shell/useNow";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { runAlertRule } from "@/lib/console/alerts";
+import { eventAlerts, type EventLite } from "@/lib/console/widgets/events.rules";
+import type { SeverityTier } from "@/lib/events/model";
+
+function EventsBody({ config }: WidgetBodyProps) {
+  const scope = useScope();
+  const win = useTimeWindow();
+  const now = useNow(60_000);
+  const { bySource, status } = useEventFeeds();
+
+  // Exact pattern copied from components/shell/EventFeed.tsx.
+  const inputs: FeedInput[] = useMemo(
+    () => EVENT_SOURCES.map((source) => ({ source, features: bySource[source.id] ?? [] })),
+    [bySource],
+  );
+
+  const minTier = ((config.minTier as string) ?? "S1") as SeverityTier;
+  const sort = ((config.sort as string) ?? "severity") as FeedSort;
+
+  const projected = useMemo(
+    () =>
+      projectEventFeed(inputs, scope, windowMsFor(win), now, {
+        types: null,
+        minTier,
+        sort: sort === "nearest" && !scope.center ? "severity" : sort,
+      }),
+    [inputs, scope, win, now, minTier, sort],
+  );
+
+  // Map NormalizedEvent rows → EventLite for the alert rules.
+  // Key field renames: r.severity.tier → tier; r.magnitude?.value → magnitude.
+  const lite: EventLite[] = useMemo(
+    () =>
+      projected.rows.map((r) => ({
+        id: r.id,
+        type: r.type,
+        tier: r.severity.tier,
+        title: r.title,
+        magnitude: r.magnitude?.value,
+      })),
+    [projected.rows],
+  );
+
+  const report = useWidgetReport();
+  useEffect(() => {
+    report({
+      alerts: runAlertRule(eventAlerts, lite, config),
+      count: projected.shown,
+      freshLabel: "5m",
+    });
+  }, [lite, projected.shown, report, config]);
+
+  if (status === "loading" && projected.shown === 0) {
+    return <p className="tn-w-empty">Loading events…</p>;
+  }
+  if (projected.shown === 0) {
+    return (
+      <p className="tn-w-empty">
+        No events above {minTier} in {scope.label}.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="tn-w-list">
+      {projected.rows.slice(0, 100).map((r) => (
+        <li key={r.id}>
+          <span className={`tn-w-sev tn-sev-${r.severity.tier}`}>{r.severity.tier}</span>{" "}
+          <b className="tn-w-kind">{r.type}</b>{" "}
+          <span className="tn-w-place">{r.place.name}</span>
+          {r.magnitude && (
+            <span className="tn-w-mag">
+              {" "}
+              {r.magnitude.value}
+              {r.magnitude.unit}
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export const EVENTS_WIDGET = {
+  id: "events",
+  title: "Disasters & Events",
+  icon: "🌎",
+  category: "Events",
+  defaultHeight: 320,
+  defaultConfig: { minTier: "S1", sort: "severity" },
+  component: EventsBody,
+  capabilities: { filter: true, sort: true },
+};
+registerWidget(EVENTS_WIDGET);

--- a/lib/console/widgets/index.ts
+++ b/lib/console/widgets/index.ts
@@ -1,0 +1,5 @@
+// Importing this file registers every console widget exactly once.
+import "@/lib/console/widgets/aviation";
+import "@/lib/console/widgets/events";
+import "@/lib/console/widgets/cameras";
+import "@/lib/console/widgets/news";

--- a/lib/console/widgets/news.tsx
+++ b/lib/console/widgets/news.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+
+function NewsBody({ instanceId, config }: WidgetBodyProps) {
+  const report = useWidgetReport();
+  const activeId = (config.providerId as string) ?? NEWS_PROVIDERS[0].id;
+  const custom = config.customProvider as NewsProvider | undefined;
+  const active = custom?.id === activeId ? custom : NEWS_PROVIDERS.find((p) => p.id === activeId) ?? NEWS_PROVIDERS[0];
+  const embed = resolveEmbed(active);
+  const favorites = NEWS_PROVIDERS.filter((p) => p.favorite).slice(0, 4);
+  const [picker, setPicker] = useState(false);
+  useEffect(() => { report({ alerts: [], freshLabel: "live" }); }, [report]);
+
+  const choose = (id: string) => { import("@/lib/console/store").then((m) => m.shellLayoutStore.configure(instanceId, { providerId: id })); };
+  const videoRef = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (embed.kind !== "hls" || !videoRef.current) return;
+    const v = videoRef.current; let hls: { destroy(): void } | null = null; let cancelled = false;
+    if (v.canPlayType("application/vnd.apple.mpegurl")) { v.src = embed.src; return; }
+    (async () => { const Hls = (await import("hls.js")).default; if (cancelled || !Hls.isSupported()) return; const h = new Hls(); hls = h; h.loadSource(embed.src); h.attachMedia(v); })();
+    return () => { cancelled = true; hls?.destroy(); };
+  }, [embed.kind, embed.src]);
+
+  return (
+    <div className="tn-news">
+      <div className="tn-news-screen">
+        {embed.kind === "youtube"
+          ? <iframe className="tn-news-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
+          : <video ref={videoRef} className="tn-news-video" muted autoPlay playsInline controls />}
+        <span className="tn-news-ch">{active.name}</span>
+      </div>
+      <div className="tn-news-tabs">
+        {favorites.map((p) => (
+          <button key={p.id} className={p.id === activeId ? "is-on" : ""} onClick={() => choose(p.id)}>{p.name.split(" ")[0]}</button>
+        ))}
+        <button className="tn-news-more" onClick={() => setPicker((o) => !o)}>&#xFF0B; More&hellip;</button>
+      </div>
+      {picker && (
+        <div className="tn-news-picker">
+          {NEWS_PROVIDERS.map((p) => (
+            <button key={p.id} onClick={() => { choose(p.id); setPicker(false); }}>{p.id === activeId ? "✓ " : ""}{p.name} <span className="tn-news-cat">{p.category}</span></button>
+          ))}
+          <input className="tn-news-custom" placeholder="Add stream URL (YouTube / .m3u8)…"
+                 onKeyDown={(e) => {
+                   if (e.key !== "Enter") return;
+                   const p = parseCustomStream((e.target as HTMLInputElement).value);
+                   if (p) import("@/lib/console/store").then((m) => m.shellLayoutStore.configure(instanceId, { providerId: p.id, customProvider: p }));
+                 }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const NEWS_WIDGET = {
+  id: "news", title: "Live News", icon: "📺", category: "News",
+  defaultHeight: 240, defaultConfig: { providerId: "aljazeera" }, component: NewsBody,
+};
+registerWidget(NEWS_WIDGET);

--- a/lib/console/widgets/news.tsx
+++ b/lib/console/widgets/news.tsx
@@ -25,25 +25,25 @@ function NewsBody({ instanceId, config }: WidgetBodyProps) {
   }, [embed.kind, embed.src]);
 
   return (
-    <div className="tn-news">
-      <div className="tn-news-screen">
+    <div className="tn-newsw">
+      <div className="tn-newsw-screen">
         {embed.kind === "youtube"
-          ? <iframe className="tn-news-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
-          : <video ref={videoRef} className="tn-news-video" muted autoPlay playsInline controls />}
-        <span className="tn-news-ch">{active.name}</span>
+          ? <iframe className="tn-newsw-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
+          : <video ref={videoRef} className="tn-newsw-video" muted autoPlay playsInline controls />}
+        <span className="tn-newsw-ch">{active.name}</span>
       </div>
-      <div className="tn-news-tabs">
+      <div className="tn-newsw-tabs">
         {favorites.map((p) => (
           <button key={p.id} className={p.id === activeId ? "is-on" : ""} onClick={() => choose(p.id)}>{p.name.split(" ")[0]}</button>
         ))}
-        <button className="tn-news-more" onClick={() => setPicker((o) => !o)}>&#xFF0B; More&hellip;</button>
+        <button className="tn-newsw-more" onClick={() => setPicker((o) => !o)}>&#xFF0B; More&hellip;</button>
       </div>
       {picker && (
-        <div className="tn-news-picker">
+        <div className="tn-newsw-picker">
           {NEWS_PROVIDERS.map((p) => (
-            <button key={p.id} onClick={() => { choose(p.id); setPicker(false); }}>{p.id === activeId ? "✓ " : ""}{p.name} <span className="tn-news-cat">{p.category}</span></button>
+            <button key={p.id} onClick={() => { choose(p.id); setPicker(false); }}>{p.id === activeId ? "✓ " : ""}{p.name} <span className="tn-newsw-cat">{p.category}</span></button>
           ))}
-          <input className="tn-news-custom" placeholder="Add stream URL (YouTube / .m3u8)…"
+          <input className="tn-newsw-custom" placeholder="Add stream URL (YouTube / .m3u8)…"
                  onKeyDown={(e) => {
                    if (e.key !== "Enter") return;
                    const p = parseCustomStream((e.target as HTMLInputElement).value);

--- a/lib/events/adapter.ts
+++ b/lib/events/adapter.ts
@@ -1,0 +1,48 @@
+// lib/events/adapter.ts
+// SignalFeature → NormalizedEvent, plus the severity×recency ranking. The general
+// form of lib/widgets/topEvents.ts (which this supersedes): the magnitude/place/
+// time the rows need already ride in each feature — this surfaces them.
+
+import type { SignalFeature } from "@/lib/signals/types";
+import type { EventSource } from "@/lib/events/sources";
+import {
+  type NormalizedEvent,
+  severityTier,
+  severityRank,
+  placeName,
+  SEVERITY_COLOR,
+} from "@/lib/events/model";
+
+export function toEvent(f: SignalFeature, src: EventSource): NormalizedEvent {
+  const raw = Number(f.props?.magnitude ?? 0);
+  const tier = severityTier(raw);
+  const event: NormalizedEvent = {
+    id: f.id,
+    type: src.type,
+    title: f.title,
+    place: { name: placeName(f.title, f.props) },
+    geo: { lat: f.lat, lon: f.lon, precision: src.precision },
+    occurredAt: f.ts ?? null,
+    severity: { tier, raw },
+    source: { id: src.id, label: src.label, attribution: src.attribution },
+    link: f.link,
+    color: SEVERITY_COLOR[tier],
+  };
+  if (src.magnitudeUnit && Number.isFinite(raw) && raw > 0) {
+    event.magnitude = { value: raw, unit: src.magnitudeUnit };
+  }
+  return event;
+}
+
+/** Severity tier desc, then newest-first (undated sorts last). Mirrors topEventsRows. */
+export function rankEvents(events: NormalizedEvent[]): NormalizedEvent[] {
+  return [...events].sort((a, b) => {
+    const sev = severityRank(b.severity.tier) - severityRank(a.severity.tier);
+    if (sev !== 0) return sev;
+    const at = a.occurredAt ?? "";
+    const bt = b.occurredAt ?? "";
+    if (at < bt) return 1;
+    if (at > bt) return -1;
+    return 0;
+  });
+}

--- a/lib/events/model.ts
+++ b/lib/events/model.ts
@@ -1,0 +1,69 @@
+// The Event spine. Every hazard signal normalizes to ONE NormalizedEvent — the
+// unit the feed, the map and the dossier all read. (Named NormalizedEvent, not
+// `Event`, to avoid shadowing the DOM `Event` global.)
+//
+// P1 severity uses ONE transparent 0–10 magnitude ramp (the shared SignalFeature
+// `props.magnitude` convention). P3 (§10.3) replaces this with a per-domain,
+// exposure-weighted basis — until then `severity.raw` is surfaced honestly.
+
+export type EventType =
+  | "quake" | "fire" | "disaster" | "cyclone"
+  | "flood" | "storm" | "volcano" | "conflict" | "other";
+
+export type SeverityTier = "S0" | "S1" | "S2" | "S3" | "S4";
+
+export type GeoPrecision = "EXACT" | "CITY" | "ADMIN" | "COUNTRY_CENTROID";
+
+export interface NormalizedEvent {
+  /** Stable id (the source feature id). */
+  id: string;
+  type: EventType;
+  /** Human, specific — reused verbatim from the source feature title. */
+  title: string;
+  place: { name: string };
+  geo: { lat: number; lon: number; precision: GeoPrecision };
+  /** ISO UTC event time; null when the source carries none (never faked). */
+  occurredAt: string | null;
+  /** Display tier + the raw normalized magnitude it derives from (shown, not hidden). */
+  severity: { tier: SeverityTier; raw: number };
+  /** Native magnitude — populated only where the unit is known-safe (P1: quakes). */
+  magnitude?: { value: number; unit: string };
+  /** Lightweight source credit (P1). The full Provenance object lands in P3. */
+  source: { id: string; label: string; attribution: string };
+  link?: string;
+  /** Marker/chip colour, from the severity ramp. */
+  color: string;
+}
+
+const TIER_RANK: Record<SeverityTier, number> = { S0: 0, S1: 1, S2: 2, S3: 3, S4: 4 };
+
+export const SEVERITY_COLOR: Record<SeverityTier, string> = {
+  S0: "#94a3b8",
+  S1: "#eab308",
+  S2: "#f97316",
+  S3: "#ef4444",
+  S4: "#b91c1c",
+};
+
+/** Map the shared 0–10 normalized magnitude to a display tier (interim — see header). */
+export function severityTier(magnitude: number): SeverityTier {
+  if (Number.isNaN(magnitude)) return "S0";
+  if (magnitude >= 8) return "S4";
+  if (magnitude >= 6) return "S3";
+  if (magnitude >= 4) return "S2";
+  if (magnitude >= 2) return "S1";
+  return "S0";
+}
+
+export function severityRank(tier: SeverityTier): number {
+  return TIER_RANK[tier];
+}
+
+/** Best-effort row place (P1-honest): explicit props.place → the title tail after
+ *  a dash/em-dash → the whole title. Country/admin enrichment is P3. */
+export function placeName(title: string, props?: Record<string, unknown>): string {
+  const explicit = props?.place;
+  if (typeof explicit === "string" && explicit.trim()) return explicit.trim();
+  const m = title.match(/\s[—-]\s(.+)$/);
+  return (m ? m[1] : title).trim();
+}

--- a/lib/events/model.ts
+++ b/lib/events/model.ts
@@ -41,8 +41,8 @@ export const SEVERITY_COLOR: Record<SeverityTier, string> = {
   S0: "#94a3b8",
   S1: "#eab308",
   S2: "#f97316",
-  S3: "#ef4444",
-  S4: "#b91c1c",
+  S3: "#b91c1c",
+  S4: "#7f1d1d",
 };
 
 /** Map the shared 0–10 normalized magnitude to a display tier (interim — see header). */

--- a/lib/events/sources.ts
+++ b/lib/events/sources.ts
@@ -1,0 +1,32 @@
+// lib/events/sources.ts
+// The curated set of signal sources that emit discrete, time/place-stamped EVENTS
+// for the feed. Seeded with the proven ids the Top Events panel already fetches
+// successfully (components/shell/TopEventsPanel.tsx). Add more (floods, severe-
+// storms, volcanoes, conflict) as each one's normalized magnitude scale is
+// confirmed — see the registry in lib/signals/registry.ts.
+//
+// magnitudeUnit is set ONLY where props.magnitude genuinely IS that unit, so the
+// row can show a native value without the Round-1 "MW" mislabel. Leave it unset
+// and the row leans on the source's own title for the human magnitude.
+
+import type { EventType, GeoPrecision } from "@/lib/events/model";
+
+export interface EventSource {
+  /** Signal source id — the /api/signals/<id> route segment + store key. */
+  id: string;
+  type: EventType;
+  /** Human source label for the row's source credit. */
+  label: string;
+  attribution: string;
+  /** Default geo-precision for this source's points (per-feature precision is P3). */
+  precision: GeoPrecision;
+  /** Native magnitude unit, only when props.magnitude IS that unit. */
+  magnitudeUnit?: string;
+}
+
+export const EVENT_SOURCES: EventSource[] = [
+  { id: "earthquakes", type: "quake", label: "Earthquakes (USGS)", attribution: "USGS", precision: "EXACT", magnitudeUnit: "M" },
+  { id: "fire-active", type: "fire", label: "Active fire (FIRMS)", attribution: "NASA FIRMS", precision: "EXACT" },
+  { id: "gdacs", type: "disaster", label: "Disasters (GDACS)", attribution: "GDACS", precision: "ADMIN" },
+  { id: "tropical-cyclones", type: "cyclone", label: "Cyclones (NOAA NHC)", attribution: "NOAA NHC", precision: "ADMIN" },
+];

--- a/lib/events/sources.ts
+++ b/lib/events/sources.ts
@@ -24,9 +24,9 @@ export interface EventSource {
   magnitudeUnit?: string;
 }
 
+// FIRMS active-fire is a dense detection layer (~1500 raw points), not discrete events; significant wildfires arrive via GDACS WF.
 export const EVENT_SOURCES: EventSource[] = [
   { id: "earthquakes", type: "quake", label: "Earthquakes (USGS)", attribution: "USGS", precision: "EXACT", magnitudeUnit: "M" },
-  { id: "fire-active", type: "fire", label: "Active fire (FIRMS)", attribution: "NASA FIRMS", precision: "EXACT" },
   { id: "gdacs", type: "disaster", label: "Disasters (GDACS)", attribution: "GDACS", precision: "ADMIN" },
   { id: "tropical-cyclones", type: "cyclone", label: "Cyclones (NOAA NHC)", attribution: "NOAA NHC", precision: "ADMIN" },
 ];

--- a/lib/shell/scope.ts
+++ b/lib/shell/scope.ts
@@ -1,0 +1,103 @@
+"use client";
+// The global Scope — the relevance spine. A single persisted store (the lib/shell
+// idiom) the feed, the map and (later) the alerts all read: World (firehose) /
+// Near-me / Region / AOI. Pure withinScope is unit-tested; the store is a thin
+// useSyncExternalStore shell. AOI's bbox is modelled now; the draw interaction is
+// P4 — withinScope already handles it so nothing changes when the UI arrives.
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { haversineKm } from "@/lib/geo/haversine";
+
+export type ScopeMode = "world" | "near-me" | "region" | "aoi";
+
+export interface Scope {
+  mode: ScopeMode;
+  /** Centre for near-me / region. */
+  center?: { lat: number; lon: number };
+  /** Radius (km) for centre-based scopes. */
+  radiusKm?: number;
+  /** [west, south, east, north] for aoi. */
+  bbox?: [number, number, number, number];
+  /** Human label for the top bar + the feed's honest empty state. */
+  label: string;
+}
+
+export const WORLD_SCOPE: Scope = { mode: "world", label: "World" };
+export const DEFAULT_RADIUS_KM = 250;
+const MIN_RADIUS_KM = 10;
+
+/** Pure: is a point inside the scope? Malformed centre/aoi scopes admit
+ *  everything — we never silently hide data we cannot test. */
+export function withinScope(lat: number, lon: number, scope: Scope): boolean {
+  switch (scope.mode) {
+    case "near-me":
+    case "region":
+      if (!scope.center || scope.radiusKm == null) return true;
+      return haversineKm(scope.center.lat, scope.center.lon, lat, lon) <= scope.radiusKm;
+    case "aoi": {
+      if (!scope.bbox) return true;
+      const [w, s, e, n] = scope.bbox;
+      return lon >= w && lon <= e && lat >= s && lat <= n;
+    }
+    case "world":
+    default:
+      return true;
+  }
+}
+
+/** Radius (km) covering a geocoder extent [west,south,east,north], floored. */
+export function radiusFromBbox(bbox: [number, number, number, number]): number {
+  const [w, s, e, n] = bbox;
+  const halfDiag = haversineKm(s, w, n, e) / 2;
+  return Math.max(MIN_RADIUS_KM, Math.round(halfDiag));
+}
+
+/** A persisted near-me rehydrates to World (we never auto-geolocate on load);
+ *  region/aoi/world survive; junk → World. */
+export function coerceSavedScope(saved: unknown): Scope {
+  const s = saved as Scope | null;
+  if (!s || typeof s !== "object" || typeof s.mode !== "string") return WORLD_SCOPE;
+  if (s.mode === "near-me") return WORLD_SCOPE;
+  if (s.mode === "region" || s.mode === "aoi" || s.mode === "world") return s;
+  return WORLD_SCOPE;
+}
+
+const PERSIST_KEY = "tn.scope.v1";
+const PERSIST_VERSION = 1;
+
+let state: Scope = WORLD_SCOPE;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+}
+
+export const scopeStore = {
+  set(scope: Scope) {
+    state = scope;
+    emit();
+  },
+  get(): Scope {
+    return state;
+  },
+  reset() {
+    state = WORLD_SCOPE;
+    emit();
+  },
+  hydrate() {
+    state = coerceSavedScope(loadPersisted<Scope>(PERSIST_KEY, PERSIST_VERSION));
+    emit();
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export function useScope(): Scope {
+  return useSyncExternalStore(scopeStore.subscribe, scopeStore.get, scopeStore.get);
+}

--- a/lib/shell/viewMode.ts
+++ b/lib/shell/viewMode.ts
@@ -1,0 +1,55 @@
+"use client";
+// Console (default, flat 2D map) vs Explore (the 3D globe + cinematic dive). One
+// persisted store the shell reads to choose chrome, and WorldMap reads to choose
+// its MapLibre projection. The redesign flips the default from globe-as-hero to
+// console-as-hero (spec §4, §11).
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export type ViewMode = "console" | "explore";
+export const DEFAULT_VIEW_MODE: ViewMode = "console";
+
+export function coerceViewMode(saved: unknown): ViewMode {
+  return saved === "explore" || saved === "console" ? saved : DEFAULT_VIEW_MODE;
+}
+
+const PERSIST_KEY = "tn.viewmode.v1";
+const PERSIST_VERSION = 1;
+
+let state: ViewMode = DEFAULT_VIEW_MODE;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+}
+
+export const viewModeStore = {
+  set(m: ViewMode) {
+    if (state === m) return;
+    state = m;
+    emit();
+  },
+  toggle() {
+    state = state === "console" ? "explore" : "console";
+    emit();
+  },
+  get(): ViewMode {
+    return state;
+  },
+  hydrate() {
+    state = coerceViewMode(loadPersisted<ViewMode>(PERSIST_KEY, PERSIST_VERSION));
+    emit();
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};
+
+export function useViewMode(): ViewMode {
+  return useSyncExternalStore(viewModeStore.subscribe, viewModeStore.get, viewModeStore.get);
+}

--- a/lib/signals/gdacs.ts
+++ b/lib/signals/gdacs.ts
@@ -62,6 +62,9 @@ function gdacsTimeToIso(s: string | undefined): string | undefined {
   return Number.isFinite(t) ? new Date(t).toISOString() : undefined;
 }
 
+/** Maps GDACS alert level to a 0–10 normalized magnitude for the severity ramp. */
+const GDACS_MAG: Record<string, number> = { Green: 3, Orange: 6, Red: 8 };
+
 /** Pure: GDACS FeatureCollection → SignalFeature[]. Skips features without coords/id. */
 export function normalizeGdacs(geojson: { features?: GdacsFeature[] }): SignalFeature[] {
   const out: SignalFeature[] = [];
@@ -90,6 +93,7 @@ export function normalizeGdacs(geojson: { features?: GdacsFeature[] }): SignalFe
       props: {
         hazard: typeLabel,
         alertLevel: level,
+        magnitude: GDACS_MAG[level] ?? 5,
         severity: p.severitydata?.severitytext?.trim() || "—",
         country: p.country?.trim() || "—",
         from: p.fromdate?.slice(0, 10) ?? "—",

--- a/lib/widgets/eventFeed.ts
+++ b/lib/widgets/eventFeed.ts
@@ -44,10 +44,20 @@ export function projectEventFeed(
   for (const { source, features } of inputs) {
     for (const f of features) all.push(toEvent(f, source));
   }
-  const total = all.length;
+  // Dedup by id — some sources (e.g. GDACS) emit the same event id more than once
+  // (multiple episodes/updates of one alert). Collapsing keeps the counts honest and
+  // avoids duplicate feed rows / React key collisions on `event.id`.
+  const seen = new Set<string>();
+  const unique: NormalizedEvent[] = [];
+  for (const e of all) {
+    if (seen.has(e.id)) continue;
+    seen.add(e.id);
+    unique.push(e);
+  }
+  const total = unique.length;
   const floor = severityRank(filters.minTier);
 
-  let rows = all.filter(
+  let rows = unique.filter(
     (e) =>
       withinScope(e.geo.lat, e.geo.lon, scope) &&
       withinWindow(e.occurredAt, windowMs, now) &&

--- a/lib/widgets/eventFeed.ts
+++ b/lib/widgets/eventFeed.ts
@@ -1,0 +1,76 @@
+// lib/widgets/eventFeed.ts
+// PURE feed projection: SignalFeature[] (by source) → scoped, windowed, filtered,
+// ranked NormalizedEvent[] + honest counts. The single place the feed's logic
+// lives; the component and the hook are dumb shells around this.
+
+import type { SignalFeature } from "@/lib/signals/types";
+import type { EventSource } from "@/lib/events/sources";
+import { type NormalizedEvent, type SeverityTier, type EventType, severityRank } from "@/lib/events/model";
+import { toEvent, rankEvents } from "@/lib/events/adapter";
+import { withinWindow } from "@/lib/shell/timeWindow";
+import { withinScope, type Scope } from "@/lib/shell/scope";
+import { haversineKm } from "@/lib/geo/haversine";
+
+export type FeedSort = "severity" | "recent" | "nearest";
+
+export interface FeedFilters {
+  /** null = all types; otherwise the set to keep. */
+  types: Set<EventType> | null;
+  minTier: SeverityTier;
+  sort: FeedSort;
+}
+
+export interface FeedInput {
+  source: EventSource;
+  features: SignalFeature[];
+}
+
+export interface ProjectedFeed {
+  rows: NormalizedEvent[];
+  /** Events emitted before scope/window/filter trimming (for the "N of M" honesty). */
+  total: number;
+  /** rows.length after trimming. */
+  shown: number;
+}
+
+export function projectEventFeed(
+  inputs: FeedInput[],
+  scope: Scope,
+  windowMs: number | null,
+  now: number,
+  filters: FeedFilters,
+): ProjectedFeed {
+  const all: NormalizedEvent[] = [];
+  for (const { source, features } of inputs) {
+    for (const f of features) all.push(toEvent(f, source));
+  }
+  const total = all.length;
+  const floor = severityRank(filters.minTier);
+
+  let rows = all.filter(
+    (e) =>
+      withinScope(e.geo.lat, e.geo.lon, scope) &&
+      withinWindow(e.occurredAt, windowMs, now) &&
+      severityRank(e.severity.tier) >= floor &&
+      (filters.types == null || filters.types.has(e.type)),
+  );
+
+  if (filters.sort === "nearest" && scope.center) {
+    const c = scope.center;
+    rows = [...rows].sort(
+      (a, b) =>
+        haversineKm(c.lat, c.lon, a.geo.lat, a.geo.lon) -
+        haversineKm(c.lat, c.lon, b.geo.lat, b.geo.lon),
+    );
+  } else if (filters.sort === "recent") {
+    rows = [...rows].sort((a, b) => {
+      const at = a.occurredAt ?? "";
+      const bt = b.occurredAt ?? "";
+      return at < bt ? 1 : at > bt ? -1 : 0;
+    });
+  } else {
+    rows = rankEvents(rows);
+  }
+
+  return { rows, total, shown: rows.length };
+}

--- a/lib/widgets/useEventFeeds.ts
+++ b/lib/widgets/useEventFeeds.ts
@@ -1,0 +1,55 @@
+"use client";
+// Fetch every EVENT_SOURCES feed through the generic /api/signals/<id> proxy on a
+// cadence, accumulating the latest features per source. A thin impure shell (no
+// unit test — the logic it feeds lives in lib/widgets/eventFeed.ts). Dormant-safe:
+// a failed source keeps its last features; status is "error" only if ALL fail.
+
+import { useEffect, useState } from "react";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+
+export interface RawFeeds {
+  bySource: Record<string, SignalFeature[]>;
+  status: "idle" | "loading" | "error";
+  updatedAt: number | null;
+}
+
+const POLL_MS = 5 * 60_000;
+
+export function useEventFeeds(): RawFeeds {
+  const [bySource, setBySource] = useState<Record<string, SignalFeature[]>>({});
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("loading");
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const load = () => {
+      setStatus("loading");
+      Promise.all(
+        EVENT_SOURCES.map((s) =>
+          fetch(`/api/signals/${encodeURIComponent(s.id)}`)
+            .then((r) => r.json())
+            .then((d) => ({ id: s.id, features: (d.features as SignalFeature[]) ?? [], ok: true }))
+            .catch(() => ({ id: s.id, features: [] as SignalFeature[], ok: false })),
+        ),
+      ).then((results) => {
+        if (!alive) return;
+        setBySource((prev) => {
+          const next = { ...prev };
+          for (const r of results) if (r.ok) next[r.id] = r.features;
+          return next;
+        });
+        setStatus(results.every((r) => !r.ok) ? "error" : "idle");
+        setUpdatedAt(Date.now());
+      });
+    };
+    load();
+    const t = setInterval(load, POLL_MS);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, []);
+
+  return { bySource, status, updatedAt };
+}

--- a/tests/e2e/console.spec.ts
+++ b/tests/e2e/console.spec.ts
@@ -1,0 +1,32 @@
+// tests/e2e/console.spec.ts
+import { test, expect } from "@playwright/test";
+
+test("first-run seeds the World preset with widgets in segments", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".tn-cw").first()).toBeVisible();
+  await expect(page.locator('[data-segment="left"] .tn-cw')).not.toHaveCount(0);
+});
+
+test("⌘K adds a widget instance", async ({ page }) => {
+  await page.goto("/");
+  const before = await page.locator(".tn-cw").count();
+  await page.keyboard.press("Control+k");
+  await page.getByPlaceholder(/Search/).fill("Add Aviation");
+  await page.keyboard.press("Enter");
+  await expect(page.locator(".tn-cw")).toHaveCount(before + 1);
+});
+
+test("stage switch swaps to the world clock", async ({ page }) => {
+  await page.goto("/");
+  await page.locator(".tn-stage-switch button", { hasText: "🕐" }).click();
+  await expect(page.locator(".tn-clock")).toBeVisible();
+});
+
+test("collapsing the left segment hides its widgets", async ({ page }) => {
+  await page.goto("/");
+  // drag the left grip fully left
+  const grip = page.locator(".tn-grip").first();
+  const box = await grip.boundingBox();
+  if (box) { await page.mouse.move(box.x + 2, box.y + 20); await page.mouse.down(); await page.mouse.move(0, box.y + 20); await page.mouse.up(); }
+  await expect(page.locator('[data-segment="left"]')).toHaveCSS("width", /0px|(\d|10|20)px/);
+});

--- a/tests/unit/console-alerts.test.ts
+++ b/tests/unit/console-alerts.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "vitest";
+import { runAlertRule, topSeverity, type Alert } from "@/lib/console/alerts";
+
+test("runAlertRule passes through results", () => {
+  const rule = (xs: number[]): Alert[] => xs.filter((n) => n > 5).map((n) => ({ id: `a${n}`, severity: "warn", text: `${n}` }));
+  expect(runAlertRule(rule, [1, 9], {}).map((a) => a.id)).toEqual(["a9"]);
+});
+
+test("runAlertRule swallows rule errors", () => {
+  const boom = () => { throw new Error("bad data"); };
+  expect(runAlertRule(boom, [], {})).toEqual([]);
+});
+
+test("topSeverity ranks critical > warn > info", () => {
+  expect(topSeverity([{ id: "1", severity: "info", text: "" }, { id: "2", severity: "critical", text: "" }])).toBe("critical");
+  expect(topSeverity([])).toBeNull();
+});

--- a/tests/unit/console-aviation.test.ts
+++ b/tests/unit/console-aviation.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import { aviationAlerts, type PlaneLite } from "@/lib/console/widgets/aviation.rules";
+
+const planes: PlaneLite[] = [
+  { callsign: "AF23", squawk: "7700" },
+  { callsign: "BA117", squawk: "2200" },
+  { callsign: "RCH804", squawk: "1234", isMilitary: true },
+  { callsign: "UA90", squawk: "7600" },
+];
+
+test("flags emergency squawks 7500/7600/7700 as critical", () => {
+  const a = aviationAlerts(planes, {});
+  const crit = a.filter((x) => x.severity === "critical").map((x) => x.ref);
+  expect(crit.sort()).toEqual(["AF23", "UA90"]);
+});
+
+test("flags military entry as info", () => {
+  const a = aviationAlerts(planes, {});
+  expect(a.find((x) => x.ref === "RCH804")?.severity).toBe("info");
+});
+
+test("clean traffic produces no alerts", () => {
+  expect(aviationAlerts([{ callsign: "X", squawk: "1000" }], {})).toEqual([]);
+});

--- a/tests/unit/console-cameras.test.ts
+++ b/tests/unit/console-cameras.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+import { cameraAlerts, type CameraLite } from "@/lib/console/widgets/cameras.rules";
+
+const cams: CameraLite[] = [
+  { id: "a", name: "LHR A4", available: true },
+  { id: "b", name: "I-95 MM12", available: false },
+];
+
+test("flags offline cameras as warn", () => {
+  const a = cameraAlerts(cams, {});
+  expect(a.length).toBe(1);
+  expect(a[0].severity).toBe("warn");
+  expect(a[0].ref).toBe("b");
+});

--- a/tests/unit/console-events.test.ts
+++ b/tests/unit/console-events.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+import { eventAlerts, type EventLite } from "@/lib/console/widgets/events.rules";
+
+const evs: EventLite[] = [
+  { id: "1", type: "quake", tier: "S2", title: "M4.7 quake", magnitude: 4.7 },
+  { id: "2", type: "quake", tier: "S2", title: "M5.2 quake", magnitude: 5.2 },
+  { id: "3", type: "disaster", tier: "S4", title: "Earthquake Venezuela" },
+  { id: "4", type: "cyclone", tier: "S1", title: "Storm" },
+];
+
+test("flags S3/S4 tiers and M5+ quakes; ignores routine", () => {
+  const ids = eventAlerts(evs, {}).map((a) => a.ref).sort();
+  expect(ids).toEqual(["2", "3"]);
+});
+
+test("S4 is critical, S3 is warn", () => {
+  const a = eventAlerts([{ id: "x", type: "disaster", tier: "S3", title: "Drought" }], {});
+  expect(a[0].severity).toBe("warn");
+});

--- a/tests/unit/console-news-providers.test.ts
+++ b/tests/unit/console-news-providers.test.ts
@@ -7,9 +7,9 @@ test("seeds at least 10 free providers with valid kinds", () => {
 });
 
 test("parseCustomStream reads a YouTube live URL", () => {
-  const p = parseCustomStream("https://www.youtube.com/watch?v=abc123XYZ");
+  const p = parseCustomStream("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
   expect(p?.kind).toBe("youtube");
-  expect(p?.ref).toBe("abc123XYZ");
+  expect(p?.ref).toBe("dQw4w9WgXcQ");
 });
 
 test("parseCustomStream reads an HLS url and rejects junk", () => {
@@ -18,9 +18,10 @@ test("parseCustomStream reads an HLS url and rejects junk", () => {
 });
 
 test("resolveEmbed builds a youtube embed src", () => {
-  const e = resolveEmbed({ id: "x", name: "X", category: "World", kind: "youtube", ref: "abc123XYZ" });
+  const e = resolveEmbed({ id: "x", name: "X", category: "World", kind: "youtube", ref: "dQw4w9WgXcQ" });
   expect(e.kind).toBe("youtube");
-  expect(e.src).toContain("youtube.com/embed/abc123XYZ");
+  expect(e.src).toContain("youtube.com/embed/dQw4w9WgXcQ");
   expect(e.src).toContain("autoplay=1");
   expect(e.src).toContain("mute=1");
+  expect(e.src).toContain("playsinline=1");
 });

--- a/tests/unit/console-news-providers.test.ts
+++ b/tests/unit/console-news-providers.test.ts
@@ -25,3 +25,9 @@ test("resolveEmbed builds a youtube embed src", () => {
   expect(e.src).toContain("mute=1");
   expect(e.src).toContain("playsinline=1");
 });
+
+test("resolveEmbed rejects a non-http(s) hls ref", () => {
+  const e = resolveEmbed({ id: "x", name: "X", category: "Custom", kind: "hls", ref: "javascript:alert(1)" });
+  expect(e.kind).toBe("hls");
+  expect(e.src).toBeFalsy();
+});

--- a/tests/unit/console-news-providers.test.ts
+++ b/tests/unit/console-news-providers.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed } from "@/lib/console/news/providers";
+
+test("seeds at least 10 free providers with valid kinds", () => {
+  expect(NEWS_PROVIDERS.length).toBeGreaterThanOrEqual(10);
+  for (const p of NEWS_PROVIDERS) expect(["youtube", "hls"]).toContain(p.kind);
+});
+
+test("parseCustomStream reads a YouTube live URL", () => {
+  const p = parseCustomStream("https://www.youtube.com/watch?v=abc123XYZ");
+  expect(p?.kind).toBe("youtube");
+  expect(p?.ref).toBe("abc123XYZ");
+});
+
+test("parseCustomStream reads an HLS url and rejects junk", () => {
+  expect(parseCustomStream("https://x.com/live/stream.m3u8")?.kind).toBe("hls");
+  expect(parseCustomStream("not a url")).toBeNull();
+});
+
+test("resolveEmbed builds a youtube embed src", () => {
+  const e = resolveEmbed({ id: "x", name: "X", category: "World", kind: "youtube", ref: "abc123XYZ" });
+  expect(e.kind).toBe("youtube");
+  expect(e.src).toContain("youtube.com/embed/abc123XYZ");
+  expect(e.src).toContain("autoplay=1");
+  expect(e.src).toContain("mute=1");
+});

--- a/tests/unit/console-presets.test.ts
+++ b/tests/unit/console-presets.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "vitest";
+import { BUILTIN_PRESETS } from "@/lib/console/presets";
+
+test("built-ins are non-empty and within the cap", () => {
+  const ids = BUILTIN_PRESETS.map((p) => p.id);
+  expect(ids).toContain("world");
+  expect(ids).toContain("aviation-ops");
+  expect(ids).toContain("disaster-response");
+  for (const p of BUILTIN_PRESETS) {
+    const l = p.build();
+    expect(l.widgets.length).toBeGreaterThan(0);
+    expect(l.widgets.length).toBeLessThanOrEqual(50);
+  }
+});
+
+test("aviation-ops puts an aviation widget on the canvas with a stage", () => {
+  const l = BUILTIN_PRESETS.find((p) => p.id === "aviation-ops")!.build();
+  expect(l.widgets.some((w) => w.type === "aviation")).toBe(true);
+  expect(["map2d", "map3d", "clock"]).toContain(l.stage);
+});

--- a/tests/unit/console-reducers.test.ts
+++ b/tests/unit/console-reducers.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "vitest";
 import { createDefaultLayout, MAX_WIDGETS } from "@/lib/console/types";
+import {
+  addWidget, removeWidget, moveWidget, setWidgetHeight, setSegmentSize,
+  setStage, widgetsInSegment, isAtCapacity,
+} from "@/lib/console/reducers";
+import { newInstanceId } from "@/lib/console/types";
 
 test("default layout has three segments, a 2D stage, and no widgets", () => {
   const l = createDefaultLayout();
@@ -9,4 +14,47 @@ test("default layout has three segments, a 2D stage, and no widgets", () => {
   expect(l.stage).toBe("map2d");
   expect(l.widgets).toEqual([]);
   expect(MAX_WIDGETS).toBe(50);
+});
+
+test("addWidget appends to the emptiest segment and assigns dense order", () => {
+  let l = createDefaultLayout();
+  l = addWidget(l, "aviation", "a");
+  l = addWidget(l, "events", "b", { segment: "left" });
+  expect(widgetsInSegment(l, "left").map((w) => w.id)).toEqual(["a", "b"]);
+  expect(widgetsInSegment(l, "left").map((w) => w.order)).toEqual([0, 1]);
+});
+
+test("addWidget is a no-op at capacity", () => {
+  let l = createDefaultLayout();
+  for (let i = 0; i < 50; i++) l = addWidget(l, "aviation", newInstanceId(i));
+  expect(l.widgets.length).toBe(50);
+  expect(isAtCapacity(l)).toBe(true);
+  const same = addWidget(l, "aviation", "overflow");
+  expect(same).toBe(l); // identity — caller can detect rejection
+});
+
+test("moveWidget re-segments and densely reindexes order", () => {
+  let l = createDefaultLayout();
+  l = addWidget(l, "aviation", "a", { segment: "left" });
+  l = addWidget(l, "events", "b", { segment: "left" });
+  l = moveWidget(l, "a", "right", 0);
+  expect(widgetsInSegment(l, "left").map((w) => w.id)).toEqual(["b"]);
+  expect(widgetsInSegment(l, "right").map((w) => w.id)).toEqual(["a"]);
+  expect(widgetsInSegment(l, "left")[0].order).toBe(0);
+});
+
+test("setWidgetHeight clamps; setSegmentSize clamps; setStage swaps", () => {
+  let l = addWidget(createDefaultLayout(), "aviation", "a");
+  l = setWidgetHeight(l, "a", 5);
+  expect(l.widgets[0].height).toBe(120);
+  l = setSegmentSize(l, "left", -10);
+  expect(l.segments.left.size).toBe(0);
+  l = setStage(l, "clock");
+  expect(l.stage).toBe("clock");
+});
+
+test("removeWidget drops the instance and leaves others intact", () => {
+  let l = addWidget(addWidget(createDefaultLayout(), "aviation", "a"), "events", "b");
+  l = removeWidget(l, "a");
+  expect(l.widgets.map((w) => w.id)).toEqual(["b"]);
 });

--- a/tests/unit/console-reducers.test.ts
+++ b/tests/unit/console-reducers.test.ts
@@ -58,3 +58,25 @@ test("removeWidget drops the instance and leaves others intact", () => {
   l = removeWidget(l, "a");
   expect(l.widgets.map((w) => w.id)).toEqual(["b"]);
 });
+
+test("add→remove→add keeps dense, unique order in the segment (regression)", () => {
+  let l = createDefaultLayout();
+  l = addWidget(l, "aviation", "a", { segment: "left" });
+  l = addWidget(l, "events", "b", { segment: "left" });
+  l = removeWidget(l, "a");
+  l = addWidget(l, "cameras", "c", { segment: "left" });
+  const seg = widgetsInSegment(l, "left");
+  expect(seg.map((w) => w.id)).toEqual(["b", "c"]);
+  expect(seg.map((w) => w.order)).toEqual([0, 1]); // dense + unique, no duplicate order
+});
+
+test("setWidgetHeight clamps the UPPER bound to 1200", () => {
+  let l = addWidget(createDefaultLayout(), "aviation", "a");
+  l = setWidgetHeight(l, "a", 9999);
+  expect(l.widgets[0].height).toBe(1200);
+});
+
+test("setSegmentSize clamps the UPPER bound to 900", () => {
+  let l = setSegmentSize(createDefaultLayout(), "left", 9999);
+  expect(l.segments.left.size).toBe(900);
+});

--- a/tests/unit/console-reducers.test.ts
+++ b/tests/unit/console-reducers.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest";
+import { createDefaultLayout, MAX_WIDGETS } from "@/lib/console/types";
+
+test("default layout has three segments, a 2D stage, and no widgets", () => {
+  const l = createDefaultLayout();
+  expect(Object.keys(l.segments).sort()).toEqual(["bottom", "left", "right"]);
+  expect(l.segments.left).toEqual({ size: 320, collapsed: false });
+  expect(l.segments.bottom).toEqual({ size: 240, collapsed: false });
+  expect(l.stage).toBe("map2d");
+  expect(l.widgets).toEqual([]);
+  expect(MAX_WIDGETS).toBe(50);
+});

--- a/tests/unit/console-registry.test.ts
+++ b/tests/unit/console-registry.test.ts
@@ -20,3 +20,10 @@ test("widgetsByCategory groups and preserves insertion order", () => {
   expect(groups.map((g) => g.category)).toEqual(["Aviation", "News"]);
   expect(groups[0].types.map((t) => t.id)).toEqual(["aviation", "emerg"]);
 });
+
+test("listWidgetTypes preserves registration order; getWidgetType misses return undefined", () => {
+  registerWidget(stub("aviation", "Aviation"));
+  registerWidget(stub("news", "News"));
+  expect(listWidgetTypes().map((t) => t.id)).toEqual(["aviation", "news"]);
+  expect(getWidgetType("nope")).toBeUndefined();
+});

--- a/tests/unit/console-registry.test.ts
+++ b/tests/unit/console-registry.test.ts
@@ -1,0 +1,22 @@
+import { expect, test, beforeEach } from "vitest";
+import { registerWidget, getWidgetType, listWidgetTypes, widgetsByCategory, __resetRegistry } from "@/lib/console/registry";
+
+const stub = (id: string, category: string) =>
+  ({ id, title: id, icon: "■", category, defaultHeight: 200, defaultConfig: {}, component: (() => null) as never });
+
+beforeEach(() => __resetRegistry());
+
+test("register + get + list", () => {
+  registerWidget(stub("aviation", "Aviation"));
+  expect(getWidgetType("aviation")?.title).toBe("aviation");
+  expect(listWidgetTypes().map((t) => t.id)).toEqual(["aviation"]);
+});
+
+test("widgetsByCategory groups and preserves insertion order", () => {
+  registerWidget(stub("aviation", "Aviation"));
+  registerWidget(stub("news", "News"));
+  registerWidget(stub("emerg", "Aviation"));
+  const groups = widgetsByCategory();
+  expect(groups.map((g) => g.category)).toEqual(["Aviation", "News"]);
+  expect(groups[0].types.map((t) => t.id)).toEqual(["aviation", "emerg"]);
+});

--- a/tests/unit/console-sanitize.test.ts
+++ b/tests/unit/console-sanitize.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "vitest";
+import { sanitizeLayout } from "@/lib/console/sanitize";
+import { createDefaultLayout, MAX_WIDGETS } from "@/lib/console/types";
+
+test("sanitizeLayout returns null for unrecoverable input", () => {
+  expect(sanitizeLayout(null)).toBeNull();
+  expect(sanitizeLayout("nope")).toBeNull();
+  expect(sanitizeLayout(42)).toBeNull();
+  expect(sanitizeLayout({ stage: "map2d", widgets: [] })).toBeNull(); // no segments
+  expect(sanitizeLayout({ segments: {}, stage: "nope", widgets: [] })).toBeNull(); // bad stage
+  expect(sanitizeLayout({ segments: {}, stage: "map2d" })).toBeNull(); // widgets not an array
+});
+
+test("sanitizeLayout backfills all three segments and clamps sizes", () => {
+  const out = sanitizeLayout({ segments: { left: { size: 99999, collapsed: false } }, stage: "map2d", widgets: [] });
+  expect(out).not.toBeNull();
+  expect(out!.segments.left).toBeDefined();
+  expect(out!.segments.right).toBeDefined();
+  expect(out!.segments.bottom).toBeDefined();
+  expect(out!.segments.left.size).toBe(900); // clamped into [0,900]
+});
+
+test("sanitizeLayout drops widgets missing id/type and defaults config to {}", () => {
+  const out = sanitizeLayout({
+    segments: createDefaultLayout().segments,
+    stage: "map2d",
+    widgets: [
+      { id: "ok", type: "clock" },                 // valid; missing config → {}
+      { type: "clock" },                           // missing id → dropped
+      { id: "noType" },                            // missing type → dropped
+      { id: "badcfg", type: "clock", config: 5 },  // non-object config → {}
+      "garbage",                                   // not an object → dropped
+    ],
+  });
+  expect(out!.widgets.length).toBe(2);
+  expect(out!.widgets[0].id).toBe("ok");
+  expect(out!.widgets[0].config).toEqual({});
+  expect(out!.widgets[1].config).toEqual({});
+});
+
+test("sanitizeLayout clamps widget height into [120,1200] and caps count", () => {
+  const tall = sanitizeLayout({
+    segments: createDefaultLayout().segments, stage: "map2d",
+    widgets: [{ id: "a", type: "clock", height: 99999 }, { id: "b", type: "clock", height: 1 }],
+  });
+  expect(tall!.widgets[0].height).toBe(1200);
+  expect(tall!.widgets[1].height).toBe(120);
+
+  const many = sanitizeLayout({
+    segments: createDefaultLayout().segments, stage: "map2d",
+    widgets: Array.from({ length: 60 }, (_, i) => ({ id: `w${i}`, type: "clock" })),
+  });
+  expect(many!.widgets.length).toBe(MAX_WIDGETS);
+});

--- a/tests/unit/console-share.test.ts
+++ b/tests/unit/console-share.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+import { encodeLayout, decodeLayout } from "@/lib/console/share";
+import { BUILTIN_PRESETS } from "@/lib/console/presets";
+
+test("encode→decode round-trips a layout", () => {
+  const l = BUILTIN_PRESETS.find((p) => p.id === "disaster-response")!.build();
+  const round = decodeLayout(encodeLayout(l));
+  expect(round?.stage).toBe(l.stage);
+  expect(round?.widgets.map((w) => w.type)).toEqual(l.widgets.map((w) => w.type));
+});
+
+test("decode returns null on garbage", () => {
+  expect(decodeLayout("@@@notjson@@@")).toBeNull();
+});

--- a/tests/unit/console-share.test.ts
+++ b/tests/unit/console-share.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { encodeLayout, decodeLayout } from "@/lib/console/share";
 import { BUILTIN_PRESETS } from "@/lib/console/presets";
+import { createDefaultLayout, type ShellLayout } from "@/lib/console/types";
 
 test("encode→decode round-trips a layout", () => {
   const l = BUILTIN_PRESETS.find((p) => p.id === "disaster-response")!.build();
@@ -11,4 +12,22 @@ test("encode→decode round-trips a layout", () => {
 
 test("decode returns null on garbage", () => {
   expect(decodeLayout("@@@notjson@@@")).toBeNull();
+});
+
+test("decode backfills missing segments through sanitize", () => {
+  const partial = { segments: { left: { size: 320, collapsed: false } }, stage: "map2d", widgets: [] };
+  const round = decodeLayout(encodeLayout(partial as unknown as ShellLayout));
+  expect(round).not.toBeNull();
+  expect(round!.segments.right).toBeDefined();
+  expect(round!.segments.bottom).toBeDefined();
+  expect(typeof round!.segments.right.size).toBe("number");
+});
+
+test("decode caps an oversized layout at 50 widgets", () => {
+  const widgets = Array.from({ length: 60 }, (_, i) => ({
+    id: `w${i}`, type: "clock", segment: "left", order: i, height: 240, collapsed: false, config: {},
+  }));
+  const layout = { segments: createDefaultLayout().segments, stage: "map2d", widgets };
+  const round = decodeLayout(encodeLayout(layout as unknown as ShellLayout));
+  expect(round!.widgets.length).toBe(50);
 });

--- a/tests/unit/console-store.test.ts
+++ b/tests/unit/console-store.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, expect, test } from "vitest";
+import { shellLayoutStore } from "@/lib/console/store";
+import { createDefaultLayout } from "@/lib/console/types";
+
+afterEach(() => shellLayoutStore.replace(createDefaultLayout()));
+
+test("add returns the new id and lands the widget", () => {
+  const r = shellLayoutStore.add("aviation", { segment: "left" });
+  expect(r.ok).toBe(true);
+  expect(shellLayoutStore.get().widgets.find((w) => w.id === r.id)?.type).toBe("aviation");
+});
+
+test("add past 50 is rejected with ok:false", () => {
+  for (let i = 0; i < 50; i++) shellLayoutStore.add("aviation");
+  const r = shellLayoutStore.add("aviation");
+  expect(r.ok).toBe(false);
+  expect(shellLayoutStore.get().widgets.length).toBe(50);
+});
+
+test("subscribers fire on mutation", () => {
+  let n = 0;
+  const unsub = shellLayoutStore.subscribe(() => n++);
+  shellLayoutStore.add("events");
+  shellLayoutStore.stage("clock");
+  unsub();
+  shellLayoutStore.add("events"); // not counted
+  expect(n).toBe(2);
+});

--- a/tests/unit/eventFeed.test.ts
+++ b/tests/unit/eventFeed.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import { projectEventFeed, type FeedFilters, type FeedInput } from "@/lib/widgets/eventFeed";
+import { WORLD_SCOPE, type Scope } from "@/lib/shell/scope";
+
+const QUAKE = EVENT_SOURCES.find((s) => s.id === "earthquakes")!;
+const sf = (over: Partial<SignalFeature>): SignalFeature => ({
+  id: "x", lat: 1, lon: 2, title: "T", signalId: "s", ...over,
+});
+const NOW = Date.parse("2026-06-28T12:00:00Z");
+const base: FeedFilters = { types: null, minTier: "S0", sort: "severity" };
+
+const inputs = (feats: SignalFeature[]): FeedInput[] => [{ source: QUAKE, features: feats }];
+
+describe("projectEventFeed", () => {
+  it("ranks by severity×recency and reports total vs shown", () => {
+    const r = projectEventFeed(inputs([
+      sf({ id: "a", props: { magnitude: 5 }, ts: "2026-06-28T10:00:00Z" }),
+      sf({ id: "b", props: { magnitude: 8 }, ts: "2026-06-28T09:00:00Z" }),
+    ]), WORLD_SCOPE, null, NOW, base);
+    expect(r.rows.map((x) => x.id)).toEqual(["b", "a"]);
+    expect(r.total).toBe(2);
+    expect(r.shown).toBe(2);
+  });
+
+  it("applies the severity floor", () => {
+    const r = projectEventFeed(inputs([
+      sf({ id: "lo", props: { magnitude: 1 } }),
+      sf({ id: "hi", props: { magnitude: 9 } }),
+    ]), WORLD_SCOPE, null, NOW, { ...base, minTier: "S3" });
+    expect(r.rows.map((x) => x.id)).toEqual(["hi"]);
+    expect(r.total).toBe(2);
+    expect(r.shown).toBe(1);
+  });
+
+  it("filters by type", () => {
+    const r = projectEventFeed(inputs([sf({ id: "q", props: { magnitude: 5 } })]),
+      WORLD_SCOPE, null, NOW, { ...base, types: new Set(["fire"]) });
+    expect(r.shown).toBe(0);
+  });
+
+  it("trims by scope radius", () => {
+    const near: Scope = { mode: "region", center: { lat: 51.5, lon: -0.12 }, radiusKm: 50, label: "London" };
+    const r = projectEventFeed(inputs([
+      sf({ id: "in", lat: 51.51, lon: -0.13, props: { magnitude: 5 } }),
+      sf({ id: "out", lat: 35, lon: 139, props: { magnitude: 5 } }),
+    ]), near, null, NOW, base);
+    expect(r.rows.map((x) => x.id)).toEqual(["in"]);
+  });
+
+  it("trims by the time window (old events drop, undated stay)", () => {
+    const r = projectEventFeed(inputs([
+      sf({ id: "fresh", props: { magnitude: 5 }, ts: "2026-06-28T11:30:00Z" }),
+      sf({ id: "old", props: { magnitude: 5 }, ts: "2026-06-01T00:00:00Z" }),
+      sf({ id: "undated", props: { magnitude: 5 } }),
+    ]), WORLD_SCOPE, 60 * 60 * 1000, NOW, base);
+    expect(r.rows.map((x) => x.id).sort()).toEqual(["fresh", "undated"]);
+  });
+
+  it("sort=nearest orders by distance to the scope centre", () => {
+    const near: Scope = { mode: "region", center: { lat: 0, lon: 0 }, radiusKm: 100000, label: "x" };
+    const r = projectEventFeed(inputs([
+      sf({ id: "far", lat: 10, lon: 10, props: { magnitude: 9 } }),
+      sf({ id: "close", lat: 1, lon: 1, props: { magnitude: 1 } }),
+    ]), near, null, NOW, { ...base, sort: "nearest" });
+    expect(r.rows.map((x) => x.id)).toEqual(["close", "far"]);
+  });
+});

--- a/tests/unit/eventFeed.test.ts
+++ b/tests/unit/eventFeed.test.ts
@@ -66,4 +66,15 @@ describe("projectEventFeed", () => {
     ]), near, null, NOW, { ...base, sort: "nearest" });
     expect(r.rows.map((x) => x.id)).toEqual(["close", "far"]);
   });
+
+  it("dedups events sharing an id (e.g. GDACS multi-episode updates)", () => {
+    const r = projectEventFeed(inputs([
+      sf({ id: "dup", props: { magnitude: 5 } }),
+      sf({ id: "dup", props: { magnitude: 5 } }),
+      sf({ id: "other", props: { magnitude: 6 } }),
+    ]), WORLD_SCOPE, null, NOW, base);
+    expect(r.rows.map((x) => x.id)).toEqual(["other", "dup"]);
+    expect(r.total).toBe(2);
+    expect(r.shown).toBe(2);
+  });
 });

--- a/tests/unit/events-adapter.test.ts
+++ b/tests/unit/events-adapter.test.ts
@@ -4,16 +4,16 @@ import { EVENT_SOURCES } from "@/lib/events/sources";
 import { toEvent, rankEvents } from "@/lib/events/adapter";
 
 const QUAKE = EVENT_SOURCES.find((s) => s.id === "earthquakes")!;
-const FIRE = EVENT_SOURCES.find((s) => s.id === "fire-active")!;
+const CYC = EVENT_SOURCES.find((s) => s.id === "tropical-cyclones")!;
 
 const sf = (over: Partial<SignalFeature>): SignalFeature => ({
   id: "x", lat: 1, lon: 2, title: "T", signalId: "s", ...over,
 });
 
 describe("EVENT_SOURCES", () => {
-  it("seeds the 4 proven event ids", () => {
+  it("seeds the 3 curated event ids", () => {
     expect(EVENT_SOURCES.map((s) => s.id)).toEqual([
-      "earthquakes", "fire-active", "gdacs", "tropical-cyclones",
+      "earthquakes", "gdacs", "tropical-cyclones",
     ]);
   });
 });
@@ -36,9 +36,9 @@ describe("toEvent", () => {
   });
 
   it("omits native magnitude for a source with no known unit (no MW mislabel)", () => {
-    const e = toEvent(sf({ title: "Active fire — Sonoma", props: { magnitude: 7 } }), FIRE);
-    expect(e.type).toBe("fire");
-    expect(e.magnitude).toBeUndefined();     // FIRE has no magnitudeUnit
+    const e = toEvent(sf({ title: "Tropical Storm Alpha", props: { magnitude: 7 } }), CYC);
+    expect(e.type).toBe("cyclone");
+    expect(e.magnitude).toBeUndefined();     // CYC has no magnitudeUnit
     expect(e.severity.tier).toBe("S3");      // 7 → S3
   });
 

--- a/tests/unit/events-adapter.test.ts
+++ b/tests/unit/events-adapter.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import type { SignalFeature } from "@/lib/signals/types";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import { toEvent, rankEvents } from "@/lib/events/adapter";
+
+const QUAKE = EVENT_SOURCES.find((s) => s.id === "earthquakes")!;
+const FIRE = EVENT_SOURCES.find((s) => s.id === "fire-active")!;
+
+const sf = (over: Partial<SignalFeature>): SignalFeature => ({
+  id: "x", lat: 1, lon: 2, title: "T", signalId: "s", ...over,
+});
+
+describe("EVENT_SOURCES", () => {
+  it("seeds the 4 proven event ids", () => {
+    expect(EVENT_SOURCES.map((s) => s.id)).toEqual([
+      "earthquakes", "fire-active", "gdacs", "tropical-cyclones",
+    ]);
+  });
+});
+
+describe("toEvent", () => {
+  it("maps a quake feature into a NormalizedEvent with native M magnitude", () => {
+    const e = toEvent(
+      sf({ id: "usgs:1", title: "M5.8 - 9 km N of Anza, CA", lat: 33.6, lon: -116.7,
+           ts: "2026-06-28T00:00:00Z", props: { magnitude: 5.8, place: "9 km N of Anza, CA" } }),
+      QUAKE,
+    );
+    expect(e.type).toBe("quake");
+    expect(e.place.name).toBe("9 km N of Anza, CA");
+    expect(e.geo).toEqual({ lat: 33.6, lon: -116.7, precision: "EXACT" });
+    expect(e.occurredAt).toBe("2026-06-28T00:00:00Z");
+    expect(e.severity.tier).toBe("S2");      // 5.8 → S2
+    expect(e.severity.raw).toBe(5.8);
+    expect(e.magnitude).toEqual({ value: 5.8, unit: "M" });
+    expect(e.source.attribution).toBe("USGS");
+  });
+
+  it("omits native magnitude for a source with no known unit (no MW mislabel)", () => {
+    const e = toEvent(sf({ title: "Active fire — Sonoma", props: { magnitude: 7 } }), FIRE);
+    expect(e.type).toBe("fire");
+    expect(e.magnitude).toBeUndefined();     // FIRE has no magnitudeUnit
+    expect(e.severity.tier).toBe("S3");      // 7 → S3
+  });
+
+  it("treats a missing magnitude as 0 / S0 and a missing ts as null", () => {
+    const e = toEvent(sf({ title: "Quiet" }), QUAKE);
+    expect(e.severity.raw).toBe(0);
+    expect(e.severity.tier).toBe("S0");
+    expect(e.occurredAt).toBeNull();
+  });
+});
+
+describe("rankEvents", () => {
+  it("sorts by severity tier desc, then newest-first", () => {
+    const rows = rankEvents([
+      toEvent(sf({ id: "a", ts: "2026-06-27T00:00:00Z", props: { magnitude: 5 } }), QUAKE),
+      toEvent(sf({ id: "b", ts: "2026-06-26T00:00:00Z", props: { magnitude: 8 } }), QUAKE),
+      toEvent(sf({ id: "c", ts: "2026-06-28T00:00:00Z", props: { magnitude: 8 } }), QUAKE),
+    ]);
+    expect(rows.map((r) => r.id)).toEqual(["c", "b", "a"]); // S4 newest, S4 older, then S2
+  });
+  it("orders undated events after dated ones of the same tier", () => {
+    const rows = rankEvents([
+      toEvent(sf({ id: "undated", props: { magnitude: 5 } }), QUAKE),
+      toEvent(sf({ id: "dated", ts: "2026-06-28T00:00:00Z", props: { magnitude: 5 } }), QUAKE),
+    ]);
+    expect(rows.map((r) => r.id)).toEqual(["dated", "undated"]);
+  });
+});

--- a/tests/unit/events-model.test.ts
+++ b/tests/unit/events-model.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { severityTier, severityRank, placeName, SEVERITY_COLOR } from "@/lib/events/model";
+
+describe("severityTier (interim 0–10 ramp)", () => {
+  it("maps the normalized magnitude band to a tier", () => {
+    expect(severityTier(9)).toBe("S4");
+    expect(severityTier(8)).toBe("S4");
+    expect(severityTier(6)).toBe("S3");
+    expect(severityTier(4)).toBe("S2");
+    expect(severityTier(2)).toBe("S1");
+    expect(severityTier(1.9)).toBe("S0");
+    expect(severityTier(0)).toBe("S0");
+  });
+  it("treats a non-finite magnitude as S0 (never throws)", () => {
+    expect(severityTier(NaN)).toBe("S0");
+    expect(severityTier(Infinity)).toBe("S4"); // >=8 branch; finite-guard only catches NaN
+  });
+});
+
+describe("severityRank", () => {
+  it("orders tiers low→high", () => {
+    expect(severityRank("S0")).toBeLessThan(severityRank("S4"));
+    expect(severityRank("S3")).toBe(3);
+  });
+});
+
+describe("placeName", () => {
+  it("prefers an explicit props.place", () => {
+    expect(placeName("M0.7 - 9 km N of Anza, CA", { place: "Anza, CA" })).toBe("Anza, CA");
+  });
+  it("falls back to the title tail after a dash", () => {
+    expect(placeName("M5.8 - 9 km N of Anza, CA")).toBe("9 km N of Anza, CA");
+    expect(placeName("Active fire — Sonoma County")).toBe("Sonoma County");
+  });
+  it("uses the whole title when there is no delimiter", () => {
+    expect(placeName("Tropical Storm Bret")).toBe("Tropical Storm Bret");
+  });
+});
+
+describe("SEVERITY_COLOR", () => {
+  it("has a colour for every tier", () => {
+    for (const t of ["S0", "S1", "S2", "S3", "S4"] as const) {
+      expect(SEVERITY_COLOR[t]).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+});

--- a/tests/unit/scope.test.ts
+++ b/tests/unit/scope.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { withinScope, radiusFromBbox, coerceSavedScope, WORLD_SCOPE, type Scope } from "@/lib/shell/scope";
+
+describe("withinScope", () => {
+  it("world admits everything", () => {
+    expect(withinScope(80, 170, WORLD_SCOPE)).toBe(true);
+  });
+  it("near-me / region admit points inside the radius and reject those outside", () => {
+    const s: Scope = { mode: "near-me", center: { lat: 51.5, lon: -0.12 }, radiusKm: 50, label: "Near me" };
+    expect(withinScope(51.51, -0.13, s)).toBe(true);   // ~1 km away
+    expect(withinScope(48.85, 2.35, s)).toBe(false);   // Paris, far outside
+  });
+  it("aoi admits points inside the bbox [west,south,east,north]", () => {
+    const s: Scope = { mode: "aoi", bbox: [-1, 50, 1, 52], label: "AOI" };
+    expect(withinScope(51, 0, s)).toBe(true);
+    expect(withinScope(60, 0, s)).toBe(false);
+  });
+  it("falls back to admit-all on a malformed scope (never hide untestable data)", () => {
+    expect(withinScope(0, 0, { mode: "near-me", label: "x" })).toBe(true);
+    expect(withinScope(0, 0, { mode: "aoi", label: "x" })).toBe(true);
+  });
+});
+
+describe("radiusFromBbox", () => {
+  it("derives a sensible radius (km) from a place extent", () => {
+    expect(radiusFromBbox([-0.5, 51.2, 0.3, 51.7])).toBeGreaterThan(20);
+    expect(radiusFromBbox([-0.001, 51.5, 0.001, 51.501])).toBeGreaterThanOrEqual(10); // floor
+  });
+});
+
+describe("coerceSavedScope", () => {
+  it("rehydrates a persisted near-me back to World (never auto-geolocates)", () => {
+    expect(coerceSavedScope({ mode: "near-me", center: { lat: 1, lon: 2 }, radiusKm: 50, label: "Near me" }))
+      .toEqual(WORLD_SCOPE);
+  });
+  it("keeps a region scope", () => {
+    const r: Scope = { mode: "region", center: { lat: 1, lon: 2 }, radiusKm: 100, label: "Berlin" };
+    expect(coerceSavedScope(r)).toEqual(r);
+  });
+  it("returns World for junk", () => {
+    expect(coerceSavedScope(null)).toEqual(WORLD_SCOPE);
+    expect(coerceSavedScope({ nope: true })).toEqual(WORLD_SCOPE);
+  });
+});

--- a/tests/unit/signals-gdacs.test.ts
+++ b/tests/unit/signals-gdacs.test.ts
@@ -29,3 +29,18 @@ test("event-type labels and alert-level colours", () => {
   expect(gdacsAlertColor("Orange")).toBe("#f59e0b");
   expect(gdacsAlertColor("Green")).toBe("#16a34a");
 });
+
+test("alertLevel maps to the expected magnitude (0–10 ramp)", () => {
+  const make = (alertlevel: string) => ({
+    features: [
+      {
+        geometry: { coordinates: [10, 20] },
+        properties: { eventid: 1, episodeid: 1, eventtype: "EQ", alertlevel },
+      },
+    ],
+  });
+  expect(normalizeGdacs(make("Red") as never)[0].props?.magnitude).toBe(8);
+  expect(normalizeGdacs(make("Orange") as never)[0].props?.magnitude).toBe(6);
+  expect(normalizeGdacs(make("Green") as never)[0].props?.magnitude).toBe(3);
+  expect(normalizeGdacs(make("Unknown") as never)[0].props?.magnitude).toBe(5);
+});

--- a/tests/unit/viewMode.test.ts
+++ b/tests/unit/viewMode.test.ts
@@ -1,0 +1,15 @@
+// tests/unit/viewMode.test.ts
+import { describe, it, expect } from "vitest";
+import { coerceViewMode, DEFAULT_VIEW_MODE } from "@/lib/shell/viewMode";
+
+describe("coerceViewMode", () => {
+  it("defaults to console", () => {
+    expect(DEFAULT_VIEW_MODE).toBe("console");
+    expect(coerceViewMode(null)).toBe("console");
+    expect(coerceViewMode("nonsense")).toBe("console");
+  });
+  it("keeps a valid saved mode", () => {
+    expect(coerceViewMode("explore")).toBe("explore");
+    expect(coerceViewMode("console")).toBe("console");
+  });
+});


### PR DESCRIPTION
## Widget console redesign

Replaces the dashboard with a composable live-monitoring console: a fixed center **stage** surrounded by three resizable, collapsible, scrollable **segments** holding rich per-category monitor cards.

### What's new
- **Center stage** swaps between 3D map / 2D map / world clock.
- **Three segments** (left / right / bottom) — drag to resize, collapse to zero to give the stage the space, scroll independently; drag widgets between them.
- **Monitor-card widgets**, each with a curated "needs attention" alert strip + badge:
  - **Aviation** (live flights)
  - **Disasters & Events** (ranked feed; S3+/magnitude alerts fire live)
  - **Cameras** (live thumbnail grid; offline alert fires live)
  - **Live News** — actual live *video* (HLS via the existing proxy + YouTube fallback; favourites, searchable provider catalogue, add-custom-stream)
- **Multiple instances** of any widget (hard cap 50, with feedback).
- **Cmd-K command palette = the widget catalog**: add any widget (with live open-counts), switch the stage, apply/save presets, copy a share link.
- **Presets** replace the whole arrangement — built-ins (World / Aviation Ops / Disaster Response) + save-your-own + shareable `?c=` URL.
- Layout persists locally; zero new runtime dependencies.

### Architecture
Framework-light `useSyncExternalStore` singletons under `lib/console/` (pure, TDD'd: types, reducers, store, registry, alerts, sanitize, presets, share) + `components/console/` UI. Reuses the normalized Event / Scope / view-mode foundation also included in this branch. `ConsoleShell` was rewritten to mount the workspace; the map now lives in the stage.

### Quality
- `tsc --noEmit` clean - **vitest 496/496** - `npm run build` succeeds (ESLint clean).
- 4 Playwright e2e specs (`tests/e2e/console.spec.ts`): first-run seed, Cmd-K add, stage switch, segment collapse.
- Built via subagent-driven development (per-task spec+quality review) + a whole-branch review; the review's 4 findings were all fixed: untrusted-layout sanitization on the `?c=`/persist path (a crafted share link previously crashed and persisted bad state), a per-widget error boundary, chrome-reconcile cleanup, and a working "feed" alert mode.

### Known / deferred
- **Aviation squawk/military alerts are dormant** — rules are tested but `usePlanes()` does not yet surface squawk/military; needs a small `parseAdsb()` change. (Events + Cameras alerts fire live.)
- Minor: orphaned legacy controls/components from the reconcile; persist-on-every-drag debounce; intra-segment reorder off-by-one; segment aggregate badge / preset pill / Scope control not yet built.
- Local `next start` mis-infers the workspace root (multiple lockfiles) — set `outputFileTracingRoot` to fix production serving + e2e locally; `next dev` and Vercel are unaffected.

Does not auto-deploy.