### PR TITLE
feat(console): turn every data source into a monitor widget

### DIFF
--- a/lib/console/signals/signalCard.ts
+++ b/lib/console/signals/signalCard.ts
@@ -1,0 +1,128 @@
+// lib/console/signals/signalCard.ts
+// PURE projection for the GENERIC signal-monitor widget: SignalFeature[] →
+// scoped, ranked rows + honest counts + a "needs attention" alert list.
+//
+// One component (lib/console/widgets/signals.tsx) renders EVERY registered signal
+// source through this function, so the logic that turns a heterogeneous feed into
+// a glanceable monitor card lives here, once, and is unit-tested. The component
+// and the per-signal fetch hook are dumb shells around it.
+
+import type { SignalFeature } from "@/lib/signals/types";
+import { withinScope, type Scope } from "@/lib/shell/scope";
+import type { Alert, AlertSeverity } from "@/lib/console/alerts";
+
+export interface SignalRow {
+  id: string;
+  title: string;
+  /** props.magnitude when it is a finite number (drives ranking + radius elsewhere). */
+  magnitude?: number;
+  ts?: string;
+  link?: string;
+}
+
+export interface SignalProjection {
+  rows: SignalRow[];
+  /** Features emitted before scope trimming (for "N of M" honesty). */
+  total: number;
+  /** Features inside the active scope (the widget's headline count). */
+  shown: number;
+  alerts: Alert[];
+}
+
+export interface SignalCardConfig {
+  /** Flag features whose numeric magnitude is at/above this as alerts. Off when unset. */
+  alertMin?: number;
+  /** Max rows rendered (default 60). */
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 60;
+const MAX_ALERTS = 4;
+const SEV_RANK: Record<AlertSeverity, number> = { info: 0, warn: 1, critical: 2 };
+
+/** A finite numeric magnitude from a feature's props, else undefined. */
+function magnitudeOf(f: SignalFeature): number | undefined {
+  const m = f.props?.magnitude;
+  return typeof m === "number" && Number.isFinite(m) ? m : undefined;
+}
+
+/**
+ * Soft, source-agnostic severity read from common alert-level props. Only fires
+ * on words that unambiguously mean "severe" so the generic card never invents
+ * urgency a source did not declare. Returns null when nothing qualifies.
+ */
+function severityFromProps(props: Record<string, unknown> | undefined): AlertSeverity | null {
+  if (!props) return null;
+  for (const key of ["alertlevel", "alertLevel", "severity", "level", "status"]) {
+    const v = props[key];
+    if (typeof v !== "string") continue;
+    const s = v.toLowerCase();
+    if (/red|extreme|severe|critical|emergency/.test(s)) return "critical";
+    if (/orange|warning|high|moderate/.test(s)) return "warn";
+  }
+  return null;
+}
+
+function tsMillis(ts: string | undefined): number {
+  if (!ts) return -Infinity; // undated sorts last under recency
+  const t = Date.parse(ts);
+  return Number.isNaN(t) ? -Infinity : t;
+}
+
+/**
+ * Project a single source's features into a ranked monitor card.
+ * - Rows are trimmed to the active scope, then ranked: by magnitude (desc) when
+ *   any feature carries one, otherwise by recency (desc; undated last).
+ * - Alerts surface declared-severe features (always) plus, when `alertMin` is
+ *   set, features at/above that magnitude — deduped, ranked, capped at 4.
+ */
+export function projectSignal(
+  features: SignalFeature[],
+  scope: Scope,
+  config: SignalCardConfig,
+): SignalProjection {
+  const total = features.length;
+  const scoped = features.filter((f) => withinScope(f.lat, f.lon, scope));
+
+  const rows: SignalRow[] = scoped.map((f) => ({
+    id: f.id,
+    title: f.title,
+    magnitude: magnitudeOf(f),
+    ts: f.ts,
+    link: f.link,
+  }));
+
+  const hasMagnitude = rows.some((r) => r.magnitude != null);
+  rows.sort((a, b) => {
+    if (hasMagnitude) {
+      const diff = (b.magnitude ?? -Infinity) - (a.magnitude ?? -Infinity);
+      if (diff !== 0) return diff;
+    }
+    return tsMillis(b.ts) - tsMillis(a.ts);
+  });
+
+  // Alerts — keyed by feature id so magnitude + prop-severity hits collapse.
+  const alertMap = new Map<string, Alert>();
+  const consider = (f: SignalFeature, severity: AlertSeverity, mag?: number) => {
+    const prev = alertMap.get(f.id);
+    if (prev && SEV_RANK[prev.severity] >= SEV_RANK[severity]) return;
+    const tail = mag != null ? ` · ${mag}` : "";
+    alertMap.set(f.id, { id: `sig-${f.id}`, severity, text: `${f.title}${tail}`, ref: f.id });
+  };
+  for (const f of scoped) {
+    const sev = severityFromProps(f.props);
+    if (sev) consider(f, sev);
+    if (config.alertMin != null) {
+      const mag = magnitudeOf(f);
+      if (mag != null && mag >= config.alertMin) {
+        consider(f, mag >= config.alertMin + 2 ? "critical" : "warn", mag);
+      }
+    }
+  }
+  const alerts = [...alertMap.values()]
+    .sort((a, b) => SEV_RANK[b.severity] - SEV_RANK[a.severity])
+    .slice(0, MAX_ALERTS);
+
+  const limit = config.limit ?? DEFAULT_LIMIT;
+  return { rows: rows.slice(0, limit), total, shown: scoped.length, alerts };
+}

--- a/lib/console/signals/useSignalFeed.ts
+++ b/lib/console/signals/useSignalFeed.ts
@@ -1,0 +1,87 @@
+"use client";
+// One shared, ref-counted poller per signal id. Many widget instances can monitor
+// the same source without each opening its own /api/signals/<id> loop: the first
+// subscriber starts polling, the last unsubscribe stops it, and the latest
+// features stay cached so a re-mounted widget shows data instantly. A thin impure
+// shell — the projection logic it feeds lives in lib/console/signals/signalCard.ts.
+
+import { useMemo, useSyncExternalStore } from "react";
+import type { SignalFeature } from "@/lib/signals/types";
+
+export interface SignalFeed {
+  features: SignalFeature[];
+  status: "loading" | "idle" | "error";
+  updatedAt: number | null;
+}
+
+interface Entry {
+  state: SignalFeed;
+  listeners: Set<() => void>;
+  timer: ReturnType<typeof setInterval> | null;
+  refCount: number;
+}
+
+const EMPTY: SignalFeed = { features: [], status: "loading", updatedAt: null };
+const MIN_REFRESH_MS = 60_000;
+const DEFAULT_REFRESH_MS = 5 * 60_000;
+const feeds = new Map<string, Entry>();
+
+function ensure(id: string): Entry {
+  let e = feeds.get(id);
+  if (!e) {
+    e = { state: EMPTY, listeners: new Set(), timer: null, refCount: 0 };
+    feeds.set(id, e);
+  }
+  return e;
+}
+
+function emit(e: Entry) {
+  for (const l of e.listeners) l();
+}
+
+function load(id: string, e: Entry) {
+  fetch(`/api/signals/${encodeURIComponent(id)}`)
+    .then((r) => r.json())
+    .then((d) => {
+      const features = (d?.features as SignalFeature[]) ?? [];
+      e.state = { features, status: "idle", updatedAt: Date.now() };
+      emit(e);
+    })
+    .catch(() => {
+      // Keep the last good features; only show "error" if we never had any.
+      e.state = {
+        features: e.state.features,
+        status: e.state.updatedAt ? "idle" : "error",
+        updatedAt: e.state.updatedAt,
+      };
+      emit(e);
+    });
+}
+
+/** Subscribe to a single signal source's live feature feed. */
+export function useSignalFeed(signalId: string, refreshMs = DEFAULT_REFRESH_MS): SignalFeed {
+  const subscribe = useMemo(
+    () => (cb: () => void) => {
+      const e = ensure(signalId);
+      e.listeners.add(cb);
+      e.refCount += 1;
+      if (e.refCount === 1) {
+        if (!e.state.updatedAt) e.state = { ...e.state, status: "loading" };
+        load(signalId, e);
+        e.timer = setInterval(() => load(signalId, e), Math.max(MIN_REFRESH_MS, refreshMs));
+      }
+      return () => {
+        e.listeners.delete(cb);
+        e.refCount -= 1;
+        if (e.refCount === 0 && e.timer) {
+          clearInterval(e.timer);
+          e.timer = null;
+        }
+      };
+    },
+    [signalId, refreshMs],
+  );
+
+  const getSnapshot = useMemo(() => () => ensure(signalId).state, [signalId]);
+  return useSyncExternalStore(subscribe, getSnapshot, () => EMPTY);
+}

--- a/lib/console/widgets/index.ts
+++ b/lib/console/widgets/index.ts
@@ -3,3 +3,6 @@ import "@/lib/console/widgets/aviation";
 import "@/lib/console/widgets/events";
 import "@/lib/console/widgets/cameras";
 import "@/lib/console/widgets/news";
+import "@/lib/console/widgets/satellites";
+// Registers one generic monitor widget per global signal source (≈30 layers).
+import "@/lib/console/widgets/signals";

--- a/lib/console/widgets/satellites.tsx
+++ b/lib/console/widgets/satellites.tsx
@@ -1,0 +1,52 @@
+"use client";
+// Satellites widget — the last core map layer to get a monitor card. Mirrors the
+// Aviation widget: useSatellites() yields WorldObject[] (locally propagated from a
+// TLE set), which we list by altitude. A slow propagation step keeps a pinned list
+// cheap (the globe uses 1s for smooth motion; a list does not need it).
+
+import { useEffect, useMemo } from "react";
+import { useSatellites } from "@/lib/satellites/useSatellites";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+
+function SatellitesBody({ config }: WidgetBodyProps) {
+  const group = (config.group as string) ?? "visual";
+  const sats = useSatellites(group, 10_000);
+
+  const rows = useMemo(
+    () => [...sats].sort((a, b) => (b.altKm ?? 0) - (a.altKm ?? 0)).slice(0, 200),
+    [sats],
+  );
+
+  const report = useWidgetReport();
+  useEffect(() => {
+    report({ alerts: [], count: sats.length, freshLabel: "live" });
+  }, [sats.length, report]);
+
+  if (sats.length === 0) return <p className="tn-w-empty">Loading satellites…</p>;
+
+  return (
+    <table className="tn-w-table">
+      <tbody>
+        {rows.map((s) => (
+          <tr key={s.id}>
+            <td className="tn-w-strong">{s.label}</td>
+            <td className="tn-w-muted">{s.typeLabel ?? ""}</td>
+            <td className="tn-w-num">{s.altKm != null ? `${Math.round(s.altKm)}km` : ""}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export const SATELLITES_WIDGET = {
+  id: "satellites",
+  title: "Satellites",
+  icon: "🛰",
+  category: "Space",
+  defaultHeight: 280,
+  defaultConfig: { group: "visual" },
+  component: SatellitesBody,
+};
+registerWidget(SATELLITES_WIDGET);

--- a/lib/console/widgets/signals.tsx
+++ b/lib/console/widgets/signals.tsx
@@ -1,0 +1,119 @@
+"use client";
+// Generic signal-monitor widgets — ONE component renders EVERY registered global
+// signal source as its own monitor card, and the loop at the bottom registers one
+// widget type per source. "Every data piece is a widget": adding a layer to
+// lib/signals/registry.ts gives it a ⌘K-discoverable widget for free, no edits here.
+//
+// The card reuses the shared widget row classes (.tn-w-*) so it needs no new CSS,
+// reads the global Scope, and reports its count + "needs attention" alerts through
+// the same WidgetFrame contract as the bespoke widgets. Pure projection +
+// per-source ranking/alerts live in lib/console/signals/signalCard.ts.
+
+import { useEffect, useMemo } from "react";
+import { SIGNALS } from "@/lib/signals/registry";
+import type { SignalSource } from "@/lib/signals/types";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { useScope } from "@/lib/shell/scope";
+import { projectSignal } from "@/lib/console/signals/signalCard";
+import { useSignalFeed } from "@/lib/console/signals/useSignalFeed";
+
+const GROUP_ICON: Record<string, string> = {
+  Synthesis: "🧭",
+  "Natural hazards": "🌋",
+  "Space weather": "🌌",
+  Space: "🚀",
+  Infrastructure: "🛰",
+  Intel: "📰",
+  Conflict: "⚔",
+  Environment: "🌿",
+  "Civic safety": "🚨",
+  "Cyber threat": "🛡",
+  "Human cost": "🆘",
+  Military: "🎖",
+  Maritime: "🚢",
+  Weather: "🌦",
+};
+
+function iconFor(source: SignalSource): string {
+  return GROUP_ICON[source.group] ?? "📡";
+}
+
+function freshLabel(refreshMs: number): string {
+  if (refreshMs <= 90_000) return "live";
+  return `${Math.round(refreshMs / 60_000)}m`;
+}
+
+/** Compact "5m" / "2h" / "3d" since an ISO timestamp; "" when undated/unparsable. */
+function relativeTime(ts: string | undefined, now: number): string {
+  if (!ts) return "";
+  const t = Date.parse(ts);
+  if (Number.isNaN(t)) return "";
+  const s = Math.max(0, Math.round((now - t) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h}h`;
+  return `${Math.round(h / 24)}d`;
+}
+
+function makeSignalBody(source: SignalSource) {
+  function SignalBody({ config }: WidgetBodyProps) {
+    const scope = useScope();
+    const { features, status } = useSignalFeed(source.id, source.refreshMs);
+
+    const projected = useMemo(
+      () =>
+        projectSignal(features, scope, {
+          alertMin: typeof config.alertMin === "number" ? config.alertMin : undefined,
+        }),
+      [features, scope, config],
+    );
+
+    const report = useWidgetReport();
+    useEffect(() => {
+      report({ alerts: projected.alerts, count: projected.shown, freshLabel: freshLabel(source.refreshMs) });
+    }, [projected, report]);
+
+    if (status === "loading" && projected.shown === 0) {
+      return <p className="tn-w-empty">Loading {source.label}…</p>;
+    }
+    if (status === "error" && projected.shown === 0) {
+      return <p className="tn-w-empty">{source.label} unavailable.</p>;
+    }
+    if (projected.shown === 0) {
+      return <p className="tn-w-empty">Nothing in {scope.label}.</p>;
+    }
+
+    const now = Date.now();
+    return (
+      <ul className="tn-w-list">
+        {projected.rows.map((r) => {
+          const rel = relativeTime(r.ts, now);
+          return (
+            <li key={r.id}>
+              {r.magnitude != null && <span className="tn-w-mag">{r.magnitude}</span>}{" "}
+              <span className="tn-w-place">{r.title}</span>
+              {rel && <span className="tn-w-muted"> · {rel}</span>}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+  return SignalBody;
+}
+
+// Register one widget type per registered signal source.
+for (const source of SIGNALS) {
+  registerWidget({
+    id: `signal:${source.id}`,
+    title: source.label,
+    icon: iconFor(source),
+    category: source.group,
+    defaultHeight: 240,
+    defaultConfig: {},
+    component: makeSignalBody(source),
+  });
+}

--- a/tests/unit/signalCard.test.ts
+++ b/tests/unit/signalCard.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import type { SignalFeature } from "@/lib/signals/types";
+import { projectSignal } from "@/lib/console/signals/signalCard";
+import { WORLD_SCOPE, type Scope } from "@/lib/shell/scope";
+
+const sf = (over: Partial<SignalFeature>): SignalFeature => ({
+  id: "x", lat: 1, lon: 2, title: "T", signalId: "s", ...over,
+});
+
+describe("projectSignal", () => {
+  it("ranks by magnitude desc when any feature carries one", () => {
+    const r = projectSignal([
+      sf({ id: "a", props: { magnitude: 4 } }),
+      sf({ id: "b", props: { magnitude: 7 } }),
+      sf({ id: "c", props: { magnitude: 5 } }),
+    ], WORLD_SCOPE, {});
+    expect(r.rows.map((x) => x.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("ranks by recency desc when no feature has a magnitude (undated last)", () => {
+    const r = projectSignal([
+      sf({ id: "old", ts: "2026-06-20T00:00:00Z" }),
+      sf({ id: "new", ts: "2026-06-28T00:00:00Z" }),
+      sf({ id: "undated" }),
+    ], WORLD_SCOPE, {});
+    expect(r.rows.map((x) => x.id)).toEqual(["new", "old", "undated"]);
+  });
+
+  it("trims to the active scope and reports total vs shown", () => {
+    const near: Scope = { mode: "region", center: { lat: 51.5, lon: -0.12 }, radiusKm: 50, label: "London" };
+    const r = projectSignal([
+      sf({ id: "in", lat: 51.51, lon: -0.13 }),
+      sf({ id: "out", lat: 35, lon: 139 }),
+    ], near, {});
+    expect(r.rows.map((x) => x.id)).toEqual(["in"]);
+    expect(r.total).toBe(2);
+    expect(r.shown).toBe(1);
+  });
+
+  it("emits no alerts by default for a plain feed", () => {
+    const r = projectSignal([
+      sf({ id: "a", props: { magnitude: 9 } }),
+    ], WORLD_SCOPE, {});
+    expect(r.alerts).toEqual([]);
+  });
+
+  it("alerts on magnitude at/above alertMin, escalating to critical", () => {
+    const r = projectSignal([
+      sf({ id: "lo", title: "Quake A", props: { magnitude: 4 } }),
+      sf({ id: "mid", title: "Quake B", props: { magnitude: 5.5 } }),
+      sf({ id: "big", title: "Quake C", props: { magnitude: 8 } }),
+    ], WORLD_SCOPE, { alertMin: 5 });
+    const byRef = Object.fromEntries(r.alerts.map((a) => [a.ref, a.severity]));
+    expect(byRef.lo).toBeUndefined();          // below floor
+    expect(byRef.mid).toBe("warn");            // >= 5, < 7
+    expect(byRef.big).toBe("critical");        // >= alertMin + 2
+    expect(r.alerts[0].ref).toBe("big");       // critical sorts first
+  });
+
+  it("surfaces declared-severe features via alert-level props", () => {
+    const r = projectSignal([
+      sf({ id: "red", title: "GDACS storm", props: { alertlevel: "Red" } }),
+      sf({ id: "green", title: "GDACS calm", props: { alertlevel: "Green" } }),
+    ], WORLD_SCOPE, {});
+    expect(r.alerts.map((a) => a.ref)).toEqual(["red"]);
+    expect(r.alerts[0].severity).toBe("critical");
+  });
+
+  it("collapses a feature that trips both magnitude and prop severity into one alert", () => {
+    const r = projectSignal([
+      sf({ id: "dup", title: "Big severe", props: { magnitude: 9, severity: "extreme" } }),
+    ], WORLD_SCOPE, { alertMin: 5 });
+    expect(r.alerts).toHaveLength(1);
+    expect(r.alerts[0].ref).toBe("dup");
+    expect(r.alerts[0].severity).toBe("critical");
+  });
+
+  it("caps rows at the configured limit", () => {
+    const many = Array.from({ length: 80 }, (_, i) => sf({ id: `q${i}`, props: { magnitude: i } }));
+    const r = projectSignal(many, WORLD_SCOPE, { limit: 10 });
+    expect(r.rows).toHaveLength(10);
+    expect(r.shown).toBe(80);
+    expect(r.rows[0].magnitude).toBe(79); // highest first
+  });
+});


### PR DESCRIPTION
## Every data source is now a widget

The console had 4 hand-built widgets (Aviation, Cameras, Disasters & Events, Live News). This turns **every** remaining data source into a monitor-card widget.

### What's new
- **Generic signal-monitor widget** — one component renders any registered global signal source (~30 layers: earthquakes, wildfires, volcanoes, floods, GDACS, cyclones, FIRMS, aurora, space weather, launches, cables, GPS jamming, nuclear, airports, ports, internet outages, GDELT conflict/protests, ACLED, weather, air quality, crime, cyber C2/ransomware, displacement, food security, ReliefWeb, grid load, military air, AIS, instability). Each is its own command-palette-discoverable card, grouped by signal group.
- **Satellites widget** — the last core map layer to get a card (orbital list by altitude; mirrors Aviation).

### How
- `lib/console/signals/signalCard.ts` — pure, scoped + ranked projection and alert derivation (magnitude floor + declared-severity props). Unit-tested.
- `lib/console/signals/useSignalFeed.ts` — one ref-counted, deduped poller per signal id, shared across instances (no double-fetch when several widgets watch the same source).
- `lib/console/widgets/signals.tsx` — generic body + a registration loop that adds one widget type per `SIGNALS` entry.
- Reuses the existing `.tn-w-*` row classes — **no new CSS, no chrome class collision**.

**Adding a layer to `lib/signals/registry.ts` now yields a widget for free** — no edits here.

### Verification
- `tsc --noEmit` — clean
- `vitest run` — 505/505 (8 new)
- `npm run build` — green (home `/` 174 kB First Load JS)
- Runtime-smoked on the live dev server: Earthquakes widget renders 197 → 60 rows with magnitude + relative-time, honest count badge, no overlay regression, 0 console errors; ⌘K catalog lists all new widgets; Satellites adds cleanly.
