### PR TITLE
Focus Window foundation — expand any widget onto the center stage (F1+F2+W1 Events)

### DIFF
--- a/app/api/cameras/route.ts
+++ b/app/api/cameras/route.ts
@@ -11,6 +11,11 @@ export async function GET() {
   const cameras = cams.map((c) => ({
     id: c.id, name: c.name, lat: c.lat, lon: c.lon, available: c.available,
     source: c.source, country: c.country, live: isLiveStreamUrl(c.streamUrl),
+    // Enriched for the focus view (Camera fields the docked widget doesn't need).
+    // NOTE: deliberately NO imageUrl/streamUrl — snapshots go through /api/proxy?id=
+    // and /api/hls?id= (SSRF allowlist by id), never a raw upstream URL.
+    region: c.region, road: c.road, refreshSeconds: c.refreshSeconds,
+    attribution: c.attribution, license: c.license, lastSampledAt: c.lastSampledAt,
   }));
   return Response.json({ count: cameras.length, cameras });
 }

--- a/app/api/news/summary/route.ts
+++ b/app/api/news/summary/route.ts
@@ -1,0 +1,76 @@
+// app/api/news/summary/route.ts
+import { isNewsArticleUrl, extractArticleText } from "@/lib/news/article";
+import { buildSummaryPrompt, parseSummaryResponse, type SummaryPayload } from "@/lib/news/summary";
+import { freellmConfig } from "@/lib/geolocate/config";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/news/summary { url, title, source } — on-demand AI summary of ONE article.
+// Dormant ({summary:null, dormant:true}) until FREELLMAPI_* is set. SSRF-guarded to
+// the news-publisher allowlist. Dormant-safe: any failure returns JSON, never a 5xx.
+// Cached per-URL (module map) so re-opening a story is free.
+
+const cache = new Map<string, SummaryPayload>();
+
+function bad(): Response {
+  return Response.json({ summary: null, dormant: false, source: null } satisfies SummaryPayload);
+}
+
+export async function POST(req: Request) {
+  let body: { url?: unknown; title?: unknown; source?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return bad();
+  }
+  const url = typeof body.url === "string" ? body.url : "";
+  const title = typeof body.title === "string" ? body.title : "";
+  const source = typeof body.source === "string" ? body.source : "";
+  if (!isNewsArticleUrl(url)) return bad();
+
+  const cached = cache.get(url);
+  if (cached) return Response.json(cached);
+
+  const cfg = freellmConfig();
+  if (!cfg) {
+    // Not cached — dormancy can change when the env is set.
+    return Response.json({ summary: null, dormant: true, source: null } satisfies SummaryPayload);
+  }
+
+  let text = "";
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.ok) text = extractArticleText(await res.text());
+  } catch {
+    text = "";
+  }
+  if (text.length < 200) {
+    // Blocked / paywalled / too thin — tell the client to fall back to its snippet.
+    const payload: SummaryPayload = { summary: null, dormant: false, source: "snippet" };
+    return Response.json(payload);
+  }
+
+  try {
+    const r = await fetch(`${cfg.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${cfg.key}` },
+      body: JSON.stringify({
+        model: cfg.model,
+        messages: [{ role: "user", content: buildSummaryPrompt({ title, source, text }) }],
+        temperature: 0.2,
+        max_tokens: 220,
+      }),
+      signal: AbortSignal.timeout(25_000),
+    });
+    if (!r.ok) throw new Error(`gateway ${r.status}`);
+    const summary = parseSummaryResponse(await r.json());
+    const payload: SummaryPayload = { summary, dormant: false, source: summary ? "ai" : "snippet" };
+    if (summary) cache.set(url, payload);
+    return Response.json(payload);
+  } catch {
+    return Response.json({ summary: null, dormant: false, source: "snippet" } satisfies SummaryPayload);
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1247,3 +1247,20 @@ a { color: var(--tn-accent); }
 .tn-evd-export { margin-left: auto; display: flex; gap: 8px; }
 .tn-evd-export button { font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; background: transparent; color: var(--tn-accent, #38bdf8); cursor: pointer; }
 .tn-evd-export button:disabled { opacity: .4; cursor: default; }
+
+/* ── Headlines focus view (W2) ─────────────────────────────────────── */
+.tn-hd { max-width: 1000px; margin: 0 auto; }
+.tn-hd-bar { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin-bottom: 12px; }
+.tn-hd-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.tn-hd-chips button { font: inherit; font-size: 12px; padding: 3px 10px; border: 1px solid var(--tn-border); border-radius: 999px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-hd-chips button.is-on { background: var(--tn-accent); color: #fff; border-color: var(--tn-accent); }
+.tn-hd-search { margin-left: auto; font: inherit; font-size: 13px; padding: 5px 10px; border: 1px solid var(--tn-border); border-radius: 6px; background: var(--tn-surface-2); color: var(--tn-text); min-width: 180px; }
+.tn-hd-group { margin: 12px 0; }
+.tn-hd-group-h { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--tn-text-faint); margin: 0 0 6px; }
+.tn-hd-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.tn-hd-item { padding: 8px 10px; border-radius: 8px; background: var(--tn-surface-2); }
+.tn-hd-title { font-weight: 600; color: var(--tn-text); text-decoration: none; }
+.tn-hd-title:hover { text-decoration: underline; }
+.tn-hd-meta { font-size: 11px; color: var(--tn-text-faint); margin-top: 2px; }
+.tn-hd-src { color: var(--tn-accent); }
+.tn-hd-snippet { font-size: 13px; color: var(--tn-text-muted); margin: 4px 0 0; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1265,3 +1265,8 @@ a { color: var(--tn-accent); }
 .tn-hd-src { color: var(--tn-accent); }
 .tn-hd-snippet { font-size: 13px; color: var(--tn-text-muted); margin: 4px 0 0; }
 .tn-hd-vol { background: var(--tn-surface-2); border-radius: 8px; padding: 8px 10px; margin-bottom: 12px; }
+.tn-hd-sum-btn { margin-top: 6px; font: inherit; font-size: 11px; padding: 2px 8px; border: 1px solid var(--tn-border); border-radius: 6px; background: transparent; color: var(--tn-accent); cursor: pointer; }
+.tn-hd-sum-btn:disabled { opacity: .6; cursor: default; }
+.tn-hd-sum { margin-top: 6px; padding: 8px 10px; border-left: 2px solid var(--tn-accent); background: var(--tn-surface); border-radius: 4px; }
+.tn-hd-sum p { margin: 0; font-size: 13px; color: var(--tn-text); }
+.tn-hd-sum-note { display: block; margin-top: 4px; font-size: 11px; color: var(--tn-text-faint); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1211,3 +1211,14 @@ a { color: var(--tn-accent); }
    =========================================================================== */
 .tn-toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%);z-index:1200;max-width:90vw;background:#2b3640;color:#fff;font:13px/1.4 -apple-system,"Segoe UI",Roboto,sans-serif;padding:9px 16px;border-radius:999px;box-shadow:0 6px 24px rgba(20,28,38,.28);animation:tn-toast-in .18s ease-out}
 @keyframes tn-toast-in{from{opacity:0;transform:translate(-50%,8px)}to{opacity:1;transform:translate(-50%,0)}}
+
+/* Focus window — a widget expanded onto the center stage */
+.tn-detail { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--tn-surface-1, #0b1220); color: var(--tn-text-1, #e2e8f0); overflow: hidden; }
+.tn-detail-head { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--tn-border, #1e293b); flex: 0 0 auto; }
+.tn-detail-back { font: inherit; font-size: 13px; background: transparent; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; padding: 4px 10px; color: var(--tn-accent, #38bdf8); cursor: pointer; }
+.tn-detail-back:hover { background: var(--tn-surface-2, #111a2e); }
+.tn-detail-icon { font-size: 16px; }
+.tn-detail-title { font-weight: 600; font-size: 15px; }
+.tn-detail-body { flex: 1 1 auto; overflow: auto; padding: 14px; }
+.tn-detail-generic { max-width: 900px; margin: 0 auto; }
+.tn-stage-focus { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 6px; font-size: 12px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1302,3 +1302,40 @@ a { color: var(--tn-accent); }
 .tn-sd-actions { display: flex; gap: 8px; }
 .tn-sd-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
 .tn-sd-actions button:disabled { opacity: .4; cursor: default; }
+
+/* ── Aviation focus view (airspace console) — mirrors the .tn-sd visual language ── */
+.tn-av { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
+.tn-av-head { display: flex; flex-direction: column; gap: 6px; }
+.tn-av-title { font-size: 18px; font-weight: 700; }
+.tn-av-stat { font-size: 12px; color: var(--tn-text-muted); }
+.tn-av-delta.up { color: #16a34a; } .tn-av-delta.down { color: #dc2626; }
+.tn-av-spark { max-width: 320px; }
+.tn-av-ops { display: flex; flex-wrap: wrap; gap: 6px; }
+.tn-av-chip { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: var(--tn-surface-2); border: 1px solid var(--tn-border); color: var(--tn-text-muted); }
+.tn-av-emg-list { display: flex; flex-direction: column; gap: 6px; }
+.tn-av-emg { font-size: 13px; font-weight: 600; color: #fca5a5; background: rgba(220, 38, 38, .12); border: 1px solid rgba(220, 38, 38, .5); border-radius: 6px; padding: 6px 10px; }
+.tn-av-filters { display: flex; flex-direction: column; gap: 8px; }
+.tn-av-filter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.tn-av-filter-label { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin-right: 2px; }
+.tn-av-fchip { font-size: 11px; padding: 3px 10px; border-radius: 999px; background: var(--tn-surface-2); border: 1px solid var(--tn-border); color: var(--tn-text-muted); cursor: pointer; }
+.tn-av-fchip.active { background: var(--tn-accent); border-color: var(--tn-accent); color: var(--tn-surface-solid); }
+.tn-av-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+@media (max-width: 720px) { .tn-av-panels { grid-template-columns: 1fr; } }
+.tn-av-panel h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 0 0 6px; }
+.tn-av-bars { display: flex; align-items: flex-end; gap: 4px; height: 120px; }
+.tn-av-bar { flex: 1; background: var(--tn-accent); border-radius: 2px 2px 0 0; min-height: 2px; opacity: .85; }
+.tn-av-bar-label { font-size: 10px; color: var(--tn-text-faint); text-align: center; }
+.tn-av-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tn-av-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-av-table th.sortable { cursor: pointer; }
+.tn-av-table td { padding: 5px 8px; border-bottom: 1px solid var(--tn-border); white-space: nowrap; }
+.tn-av-row { cursor: pointer; }
+.tn-av-row:hover { background: var(--tn-surface-2); }
+.tn-av-drill { background: var(--tn-surface-2); }
+.tn-av-drill td { padding: 12px 14px; }
+.tn-av-sq-emg { color: #fca5a5; font-weight: 700; }
+.tn-av-foot { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; border-top: 1px solid var(--tn-border); padding-top: 8px; margin-top: auto; }
+.tn-av-attr { font-size: 11px; color: var(--tn-text-faint); }
+.tn-av-actions { display: flex; gap: 8px; }
+.tn-av-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
+.tn-av-actions button:disabled { opacity: .4; cursor: default; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1270,3 +1270,7 @@ a { color: var(--tn-accent); }
 .tn-hd-sum { margin-top: 6px; padding: 8px 10px; border-left: 2px solid var(--tn-accent); background: var(--tn-surface); border-radius: 4px; }
 .tn-hd-sum p { margin: 0; font-size: 13px; color: var(--tn-text); }
 .tn-hd-sum-note { display: block; margin-top: 4px; font-size: 11px; color: var(--tn-text-faint); }
+.tn-hd-foot { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--tn-border); display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.tn-hd-foot-src { font-size: 12px; color: var(--tn-text-faint); }
+.tn-hd-export { margin-left: auto; font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border); border-radius: 6px; background: transparent; color: var(--tn-accent); cursor: pointer; }
+.tn-hd-export:disabled { opacity: .4; cursor: default; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1264,3 +1264,4 @@ a { color: var(--tn-accent); }
 .tn-hd-meta { font-size: 11px; color: var(--tn-text-faint); margin-top: 2px; }
 .tn-hd-src { color: var(--tn-accent); }
 .tn-hd-snippet { font-size: 13px; color: var(--tn-text-muted); margin: 4px 0 0; }
+.tn-hd-vol { background: var(--tn-surface-2); border-radius: 8px; padding: 8px 10px; margin-bottom: 12px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1339,3 +1339,54 @@ a { color: var(--tn-accent); }
 .tn-av-actions { display: flex; gap: 8px; }
 .tn-av-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
 .tn-av-actions button:disabled { opacity: .4; cursor: default; }
+
+/* ── Cameras focus view (W5) — mirrors the .tn-av / .tn-sd visual language ── */
+.tn-cm { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
+.tn-cm-head { display: flex; flex-direction: column; gap: 6px; }
+.tn-cm-title { font-size: 18px; font-weight: 700; }
+.tn-cm-stat { font-size: 12px; color: var(--tn-text-muted); }
+.tn-cm-delta.up { color: #16a34a; } .tn-cm-delta.down { color: #dc2626; }
+.tn-cm-spark { max-width: 320px; }
+/* coverage-honesty bar (one chip per operator: live / still / offline) */
+.tn-cm-cov { display: flex; flex-wrap: wrap; gap: 6px; }
+.tn-cm-cov-chip { font-size: 11px; padding: 3px 9px; border-radius: 999px; background: var(--tn-surface-2); border: 1px solid var(--tn-border); color: var(--tn-text-muted); }
+.tn-cm-cov-chip b { color: var(--tn-text); font-weight: 700; }
+/* filters */
+.tn-cm-filters { display: flex; flex-direction: column; gap: 8px; }
+.tn-cm-filter-row { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.tn-cm-filter-label { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin-right: 2px; }
+.tn-cm-fchip { font-size: 11px; padding: 3px 10px; border-radius: 999px; background: var(--tn-surface-2); border: 1px solid var(--tn-border); color: var(--tn-text-muted); cursor: pointer; }
+.tn-cm-fchip.active { background: var(--tn-accent); border-color: var(--tn-accent); color: var(--tn-surface-solid); }
+.tn-cm-fchip.off { opacity: .5; text-decoration: line-through; }
+/* panels */
+.tn-cm-panels { display: grid; grid-template-columns: 1fr; gap: 14px; }
+.tn-cm-panel h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 0 0 6px; display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+/* camera wall */
+.tn-cm-group-h { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 8px 0 4px; }
+.tn-cm-wall { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; }
+.tn-cm-tile { border: 1px solid var(--tn-border); border-radius: 8px; overflow: hidden; background: var(--tn-surface-2); display: flex; flex-direction: column; }
+.tn-cm-shot { position: relative; }
+.tn-cm-tile figure { margin: 0; }
+.tn-cm-tile img, .tn-cm-tile video { width: 100%; display: block; aspect-ratio: 16 / 9; object-fit: cover; background: #000; }
+.tn-cm-tile figcaption { padding: 2px 6px; font-size: 10px; color: var(--tn-text-faint); }
+.tn-cm-live-btn { position: absolute; top: 6px; left: 6px; z-index: 1; font: inherit; font-size: 11px; padding: 3px 8px; border-radius: 6px; border: 1px solid var(--tn-border); background: var(--tn-surface-solid); color: var(--tn-accent); cursor: pointer; }
+.tn-cm-offline { display: flex; align-items: center; justify-content: center; aspect-ratio: 16 / 9; color: var(--tn-text-faint); font-size: 12px; background: var(--tn-surface); }
+.tn-cm-cap { padding: 6px 8px; display: flex; flex-direction: column; gap: 2px; }
+.tn-cm-cap-name { font-size: 12px; font-weight: 600; color: var(--tn-text); }
+.tn-cm-cap-sub { font-size: 11px; color: var(--tn-text-muted); }
+.tn-cm-count { font-size: 11px; color: var(--tn-text-faint); font-weight: 600; text-transform: none; letter-spacing: 0; }
+/* table */
+.tn-cm-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tn-cm-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-cm-table th.sortable { cursor: pointer; }
+.tn-cm-table td { padding: 5px 8px; border-bottom: 1px solid var(--tn-border); white-space: nowrap; }
+.tn-cm-row { cursor: pointer; }
+.tn-cm-row:hover { background: var(--tn-surface-2); }
+.tn-cm-drill { background: var(--tn-surface-2); }
+.tn-cm-drill td { padding: 12px 14px; }
+/* footer */
+.tn-cm-foot { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; border-top: 1px solid var(--tn-border); padding-top: 8px; margin-top: auto; }
+.tn-cm-attr { font-size: 11px; color: var(--tn-text-faint); }
+.tn-cm-actions { display: flex; gap: 8px; }
+.tn-cm-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
+.tn-cm-actions button:disabled { opacity: .4; cursor: default; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1119,7 +1119,7 @@ a { color: var(--tn-accent); }
 .tn-cw-title{font-weight:700;color:#2b3640}.tn-cw-count{font-size:11px;color:#8a97a6}.tn-cw-sp{flex:1}
 .tn-cw-badge{font-size:10px;font-weight:800;color:#fff;border-radius:8px;padding:0 5px;background:#8a97a6}
 .tn-cw-badge.tn-sev-critical{background:#d9534f}.tn-cw-badge.tn-sev-warn{background:#d9882f}.tn-cw-badge.tn-sev-info{background:#4a78c9}
-.tn-cw-fresh{font-size:10px;color:#3f8f5c}.tn-cw-menu{border:0;background:none;cursor:pointer;color:#b3bdc8;font-size:14px}
+.tn-cw-fresh{font-size:10px;color:#3f8f5c}.tn-cw-menu,.tn-cw-expand{border:0;background:none;cursor:pointer;color:#b3bdc8;font-size:14px}
 .tn-cw-menu-pop{display:flex;flex-direction:column;border-bottom:1px solid #eef2f6}
 .tn-cw-menu-pop button{text-align:left;border:0;background:none;padding:7px 10px;font-size:12px;cursor:pointer}
 .tn-cw-menu-pop button:hover{background:#f6f9fb}.tn-cw-danger{color:#d9534f}
@@ -1213,7 +1213,7 @@ a { color: var(--tn-accent); }
 @keyframes tn-toast-in{from{opacity:0;transform:translate(-50%,8px)}to{opacity:1;transform:translate(-50%,0)}}
 
 /* Focus window — a widget expanded onto the center stage */
-.tn-detail { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--tn-surface-1, #0b1220); color: var(--tn-text-1, #e2e8f0); overflow: hidden; }
+.tn-detail { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--tn-surface-solid); color: var(--tn-text); overflow: hidden; }
 .tn-detail-head { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--tn-border, #1e293b); flex: 0 0 auto; }
 .tn-detail-back { font: inherit; font-size: 13px; background: transparent; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; padding: 4px 10px; color: var(--tn-accent, #38bdf8); cursor: pointer; }
 .tn-detail-back:hover { background: var(--tn-surface-2, #111a2e); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1240,3 +1240,10 @@ a { color: var(--tn-accent); }
 .tn-evd-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 14px; }
 .tn-evd-panel { background: var(--tn-surface-2, #111a2e); border-radius: 8px; padding: 10px; }
 @media (max-width: 760px) { .tn-evd-panels { grid-template-columns: 1fr; } }
+
+.tn-evd-foot { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--tn-border, #1e293b); display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: center; }
+.tn-evd-sources { display: flex; flex-wrap: wrap; gap: 12px; font-size: 12px; color: var(--tn-text-faint, #94a3b8); }
+.tn-evd-source i { font-style: normal; opacity: .7; }
+.tn-evd-export { margin-left: auto; display: flex; gap: 8px; }
+.tn-evd-export button { font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; background: transparent; color: var(--tn-accent, #38bdf8); cursor: pointer; }
+.tn-evd-export button:disabled { opacity: .4; cursor: default; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1222,3 +1222,17 @@ a { color: var(--tn-accent); }
 .tn-detail-body { flex: 1 1 auto; overflow: auto; padding: 14px; }
 .tn-detail-generic { max-width: 900px; margin: 0 auto; }
 .tn-stage-focus { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 6px; font-size: 12px; }
+
+.tn-evd { max-width: 1100px; margin: 0 auto; }
+.tn-evd-head { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 16px; margin-bottom: 12px; }
+.tn-evd-stat b { font-size: 20px; }
+.tn-evd-scope { color: var(--tn-text-faint, #94a3b8); font-size: 12px; }
+.tn-evd-tiers { display: flex; gap: 6px; margin-left: auto; }
+.tn-evd-tier { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; padding: 2px 8px; border: 1px solid; border-radius: 999px; }
+.tn-evd-tier i { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.tn-evd-group { margin: 14px 0; }
+.tn-evd-group-h { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--tn-text-faint, #94a3b8); margin: 0 0 6px; }
+.tn-evd-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 6px; }
+.tn-evd-list li { padding: 6px 8px; border-radius: 6px; background: var(--tn-surface-2, #111a2e); }
+.tn-evd-metric { color: var(--tn-text-faint, #94a3b8); }
+.tn-evd-src { color: var(--tn-accent, #38bdf8); text-decoration: none; font-size: 12px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1236,3 +1236,7 @@ a { color: var(--tn-accent); }
 .tn-evd-list li { padding: 6px 8px; border-radius: 6px; background: var(--tn-surface-2, #111a2e); }
 .tn-evd-metric { color: var(--tn-text-faint, #94a3b8); }
 .tn-evd-src { color: var(--tn-accent, #38bdf8); text-decoration: none; font-size: 12px; }
+
+.tn-evd-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 14px; }
+.tn-evd-panel { background: var(--tn-surface-2, #111a2e); border-radius: 8px; padding: 10px; }
+@media (max-width: 760px) { .tn-evd-panels { grid-template-columns: 1fr; } }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1274,3 +1274,31 @@ a { color: var(--tn-accent); }
 .tn-hd-foot-src { font-size: 12px; color: var(--tn-text-faint); }
 .tn-hd-export { margin-left: auto; font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border); border-radius: 6px; background: transparent; color: var(--tn-accent); cursor: pointer; }
 .tn-hd-export:disabled { opacity: .4; cursor: default; }
+
+/* ── Signals focus detail (W3) ─────────────────────────────────────── */
+.tn-sd { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
+.tn-sd-head { display: flex; flex-direction: column; gap: 4px; }
+.tn-sd-title { font-size: 18px; font-weight: 700; }
+.tn-sd-stat { font-size: 12px; color: var(--tn-text-muted); }
+.tn-sd-delta.up { color: #16a34a; } .tn-sd-delta.down { color: #dc2626; }
+.tn-sd-spark { max-width: 320px; }
+.tn-sd-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+@media (max-width: 720px) { .tn-sd-panels { grid-template-columns: 1fr; } }
+.tn-sd-panel h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 0 0 6px; }
+.tn-sd-bars { display: flex; align-items: flex-end; gap: 4px; height: 120px; }
+.tn-sd-bar { flex: 1; background: var(--tn-accent); border-radius: 2px 2px 0 0; min-height: 2px; opacity: .85; }
+.tn-sd-bar-label { font-size: 10px; color: var(--tn-text-faint); text-align: center; }
+.tn-sd-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tn-sd-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; cursor: pointer; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-sd-table td { padding: 5px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-sd-row { cursor: pointer; }
+.tn-sd-row:hover { background: var(--tn-surface-2); }
+.tn-sd-drill { background: var(--tn-surface-2); }
+.tn-sd-drill dl { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 6px 0; }
+.tn-sd-drill dt { color: var(--tn-accent); text-transform: uppercase; font-size: 10px; letter-spacing: .06em; font-weight: 600; }
+.tn-sd-drill dd { margin: 0; }
+.tn-sd-foot { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; border-top: 1px solid var(--tn-border); padding-top: 8px; margin-top: auto; }
+.tn-sd-attr { font-size: 11px; color: var(--tn-text-faint); }
+.tn-sd-actions { display: flex; gap: 8px; }
+.tn-sd-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
+.tn-sd-actions button:disabled { opacity: .4; cursor: default; }

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,0 +1,38 @@
+// components/Chart.tsx
+// Native SVG line/area chart — the shared, dependency-free charting primitive
+// (generalises Sparkline). Presentational: caller supplies {x,y} points already
+// in data space. Renders nothing below 2 points. up tints the stroke green/red.
+import { extent, linear } from "@/lib/chart/scale";
+
+export interface ChartPoint { x: number; y: number }
+
+export function Chart({
+  points,
+  width = 640,
+  height = 200,
+  area = true,
+  up,
+}: {
+  points: ChartPoint[];
+  width?: number;
+  height?: number;
+  area?: boolean;
+  up?: boolean | null;
+}) {
+  if (!points || points.length < 2) return null;
+  const pad = 6;
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  const sx = linear(extent(xs), [pad, width - pad]);
+  const sy = linear(extent([0, ...ys]), [height - pad, pad]); // baseline at 0
+  const line = points.map((p, i) => `${i === 0 ? "M" : "L"}${sx(p.x).toFixed(1)},${sy(p.y).toFixed(1)}`).join(" ");
+  const stroke = up == null ? "var(--tn-accent, #38bdf8)" : up ? "#16a34a" : "#dc2626";
+  const fillPath = `${line} L${sx(points[points.length - 1].x).toFixed(1)},${(height - pad).toFixed(1)} L${sx(points[0].x).toFixed(1)},${(height - pad).toFixed(1)} Z`;
+  return (
+    <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} className="tn-chart" preserveAspectRatio="none" role="img">
+      <line x1={pad} y1={height - pad} x2={width - pad} y2={height - pad} stroke="var(--tn-border, #1e293b)" strokeWidth="1" />
+      {area && <path d={fillPath} fill={stroke} opacity="0.12" />}
+      <path d={line} fill="none" stroke={stroke} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/components/InsetMap.tsx
+++ b/components/InsetMap.tsx
@@ -1,0 +1,81 @@
+// components/InsetMap.tsx
+"use client";
+// A small, single-layer MapLibre map for detail views: renders one set of point
+// features on the keyless CARTO Positron basemap, auto-fits to their bounds, and
+// calls onSelect(id) when a point is clicked. Dependency-free beyond maplibre-gl
+// (already used by the globe). NOT the 1379-line WorldMap — deliberately minimal.
+import { useEffect, useRef } from "react";
+import maplibregl, { type GeoJSONSource } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { pointsToFC, boundsOf, type InsetPoint } from "@/lib/map/inset";
+
+const SRC = "inset-points";
+const LAYER = "inset-point-circles";
+const POSITRON = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+
+export default function InsetMap({
+  points,
+  height = 320,
+  onSelect,
+}: {
+  points: InsetPoint[];
+  height?: number;
+  onSelect?: (id: string) => void;
+}) {
+  const boxRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const selectRef = useRef(onSelect);
+  selectRef.current = onSelect;
+
+  // Create the map once.
+  useEffect(() => {
+    if (!boxRef.current || mapRef.current) return;
+    const map = new maplibregl.Map({
+      container: boxRef.current,
+      style: POSITRON,
+      center: [0, 20],
+      zoom: 1,
+      attributionControl: { compact: true },
+    });
+    mapRef.current = map;
+    map.on("load", () => {
+      map.addSource(SRC, { type: "geojson", data: pointsToFC(points) });
+      map.addLayer({
+        id: LAYER,
+        type: "circle",
+        source: SRC,
+        paint: {
+          "circle-radius": 6,
+          "circle-color": ["get", "color"],
+          "circle-stroke-color": "#0b1220",
+          "circle-stroke-width": 1,
+          "circle-opacity": 0.9,
+        },
+      });
+      map.on("click", LAYER, (e) => {
+        const id = e.features?.[0]?.properties?.id;
+        if (typeof id === "string" && id) selectRef.current?.(id);
+      });
+      map.on("mouseenter", LAYER, () => { map.getCanvas().style.cursor = "pointer"; });
+      map.on("mouseleave", LAYER, () => { map.getCanvas().style.cursor = ""; });
+      fit(map, points);
+    });
+    return () => { map.remove(); mapRef.current = null; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Push new features + refit when points change.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+    const src = map.getSource(SRC) as GeoJSONSource | undefined;
+    if (src) { src.setData(pointsToFC(points)); fit(map, points); }
+  }, [points]);
+
+  return <div ref={boxRef} className="tn-inset-map" style={{ width: "100%", height }} />;
+}
+
+function fit(map: maplibregl.Map, points: InsetPoint[]) {
+  const b = boundsOf(points);
+  if (b) map.fitBounds(b, { padding: 40, maxZoom: 6, duration: 0 });
+}

--- a/components/SignalDetail.tsx
+++ b/components/SignalDetail.tsx
@@ -6,13 +6,7 @@
 // live globe by <FeedOverlay>.
 
 import type { WorldObject } from "@/lib/world";
-
-// Humanise a camelCase props key for the definition-list term, e.g.
-// "forecastFor" → "Forecast for".
-function humanise(key: string): string {
-  const spaced = key.replace(/([a-z])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ");
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
+import { humaniseKey } from "@/lib/text/humanise";
 
 export default function SignalDetail({ object }: { object: WorldObject }) {
   const meta = object.meta ?? {};
@@ -65,7 +59,7 @@ export default function SignalDetail({ object }: { object: WorldObject }) {
                   alignSelf: "center",
                 }}
               >
-                {humanise(k)}
+                {humaniseKey(k)}
               </dt>
               <dd style={{ margin: 0, color: "var(--tn-text)", fontWeight: 600 }}>{String(v)}</dd>
             </div>

--- a/components/console/StageHost.tsx
+++ b/components/console/StageHost.tsx
@@ -3,16 +3,25 @@ import dynamic from "next/dynamic";
 import { useEffect } from "react";
 import type { StageId } from "@/lib/console/types";
 import { viewModeStore } from "@/lib/shell/viewMode";
+import { useShellLayout } from "@/lib/console/store";
+import { getWidgetType } from "@/lib/console/registry";
 import WorldClock from "@/components/console/WorldClock";
+import WidgetDetail from "@/components/console/WidgetDetail";
 
 const WorldMap = dynamic(() => import("@/components/WorldMap"), { ssr: false });
 
 export default function StageHost({ stage }: { stage: StageId }) {
+  const { focusedWidgetId, widgets } = useShellLayout();
   // The map reads viewModeStore for its MapLibre projection: 3D=globe(explore), 2D=flat(console).
   useEffect(() => {
     if (stage === "map3d") viewModeStore.set("explore");
     else if (stage === "map2d") viewModeStore.set("console");
   }, [stage]);
+
+  const focused = focusedWidgetId
+    ? widgets.find((w) => w.id === focusedWidgetId && getWidgetType(w.type))
+    : undefined;
+  if (focused) return <WidgetDetail instance={focused} />;
   if (stage === "clock") return <WorldClock />;
   return <WorldMap />;
 }

--- a/components/console/StageSwitch.tsx
+++ b/components/console/StageSwitch.tsx
@@ -9,19 +9,21 @@ const OPTS: { id: StageId; label: string }[] = [
 ];
 
 export default function StageSwitch() {
-  const { stage } = useShellLayout();
+  const { stage, focusedWidgetId } = useShellLayout();
+  const focused = focusedWidgetId != null;
   return (
     <div className="tn-stage-switch" role="group" aria-label="Centre stage">
       {OPTS.map((o) => (
         <button
           key={o.id}
-          className={stage === o.id ? "is-on" : ""}
-          aria-pressed={stage === o.id}
-          onClick={() => shellLayoutStore.stage(o.id)}
+          className={!focused && stage === o.id ? "is-on" : ""}
+          aria-pressed={!focused && stage === o.id}
+          onClick={() => { if (focused) shellLayoutStore.unfocus(); shellLayoutStore.stage(o.id); }}
         >
           {o.label}
         </button>
       ))}
+      {focused && <span className="tn-stage-focus is-on" aria-current="true" title="A widget is expanded onto the stage">◱ Focus</span>}
     </div>
   );
 }

--- a/components/console/WidgetDetail.tsx
+++ b/components/console/WidgetDetail.tsx
@@ -1,0 +1,32 @@
+"use client";
+// Renders the focused widget on the center stage: a header (back-to-map + title)
+// plus the widget's bespoke `detail` component, or a generic fallback (the normal
+// widget body at full size) so no expand button is ever dead.
+import type { WidgetInstance } from "@/lib/console/types";
+import { getWidgetType, type WidgetType } from "@/lib/console/registry";
+import { shellLayoutStore } from "@/lib/console/store";
+
+export default function WidgetDetail({ instance }: { instance: WidgetInstance }) {
+  const type = getWidgetType(instance.type);
+  if (!type) return null;
+  const Detail = type.detail;
+  return (
+    <div className="tn-detail" role="region" aria-label={`${type.title} — expanded`}>
+      <header className="tn-detail-head">
+        <button className="tn-detail-back" onClick={() => shellLayoutStore.unfocus()}>← Back to map</button>
+        <span className="tn-detail-icon" aria-hidden>{type.icon}</span>
+        <span className="tn-detail-title">{type.title}</span>
+      </header>
+      <div className="tn-detail-body">
+        {Detail
+          ? <Detail instanceId={instance.id} config={instance.config} />
+          : <GenericDetail type={type} instance={instance} />}
+      </div>
+    </div>
+  );
+}
+
+function GenericDetail({ type, instance }: { type: WidgetType; instance: WidgetInstance }) {
+  const Body = type.component; // report() falls back to the no-op default context — safe here
+  return <div className="tn-detail-generic"><Body instanceId={instance.id} config={instance.config} /></div>;
+}

--- a/components/console/WidgetFrame.tsx
+++ b/components/console/WidgetFrame.tsx
@@ -81,6 +81,7 @@ export default function WidgetFrame({ instance }: { instance: WidgetInstance }) 
         <span className="tn-cw-sp" />
         {report.alerts.length > 0 && <span className={`tn-cw-badge tn-sev-${sev}`}>{report.alerts.length}</span>}
         {report.freshLabel && <span className="tn-cw-fresh">{report.freshLabel}</span>}
+        <button className="tn-cw-expand" aria-label="Expand widget" title="Expand to main window" onClick={() => shellLayoutStore.focus(instance.id)}>⤢</button>
         <button className="tn-cw-menu" aria-label="Widget menu" onClick={() => setMenuOpen((o) => !o)}>⋯</button>
       </header>
 

--- a/docs/superpowers/plans/2026-07-08-focus-window-foundation.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-foundation.md
@@ -436,9 +436,12 @@ In `components/console/WidgetFrame.tsx`, add an expand button in the header, imm
 
 Append to `app/globals.css`:
 
+Also extend the existing borderless-button rule so the new expand button matches the `⋯` menu — change `.tn-cw-menu{…}` to `.tn-cw-menu,.tn-cw-expand{…}`.
+
 ```css
 /* Focus window — a widget expanded onto the center stage */
-.tn-detail { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--tn-surface-1, #0b1220); color: var(--tn-text-1, #e2e8f0); overflow: hidden; }
+/* Use the real theme tokens (--tn-surface-solid / --tn-text) so this is light-default correct. */
+.tn-detail { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--tn-surface-solid); color: var(--tn-text); overflow: hidden; }
 .tn-detail-head { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--tn-border, #1e293b); flex: 0 0 auto; }
 .tn-detail-back { font: inherit; font-size: 13px; background: transparent; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; padding: 4px 10px; color: var(--tn-accent, #38bdf8); cursor: pointer; }
 .tn-detail-back:hover { background: var(--tn-surface-2, #111a2e); }

--- a/docs/superpowers/plans/2026-07-08-focus-window-foundation.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-foundation.md
@@ -1,0 +1,1336 @@
+# Focus Window — Foundation (F1 + F2 + W1 Events) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the focus-window feature end-to-end — any docked widget can expand onto the center stage — by shipping the focus foundation (F1), the shared primitives it needs (F2: buckets, `<Chart>`, `<InsetMap>`), and the first bespoke detail view (W1: Events).
+
+**Architecture:** Focus is a single `focusedWidgetId` field on the persisted `ShellLayout`; when set, `StageHost` renders `<WidgetDetail>` instead of the globe (the `stage` field is untouched, so "back" restores the previous stage for free). A widget declares depth by adding an optional `detail` component to its `WidgetType`; the detail reuses the widget's existing data hook. Two shared, dependency-free primitives (`<Chart>` SVG, `<InsetMap>` single-layer MapLibre) and pure helpers (`buckets`, `chart/scale`, `map/inset`) back the detail views.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, MapLibre GL v5 (already a dep), vitest. **No new dependencies.**
+
+## Global Constraints
+
+- **Build gate (run for every task):** `npx tsc --noEmit && npm test`
+- **Keyless-first / dormant-safe:** no feature in this plan needs an API key; data hooks already degrade to empty on failure — render honest empty states, never throw or 5xx.
+- **Zero new dependencies:** charts and helpers are hand-rolled SVG/TS (repo convention — `Sparkline` and the RSS parser were both hand-rolled).
+- **Commit style:** one commit per task, `<type>: <summary>` (e.g. `feat:`, `test:`), **solo attribution — NO Claude co-author trailer** (repo convention).
+- **Styling:** use existing `tn-*` CSS tokens/classes in `app/globals.css` (`--tn-text-*`, `--tn-surface-2`, `--tn-accent`, etc.).
+- **Purity:** pure logic (reducers, helpers) lives in testable `.ts` modules with vitest tests written first; React + MapLibre shells are verified with a Playwright screenshot.
+- **Honesty:** never fabricate a value. Cyclone/GDACS events show native alert-level / wind / pressure, not a fake unified magnitude; empty feeds show an explicit empty state.
+
+---
+
+## File Structure
+
+**Foundation (F1):**
+- Modify `lib/console/types.ts` — add `focusedWidgetId` to `ShellLayout`.
+- Modify `lib/console/reducers.ts` — `setFocus`; clear focus in `removeWidget`.
+- Modify `lib/console/store.ts` — `focus()` / `unfocus()` actions.
+- Modify `lib/console/sanitize.ts` — validate/round-trip `focusedWidgetId`.
+- Modify `lib/console/registry.ts` — `WidgetDetailProps` + `WidgetType.detail?`.
+- Create `components/console/WidgetDetail.tsx` — resolves the focused widget → its detail (or a generic fallback).
+- Modify `components/console/StageHost.tsx` — focus branch.
+- Modify `components/console/StageSwitch.tsx` — FOCUS chip; exit-focus on stage pick.
+- Modify `components/console/WidgetFrame.tsx` — expand button.
+- Modify `app/globals.css` — detail-surface styles.
+
+**Primitives (F2):**
+- Create `lib/widgets/buckets.ts` + `tests/unit/buckets.test.ts`.
+- Create `lib/chart/scale.ts` + `tests/unit/chart-scale.test.ts`.
+- Create `components/Chart.tsx`.
+- Create `lib/map/inset.ts` + `tests/unit/map-inset.test.ts`.
+- Create `components/InsetMap.tsx`.
+
+**Events detail (W1):**
+- Create `lib/widgets/eventMetrics.ts` + `tests/unit/event-metrics.test.ts`.
+- Create `lib/console/widgets/events.detail.tsx`.
+- Modify `lib/console/widgets/events.tsx` — attach `detail`.
+
+---
+
+## Task 1: Focus state (types + reducer + store)
+
+**Files:**
+- Modify: `lib/console/types.ts`
+- Modify: `lib/console/reducers.ts`
+- Modify: `lib/console/store.ts`
+- Test: `tests/unit/focus-reducer.test.ts`
+
+**Interfaces:**
+- Consumes: `ShellLayout`, `createDefaultLayout`, `removeWidget` (existing).
+- Produces:
+  - `ShellLayout.focusedWidgetId: string | null`
+  - `setFocus(l: ShellLayout, id: string | null): ShellLayout` (in `reducers.ts`)
+  - `shellLayoutStore.focus(id: string): void` and `shellLayoutStore.unfocus(): void`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/focus-reducer.test.ts
+import { describe, it, expect } from "vitest";
+import { createDefaultLayout } from "@/lib/console/types";
+import { setFocus, addWidget, removeWidget } from "@/lib/console/reducers";
+
+describe("focus reducer", () => {
+  it("defaults to no focused widget", () => {
+    expect(createDefaultLayout().focusedWidgetId).toBeNull();
+  });
+
+  it("setFocus sets and clears the focused id", () => {
+    const l0 = createDefaultLayout();
+    const l1 = setFocus(l0, "wabc");
+    expect(l1.focusedWidgetId).toBe("wabc");
+    expect(setFocus(l1, null).focusedWidgetId).toBeNull();
+  });
+
+  it("removing the focused widget clears focus", () => {
+    let l = addWidget(createDefaultLayout(), "events", "w1");
+    l = setFocus(l, "w1");
+    l = removeWidget(l, "w1");
+    expect(l.focusedWidgetId).toBeNull();
+  });
+
+  it("removing a different widget leaves focus intact", () => {
+    let l = addWidget(createDefaultLayout(), "events", "w1");
+    l = addWidget(l, "markets", "w2");
+    l = setFocus(l, "w1");
+    l = removeWidget(l, "w2");
+    expect(l.focusedWidgetId).toBe("w1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/focus-reducer.test.ts`
+Expected: FAIL — `focusedWidgetId` missing / `setFocus is not a function`.
+
+- [ ] **Step 3: Add the field to the type**
+
+In `lib/console/types.ts`, add the field to `ShellLayout` and default it:
+
+```ts
+export interface ShellLayout {
+  segments: Record<SegmentId, SegmentState>;
+  stage: StageId;
+  widgets: WidgetInstance[];
+  /** The widget expanded onto the center stage, or null when the map is shown. */
+  focusedWidgetId: string | null;
+}
+```
+
+```ts
+export function createDefaultLayout(): ShellLayout {
+  return {
+    segments: {
+      left: { size: 320, collapsed: false },
+      right: { size: 320, collapsed: false },
+      bottom: { size: 240, collapsed: false },
+    },
+    stage: "map2d",
+    widgets: [],
+    focusedWidgetId: null,
+  };
+}
+```
+
+- [ ] **Step 4: Add the reducer + clear-on-remove**
+
+In `lib/console/reducers.ts`, add `setFocus` at the end and update `removeWidget` to clear a dangling focus:
+
+```ts
+export function setFocus(l: ShellLayout, id: string | null): ShellLayout {
+  return { ...l, focusedWidgetId: id };
+}
+```
+
+In `removeWidget`, change the final return so a removed focused widget clears focus:
+
+```ts
+export function removeWidget(l: ShellLayout, id: string): ShellLayout {
+  const removed = l.widgets.find((w) => w.id === id);
+  if (!removed) return l;
+  const kept = l.widgets.filter((w) => w.id !== id);
+  const segSorted = kept.filter((w) => w.segment === removed.segment).sort((a, b) => a.order - b.order);
+  const orderMap = new Map(segSorted.map((w, i) => [w.id, i] as const));
+  return {
+    ...l,
+    focusedWidgetId: l.focusedWidgetId === id ? null : l.focusedWidgetId,
+    widgets: kept.map((w) => (orderMap.has(w.id) ? { ...w, order: orderMap.get(w.id)! } : w)),
+  };
+}
+```
+
+- [ ] **Step 5: Add the store actions**
+
+In `lib/console/store.ts`, add two actions to the `shellLayoutStore` object (after `stage`):
+
+```ts
+  focus(id: string) { state = R.setFocus(state, id); emit(); },
+  unfocus() { state = R.setFocus(state, null); emit(); },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/focus-reducer.test.ts && npx tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/console/types.ts lib/console/reducers.ts lib/console/store.ts tests/unit/focus-reducer.test.ts
+git commit -m "feat(console): focus state — focusedWidgetId on ShellLayout + setFocus reducer + store actions"
+```
+
+---
+
+## Task 2: Persist & sanitize focus
+
+**Files:**
+- Modify: `lib/console/sanitize.ts`
+- Test: `tests/unit/sanitize-focus.test.ts`
+
+**Interfaces:**
+- Consumes: `sanitizeLayout(raw: unknown): ShellLayout | null` (existing).
+- Produces: `sanitizeLayout` now preserves `focusedWidgetId` **only** when it matches a surviving widget id; otherwise `null`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/sanitize-focus.test.ts
+import { describe, it, expect } from "vitest";
+import { sanitizeLayout } from "@/lib/console/sanitize";
+
+const base = {
+  segments: { left: { size: 320, collapsed: false }, right: { size: 320, collapsed: false }, bottom: { size: 240, collapsed: false } },
+  stage: "map2d",
+  widgets: [{ id: "w1", type: "events", segment: "left", order: 0, width: 12, height: 240, collapsed: false, config: {} }],
+};
+
+describe("sanitizeLayout focus", () => {
+  it("keeps a focusedWidgetId that matches a widget", () => {
+    const out = sanitizeLayout({ ...base, focusedWidgetId: "w1" });
+    expect(out?.focusedWidgetId).toBe("w1");
+  });
+  it("drops a focusedWidgetId with no matching widget", () => {
+    const out = sanitizeLayout({ ...base, focusedWidgetId: "ghost" });
+    expect(out?.focusedWidgetId).toBeNull();
+  });
+  it("defaults missing/invalid focus to null", () => {
+    expect(sanitizeLayout({ ...base })?.focusedWidgetId).toBeNull();
+    expect(sanitizeLayout({ ...base, focusedWidgetId: 42 })?.focusedWidgetId).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/sanitize-focus.test.ts`
+Expected: FAIL — `focusedWidgetId` is `undefined` on the returned object.
+
+- [ ] **Step 3: Implement**
+
+In `lib/console/sanitize.ts`, replace the final `return` with a focus-validating version (the `widgets` array is already built above it):
+
+```ts
+  const ids = new Set(widgets.map((w) => w.id));
+  const focusedWidgetId =
+    typeof r.focusedWidgetId === "string" && ids.has(r.focusedWidgetId) ? r.focusedWidgetId : null;
+  return { segments, stage: r.stage as StageId, widgets, focusedWidgetId };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/sanitize-focus.test.ts && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/console/sanitize.ts tests/unit/sanitize-focus.test.ts
+git commit -m "feat(console): sanitize round-trips focusedWidgetId (validated against widget ids)"
+```
+
+---
+
+## Task 3: Detail contract + WidgetDetail host
+
+**Files:**
+- Modify: `lib/console/registry.ts`
+- Create: `components/console/WidgetDetail.tsx`
+
+**Interfaces:**
+- Consumes: `WidgetType`, `getWidgetType` (registry); `WidgetInstance` (types); `shellLayoutStore.unfocus()` (Task 1).
+- Produces:
+  - `WidgetDetailProps { instanceId: string; config: Record<string, unknown> }`
+  - `WidgetType.detail?: ComponentType<WidgetDetailProps>`
+  - `components/console/WidgetDetail.tsx` default export `WidgetDetail({ instance }: { instance: WidgetInstance })`
+
+- [ ] **Step 1: Extend the registry type**
+
+In `lib/console/registry.ts`, add the props type and the optional field:
+
+```ts
+export interface WidgetDetailProps { instanceId: string; config: Record<string, unknown> }
+
+export interface WidgetType {
+  id: string;
+  title: string;
+  icon: string;
+  category: string;
+  defaultHeight: number;
+  defaultConfig: Record<string, unknown>;
+  component: ComponentType<WidgetBodyProps>;
+  /** Optional rich "focus" view shown when the widget is expanded onto the center stage. */
+  detail?: ComponentType<WidgetDetailProps>;
+  capabilities?: { filter?: boolean; sort?: boolean };
+}
+```
+
+- [ ] **Step 2: Create the host component**
+
+```tsx
+// components/console/WidgetDetail.tsx
+"use client";
+// Renders the focused widget on the center stage: a header (back-to-map + title)
+// plus the widget's bespoke `detail` component, or a generic fallback (the normal
+// widget body at full size) so no expand button is ever dead.
+import type { WidgetInstance } from "@/lib/console/types";
+import { getWidgetType, type WidgetType } from "@/lib/console/registry";
+import { shellLayoutStore } from "@/lib/console/store";
+
+export default function WidgetDetail({ instance }: { instance: WidgetInstance }) {
+  const type = getWidgetType(instance.type);
+  if (!type) return null;
+  const Detail = type.detail;
+  return (
+    <div className="tn-detail" role="region" aria-label={`${type.title} — expanded`}>
+      <header className="tn-detail-head">
+        <button className="tn-detail-back" onClick={() => shellLayoutStore.unfocus()}>← Back to map</button>
+        <span className="tn-detail-icon" aria-hidden>{type.icon}</span>
+        <span className="tn-detail-title">{type.title}</span>
+      </header>
+      <div className="tn-detail-body">
+        {Detail
+          ? <Detail instanceId={instance.id} config={instance.config} />
+          : <GenericDetail type={type} instance={instance} />}
+      </div>
+    </div>
+  );
+}
+
+function GenericDetail({ type, instance }: { type: WidgetType; instance: WidgetInstance }) {
+  const Body = type.component; // report() falls back to the no-op default context — safe here
+  return <div className="tn-detail-generic"><Body instanceId={instance.id} config={instance.config} /></div>;
+}
+```
+
+- [ ] **Step 3: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: no errors (the component is not yet mounted — Task 4 wires it in).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/console/registry.ts components/console/WidgetDetail.tsx
+git commit -m "feat(console): WidgetType.detail contract + WidgetDetail host (generic fallback)"
+```
+
+---
+
+## Task 4: Wire the focus UI (expand → stage → back)
+
+**Files:**
+- Modify: `components/console/StageHost.tsx`
+- Modify: `components/console/StageSwitch.tsx`
+- Modify: `components/console/WidgetFrame.tsx`
+- Modify: `app/globals.css`
+
+**Interfaces:**
+- Consumes: `useShellLayout()` (store), `getWidgetType` (registry), `WidgetDetail` (Task 3), `shellLayoutStore.focus/unfocus/stage`.
+- Produces: a working expand→focus→back loop on the center stage.
+
+- [ ] **Step 1: Add the focus branch to StageHost**
+
+Replace `components/console/StageHost.tsx` with:
+
+```tsx
+"use client";
+import dynamic from "next/dynamic";
+import { useEffect } from "react";
+import type { StageId } from "@/lib/console/types";
+import { viewModeStore } from "@/lib/shell/viewMode";
+import { useShellLayout } from "@/lib/console/store";
+import { getWidgetType } from "@/lib/console/registry";
+import WorldClock from "@/components/console/WorldClock";
+import WidgetDetail from "@/components/console/WidgetDetail";
+
+const WorldMap = dynamic(() => import("@/components/WorldMap"), { ssr: false });
+
+export default function StageHost({ stage }: { stage: StageId }) {
+  const { focusedWidgetId, widgets } = useShellLayout();
+  // The map reads viewModeStore for its MapLibre projection: 3D=globe(explore), 2D=flat(console).
+  useEffect(() => {
+    if (stage === "map3d") viewModeStore.set("explore");
+    else if (stage === "map2d") viewModeStore.set("console");
+  }, [stage]);
+
+  const focused = focusedWidgetId
+    ? widgets.find((w) => w.id === focusedWidgetId && getWidgetType(w.type))
+    : undefined;
+  if (focused) return <WidgetDetail instance={focused} />;
+  if (stage === "clock") return <WorldClock />;
+  return <WorldMap />;
+}
+```
+
+- [ ] **Step 2: Add the FOCUS chip to StageSwitch**
+
+Replace `components/console/StageSwitch.tsx` with:
+
+```tsx
+"use client";
+import { useShellLayout, shellLayoutStore } from "@/lib/console/store";
+import type { StageId } from "@/lib/console/types";
+
+const OPTS: { id: StageId; label: string }[] = [
+  { id: "map3d", label: "3D" },
+  { id: "map2d", label: "2D" },
+  { id: "clock", label: "🕐" },
+];
+
+export default function StageSwitch() {
+  const { stage, focusedWidgetId } = useShellLayout();
+  const focused = focusedWidgetId != null;
+  return (
+    <div className="tn-stage-switch" role="group" aria-label="Centre stage">
+      {OPTS.map((o) => (
+        <button
+          key={o.id}
+          className={!focused && stage === o.id ? "is-on" : ""}
+          aria-pressed={!focused && stage === o.id}
+          onClick={() => { if (focused) shellLayoutStore.unfocus(); shellLayoutStore.stage(o.id); }}
+        >
+          {o.label}
+        </button>
+      ))}
+      {focused && <span className="tn-stage-focus is-on" aria-current="true" title="A widget is expanded onto the stage">◱ Focus</span>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add the expand button to WidgetFrame**
+
+In `components/console/WidgetFrame.tsx`, add an expand button in the header, immediately before the `⋯` menu button (line ~84):
+
+```tsx
+        <button className="tn-cw-expand" aria-label="Expand widget" title="Expand to main window" onClick={() => shellLayoutStore.focus(instance.id)}>⤢</button>
+        <button className="tn-cw-menu" aria-label="Widget menu" onClick={() => setMenuOpen((o) => !o)}>⋯</button>
+```
+
+(`shellLayoutStore` is already imported in this file.)
+
+- [ ] **Step 4: Add the detail-surface styles**
+
+Append to `app/globals.css`:
+
+```css
+/* Focus window — a widget expanded onto the center stage */
+.tn-detail { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--tn-surface-1, #0b1220); color: var(--tn-text-1, #e2e8f0); overflow: hidden; }
+.tn-detail-head { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--tn-border, #1e293b); flex: 0 0 auto; }
+.tn-detail-back { font: inherit; font-size: 13px; background: transparent; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; padding: 4px 10px; color: var(--tn-accent, #38bdf8); cursor: pointer; }
+.tn-detail-back:hover { background: var(--tn-surface-2, #111a2e); }
+.tn-detail-icon { font-size: 16px; }
+.tn-detail-title { font-weight: 600; font-size: 15px; }
+.tn-detail-body { flex: 1 1 auto; overflow: auto; padding: 14px; }
+.tn-detail-generic { max-width: 900px; margin: 0 auto; }
+.tn-stage-focus { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 6px; font-size: 12px; }
+```
+
+- [ ] **Step 5: Verify build + focus loop end-to-end (Playwright)**
+
+Run: `npx tsc --noEmit && npm test` → PASS.
+Then start the dev server and screenshot the loop:
+
+```bash
+npm run dev   # in a background shell
+```
+
+Using the Playwright MCP: navigate to `http://localhost:3000`, add an **Events** widget if none is docked, click its **⤢** expand button, confirm the center stage shows the Events detail header ("← Back to map"), screenshot to `persona-shots/focus-events-generic.png`, click **← Back to map**, confirm the globe returns.
+Expected: expand replaces the globe with the (generic, for now) Events detail; back restores the map; reloading the page with a widget focused keeps it focused (persisted).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/console/StageHost.tsx components/console/StageSwitch.tsx components/console/WidgetFrame.tsx app/globals.css
+git commit -m "feat(console): expand-to-stage focus loop — WidgetFrame ⤢ button, StageHost branch, StageSwitch FOCUS chip"
+```
+
+---
+
+## Task 5: buckets helper (histogram / countBy / timeBins)
+
+**Files:**
+- Create: `lib/widgets/buckets.ts`
+- Test: `tests/unit/buckets.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `countBy<T>(items: T[], key: (t: T) => string): Record<string, number>`
+  - `histogram(values: number[], edges: number[]): number[]` (edges ascending, length n+1 → n bins; `[lo, hi)`, last bin `[lo, hi]`)
+  - `TimeBin { start: number; count: number }`
+  - `timeBins(tsList: number[], binMs: number, now: number, spanMs: number): TimeBin[]`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/buckets.test.ts
+import { describe, it, expect } from "vitest";
+import { countBy, histogram, timeBins } from "@/lib/widgets/buckets";
+
+describe("buckets", () => {
+  it("countBy tallies by key", () => {
+    expect(countBy(["a", "b", "a"], (s) => s)).toEqual({ a: 2, b: 1 });
+  });
+
+  it("histogram bins [lo,hi) with an inclusive last edge", () => {
+    // edges 0,2,4,6 → bins [0,2) [2,4) [4,6]
+    expect(histogram([0, 1, 2, 3, 4, 5, 6], [0, 2, 4, 6])).toEqual([2, 2, 3]);
+  });
+
+  it("timeBins buckets timestamps into fixed windows and ignores out-of-range", () => {
+    const now = 1_000_000;
+    const bins = timeBins([now - 1, now - 3500, now + 999], 1000, now, 3000);
+    expect(bins).toHaveLength(3);
+    expect(bins.reduce((a, b) => a + b.count, 0)).toBe(1); // only now-1 is inside [now-3000, now]
+    expect(bins[2].count).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/buckets.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/widgets/buckets.ts
+// Pure bucketing helpers for the detail-view distribution/timeline charts.
+
+export function countBy<T>(items: T[], key: (t: T) => string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const it of items) { const k = key(it); out[k] = (out[k] ?? 0) + 1; }
+  return out;
+}
+
+/** edges ascending, length n+1 → n bins. Value v lands in bin i when
+ *  edges[i] <= v < edges[i+1]; the LAST bin is inclusive of the top edge. */
+export function histogram(values: number[], edges: number[]): number[] {
+  const n = Math.max(0, edges.length - 1);
+  const bins = new Array<number>(n).fill(0);
+  for (const v of values) {
+    for (let i = 0; i < n; i++) {
+      const lo = edges[i], hi = edges[i + 1];
+      const inside = i === n - 1 ? v >= lo && v <= hi : v >= lo && v < hi;
+      if (inside) { bins[i]++; break; }
+    }
+  }
+  return bins;
+}
+
+export interface TimeBin { start: number; count: number }
+
+/** n = ceil(spanMs/binMs) contiguous bins ending at `now`. Timestamps outside
+ *  [now-n*binMs, now] are ignored. */
+export function timeBins(tsList: number[], binMs: number, now: number, spanMs: number): TimeBin[] {
+  const n = Math.max(1, Math.ceil(spanMs / binMs));
+  const start0 = now - n * binMs;
+  const bins: TimeBin[] = Array.from({ length: n }, (_, i) => ({ start: start0 + i * binMs, count: 0 }));
+  for (const ts of tsList) {
+    if (ts < start0 || ts > now) continue;
+    const idx = Math.min(n - 1, Math.floor((ts - start0) / binMs));
+    bins[idx].count++;
+  }
+  return bins;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/buckets.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/buckets.ts tests/unit/buckets.test.ts
+git commit -m "feat(widgets): pure buckets helper — countBy / histogram / timeBins"
+```
+
+---
+
+## Task 6: `<Chart>` primitive (SVG line/area + scale)
+
+**Files:**
+- Create: `lib/chart/scale.ts`
+- Test: `tests/unit/chart-scale.test.ts`
+- Create: `components/Chart.tsx`
+
+**Interfaces:**
+- Produces:
+  - `extent(values: number[]): [number, number]`
+  - `linear(domain: [number, number], range: [number, number]): (x: number) => number`
+  - `ChartPoint { x: number; y: number }`
+  - `Chart({ points, width, height, area, up }: { points: ChartPoint[]; width?: number; height?: number; area?: boolean; up?: boolean | null })`
+
+> **Scope note:** this plan builds the **line/area** `<Chart>` that W1 (Events recency) exercises. Candlestick mode and the hover crosshair (spec §4) are added in the **Markets (W7)** milestone where they are first needed; the `points`/props surface is designed to accommodate them.
+
+- [ ] **Step 1: Write the failing test (scale maths)**
+
+```ts
+// tests/unit/chart-scale.test.ts
+import { describe, it, expect } from "vitest";
+import { extent, linear } from "@/lib/chart/scale";
+
+describe("chart scale", () => {
+  it("extent returns [min,max], padding a flat series", () => {
+    expect(extent([3, 1, 2])).toEqual([1, 3]);
+    expect(extent([5, 5])).toEqual([4, 6]);
+    expect(extent([])).toEqual([0, 1]);
+  });
+
+  it("linear maps domain onto range", () => {
+    const s = linear([0, 10], [0, 100]);
+    expect(s(0)).toBe(0);
+    expect(s(5)).toBe(50);
+    expect(s(10)).toBe(100);
+  });
+
+  it("linear is flat when the domain is degenerate", () => {
+    const s = linear([4, 4], [0, 100]);
+    expect(s(4)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/chart-scale.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the scale helpers**
+
+```ts
+// lib/chart/scale.ts
+// Pure 1-D scale maths shared by the native SVG charts. No DOM, node-testable.
+
+export function extent(values: number[]): [number, number] {
+  let lo = Infinity, hi = -Infinity;
+  for (const v of values) { if (v < lo) lo = v; if (v > hi) hi = v; }
+  if (!Number.isFinite(lo)) return [0, 1];
+  if (lo === hi) return [lo - 1, hi + 1];
+  return [lo, hi];
+}
+
+export function linear(domain: [number, number], range: [number, number]): (x: number) => number {
+  const [d0, d1] = domain, [r0, r1] = range;
+  const m = d1 === d0 ? 0 : (r1 - r0) / (d1 - d0);
+  return (x) => r0 + (x - d0) * m;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/chart-scale.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Implement the Chart component**
+
+```tsx
+// components/Chart.tsx
+// Native SVG line/area chart — the shared, dependency-free charting primitive
+// (generalises Sparkline). Presentational: caller supplies {x,y} points already
+// in data space. Renders nothing below 2 points. up tints the stroke green/red.
+import { extent, linear } from "@/lib/chart/scale";
+
+export interface ChartPoint { x: number; y: number }
+
+export function Chart({
+  points,
+  width = 640,
+  height = 200,
+  area = true,
+  up,
+}: {
+  points: ChartPoint[];
+  width?: number;
+  height?: number;
+  area?: boolean;
+  up?: boolean | null;
+}) {
+  if (!points || points.length < 2) return null;
+  const pad = 6;
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  const sx = linear(extent(xs), [pad, width - pad]);
+  const sy = linear(extent([0, ...ys]), [height - pad, pad]); // baseline at 0
+  const line = points.map((p, i) => `${i === 0 ? "M" : "L"}${sx(p.x).toFixed(1)},${sy(p.y).toFixed(1)}`).join(" ");
+  const stroke = up == null ? "var(--tn-accent, #38bdf8)" : up ? "#16a34a" : "#dc2626";
+  const fillPath = `${line} L${sx(points[points.length - 1].x).toFixed(1)},${(height - pad).toFixed(1)} L${sx(points[0].x).toFixed(1)},${(height - pad).toFixed(1)} Z`;
+  return (
+    <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} className="tn-chart" preserveAspectRatio="none" role="img">
+      <line x1={pad} y1={height - pad} x2={width - pad} y2={height - pad} stroke="var(--tn-border, #1e293b)" strokeWidth="1" />
+      {area && <path d={fillPath} fill={stroke} opacity="0.12" />}
+      <path d={line} fill="none" stroke={stroke} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: PASS (component is exercised in Task 10).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/chart/scale.ts tests/unit/chart-scale.test.ts components/Chart.tsx
+git commit -m "feat: native SVG <Chart> (line/area) + pure scale helpers"
+```
+
+---
+
+## Task 7: `<InsetMap>` primitive (single-layer MapLibre)
+
+**Files:**
+- Create: `lib/map/inset.ts`
+- Test: `tests/unit/map-inset.test.ts`
+- Create: `components/InsetMap.tsx`
+
+**Interfaces:**
+- Produces:
+  - `InsetPoint { lat: number; lon: number; id?: string; color?: string; props?: Record<string, unknown> }`
+  - `pointsToFC(points: InsetPoint[]): GeoJSON.FeatureCollection`
+  - `boundsOf(points: InsetPoint[]): [[number, number], [number, number]] | null` (`[[west,south],[east,north]]`)
+  - `InsetMap({ points, height, onSelect }: { points: InsetPoint[]; height?: number; onSelect?: (id: string) => void })`
+
+- [ ] **Step 1: Write the failing test (pure helpers)**
+
+```ts
+// tests/unit/map-inset.test.ts
+import { describe, it, expect } from "vitest";
+import { pointsToFC, boundsOf } from "@/lib/map/inset";
+
+describe("inset map helpers", () => {
+  it("pointsToFC builds [lon,lat] point features and drops non-finite coords", () => {
+    const fc = pointsToFC([{ lat: 10, lon: 20, id: "a" }, { lat: NaN, lon: 5, id: "b" }]);
+    expect(fc.features).toHaveLength(1);
+    expect(fc.features[0].geometry).toEqual({ type: "Point", coordinates: [20, 10] });
+    expect(fc.features[0].properties).toMatchObject({ id: "a" });
+  });
+
+  it("boundsOf returns [[w,s],[e,n]] or null when empty", () => {
+    expect(boundsOf([{ lat: 10, lon: 20 }, { lat: -5, lon: 40 }])).toEqual([[20, -5], [40, 10]]);
+    expect(boundsOf([])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/map-inset.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the pure helpers**
+
+```ts
+// lib/map/inset.ts
+// Pure GeoJSON + bounds helpers for the shared <InsetMap>. Node-testable.
+
+export interface InsetPoint {
+  lat: number;
+  lon: number;
+  id?: string;
+  color?: string;
+  props?: Record<string, unknown>;
+}
+
+export function pointsToFC(points: InsetPoint[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: points
+      .filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lon))
+      .map((p) => ({
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [p.lon, p.lat] },
+        properties: { id: p.id ?? "", color: p.color ?? "#38bdf8", ...(p.props ?? {}) },
+      })),
+  };
+}
+
+export function boundsOf(points: InsetPoint[]): [[number, number], [number, number]] | null {
+  let w = Infinity, s = Infinity, e = -Infinity, n = -Infinity;
+  for (const p of points) {
+    if (!Number.isFinite(p.lat) || !Number.isFinite(p.lon)) continue;
+    if (p.lon < w) w = p.lon; if (p.lon > e) e = p.lon;
+    if (p.lat < s) s = p.lat; if (p.lat > n) n = p.lat;
+  }
+  if (!Number.isFinite(w)) return null;
+  return [[w, s], [e, n]];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/map-inset.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Implement the InsetMap component**
+
+Mirrors the WorldMap MapLibre init (`components/WorldMap.tsx:14-16`) but is a small, flat, single-layer map. Uses the keyless CARTO Positron style.
+
+```tsx
+// components/InsetMap.tsx
+"use client";
+// A small, single-layer MapLibre map for detail views: renders one set of point
+// features on the keyless CARTO Positron basemap, auto-fits to their bounds, and
+// calls onSelect(id) when a point is clicked. Dependency-free beyond maplibre-gl
+// (already used by the globe). NOT the 1379-line WorldMap — deliberately minimal.
+import { useEffect, useRef } from "react";
+import maplibregl, { type GeoJSONSource } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { pointsToFC, boundsOf, type InsetPoint } from "@/lib/map/inset";
+
+const SRC = "inset-points";
+const LAYER = "inset-point-circles";
+const POSITRON = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+
+export default function InsetMap({
+  points,
+  height = 320,
+  onSelect,
+}: {
+  points: InsetPoint[];
+  height?: number;
+  onSelect?: (id: string) => void;
+}) {
+  const boxRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const selectRef = useRef(onSelect);
+  selectRef.current = onSelect;
+
+  // Create the map once.
+  useEffect(() => {
+    if (!boxRef.current || mapRef.current) return;
+    const map = new maplibregl.Map({
+      container: boxRef.current,
+      style: POSITRON,
+      center: [0, 20],
+      zoom: 1,
+      attributionControl: { compact: true },
+    });
+    mapRef.current = map;
+    map.on("load", () => {
+      map.addSource(SRC, { type: "geojson", data: pointsToFC(points) });
+      map.addLayer({
+        id: LAYER,
+        type: "circle",
+        source: SRC,
+        paint: {
+          "circle-radius": 6,
+          "circle-color": ["get", "color"],
+          "circle-stroke-color": "#0b1220",
+          "circle-stroke-width": 1,
+          "circle-opacity": 0.9,
+        },
+      });
+      map.on("click", LAYER, (e) => {
+        const id = e.features?.[0]?.properties?.id;
+        if (typeof id === "string" && id) selectRef.current?.(id);
+      });
+      map.on("mouseenter", LAYER, () => { map.getCanvas().style.cursor = "pointer"; });
+      map.on("mouseleave", LAYER, () => { map.getCanvas().style.cursor = ""; });
+      fit(map, points);
+    });
+    return () => { map.remove(); mapRef.current = null; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Push new features + refit when points change.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+    const src = map.getSource(SRC) as GeoJSONSource | undefined;
+    if (src) { src.setData(pointsToFC(points)); fit(map, points); }
+  }, [points]);
+
+  return <div ref={boxRef} className="tn-inset-map" style={{ width: "100%", height }} />;
+}
+
+function fit(map: maplibregl.Map, points: InsetPoint[]) {
+  const b = boundsOf(points);
+  if (b) map.fitBounds(b, { padding: 40, maxZoom: 6, duration: 0 });
+}
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: PASS (component is exercised in Task 10).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/map/inset.ts tests/unit/map-inset.test.ts components/InsetMap.tsx
+git commit -m "feat(map): shared <InsetMap> (single-layer MapLibre) + pure FC/bounds helpers"
+```
+
+---
+
+## Task 8: eventMetricLine (per-domain metric strings)
+
+**Files:**
+- Create: `lib/widgets/eventMetrics.ts`
+- Test: `tests/unit/event-metrics.test.ts`
+
+**Interfaces:**
+- Consumes: `EventType` (`lib/events/model.ts`).
+- Produces: `eventMetricLine(type: EventType, props: Record<string, unknown> | undefined): string` — an honest, domain-specific one-liner from the RAW `SignalFeature.props`; `""` when nothing usable is present.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/event-metrics.test.ts
+import { describe, it, expect } from "vitest";
+import { eventMetricLine } from "@/lib/widgets/eventMetrics";
+
+describe("eventMetricLine", () => {
+  it("quake: magnitude + depth", () => {
+    expect(eventMetricLine("quake", { magnitude: 5.2, depth: "12.3 km" })).toBe("M 5.2 · depth 12.3 km");
+  });
+  it("cyclone: category + wind + pressure + movement", () => {
+    expect(eventMetricLine("cyclone", { category: "Cat 3 hurricane", maxWind: "90 kt", pressure: "960 mb", movement: "315° at 12 kt" }))
+      .toBe("Cat 3 hurricane · 90 kt · 960 mb · moving 315° at 12 kt");
+  });
+  it("disaster: alert level + country + ongoing (no fake magnitude)", () => {
+    expect(eventMetricLine("disaster", { alertLevel: "Red", country: "Nigeria", ongoing: "yes" }))
+      .toBe("Red alert · Nigeria · ongoing");
+  });
+  it("returns empty string when nothing usable is present", () => {
+    expect(eventMetricLine("other", undefined)).toBe("");
+    expect(eventMetricLine("disaster", {})).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/event-metrics.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/widgets/eventMetrics.ts
+// Pure: RAW SignalFeature props → an honest, domain-specific metric line for the
+// Events detail feed. Only shows what the source actually provides — no fabricated
+// unified "magnitude" for cyclones/disasters (their native fields are shown instead).
+import type { EventType } from "@/lib/events/model";
+
+const str = (v: unknown): string => (typeof v === "string" && v.trim() ? v.trim() : typeof v === "number" && Number.isFinite(v) ? String(v) : "");
+
+export function eventMetricLine(type: EventType, props: Record<string, unknown> | undefined): string {
+  if (!props) return "";
+  const parts: string[] = [];
+  if (type === "quake") {
+    const m = str(props.magnitude);
+    if (m) parts.push(`M ${m}`);
+    const d = str(props.depth);
+    if (d) parts.push(`depth ${d}`);
+  } else if (type === "cyclone") {
+    for (const key of ["category", "maxWind", "pressure"] as const) {
+      const v = str(props[key]);
+      if (v) parts.push(v);
+    }
+    const mv = str(props.movement);
+    if (mv) parts.push(`moving ${mv}`);
+  } else if (type === "disaster") {
+    const al = str(props.alertLevel);
+    if (al) parts.push(`${al} alert`);
+    const c = str(props.country);
+    if (c) parts.push(c);
+    if (str(props.ongoing).toLowerCase() === "yes") parts.push("ongoing");
+  } else {
+    const m = str(props.magnitude);
+    if (m) parts.push(`M ${m}`);
+  }
+  return parts.join(" · ");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/event-metrics.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/eventMetrics.ts tests/unit/event-metrics.test.ts
+git commit -m "feat(widgets): eventMetricLine — honest per-domain event metrics from raw props"
+```
+
+---
+
+## Task 9: Events detail — header counts + grouped feed
+
+**Files:**
+- Create: `lib/console/widgets/events.detail.tsx`
+- Modify: `lib/console/widgets/events.tsx`
+
+**Interfaces:**
+- Consumes: `WidgetDetailProps` (registry); `useScope`, `useTimeWindow`/`windowMsFor`, `useNow`, `useEventFeeds`, `projectEventFeed`, `EVENT_SOURCES`, `SEVERITY_COLOR`, `countBy` (Task 5), `eventMetricLine` (Task 8).
+- Produces: `EventsDetail(props: WidgetDetailProps)` default export, attached as `EVENTS_WIDGET.detail`.
+
+- [ ] **Step 1: Create the detail component (header + grouped feed)**
+
+```tsx
+// lib/console/widgets/events.detail.tsx
+"use client";
+// Events focus view. Reuses the SAME feed pipeline as the docked widget
+// (useEventFeeds → projectEventFeed) but renders deep: a tier/type triage header,
+// a feed grouped by event type with honest per-domain metric lines joined back to
+// the raw SignalFeature props, and (Task 10/11) a recency chart, event map and export.
+import { useMemo } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
+import { projectEventFeed, type FeedInput } from "@/lib/widgets/eventFeed";
+import { useScope } from "@/lib/shell/scope";
+import { useTimeWindow, windowMsFor } from "@/lib/shell/timeWindow";
+import { useNow } from "@/lib/shell/useNow";
+import { SEVERITY_COLOR, type SeverityTier, type EventType } from "@/lib/events/model";
+import type { SignalFeature } from "@/lib/signals/types";
+import { countBy } from "@/lib/widgets/buckets";
+import { eventMetricLine } from "@/lib/widgets/eventMetrics";
+
+const TIERS: SeverityTier[] = ["S4", "S3", "S2", "S1", "S0"];
+const TYPE_LABEL: Partial<Record<EventType, string>> = { quake: "Quakes", disaster: "Disasters", cyclone: "Cyclones" };
+
+export default function EventsDetail({ config }: WidgetDetailProps) {
+  const scope = useScope();
+  const win = useTimeWindow();
+  const now = useNow(60_000);
+  const { bySource, status, updatedAt } = useEventFeeds();
+
+  const inputs: FeedInput[] = useMemo(
+    () => EVENT_SOURCES.map((source) => ({ source, features: bySource[source.id] ?? [] })),
+    [bySource],
+  );
+  const minTier = ((config.minTier as string) ?? "S1") as SeverityTier;
+
+  const projected = useMemo(
+    () => projectEventFeed(inputs, scope, windowMsFor(win), now, { types: null, minTier, sort: "severity" }),
+    [inputs, scope, win, now, minTier],
+  );
+
+  // Join back to raw props for per-domain metrics (lost in NormalizedEvent).
+  const featureById = useMemo(() => {
+    const m = new Map<string, SignalFeature>();
+    for (const s of EVENT_SOURCES) for (const f of bySource[s.id] ?? []) m.set(f.id, f);
+    return m;
+  }, [bySource]);
+
+  const tierCounts = useMemo(() => countBy(projected.rows, (e) => e.severity.tier), [projected.rows]);
+  const groups = useMemo(() => {
+    const by = new Map<EventType, typeof projected.rows>();
+    for (const e of projected.rows) { const g = by.get(e.type) ?? []; g.push(e); by.set(e.type, g); }
+    return [...by.entries()];
+  }, [projected.rows]);
+
+  return (
+    <div className="tn-evd">
+      <div className="tn-evd-head">
+        <div className="tn-evd-stat"><b>{projected.shown}</b> of {projected.total} events</div>
+        <div className="tn-evd-scope">{scope.label}{updatedAt ? ` · updated ${Math.round((now - updatedAt) / 60000)}m ago` : ""}</div>
+        <div className="tn-evd-tiers">
+          {TIERS.map((t) => (
+            <span key={t} className="tn-evd-tier" style={{ borderColor: SEVERITY_COLOR[t] }}>
+              <i style={{ background: SEVERITY_COLOR[t] }} /> {t} {tierCounts[t] ?? 0}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {status === "loading" && projected.shown === 0 && <p className="tn-w-empty">Loading events…</p>}
+      {projected.shown === 0 && status !== "loading" && (
+        <p className="tn-w-empty">No events above {minTier} in {scope.label}.</p>
+      )}
+
+      {groups.map(([type, rows]) => (
+        <section key={type} className="tn-evd-group">
+          <h3 className="tn-evd-group-h">{TYPE_LABEL[type] ?? type} · {rows.length}</h3>
+          <ul className="tn-evd-list">
+            {rows.map((e) => {
+              const metric = eventMetricLine(e.type, featureById.get(e.id)?.props);
+              return (
+                <li key={e.id}>
+                  <span className="tn-w-sev" style={{ background: SEVERITY_COLOR[e.severity.tier] }}>{e.severity.tier}</span>{" "}
+                  <b>{e.title}</b> <span className="tn-w-place">{e.place.name}</span>
+                  {metric && <span className="tn-evd-metric"> · {metric}</span>}
+                  {e.link && <a className="tn-evd-src" href={e.link} target="_blank" rel="noreferrer"> source ↗</a>}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Attach the detail to the widget + add styles**
+
+In `lib/console/widgets/events.tsx`, import and attach the detail:
+
+```tsx
+import EventsDetail from "@/lib/console/widgets/events.detail";
+```
+
+Add `detail: EventsDetail` to the `EVENTS_WIDGET` object (after `component: EventsBody`):
+
+```tsx
+export const EVENTS_WIDGET = {
+  id: "events",
+  title: "Disasters & Events",
+  icon: "🌎",
+  category: "Events",
+  defaultHeight: 320,
+  defaultConfig: { minTier: "S1", sort: "severity" },
+  component: EventsBody,
+  detail: EventsDetail,
+  capabilities: { filter: true, sort: true },
+};
+```
+
+Append to `app/globals.css`:
+
+```css
+.tn-evd { max-width: 1100px; margin: 0 auto; }
+.tn-evd-head { display: flex; flex-wrap: wrap; align-items: center; gap: 10px 16px; margin-bottom: 12px; }
+.tn-evd-stat b { font-size: 20px; }
+.tn-evd-scope { color: var(--tn-text-faint, #94a3b8); font-size: 12px; }
+.tn-evd-tiers { display: flex; gap: 6px; margin-left: auto; }
+.tn-evd-tier { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; padding: 2px 8px; border: 1px solid; border-radius: 999px; }
+.tn-evd-tier i { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.tn-evd-group { margin: 14px 0; }
+.tn-evd-group-h { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--tn-text-faint, #94a3b8); margin: 0 0 6px; }
+.tn-evd-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 6px; }
+.tn-evd-list li { padding: 6px 8px; border-radius: 6px; background: var(--tn-surface-2, #111a2e); }
+.tn-evd-metric { color: var(--tn-text-faint, #94a3b8); }
+.tn-evd-src { color: var(--tn-accent, #38bdf8); text-decoration: none; font-size: 12px; }
+```
+
+- [ ] **Step 3: Verify build + screenshot**
+
+Run: `npx tsc --noEmit && npm test` → PASS.
+With the dev server running, expand the Events widget; confirm the detail shows the "N of M events" header, the S4–S0 tier chips with counts, and events grouped under Quakes/Disasters/Cyclones with metric lines. Screenshot to `persona-shots/focus-events-feed.png`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/console/widgets/events.detail.tsx lib/console/widgets/events.tsx app/globals.css
+git commit -m "feat(events): focus detail view — triage header + grouped feed with honest per-domain metrics"
+```
+
+---
+
+## Task 10: Events detail — recency chart + event map
+
+**Files:**
+- Modify: `lib/console/widgets/events.detail.tsx`
+
+**Interfaces:**
+- Consumes: `timeBins` (Task 5), `Chart`/`ChartPoint` (Task 6), `InsetMap`/`InsetPoint` (Task 7).
+- Produces: recency `<Chart>` + event `<InsetMap>` panels inside `EventsDetail`.
+
+- [ ] **Step 1: Add imports**
+
+At the top of `lib/console/widgets/events.detail.tsx`:
+
+```tsx
+import { timeBins } from "@/lib/widgets/buckets";
+import { Chart, type ChartPoint } from "@/components/Chart";
+import InsetMap, { } from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
+```
+
+- [ ] **Step 2: Derive the chart + map data (inside the component, after `groups`)**
+
+```tsx
+  const recency: ChartPoint[] = useMemo(() => {
+    const ts = projected.rows
+      .map((e) => (e.occurredAt ? Date.parse(e.occurredAt) : NaN))
+      .filter((n) => Number.isFinite(n));
+    return timeBins(ts, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
+  }, [projected.rows, now]);
+
+  const mapPoints: InsetPoint[] = useMemo(
+    () => projected.rows.map((e) => ({
+      lat: e.geo.lat, lon: e.geo.lon, id: e.id, color: e.color,
+      props: { title: e.title, tier: e.severity.tier },
+    })),
+    [projected.rows],
+  );
+```
+
+- [ ] **Step 3: Render the two panels (after the `<div className="tn-evd-head">` block, before the groups loop)**
+
+```tsx
+      <div className="tn-evd-panels">
+        <div className="tn-evd-panel">
+          <h3 className="tn-evd-group-h">Events over the last 24h</h3>
+          {recency.some((p) => p.y > 0)
+            ? <Chart points={recency} height={140} up={null} />
+            : <p className="tn-w-empty">No timestamped events in the window.</p>}
+        </div>
+        <div className="tn-evd-panel">
+          <h3 className="tn-evd-group-h">Locations</h3>
+          {mapPoints.length > 0
+            ? <InsetMap points={mapPoints} height={220} />
+            : <p className="tn-w-empty">No mappable events right now.</p>}
+        </div>
+      </div>
+```
+
+- [ ] **Step 4: Add panel styles**
+
+Append to `app/globals.css`:
+
+```css
+.tn-evd-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 14px; }
+.tn-evd-panel { background: var(--tn-surface-2, #111a2e); border-radius: 8px; padding: 10px; }
+@media (max-width: 760px) { .tn-evd-panels { grid-template-columns: 1fr; } }
+```
+
+- [ ] **Step 5: Verify build + screenshot**
+
+Run: `npx tsc --noEmit && npm test` → PASS.
+Expand Events; confirm the recency area chart and the inset map of event locations render (or their honest empty states in a quiet window). Screenshot to `persona-shots/focus-events-chart-map.png`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/console/widgets/events.detail.tsx app/globals.css
+git commit -m "feat(events): focus detail — 24h recency <Chart> + event <InsetMap>"
+```
+
+---
+
+## Task 11: Events detail — sources footer + export
+
+**Files:**
+- Modify: `lib/console/widgets/events.detail.tsx`
+
+**Interfaces:**
+- Consumes: `toCsv`, `toGeoJson`, `downloadText`, `exportFilename` (`lib/export.ts`), `EVENT_SOURCES`.
+- Produces: a sources/attribution footer with CSV + GeoJSON export of the visible events.
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
+```
+
+- [ ] **Step 2: Build export rows + per-source counts (inside the component)**
+
+```tsx
+  const perSource = useMemo(() => {
+    const counts = countBy(projected.rows, (e) => e.source.id);
+    return EVENT_SOURCES.map((s) => ({ id: s.id, label: s.label, attribution: s.attribution, count: counts[s.id] ?? 0 }));
+  }, [projected.rows]);
+
+  const exportRows = useMemo(
+    () => projected.rows.map((e) => ({
+      tier: e.severity.tier, type: e.type, title: e.title, place: e.place.name,
+      metric: eventMetricLine(e.type, featureById.get(e.id)?.props),
+      lat: e.geo.lat, lon: e.geo.lon, occurredAt: e.occurredAt ?? "",
+    })),
+    [projected.rows, featureById],
+  );
+  const exportGeo = useMemo(
+    () => projected.rows.map((e) => ({ lat: e.geo.lat, lon: e.geo.lon, properties: { tier: e.severity.tier, type: e.type, title: e.title } })),
+    [projected.rows],
+  );
+```
+
+- [ ] **Step 3: Render the footer (last child of the outer `tn-evd` div)**
+
+```tsx
+      <footer className="tn-evd-foot">
+        <div className="tn-evd-sources">
+          {perSource.map((s) => (
+            <span key={s.id} className="tn-evd-source">{s.label} · {s.count} <i>({s.attribution})</i></span>
+          ))}
+        </div>
+        <div className="tn-evd-export">
+          <button
+            disabled={exportRows.length === 0}
+            onClick={() => downloadText(`${exportFilename("events", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+          >⬇ CSV</button>
+          <button
+            disabled={exportGeo.length === 0}
+            onClick={() => downloadText(`${exportFilename("events", Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}
+          >⬇ GeoJSON</button>
+        </div>
+      </footer>
+```
+
+- [ ] **Step 4: Add footer styles**
+
+Append to `app/globals.css`:
+
+```css
+.tn-evd-foot { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--tn-border, #1e293b); display: flex; flex-wrap: wrap; gap: 10px 16px; align-items: center; }
+.tn-evd-sources { display: flex; flex-wrap: wrap; gap: 12px; font-size: 12px; color: var(--tn-text-faint, #94a3b8); }
+.tn-evd-source i { font-style: normal; opacity: .7; }
+.tn-evd-export { margin-left: auto; display: flex; gap: 8px; }
+.tn-evd-export button { font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; background: transparent; color: var(--tn-accent, #38bdf8); cursor: pointer; }
+.tn-evd-export button:disabled { opacity: .4; cursor: default; }
+```
+
+- [ ] **Step 5: Final gate + milestone screenshot**
+
+Run: `npx tsc --noEmit && npm test` → PASS.
+Expand Events; confirm the footer lists the three sources with counts + attribution and that **⬇ CSV** downloads a file. Screenshot the full detail to `persona-shots/focus-events-final.png`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/console/widgets/events.detail.tsx app/globals.css
+git commit -m "feat(events): focus detail — sources/attribution footer + CSV/GeoJSON export"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (F1 + F2 + W1 sections of `2026-07-08-focus-window-design.md`):**
+- §3 focus foundation → Tasks 1–4 (store field, reducer, sanitize, detail contract, host, wired UI). ✅
+- §4 primitives: `buckets` → Task 5; `<Chart>` → Task 6 (line/area; candlestick+crosshair deferred to W7, noted); `<InsetMap>` → Task 7. ✅
+- §5 data flow (expand → focusStore → StageHost → detail reusing the data hook) → Tasks 4 + 9. ✅
+- §6 honesty/dormant (empty states, no fake magnitude, raw-props join) → Tasks 8–11. ✅
+- §7.1 Events detail (triage header, grouped feed w/ per-domain metrics, event map, distribution, sources footer, export) → Tasks 9–11. Severity/type distribution is delivered as the tier-count chips (Task 9) + the 24h recency chart (Task 10); a dedicated magnitude histogram is a W-series follow-up, not required for the "foundation proven" milestone. ✅
+- §8 testing (pure logic unit-tested first; UI via Playwright) → every task. ✅
+
+**Placeholder scan:** none — every step has real code/commands.
+
+**Type consistency:** `focusedWidgetId` (types/reducer/sanitize/store) consistent; `WidgetDetailProps {instanceId, config}` used in registry + `EventsDetail`; `ChartPoint {x,y}`, `InsetPoint {lat,lon,id?,color?,props?}`, `TimeBin {start,count}`, `eventMetricLine(type,props)` used with matching signatures across tasks. `EVENT_SOURCES`/`SEVERITY_COLOR`/`projectEventFeed`/`useEventFeeds` match the real source signatures read from the codebase.
+
+**Deferred-with-intent (documented, not gaps):** candlestick + crosshair (`<Chart>`) land in W7 Markets; the magnitude histogram + severity-filter interactions are W-series polish. W2–W8 detail views follow as their own plans per the spec's milestone list.

--- a/docs/superpowers/plans/2026-07-08-focus-window-w2-headlines.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-w2-headlines.md
@@ -1,0 +1,781 @@
+# Focus Window — W2: Headlines detail + on-demand AI article summary
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** The Headlines widget's focus view becomes a newsroom board — full grouped feed with RSS snippets, source filter + search, an hourly volume strip, and a per-article **on-demand AI summary** that fetches the full article server-side (dormant until `FREELLMAPI_*`, honest fallback to the snippet).
+
+**Architecture:** Reuse the W1 focus foundation (`WidgetType.detail`, `StageHost`, `<Chart>`, `buckets`). Extend the keyless RSS parser to capture `<description>`. Add a dormant-safe `/api/news/summary` route modelled exactly on `/api/brief` (pure prompt builder + gateway call), guarded by a **news-specific SSRF allowlist** (the existing `isAllowed` is camera-hosts only). The detail view reuses the widget's existing `useJsonPoll("/api/news")` data.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, vitest. **No new dependencies.**
+
+## Global Constraints
+
+- **Build gate (every task):** `npx tsc --noEmit && npm test`
+- **Keyless-first / dormant-safe:** the AI summary is the only key-gated piece — dormant (`{summary:null, dormant:true}`) until `FREELLMAPI_BASE_URL`+`FREELLMAPI_KEY`; every failure returns JSON, never a 5xx. Snippets are keyless.
+- **SSRF:** `/api/news/summary` fetches a URL server-side — it MUST validate the URL against a news-publisher allowlist before fetching (the existing `lib/proxy/allowlist.ts` `isAllowed` is for camera hosts and must NOT be reused here).
+- **Back-compat:** `NewsItem.description` is OPTIONAL — `NewsTicker`, `BreakingBanner`, and the docked Headlines widget must keep working unchanged.
+- **Zero new deps**; native SVG + hand-rolled parsing (repo convention).
+- **Commit style:** one commit per task, `<type>: <summary>`, `git commit -m "..."` with plain double quotes (NOT a `@'...'` heredoc), **solo attribution — NO Claude co-author trailer**.
+- **Styling:** real `tn-*` tokens only — `--tn-surface`/`--tn-surface-solid`/`--tn-surface-2`/`--tn-text`/`--tn-text-muted`/`--tn-text-faint`/`--tn-border`/`--tn-accent` (do NOT invent `--tn-*-1` names).
+- **Honesty:** an AI summary is labelled AI-generated; a blocked/paywalled fetch falls back to the RSS snippet with an honest note; never fabricate article content.
+
+---
+
+## File Structure
+
+- Modify `lib/news.ts` — capture `<description>` into `NewsItem.description?`.
+- Create `lib/news/article.ts` + test — news-host SSRF allowlist + readability text extraction (pure).
+- Create `lib/news/summary.ts` + test — AI summary prompt builder + response parser (pure).
+- Create `app/api/news/summary/route.ts` — dormant-safe summary route (impure shell).
+- Create `lib/console/widgets/headlines.detail.tsx` — the focus view (built up across Tasks 5–8).
+- Modify `lib/console/widgets/headlines.tsx` — attach `detail`.
+- Modify `app/globals.css` — `.tn-hd*` styles (appended across Tasks 5–8).
+
+---
+
+## Task 1: Capture RSS `<description>` (keyless snippet)
+
+**Files:**
+- Modify: `lib/news.ts`
+- Test: `tests/unit/news-description.test.ts`
+
+**Interfaces:**
+- Produces: `NewsItem.description?: string` (cleaned snippet), populated by `parseRss`; rides through `mergeNews` unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/news-description.test.ts
+import { describe, it, expect } from "vitest";
+import { parseRss } from "@/lib/news";
+
+const XML = `<rss><channel>
+  <item>
+    <title>Big story &amp; more</title>
+    <link>https://www.bbc.com/news/world-123</link>
+    <pubDate>Wed, 08 Jul 2026 08:00:00 GMT</pubDate>
+    <description><![CDATA[<p>A short <b>summary</b> of the story.</p>]]></description>
+  </item>
+  <item>
+    <title>No description here</title>
+    <link>https://www.bbc.com/news/world-124</link>
+  </item>
+</channel></rss>`;
+
+describe("parseRss description", () => {
+  it("captures a cleaned <description> snippet", () => {
+    const items = parseRss(XML, "BBC");
+    expect(items[0].description).toBe("A short summary of the story.");
+  });
+  it("leaves description undefined when the item has none", () => {
+    const items = parseRss(XML, "BBC");
+    expect(items[1].description).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/news-description.test.ts`
+Expected: FAIL — `description` is `undefined` on item[0].
+
+- [ ] **Step 3: Implement**
+
+In `lib/news.ts`, add the optional field to the interface:
+
+```ts
+export interface NewsItem {
+  title: string;
+  source: string;
+  url: string;
+  ts: number; // epoch ms (0 when the feed omits a parseable date)
+  /** Cleaned RSS <description>/<summary> snippet, when the feed provides one. */
+  description?: string;
+}
+```
+
+In `parseRss`, inside the `for (const block of blocks)` loop, after computing `title`/`url` and before `out.push(...)`, derive the description and include it:
+
+```ts
+    const title = cleanText(tag(block, "title"));
+    const url = extractLink(block);
+    if (!title || !url || !/^https?:\/\//i.test(url)) continue;
+    const descRaw = tag(block, "description") ?? tag(block, "summary");
+    const description = cleanText(descRaw) || undefined;
+    out.push({ title, source, url: url.trim(), ts: parseDate(block), description });
+```
+
+(`cleanText` already strips CDATA, tags, and entities. `mergeNews` pushes each `NewsItem` as-is, so `description` carries through automatically.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/news-description.test.ts && npx tsc --noEmit`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/news.ts tests/unit/news-description.test.ts
+git commit -m "feat(news): capture RSS <description> snippet on NewsItem (keyless, back-compatible)"
+```
+
+---
+
+## Task 2: News-host SSRF allowlist + article text extraction
+
+**Files:**
+- Create: `lib/news/article.ts`
+- Test: `tests/unit/news-article.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `isNewsArticleUrl(raw: string): boolean` — true only for https URLs on an allowlisted news-publisher domain (or subdomain).
+  - `extractArticleText(html: string, maxChars?: number): string` — strips scripts/styles/tags, collapses whitespace, caps length; returns `""` when nothing usable.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/news-article.test.ts
+import { describe, it, expect } from "vitest";
+import { isNewsArticleUrl, extractArticleText } from "@/lib/news/article";
+
+describe("isNewsArticleUrl", () => {
+  it("allows the known publisher domains + subdomains over https", () => {
+    expect(isNewsArticleUrl("https://www.bbc.com/news/world-123")).toBe(true);
+    expect(isNewsArticleUrl("https://www.theguardian.com/world/x")).toBe(true);
+    expect(isNewsArticleUrl("https://text.npr.org/12345")).toBe(true);
+    expect(isNewsArticleUrl("https://www.aljazeera.com/news/x")).toBe(true);
+  });
+  it("rejects other hosts, non-https, and junk", () => {
+    expect(isNewsArticleUrl("https://evil.example.com/x")).toBe(false);
+    expect(isNewsArticleUrl("http://www.bbc.com/news/x")).toBe(false); // must be https
+    expect(isNewsArticleUrl("not a url")).toBe(false);
+    expect(isNewsArticleUrl("https://notbbc.com.evil.com/x")).toBe(false);
+  });
+});
+
+describe("extractArticleText", () => {
+  it("strips scripts/styles/markup and collapses whitespace", () => {
+    const html = `<html><head><style>.x{}</style><script>bad()</script></head>
+      <body><h1>Title</h1><p>First para.</p><p>Second   para.</p></body></html>`;
+    const text = extractArticleText(html);
+    expect(text).toContain("First para.");
+    expect(text).toContain("Second para.");
+    expect(text).not.toContain("bad()");
+    expect(text).not.toContain(".x{}");
+  });
+  it("caps length and returns empty for blank input", () => {
+    expect(extractArticleText("")).toBe("");
+    expect(extractArticleText("<p>" + "a".repeat(50000) + "</p>", 100).length).toBe(100);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/news-article.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/news/article.ts
+// SSRF guard + lightweight readability for the AI-summary route. Pure + node-testable.
+// The allowlist is the news PUBLISHERS behind the /api/news feeds (article links live
+// on the publisher's main domain, e.g. bbc.com — NOT the feeds.* host). This is a
+// SEPARATE list from lib/proxy/allowlist.ts (which is camera hosts only).
+
+const NEWS_DOMAINS = ["bbc.com", "bbc.co.uk", "theguardian.com", "aljazeera.com", "npr.org"];
+
+/** https + hostname is one of NEWS_DOMAINS or a subdomain of one. */
+export function isNewsArticleUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  const host = url.hostname.toLowerCase();
+  return NEWS_DOMAINS.some((d) => host === d || host.endsWith("." + d));
+}
+
+/** Strip scripts/styles/all tags, decode a few entities, collapse whitespace, cap length. */
+export function extractArticleText(html: string, maxChars = 6000): string {
+  if (!html) return "";
+  const text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.slice(0, maxChars);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/news-article.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/news/article.ts tests/unit/news-article.test.ts
+git commit -m "feat(news): news-host SSRF allowlist + readability text extraction (pure)"
+```
+
+---
+
+## Task 3: AI summary prompt builder + response parser
+
+**Files:**
+- Create: `lib/news/summary.ts`
+- Test: `tests/unit/news-summary.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `SummaryInput { title: string; source: string; text: string }`
+  - `buildSummaryPrompt(input: SummaryInput): string`
+  - `parseSummaryResponse(json: unknown): string | null`
+  - `SummaryPayload { summary: string | null; dormant: boolean; source: "ai" | "snippet" | null }`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/news-summary.test.ts
+import { describe, it, expect } from "vitest";
+import { buildSummaryPrompt, parseSummaryResponse } from "@/lib/news/summary";
+
+describe("news summary", () => {
+  it("builds a grounded, non-speculative prompt containing the article text", () => {
+    const p = buildSummaryPrompt({ title: "T", source: "BBC", text: "Body of the article." });
+    expect(p).toContain("Body of the article.");
+    expect(p.toLowerCase()).toContain("do not");   // the anti-speculation guard
+  });
+  it("parses the gateway chat-completion content, or null", () => {
+    expect(parseSummaryResponse({ choices: [{ message: { content: "  A summary.  " } }] })).toBe("A summary.");
+    expect(parseSummaryResponse({ choices: [] })).toBeNull();
+    expect(parseSummaryResponse({})).toBeNull();
+    expect(parseSummaryResponse(null)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/news-summary.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/news/summary.ts
+// Pure prompt builder + response parser for the on-demand article summary.
+// Mirrors lib/brief.ts: honesty-guarded, node-testable; the network call lives in
+// the route. The summary is grounded ONLY in the supplied article text.
+
+export interface SummaryInput {
+  title: string;
+  source: string;
+  text: string;
+}
+
+export interface SummaryPayload {
+  summary: string | null;
+  dormant: boolean;
+  /** where the text came from: the AI over the fetched article, the RSS snippet, or nothing. */
+  source: "ai" | "snippet" | null;
+}
+
+/** Pure: article text → the chat prompt sent to the gateway. */
+export function buildSummaryPrompt(input: SummaryInput): string {
+  return [
+    "You are a neutral news editor. Summarise the article below in 3 short, factual sentences.",
+    "Use ONLY the article text provided. Do not add facts, figures, or opinions not present in it. Do not speculate.",
+    "",
+    `Headline: ${input.title}`,
+    `Source: ${input.source}`,
+    "",
+    "Article text:",
+    input.text,
+  ].join("\n");
+}
+
+/** Pure: parse the gateway's chat-completion response → summary text, or null. */
+export function parseSummaryResponse(json: unknown): string | null {
+  const content = (json as { choices?: { message?: { content?: unknown } }[] })?.choices?.[0]?.message?.content;
+  return typeof content === "string" && content.trim() ? content.trim() : null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/news-summary.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/news/summary.ts tests/unit/news-summary.test.ts
+git commit -m "feat(news): AI summary prompt builder + response parser (pure, honesty-guarded)"
+```
+
+---
+
+## Task 4: `/api/news/summary` route (dormant-safe)
+
+**Files:**
+- Create: `app/api/news/summary/route.ts`
+
+**Interfaces:**
+- Consumes: `isNewsArticleUrl`, `extractArticleText` (Task 2); `buildSummaryPrompt`, `parseSummaryResponse`, `SummaryPayload` (Task 3); `freellmConfig` (`@/lib/geolocate/config`).
+- Produces: `POST /api/news/summary` `{ url, title, source }` → `SummaryPayload` JSON. Dormant when the gateway isn't configured; falls back to the caller's snippet flag when the fetch is blocked; never 5xx.
+
+- [ ] **Step 1: Implement the route** (modelled on `app/api/brief/route.ts`)
+
+```ts
+// app/api/news/summary/route.ts
+import { isNewsArticleUrl, extractArticleText } from "@/lib/news/article";
+import { buildSummaryPrompt, parseSummaryResponse, type SummaryPayload } from "@/lib/news/summary";
+import { freellmConfig } from "@/lib/geolocate/config";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/news/summary { url, title, source } — on-demand AI summary of ONE article.
+// Dormant ({summary:null, dormant:true}) until FREELLMAPI_* is set. SSRF-guarded to
+// the news-publisher allowlist. Dormant-safe: any failure returns JSON, never a 5xx.
+// Cached per-URL (module map) so re-opening a story is free.
+
+const cache = new Map<string, SummaryPayload>();
+
+function bad(): Response {
+  return Response.json({ summary: null, dormant: false, source: null } satisfies SummaryPayload);
+}
+
+export async function POST(req: Request) {
+  let body: { url?: unknown; title?: unknown; source?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return bad();
+  }
+  const url = typeof body.url === "string" ? body.url : "";
+  const title = typeof body.title === "string" ? body.title : "";
+  const source = typeof body.source === "string" ? body.source : "";
+  if (!isNewsArticleUrl(url)) return bad();
+
+  const cached = cache.get(url);
+  if (cached) return Response.json(cached);
+
+  const cfg = freellmConfig();
+  if (!cfg) {
+    // Not cached — dormancy can change when the env is set.
+    return Response.json({ summary: null, dormant: true, source: null } satisfies SummaryPayload);
+  }
+
+  let text = "";
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.ok) text = extractArticleText(await res.text());
+  } catch {
+    text = "";
+  }
+  if (text.length < 200) {
+    // Blocked / paywalled / too thin — tell the client to fall back to its snippet.
+    const payload: SummaryPayload = { summary: null, dormant: false, source: "snippet" };
+    return Response.json(payload);
+  }
+
+  try {
+    const r = await fetch(`${cfg.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${cfg.key}` },
+      body: JSON.stringify({
+        model: cfg.model,
+        messages: [{ role: "user", content: buildSummaryPrompt({ title, source, text }) }],
+        temperature: 0.2,
+        max_tokens: 220,
+      }),
+      signal: AbortSignal.timeout(25_000),
+    });
+    if (!r.ok) throw new Error(`gateway ${r.status}`);
+    const summary = parseSummaryResponse(await r.json());
+    const payload: SummaryPayload = { summary, dormant: false, source: summary ? "ai" : "snippet" };
+    if (summary) cache.set(url, payload);
+    return Response.json(payload);
+  } catch {
+    return Response.json({ summary: null, dormant: false, source: "snippet" } satisfies SummaryPayload);
+  }
+}
+```
+
+- [ ] **Step 2: Gate**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: clean + all tests pass (route has no unit test; its pure deps are covered by Tasks 2–3; behaviour is verified live by the integrator).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/news/summary/route.ts
+git commit -m "feat(news): /api/news/summary — dormant-safe, SSRF-guarded on-demand article summary"
+```
+
+---
+
+## Task 5: Headlines detail — control bar + grouped feed with snippets
+
+**Files:**
+- Create: `lib/console/widgets/headlines.detail.tsx`
+- Modify: `lib/console/widgets/headlines.tsx`
+- Modify: `app/globals.css`
+
+**Interfaces:**
+- Consumes: `WidgetDetailProps` (registry); `useJsonPoll` (`@/lib/console/widgets/useJsonPoll`); `NewsItem` (`@/lib/news`); `countBy` (`@/lib/widgets/buckets`).
+- Produces: `HeadlinesDetail(props: WidgetDetailProps)` default export, attached as `HEADLINES_WIDGET.detail`.
+
+- [ ] **Step 1: Create the detail component**
+
+```tsx
+// lib/console/widgets/headlines.detail.tsx
+"use client";
+// Headlines focus view — a newsroom board. Reuses the SAME /api/news poll as the
+// docked widget, rendering deep: source filter + search, a recency-grouped feed with
+// snippets, an hourly volume strip (Task 6), on-demand AI summaries (Task 7), and a
+// sources footer + export (Task 8).
+import { useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import type { NewsItem } from "@/lib/news";
+import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
+import { countBy } from "@/lib/widgets/buckets";
+
+interface NewsPayload { generatedAt: number; items: NewsItem[] }
+const EMPTY: NewsPayload = { generatedAt: 0, items: [] };
+const SOURCES = ["BBC", "Al Jazeera", "NPR", "The Guardian"];
+
+function rel(ts: number, now: number): string {
+  if (!ts) return "";
+  const m = Math.max(0, Math.round((now - ts) / 60000));
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  return h < 48 ? `${h}h` : `${Math.round(h / 24)}d`;
+}
+function bucketOf(ts: number, now: number): "Last hour" | "Today" | "Earlier" {
+  const h = (now - ts) / 3_600_000;
+  if (ts && h < 1) return "Last hour";
+  if (ts && h < 24) return "Today";
+  return "Earlier";
+}
+const BUCKET_ORDER = ["Last hour", "Today", "Earlier"] as const;
+
+export default function HeadlinesDetail({ }: WidgetDetailProps) {
+  const { data, status } = useJsonPoll<NewsPayload>("/api/news", 120_000, EMPTY);
+  const items = useMemo(() => data.items ?? [], [data.items]);
+  const [srcFilter, setSrcFilter] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const now = Date.now();
+
+  const counts = useMemo(() => countBy(items, (it) => it.source), [items]);
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return items.filter(
+      (it) =>
+        (srcFilter == null || it.source === srcFilter) &&
+        (!q || it.title.toLowerCase().includes(q) || (it.description ?? "").toLowerCase().includes(q)),
+    );
+  }, [items, srcFilter, query]);
+
+  const groups = useMemo(() => {
+    const by = new Map<string, NewsItem[]>();
+    for (const it of filtered) {
+      const b = bucketOf(it.ts, now);
+      const g = by.get(b) ?? [];
+      g.push(it);
+      by.set(b, g);
+    }
+    return BUCKET_ORDER.filter((b) => by.has(b)).map((b) => [b, by.get(b)!] as const);
+  }, [filtered, now]);
+
+  return (
+    <div className="tn-hd">
+      <div className="tn-hd-bar">
+        <div className="tn-hd-chips">
+          <button className={srcFilter == null ? "is-on" : ""} onClick={() => setSrcFilter(null)}>All {items.length}</button>
+          {SOURCES.map((s) => (
+            <button key={s} className={srcFilter === s ? "is-on" : ""} onClick={() => setSrcFilter(s)}>{s} {counts[s] ?? 0}</button>
+          ))}
+        </div>
+        <input className="tn-hd-search" placeholder="Search headlines…" value={query} onChange={(e) => setQuery(e.target.value)} />
+      </div>
+
+      {status === "loading" && items.length === 0 && <p className="tn-w-empty">Loading headlines…</p>}
+      {items.length > 0 && filtered.length === 0 && <p className="tn-w-empty">No headlines match.</p>}
+
+      {groups.map(([bucket, rows]) => (
+        <section key={bucket} className="tn-hd-group">
+          <h3 className="tn-hd-group-h">{bucket} · {rows.length}</h3>
+          <ul className="tn-hd-list">
+            {rows.map((it, i) => (
+              <li key={it.url || i} className="tn-hd-item">
+                <a className="tn-hd-title" href={it.url} target="_blank" rel="noreferrer">{it.title}</a>
+                <div className="tn-hd-meta"><span className="tn-hd-src">{it.source}</span>{it.ts ? ` · ${rel(it.ts, now)}` : ""}</div>
+                {it.description && <p className="tn-hd-snippet">{it.description}</p>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Attach + style**
+
+In `lib/console/widgets/headlines.tsx`, import and attach:
+
+```tsx
+import HeadlinesDetail from "@/lib/console/widgets/headlines.detail";
+```
+
+Add `detail: HeadlinesDetail` to `HEADLINES_WIDGET` (after `component: HeadlinesBody`).
+
+Append to `app/globals.css`:
+
+```css
+.tn-hd { max-width: 1000px; margin: 0 auto; }
+.tn-hd-bar { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin-bottom: 12px; }
+.tn-hd-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.tn-hd-chips button { font: inherit; font-size: 12px; padding: 3px 10px; border: 1px solid var(--tn-border); border-radius: 999px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-hd-chips button.is-on { background: var(--tn-accent); color: #fff; border-color: var(--tn-accent); }
+.tn-hd-search { margin-left: auto; font: inherit; font-size: 13px; padding: 5px 10px; border: 1px solid var(--tn-border); border-radius: 6px; background: var(--tn-surface-2); color: var(--tn-text); min-width: 180px; }
+.tn-hd-group { margin: 12px 0; }
+.tn-hd-group-h { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--tn-text-faint); margin: 0 0 6px; }
+.tn-hd-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.tn-hd-item { padding: 8px 10px; border-radius: 8px; background: var(--tn-surface-2); }
+.tn-hd-title { font-weight: 600; color: var(--tn-text); text-decoration: none; }
+.tn-hd-title:hover { text-decoration: underline; }
+.tn-hd-meta { font-size: 11px; color: var(--tn-text-faint); margin-top: 2px; }
+.tn-hd-src { color: var(--tn-accent); }
+.tn-hd-snippet { font-size: 13px; color: var(--tn-text-muted); margin: 4px 0 0; }
+```
+
+- [ ] **Step 3: Gate + verify**
+
+Run: `npx tsc --noEmit && npm test` → green. (Integrator verifies live: expand Headlines → source chips + counts, search filters, recency groups with snippets.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/console/widgets/headlines.detail.tsx lib/console/widgets/headlines.tsx app/globals.css
+git commit -m "feat(headlines): focus detail — source filter + search + recency-grouped feed with snippets"
+```
+
+---
+
+## Task 6: Headlines detail — hourly volume strip
+
+**Files:**
+- Modify: `lib/console/widgets/headlines.detail.tsx`
+- Modify: `app/globals.css`
+
+**Interfaces:**
+- Consumes: `timeBins` (`@/lib/widgets/buckets`), `Chart`/`ChartPoint` (`@/components/Chart`).
+
+- [ ] **Step 1: Add imports + derived data**
+
+Add imports at the top:
+
+```tsx
+import { timeBins } from "@/lib/widgets/buckets";
+import { Chart, type ChartPoint } from "@/components/Chart";
+```
+
+Inside the component, after `groups`:
+
+```tsx
+  const volume: ChartPoint[] = useMemo(() => {
+    const ts = filtered.map((it) => it.ts).filter((n) => n > 0);
+    return timeBins(ts, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
+  }, [filtered, now]);
+```
+
+- [ ] **Step 2: Render the strip** (place immediately after the `.tn-hd-bar` block, before the loading/empty lines)
+
+```tsx
+      {volume.some((p) => p.y > 0) && (
+        <div className="tn-hd-vol">
+          <div className="tn-hd-group-h">Headlines per hour · last 24h</div>
+          <Chart points={volume} height={80} up={null} />
+        </div>
+      )}
+```
+
+- [ ] **Step 3: Style**
+
+Append to `app/globals.css`:
+
+```css
+.tn-hd-vol { background: var(--tn-surface-2); border-radius: 8px; padding: 8px 10px; margin-bottom: 12px; }
+```
+
+- [ ] **Step 4: Gate + commit**
+
+Run: `npx tsc --noEmit && npm test` → green.
+
+```bash
+git add lib/console/widgets/headlines.detail.tsx app/globals.css
+git commit -m "feat(headlines): focus detail — hourly headline-volume strip"
+```
+
+---
+
+## Task 7: Headlines detail — on-demand AI summary
+
+**Files:**
+- Modify: `lib/console/widgets/headlines.detail.tsx`
+- Modify: `app/globals.css`
+
+**Interfaces:**
+- Consumes: `POST /api/news/summary` → `SummaryPayload` (Task 4).
+
+- [ ] **Step 1: Add per-item summary state + fetcher** (inside the component)
+
+```tsx
+  type SumState = { loading?: boolean; text?: string; note?: string };
+  const [summaries, setSummaries] = useState<Record<string, SumState>>({});
+  const summarize = (it: NewsItem) => {
+    if (summaries[it.url]?.loading || summaries[it.url]?.text) return;
+    setSummaries((s) => ({ ...s, [it.url]: { loading: true } }));
+    fetch("/api/news/summary", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: it.url, title: it.title, source: it.source }),
+    })
+      .then((r) => r.json())
+      .then((d: { summary: string | null; dormant: boolean; source: string | null }) => {
+        const note = d.dormant
+          ? "AI summary needs the FREELLMAPI gateway — showing the snippet."
+          : d.summary
+            ? undefined
+            : "Couldn’t read this article — showing the snippet.";
+        setSummaries((s) => ({ ...s, [it.url]: { text: d.summary ?? it.description ?? "No preview available.", note } }));
+      })
+      .catch(() => setSummaries((s) => ({ ...s, [it.url]: { text: it.description ?? "No preview available.", note: "Summary unavailable." } })));
+  };
+```
+
+- [ ] **Step 2: Render the button + result** (inside each `<li className="tn-hd-item">`, after the snippet `<p>`)
+
+```tsx
+                <button className="tn-hd-sum-btn" onClick={() => summarize(it)} disabled={!!summaries[it.url]?.loading}>
+                  {summaries[it.url]?.loading ? "Summarising…" : "✨ AI summary"}
+                </button>
+                {summaries[it.url]?.text && (
+                  <div className="tn-hd-sum">
+                    <p>{summaries[it.url]!.text}</p>
+                    {summaries[it.url]!.note && <span className="tn-hd-sum-note">{summaries[it.url]!.note}</span>}
+                  </div>
+                )}
+```
+
+- [ ] **Step 3: Style**
+
+Append to `app/globals.css`:
+
+```css
+.tn-hd-sum-btn { margin-top: 6px; font: inherit; font-size: 11px; padding: 2px 8px; border: 1px solid var(--tn-border); border-radius: 6px; background: transparent; color: var(--tn-accent); cursor: pointer; }
+.tn-hd-sum-btn:disabled { opacity: .6; cursor: default; }
+.tn-hd-sum { margin-top: 6px; padding: 8px 10px; border-left: 2px solid var(--tn-accent); background: var(--tn-surface); border-radius: 4px; }
+.tn-hd-sum p { margin: 0; font-size: 13px; color: var(--tn-text); }
+.tn-hd-sum-note { display: block; margin-top: 4px; font-size: 11px; color: var(--tn-text-faint); }
+```
+
+- [ ] **Step 4: Gate + commit**
+
+Run: `npx tsc --noEmit && npm test` → green. (Integrator verifies live: clicking "✨ AI summary" with the gateway dormant shows the snippet + the honest "needs the FREELLMAPI gateway" note.)
+
+```bash
+git add lib/console/widgets/headlines.detail.tsx app/globals.css
+git commit -m "feat(headlines): focus detail — on-demand AI article summary (dormant-safe, snippet fallback)"
+```
+
+---
+
+## Task 8: Headlines detail — sources footer + CSV export
+
+**Files:**
+- Modify: `lib/console/widgets/headlines.detail.tsx`
+- Modify: `app/globals.css`
+
+**Interfaces:**
+- Consumes: `toCsv`, `downloadText`, `exportFilename` (`@/lib/export`).
+
+- [ ] **Step 1: Add import + export rows** (inside the component)
+
+```tsx
+  const exportRows = useMemo(
+    () => filtered.map((it) => ({ source: it.source, title: it.title, url: it.url, ts: it.ts, description: it.description ?? "" })),
+    [filtered],
+  );
+```
+
+Add the import at the top:
+
+```tsx
+import { toCsv, downloadText, exportFilename } from "@/lib/export";
+```
+
+- [ ] **Step 2: Render the footer** (last child of the outer `.tn-hd` div)
+
+```tsx
+      <footer className="tn-hd-foot">
+        <span className="tn-hd-foot-src">BBC World · Al Jazeera · NPR · The Guardian — keyless RSS</span>
+        <button className="tn-hd-export" disabled={exportRows.length === 0}
+          onClick={() => downloadText(`${exportFilename("headlines", Date.now())}.csv`, "text/csv", toCsv(exportRows))}>
+          ⬇ Export CSV
+        </button>
+      </footer>
+```
+
+- [ ] **Step 3: Style**
+
+Append to `app/globals.css`:
+
+```css
+.tn-hd-foot { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--tn-border); display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.tn-hd-foot-src { font-size: 12px; color: var(--tn-text-faint); }
+.tn-hd-export { margin-left: auto; font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border); border-radius: 6px; background: transparent; color: var(--tn-accent); cursor: pointer; }
+.tn-hd-export:disabled { opacity: .4; cursor: default; }
+```
+
+- [ ] **Step 4: Final gate + milestone screenshot**
+
+Run: `npx tsc --noEmit && npm test` → green. Integrator screenshots the full Headlines detail to `persona-shots/focus-headlines-final.png`.
+
+```bash
+git add lib/console/widgets/headlines.detail.tsx app/globals.css
+git commit -m "feat(headlines): focus detail — sources footer + CSV export"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§7.2 Headlines):** control bar (source chips + search) → Task 5; grouped feed with snippet → Tasks 1+5; on-demand AI full-article summary → Tasks 2+3+4+7; volume strip → Task 6; sources footer + export → Task 8. RSS `<description>` capture → Task 1. **Deferred with intent:** the cross-source *"also covered by"* cluster (spec §7.2 panel 3) needs `mergeNews` to stop discarding title-duplicates and return the related items — a change to a shared function used by `NewsTicker`/`BreakingBanner`; it's a follow-up to avoid regressing them this pass. Optional RSS thumbnail/category capture also deferred (not needed for the core value).
+
+**Placeholder scan:** none — every step has real code/commands.
+
+**Type consistency:** `NewsItem.description?` (Task 1) used by Tasks 5/7/8; `SummaryPayload {summary,dormant,source}` shared by Tasks 3/4/7; `isNewsArticleUrl`/`extractArticleText` (Task 2) consumed by Task 4; `buildSummaryPrompt`/`parseSummaryResponse` (Task 3) consumed by Task 4; `ChartPoint`/`timeBins` reused from the W1 foundation. CSS uses only real `tn-*` tokens.
+
+**Honesty:** AI summary labelled; dormant + blocked paths both fall back to the snippet with an explicit note; SSRF-guarded to the publisher allowlist; keyless snippet always available.

--- a/docs/superpowers/plans/2026-07-08-focus-window-w3-signals.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-w3-signals.md
@@ -1,0 +1,502 @@
+# W3 — Signals detail template Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** One schema-agnostic focus detail view that covers all ~30 signal layers, parameterised by the `SignalSource` descriptor.
+
+**Architecture:** A `makeSignalDetail(source)` factory returns a `WidgetDetailProps` component (mirrors `makeSignalBody(source)` in `signals.tsx`). It reuses the SAME data pipeline as the docked widget (`useSignalFeed` → `projectSignal`) plus the shared primitives (`InsetMap`, `Chart`, `buckets`, `lib/export`, `lib/series`). Pure detail logic (distribution/sort/time) lives in a testable `lib/console/signals/signalDetail.ts`. The template is registered as `detail:` on every `signal:<id>` widget in the existing registration loop.
+
+**Tech Stack:** Next 15 / React 19 / TS; MapLibre (InsetMap); native SVG (Chart); vitest.
+
+## Global Constraints
+
+- Keyless-first, dormant-safe; feeds already resolve to `[]` (never 5xx). Honest empty states — never invent data.
+- Native zero-dep `<Chart>`; one shared `<InsetMap>`; theme tokens only (`--tn-surface`/`--tn-surface-solid`/`--tn-surface-2`/`--tn-text`/`--tn-text-muted`/`--tn-text-faint`/`--tn-border`/`--tn-accent`). NO `--tn-surface-1`/`--tn-text-1` (they don't exist).
+- Build gate (every task): `npx tsc --noEmit && npm test` → green.
+- Commits: solo attribution `011-sam-110 <lesttech.dev.sam@gmail.com>`, **no Co-Authored-By / Claude trailer**, plain `git commit -m "..."` (never a `@'...'` heredoc).
+- Owned files only; never `git add -A`, `git checkout`, `git reset`, `git stash`; do not touch `.superpowers/sdd/progress.md`.
+
+## Reference pattern
+
+`lib/console/widgets/events.detail.tsx` is the canonical W1 template — mirror its structure (header/counts, panel grid with Chart + InsetMap, grouped feed, footer with source attribution + export). W3 differs only in being a `make…(source)` factory and adding the sparkline/distribution/table/drill-down/show-on-map panels from spec §7.3.
+
+## Data shapes (already exist — consume, don't redefine)
+
+- `SignalFeature { id; lat; lon; title; signalId; geometry?; color?; props?; link?; ts? }` — `@/lib/signals/types`
+- `SignalSource { id; label; group; color; refreshMs; attribution; fetch() }` — same file
+- `useSignalFeed(id, refreshMs): { features, status, updatedAt }` — `@/lib/console/signals/useSignalFeed`
+- `projectSignal(features, scope, { alertMin?, limit? }): { rows, total, shown, alerts }` — `@/lib/console/signals/signalCard` (SignalRow `{ id, title, magnitude?, ts?, link? }`)
+- `useScope(): Scope` (has `.label`, used by `withinScope`) — `@/lib/shell/scope`; `withinScope(lat, lon, scope)` from same
+- `recordSeries(key, value, t)`, `seriesSamples(key): CountSample[]`, `deltaOf(buf)` — `@/lib/series` + `@/lib/widgets/history` (`CountSample { t, n }`)
+- `Chart({ points: ChartPoint[]; height?; up? })` (`ChartPoint { x, y }`) — `@/components/Chart`
+- `InsetMap({ points: InsetPoint[]; height?; onSelect? })` (`InsetPoint { lat; lon; id?; color?; props? }`) — `@/components/InsetMap` (default), `@/lib/map/inset`
+- `countBy`, `histogram(values, edges)`, `timeBins(tsList, binMs, now, spanMs): {start,count}[]` — `@/lib/widgets/buckets`
+- `toCsv(rows)`, `toGeoJson(points: {lat,lon,properties}[])`, `downloadText(name, mime, text)`, `exportFilename(kind, at)` — `@/lib/export`
+- `signalsStore.set(id, on)` — `@/lib/signals/store` (enable the layer on the main map)
+- `shellLayoutStore.unfocus()` — `@/lib/console/store` (return to the map stage)
+- `openSignalFeature(f, sourceLabel, zoom?)` — `@/lib/widgets/openSignal` (fly + open dossier)
+
+---
+
+## File Structure
+
+- Create `lib/text/humanise.ts` — pure `humaniseKey(camelOrSnake): Title Case` (extracted from `components/SignalDetail.tsx`, DRY).
+- Modify `components/SignalDetail.tsx` — import `humaniseKey` instead of its private `humanise`.
+- Create `lib/console/signals/signalDetail.ts` — pure detail projection (distribution / sort / time / declared-severity).
+- Create `lib/console/widgets/signals.detail.tsx` — `makeSignalDetail(source)` template.
+- Modify `lib/console/widgets/signals.tsx` — attach `detail: makeSignalDetail(source)` in the registration loop.
+- Modify `app/globals.css` — append the `.tn-sd*` block.
+- Create tests `tests/unit/humanise.test.ts`, `tests/unit/signal-detail.test.ts`.
+
+---
+
+### Task 1: Pure detail projection + shared humanise
+
+**Files:**
+- Create: `lib/text/humanise.ts`, `lib/console/signals/signalDetail.ts`
+- Modify: `components/SignalDetail.tsx` (swap private `humanise` → shared `humaniseKey`)
+- Test: `tests/unit/humanise.test.ts`, `tests/unit/signal-detail.test.ts`
+
+**Produces (later tasks rely on these exact names):**
+- `humaniseKey(key: string): string`
+- `declaredSeverity(props?: Record<string, unknown>): "critical" | "warn" | null`
+- `magnitudeValues(features: SignalFeature[]): number[]`
+- `distribution(features: SignalFeature[]): { kind: "magnitude" | "severity" | "none"; bins: { label: string; count: number }[] }`
+- `timeModel(features: SignalFeature[]): { values: number[]; undated: number }`
+- `SortKey = "magnitude" | "recency" | "title"`; `sortFeatures(features, key: SortKey, dir: 1 | -1): SignalFeature[]`
+
+- [ ] **Step 1: `lib/text/humanise.ts`**
+
+```ts
+// Humanise a camelCase / snake_case / kebab key into a Title-ish label for a
+// definition-list term, e.g. "forecastFor" → "Forecast for", "alert_level" → "Alert level".
+export function humaniseKey(key: string): string {
+  const spaced = key.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+```
+
+- [ ] **Step 2: Refactor `components/SignalDetail.tsx`** — delete its local `function humanise(...)`, add `import { humaniseKey } from "@/lib/text/humanise";`, and replace the single `humanise(k)` call site with `humaniseKey(k)`.
+
+- [ ] **Step 3: `lib/console/signals/signalDetail.ts`**
+
+```ts
+// Pure projection helpers for the Signals FOCUS detail view. The distribution
+// logic is deliberately honest: it shows a magnitude histogram only when the
+// source actually carries numeric magnitudes, falls back to declared severity
+// counts, and reports "none" when neither exists (the caller then hides the panel).
+import type { SignalFeature } from "@/lib/signals/types";
+
+/** Declared severity read from common alert-level props — only unambiguous words. */
+export function declaredSeverity(props?: Record<string, unknown>): "critical" | "warn" | null {
+  if (!props) return null;
+  for (const key of ["alertlevel", "alertLevel", "severity", "level", "status"]) {
+    const v = props[key];
+    if (typeof v !== "string") continue;
+    const s = v.toLowerCase();
+    if (/red|extreme|severe|critical|emergency/.test(s)) return "critical";
+    if (/orange|warning|high|moderate/.test(s)) return "warn";
+  }
+  return null;
+}
+
+/** Finite numeric props.magnitude values. */
+export function magnitudeValues(features: SignalFeature[]): number[] {
+  const out: number[] = [];
+  for (const f of features) {
+    const m = f.props?.magnitude;
+    if (typeof m === "number" && Number.isFinite(m)) out.push(m);
+  }
+  return out;
+}
+
+export interface Distribution {
+  kind: "magnitude" | "severity" | "none";
+  bins: { label: string; count: number }[];
+}
+
+/** Honest distribution: magnitude histogram → severity counts → none. */
+export function distribution(features: SignalFeature[]): Distribution {
+  const mags = magnitudeValues(features);
+  if (mags.length > 0) {
+    const lo = Math.floor(Math.min(...mags));
+    const hi = Math.ceil(Math.max(...mags));
+    const span = Math.max(1, hi - lo);
+    const step = Math.max(1, Math.ceil(span / 8)); // integer buckets, ≤8
+    const bins: { label: string; count: number }[] = [];
+    for (let edge = lo; edge < lo + step * Math.ceil(span / step); edge += step) {
+      const top = edge + step;
+      const count = mags.filter((m) => m >= edge && (top >= hi ? m <= top : m < top)).length;
+      bins.push({ label: step === 1 ? `${edge}` : `${edge}–${top}`, count });
+    }
+    return { kind: "magnitude", bins };
+  }
+  let critical = 0, warn = 0, other = 0;
+  for (const f of features) {
+    const s = declaredSeverity(f.props);
+    if (s === "critical") critical++;
+    else if (s === "warn") warn++;
+    else other++;
+  }
+  if (critical > 0 || warn > 0) {
+    return { kind: "severity", bins: [
+      { label: "Severe", count: critical },
+      { label: "Warning", count: warn },
+      { label: "Other", count: other },
+    ] };
+  }
+  return { kind: "none", bins: [] };
+}
+
+/** Parseable ISO timestamps → ms, plus the count of undated features. */
+export function timeModel(features: SignalFeature[]): { values: number[]; undated: number } {
+  const values: number[] = [];
+  let undated = 0;
+  for (const f of features) {
+    const t = f.ts ? Date.parse(f.ts) : NaN;
+    if (Number.isFinite(t)) values.push(t);
+    else undated++;
+  }
+  return { values, undated };
+}
+
+export type SortKey = "magnitude" | "recency" | "title";
+
+/** Stable-ish sort by magnitude / recency / title. Missing values sort last. */
+export function sortFeatures(features: SignalFeature[], key: SortKey, dir: 1 | -1): SignalFeature[] {
+  const mag = (f: SignalFeature) =>
+    typeof f.props?.magnitude === "number" && Number.isFinite(f.props.magnitude) ? (f.props.magnitude as number) : -Infinity;
+  const rec = (f: SignalFeature) => (f.ts ? Date.parse(f.ts) : NaN);
+  const cmp = (a: SignalFeature, b: SignalFeature): number => {
+    if (key === "title") return a.title.localeCompare(b.title);
+    if (key === "magnitude") return mag(a) - mag(b);
+    const ra = rec(a), rb = rec(b);
+    return (Number.isFinite(ra) ? ra : -Infinity) - (Number.isFinite(rb) ? rb : -Infinity);
+  };
+  return [...features].sort((a, b) => dir * cmp(a, b));
+}
+```
+
+- [ ] **Step 4: Tests** — `tests/unit/humanise.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { humaniseKey } from "@/lib/text/humanise";
+
+describe("humaniseKey", () => {
+  it("camelCase → Title", () => expect(humaniseKey("forecastFor")).toBe("Forecast for"));
+  it("snake/kebab → Title", () => {
+    expect(humaniseKey("alert_level")).toBe("Alert level");
+    expect(humaniseKey("wind-speed")).toBe("Wind speed");
+  });
+});
+```
+
+`tests/unit/signal-detail.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { distribution, timeModel, sortFeatures } from "@/lib/console/signals/signalDetail";
+import type { SignalFeature } from "@/lib/signals/types";
+
+const f = (over: Partial<SignalFeature>): SignalFeature =>
+  ({ id: "x", lat: 0, lon: 0, title: "t", signalId: "s", ...over });
+
+describe("distribution", () => {
+  it("uses a magnitude histogram when numeric magnitudes exist", () => {
+    const d = distribution([f({ props: { magnitude: 2 } }), f({ props: { magnitude: 6 } })]);
+    expect(d.kind).toBe("magnitude");
+    expect(d.bins.reduce((n, b) => n + b.count, 0)).toBe(2);
+  });
+  it("falls back to declared severity when no magnitudes", () => {
+    const d = distribution([f({ props: { alertLevel: "Red" } }), f({ props: { severity: "warning" } })]);
+    expect(d.kind).toBe("severity");
+    expect(d.bins.find((b) => b.label === "Severe")!.count).toBe(1);
+  });
+  it("is 'none' when neither magnitude nor severity exists (honest hide)", () => {
+    expect(distribution([f({ props: { note: "hi" } })]).kind).toBe("none");
+  });
+});
+
+describe("timeModel", () => {
+  it("splits dated from undated", () => {
+    const m = timeModel([f({ ts: "2026-07-08T00:00:00Z" }), f({})]);
+    expect(m.values.length).toBe(1);
+    expect(m.undated).toBe(1);
+  });
+});
+
+describe("sortFeatures", () => {
+  it("sorts by magnitude descending with dir -1", () => {
+    const out = sortFeatures([f({ id: "a", props: { magnitude: 1 } }), f({ id: "b", props: { magnitude: 9 } })], "magnitude", -1);
+    expect(out[0].id).toBe("b");
+  });
+});
+```
+
+- [ ] **Step 5: Gate + commit** — `npx tsc --noEmit && npm test` green.
+`git add lib/text/humanise.ts lib/console/signals/signalDetail.ts components/SignalDetail.tsx tests/unit/humanise.test.ts tests/unit/signal-detail.test.ts`
+`git commit -m "feat(signals): pure detail projection (distribution/time/sort) + shared humaniseKey"`
+
+---
+
+### Task 2: Detail template skeleton — masthead, counts, freshness, count-history sparkline + register
+
+**Files:**
+- Create: `lib/console/widgets/signals.detail.tsx`
+- Modify: `lib/console/widgets/signals.tsx` (attach `detail`), `app/globals.css` (append `.tn-sd*`)
+
+**Consumes:** Task 1 exports; `useSignalFeed`, `projectSignal`, `useScope`, `recordSeries`/`seriesSamples`/`deltaOf`, `Chart`.
+
+- [ ] **Step 1: `lib/console/widgets/signals.detail.tsx`** — the factory + skeleton. Follow the `events.detail.tsx` idiom (`"use client"`, `useMemo`, honest empty states).
+
+```tsx
+"use client";
+// Signals focus view — ONE parameterised template covering every registered signal
+// layer. makeSignalDetail(source) mirrors makeSignalBody(source): it reuses the SAME
+// live pipeline (useSignalFeed → projectSignal) but renders deep — masthead + count
+// sparkline, source map, honest magnitude/severity + time distributions, a sortable
+// feature table with per-row props drill-down, attribution, and export/show-on-map.
+import { useEffect, useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import type { SignalSource, SignalFeature } from "@/lib/signals/types";
+import { useSignalFeed } from "@/lib/console/signals/useSignalFeed";
+import { useScope, withinScope } from "@/lib/shell/scope";
+import { recordSeries, seriesSamples } from "@/lib/series";
+import { deltaOf } from "@/lib/widgets/history";
+import { Chart, type ChartPoint } from "@/components/Chart";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
+import { timeBins } from "@/lib/widgets/buckets";
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
+import { signalsStore } from "@/lib/signals/store";
+import { shellLayoutStore } from "@/lib/console/store";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+import { humaniseKey } from "@/lib/text/humanise";
+import { distribution, timeModel, sortFeatures, type SortKey } from "@/lib/console/signals/signalDetail";
+
+// Sources whose upstream needs a key that may be unset — surface an honest dormant note.
+const KEYED = new Set(["acled", "firms", "aisstream", "openaq", "reliefweb", "entsoe"]);
+
+export function makeSignalDetail(source: SignalSource) {
+  function SignalDetailView(_props: WidgetDetailProps) {
+    const scope = useScope();
+    const { features, status, updatedAt } = useSignalFeed(source.id, source.refreshMs);
+    const [sortKey, setSortKey] = useState<SortKey>("magnitude");
+    const [dir, setDir] = useState<1 | -1>(-1);
+    const [open, setOpen] = useState<string | null>(null);
+
+    const scoped = useMemo(() => features.filter((f) => withinScope(f.lat, f.lon, scope)), [features, scope]);
+
+    // Wire count-history recording (spec: no signal records into the series yet).
+    useEffect(() => {
+      if (updatedAt) recordSeries(`sig:${source.id}`, scoped.length, updatedAt);
+    }, [updatedAt, scoped.length]);
+
+    const spark: ChartPoint[] = useMemo(
+      () => seriesSamples(`sig:${source.id}`).map((s) => ({ x: s.t, y: s.n })),
+      [updatedAt, scoped.length],
+    );
+    const delta = useMemo(() => deltaOf(seriesSamples(`sig:${source.id}`)), [updatedAt, scoped.length]);
+
+    const rows = useMemo(() => sortFeatures(scoped, sortKey, dir), [scoped, sortKey, dir]);
+    const dist = useMemo(() => distribution(scoped), [scoped]);
+    const tm = useMemo(() => timeModel(scoped), [scoped]);
+    const now = Date.now();
+
+    const distPoints: ChartPoint[] = dist.bins.map((b, i) => ({ x: i, y: b.count }));
+    const timePoints: ChartPoint[] = timeBins(tm.values, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
+    const mapPoints: InsetPoint[] = scoped.map((f) => ({ lat: f.lat, lon: f.lon, id: f.id, color: f.color ?? source.color, props: { title: f.title } }));
+    const freshAge = updatedAt ? `${Math.max(0, Math.round((now - updatedAt) / 60000))}m ago` : "—";
+
+    const exportRows = rows.map((f) => ({ id: f.id, title: f.title, magnitude: f.props?.magnitude ?? "", lat: f.lat, lon: f.lon, ts: f.ts ?? "", link: f.link ?? "" }));
+    const exportGeo = rows.map((f) => ({ lat: f.lat, lon: f.lon, properties: { id: f.id, title: f.title, ...(f.props ?? {}) } }));
+
+    const showOnMap = () => { signalsStore.set(source.id, true); shellLayoutStore.unfocus(); };
+
+    return (
+      <div className="tn-sd">
+        <header className="tn-sd-head">
+          <div className="tn-sd-title">{source.label}</div>
+          <div className="tn-sd-stat"><b>{scoped.length}</b> of {features.length} in {scope.label} · updated {freshAge}
+            {delta !== 0 && <span className={`tn-sd-delta ${delta > 0 ? "up" : "down"}`}> {delta > 0 ? "▲" : "▼"}{Math.abs(delta)}</span>}
+          </div>
+          {spark.length >= 2 && <div className="tn-sd-spark"><Chart points={spark} height={40} up={null} /></div>}
+        </header>
+
+        {status === "loading" && scoped.length === 0 && <p className="tn-w-empty">Loading {source.label}…</p>}
+        {status !== "loading" && scoped.length === 0 && <p className="tn-w-empty">Nothing in {scope.label}.</p>}
+
+        {/* Panels (Task 3), table (Task 4), footer (Task 5) inserted below. */}
+
+        <footer className="tn-sd-foot">
+          <span className="tn-sd-attr">{source.attribution}{KEYED.has(source.id) && " · needs an API key (dormant when unset)"}</span>
+          <span className="tn-sd-actions">
+            <button onClick={showOnMap}>🗺 Show on map</button>
+            <button disabled={!exportRows.length} onClick={() => downloadText(`${exportFilename(`signal-${source.id}`, Date.now())}.csv`, "text/csv", toCsv(exportRows))}>⬇ CSV</button>
+            <button disabled={!exportGeo.length} onClick={() => downloadText(`${exportFilename(`signal-${source.id}`, Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}>⬇ GeoJSON</button>
+          </span>
+        </footer>
+      </div>
+    );
+  }
+  return SignalDetailView;
+}
+```
+
+> The `_props`, `open`/`setOpen`, `distPoints`/`timePoints`/`mapPoints`, `openSignalFeature`, `humaniseKey`, `rows`, `setSortKey`/`setDir` bindings are consumed by Tasks 3–4. To keep this task's gate green with no unused-var errors, Task 2 MAY render a minimal panels/table stub now, OR Tasks 3–4 add the JSX in the same edit pass. Simplest: Task 2 wires everything shown and Tasks 3/4 only add JSX that references the already-declared bindings. If tsc flags an unused binding at Task 2, render it (e.g. a `hidden` table) rather than deleting it.
+
+- [ ] **Step 2: Register** — in `lib/console/widgets/signals.tsx`, add `import { makeSignalDetail } from "./signals.detail";` and inside the `for (const source of SIGNALS)` loop add `detail: makeSignalDetail(source),` to the `registerWidget({...})` call.
+
+- [ ] **Step 3: CSS** — append to `app/globals.css`:
+
+```css
+/* ── Signals focus detail (W3) ─────────────────────────────────────── */
+.tn-sd { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
+.tn-sd-head { display: flex; flex-direction: column; gap: 4px; }
+.tn-sd-title { font-size: 18px; font-weight: 700; }
+.tn-sd-stat { font-size: 12px; color: var(--tn-text-muted); }
+.tn-sd-delta.up { color: #16a34a; } .tn-sd-delta.down { color: #dc2626; }
+.tn-sd-spark { max-width: 320px; }
+.tn-sd-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+@media (max-width: 720px) { .tn-sd-panels { grid-template-columns: 1fr; } }
+.tn-sd-panel h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 0 0 6px; }
+.tn-sd-bars { display: flex; align-items: flex-end; gap: 4px; height: 120px; }
+.tn-sd-bar { flex: 1; background: var(--tn-accent); border-radius: 2px 2px 0 0; min-height: 2px; opacity: .85; }
+.tn-sd-bar-label { font-size: 10px; color: var(--tn-text-faint); text-align: center; }
+.tn-sd-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tn-sd-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; cursor: pointer; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-sd-table td { padding: 5px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-sd-row { cursor: pointer; }
+.tn-sd-row:hover { background: var(--tn-surface-2); }
+.tn-sd-drill { background: var(--tn-surface-2); }
+.tn-sd-drill dl { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 6px 0; }
+.tn-sd-drill dt { color: var(--tn-accent); text-transform: uppercase; font-size: 10px; letter-spacing: .06em; font-weight: 600; }
+.tn-sd-drill dd { margin: 0; }
+.tn-sd-foot { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; border-top: 1px solid var(--tn-border); padding-top: 8px; margin-top: auto; }
+.tn-sd-attr { font-size: 11px; color: var(--tn-text-faint); }
+.tn-sd-actions { display: flex; gap: 8px; }
+.tn-sd-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
+.tn-sd-actions button:disabled { opacity: .4; cursor: default; }
+```
+
+- [ ] **Step 4: Gate + commit** — green.
+`git add lib/console/widgets/signals.detail.tsx lib/console/widgets/signals.tsx app/globals.css`
+`git commit -m "feat(signals): focus detail skeleton — masthead, counts, freshness + count-history sparkline"`
+
+---
+
+### Task 3: Distribution + time + source-map panels
+
+**Files:** Modify `lib/console/widgets/signals.detail.tsx` (add the `.tn-sd-panels` block, after the empty-state lines, before the footer).
+
+- [ ] **Step 1:** Insert the panels JSX (references bindings already declared in Task 2):
+
+```tsx
+{scoped.length > 0 && (
+  <div className="tn-sd-panels">
+    <div className="tn-sd-panel">
+      <h3>Locations</h3>
+      {mapPoints.length > 0 ? <InsetMap points={mapPoints} height={200} onSelect={(id) => setOpen(id)} />
+        : <p className="tn-w-empty">No mappable features.</p>}
+    </div>
+    <div className="tn-sd-panel">
+      <h3>{dist.kind === "magnitude" ? "Magnitude distribution" : dist.kind === "severity" ? "Severity" : "Distribution"}</h3>
+      {dist.kind !== "none" ? (
+        <>
+          <div className="tn-sd-bars">
+            {dist.bins.map((b, i) => {
+              const max = Math.max(1, ...dist.bins.map((x) => x.count));
+              return <div key={i} className="tn-sd-bar" style={{ height: `${(b.count / max) * 100}%` }} title={`${b.label}: ${b.count}`} />;
+            })}
+          </div>
+          <div style={{ display: "flex", gap: 4 }}>{dist.bins.map((b, i) => <span key={i} className="tn-sd-bar-label" style={{ flex: 1 }}>{b.label}</span>)}</div>
+        </>
+      ) : <p className="tn-w-empty">This source declares no magnitude or severity.</p>}
+    </div>
+    <div className="tn-sd-panel">
+      <h3>Over the last 24h {tm.undated > 0 && <span className="tn-sd-bar-label">· {tm.undated} undated</span>}</h3>
+      {timePoints.some((p) => p.y > 0) ? <Chart points={timePoints} height={120} up={null} />
+        : <p className="tn-w-empty">No timestamped features in the window.</p>}
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 2: Gate + commit** — green.
+`git add lib/console/widgets/signals.detail.tsx`
+`git commit -m "feat(signals): focus detail — source map + honest magnitude/severity + 24h time panels"`
+
+---
+
+### Task 4: Sortable feature table + per-row props drill-down
+
+**Files:** Modify `lib/console/widgets/signals.detail.tsx` (add the table between the panels and the footer).
+
+- [ ] **Step 1:** Insert the table JSX (uses `rows`, `sortKey`/`setSortKey`, `dir`/`setDir`, `open`/`setOpen`, `humaniseKey`, `openSignalFeature`):
+
+```tsx
+{scoped.length > 0 && (
+  <table className="tn-sd-table">
+    <thead>
+      <tr>
+        {(["magnitude", "title", "recency"] as SortKey[]).map((k) => (
+          <th key={k} onClick={() => { if (sortKey === k) setDir((d) => (d === 1 ? -1 : 1)); else { setSortKey(k); setDir(-1); } }}>
+            {k === "recency" ? "When" : humaniseKey(k)}{sortKey === k ? (dir === -1 ? " ↓" : " ↑") : ""}
+          </th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {rows.map((f) => {
+        const entries = Object.entries(f.props ?? {}).filter(([, v]) => v != null && v !== "");
+        const isOpen = open === f.id;
+        return (
+          <>
+            <tr key={f.id} className="tn-sd-row" onClick={() => setOpen(isOpen ? null : f.id)}>
+              <td>{typeof f.props?.magnitude === "number" ? (f.props.magnitude as number) : "—"}</td>
+              <td>{f.title}</td>
+              <td>{f.ts ? new Date(f.ts).toISOString().slice(0, 16).replace("T", " ") : "—"}</td>
+            </tr>
+            {isOpen && (
+              <tr key={`${f.id}-d`} className="tn-sd-drill">
+                <td colSpan={3}>
+                  {entries.length > 0 ? (
+                    <dl>{entries.map(([k, v]) => (<div key={k} style={{ display: "contents" }}><dt>{humaniseKey(k)}</dt><dd>{String(v)}</dd></div>))}</dl>
+                  ) : <span className="tn-w-empty">No extra properties.</span>}
+                  <div style={{ display: "flex", gap: 10, marginTop: 4 }}>
+                    <button className="tn-sd-actions" onClick={(e) => { e.stopPropagation(); openSignalFeature(f, source.label); shellLayoutStore.unfocus(); }} style={{ background: "none", border: 0, color: "var(--tn-accent)", cursor: "pointer", padding: 0 }}>Show on globe ↗</button>
+                    {f.link && <a href={f.link} target="_blank" rel="noreferrer" style={{ color: "var(--tn-accent)" }}>Source ↗</a>}
+                  </div>
+                </td>
+              </tr>
+            )}
+          </>
+        );
+      })}
+    </tbody>
+  </table>
+)}
+```
+
+> Note: `<>{...}</>` fragment keys — React warns on keyed fragments with the shorthand; use `<Fragment key={f.id}>` (import `Fragment` from "react") wrapping the two `<tr>`s instead of putting `key` on each `<tr>`. Adjust the import line to `import { Fragment, useEffect, useMemo, useState } from "react";`.
+
+- [ ] **Step 2: Gate + commit** — green.
+`git add lib/console/widgets/signals.detail.tsx`
+`git commit -m "feat(signals): focus detail — sortable feature table + per-row props drill-down"`
+
+---
+
+### Task 5: Verification pass
+
+**Files:** none (review-only) unless a defect is found.
+
+- [ ] **Step 1:** Confirm the footer (attribution + dormant-key note + Show-on-map + CSV/GeoJSON) from Task 2 renders and the export buttons disable on empty. (Already coded in Task 2 — this task verifies it end to end after 3+4 land.)
+- [ ] **Step 2:** Full gate `npx tsc --noEmit && npm test` green; `git status` clean apart from `.superpowers/sdd/progress.md`.
+- [ ] **Step 3:** If the integrator has a browser: expand a live signal widget (e.g. `signal:usgs-quakes`) and confirm masthead counts, distribution (magnitude for quakes), 24h chart, map, table drill-down, export. Otherwise note that live visual verification is pending.
+
+## Self-Review
+
+- **Spec §7.3 coverage:** (1) masthead + sparkline + delta + freshness + "shown of total" → Task 2 ✓; (2) source InsetMap → Task 3 ✓; (3) magnitude/severity distribution, honest hide → Task 1 `distribution` + Task 3 ✓; (4) time distribution + undated note → Task 1 `timeModel` + Task 3 ✓; (5) sortable table + props drill-down (humanise def-list) → Task 4 ✓; (6) source/attribution + dormant-key note → Task 2 footer ✓; (7) CSV/GeoJSON + show-on-map → Task 2 footer ✓. "Wire count-history recording" → Task 2 `recordSeries` effect ✓.
+- **Type consistency:** `SortKey`, `distribution`, `timeModel`, `sortFeatures`, `humaniseKey`, `declaredSeverity` names match across Tasks 1→4. `Chart`/`InsetMap`/export/`signalsStore.set`/`shellLayoutStore.unfocus` signatures verified against source.
+- **Honesty:** distribution returns `none` (panel hidden) when a source has neither magnitude nor severity; undated features counted, not dropped; "N of M in scope"; dormant-key note for the 6 keyed sources.

--- a/docs/superpowers/plans/2026-07-08-focus-window-w4-aviation.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-w4-aviation.md
@@ -1,0 +1,300 @@
+# W4 — Aviation detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** An airspace-console focus detail for the Aviation widget — ops summary, region/altitude filters, a sortable uncapped flight table with a per-flight dossier, an altitude sparkline, and a region map — plus finally activating the already-written squawk-emergency alerts by capturing `squawk` in the ADS-B parser.
+
+**Architecture:** New default-export `AviationDetail(props: WidgetDetailProps)` registered as `detail:` on `AVIATION_WIDGET`. It reuses the SAME `usePlanes()` hook as the docked widget (`{ objects: WorldObject[], trails: PlaneTrail[] }`), pure aviation logic in a new testable `lib/planes/ops.ts`, and the shared `InsetMap`/`Chart`/`export`/`series` primitives. Squawk is threaded through `lib/sources/adsb.ts` so `meta.squawk` reaches both the table and the emergency `aviationAlerts` rule. The per-flight dossier reuses `components/PlaneDetail.tsx` unchanged.
+
+**Tech Stack:** Next 15 / React 19 / TS; MapLibre (InsetMap); native SVG (Chart); vitest.
+
+## Global Constraints
+
+- Keyless-first, dormant-safe (adsb.lol + adsbdb both resolve to null/empty, never 5xx). Honest empty states.
+- Native `<Chart>`; shared `<InsetMap>`; theme tokens only (`--tn-surface`/`--tn-surface-solid`/`--tn-surface-2`/`--tn-text`/`--tn-text-muted`/`--tn-text-faint`/`--tn-border`/`--tn-accent`). NO `--tn-surface-1`/`--tn-text-1`.
+- Build gate (every task): `npx tsc --noEmit && npm test` → green.
+- Commits: solo `011-sam-110 <lesttech.dev.sam@gmail.com>`, **no Co-Authored-By / Claude trailer**, plain `git commit -m "..."` (never a `@'...'` heredoc).
+- Owned files only; never `git add -A`/`checkout`/`reset`/`stash`; do not touch `.superpowers/sdd/progress.md`.
+
+## Reference pattern
+
+`lib/console/widgets/signals.detail.tsx` (W3) and `lib/console/widgets/events.detail.tsx` (W1) are the canonical templates — mirror their idioms: `"use client"`, `useMemo`, honest empty states, `.tn-<x>-panels` grid with `<Chart>` + `<InsetMap>`, a table, a footer with attribution + CSV/GeoJSON export, and a masthead with counts/freshness + a count sparkline via `recordSeries`/`seriesSamples`/`deltaOf`.
+
+## Data shapes (already exist — consume, don't redefine)
+
+- `usePlanes(): { objects: WorldObject[]; trails: PlaneTrail[] }` — `@/lib/planes/usePlanes`. `PlaneTrail = { id: string; color: string; points: [number, number, number][] }` (lat, lon, altKm per breadcrumb).
+- `WorldObject` — `@/lib/world`: `{ kind; id; lat; lon; altKm?; heading?; label; color?; icon?; typeLabel?; meta?: Record<string, unknown> }`. For planes `meta` carries: `callsign, registration, typeCode, adsbCategory, velocityMs, altKm, verticalRateMs, onGround, headingDeg, category (PlaneCategory), typeLabel, categorySource` — and (after Task 1) `squawk`.
+- `PlaneCategory = "airliner"|"regional"|"light"|"helicopter"|"ground"` — `@/lib/planes/classify`.
+- `ADSB_REGIONS: {lat,lon,distNm}[]` (3 regions, index 0 London / 1 California / 2 S.Carolina) — `@/lib/sources/adsb`.
+- `PlaneDetail` — `@/components/PlaneDetail` (default): `PlaneDetail({ object: WorldObject })`, self-fetches `/api/flight`, body-only.
+- `aviationAlerts` + `PlaneLite { callsign; squawk?; isMilitary? }` + `runAlertRule` — already imported in `aviation.tsx`.
+- Primitives: `Chart({points:ChartPoint[],height?,up?})` / `ChartPoint{x,y}` (`@/components/Chart`); `InsetMap({points:InsetPoint[],height?,onSelect?})` default / `InsetPoint{lat,lon,id?,color?,props?}` (`@/components/InsetMap`, `@/lib/map/inset`); `recordSeries`/`seriesSamples` (`@/lib/series`) + `deltaOf` (`@/lib/widgets/history`); `toCsv`/`toGeoJson`/`downloadText`/`exportFilename` (`@/lib/export`); `shellLayoutStore.unfocus` (`@/lib/console/store`); `humaniseKey` (`@/lib/text/humanise`).
+
+## File Structure
+
+- Modify `lib/sources/adsb.ts` — capture `squawk` (RawAircraft, Aircraft, parseAdsb, aircraftToWorldObject.meta).
+- Modify `tests/unit/adsb.test.ts` — squawk parse case.
+- Create `lib/planes/ops.ts` — pure `opsSummary` / `altitudeBand` / `regionOf` / `sortFlights` (+ `REGION_LABELS`).
+- Create `tests/unit/planes-ops.test.ts`.
+- Create `lib/console/widgets/aviation.detail.tsx` — `AviationDetail`.
+- Modify `lib/console/widgets/aviation.tsx` — attach `detail: AviationDetail`; thread `squawk` into `PlaneLite`.
+- Modify `app/globals.css` — append `.tn-av*` block.
+
+---
+
+### Task 1: Capture squawk in the ADS-B parser (activates emergency alerts)
+
+**Files:** Modify `lib/sources/adsb.ts`, `lib/console/widgets/aviation.tsx`; Test `tests/unit/adsb.test.ts`.
+
+**Produces:** `Aircraft.squawk: string`; `WorldObject.meta.squawk`; `PlaneLite.squawk` populated.
+
+- [ ] **Step 1 (failing test):** In `tests/unit/adsb.test.ts` add:
+
+```ts
+it("captures squawk (activates emergency-squawk alerts)", () => {
+  const [a] = parseAdsb([{ hex: "abc", flight: "TEST123", lat: 51, lon: 0, alt_baro: 30000, squawk: "7700" }]);
+  expect(a.squawk).toBe("7700");
+});
+```
+
+Run `npx vitest run tests/unit/adsb.test.ts` → FAIL (`squawk` missing on `Aircraft`).
+
+- [ ] **Step 2:** In `lib/sources/adsb.ts`:
+  - Add to `interface RawAircraft` (after `category?: string;`): `squawk?: string;`
+  - Add to `interface Aircraft` (after `registration: string;`): `squawk: string;`
+  - In `parseAdsb`, in the pushed object (after `registration: (a.r ?? "").trim(),`): `squawk: (a.squawk ?? "").trim(),`
+  - In `aircraftToWorldObject` `meta` (after `categorySource: …,`): `squawk: a.squawk,`
+
+- [ ] **Step 3:** In `lib/console/widgets/aviation.tsx`, change the `lite` map to thread squawk and update the notes:
+
+```tsx
+const lite: PlaneLite[] = useMemo(
+  () => planes.map((p) => ({ callsign: p.label, squawk: (p.meta?.squawk as string) || undefined })),
+  [planes],
+);
+```
+
+Update the JSDoc note bullet about squawk to reflect that it is now captured (emergency alerts live when a plane squawks 7500/7600/7700).
+
+- [ ] **Step 4:** `npx vitest run tests/unit/adsb.test.ts` → PASS. Then gate `npx tsc --noEmit && npm test` → green.
+
+- [ ] **Step 5: Commit** — `git add lib/sources/adsb.ts lib/console/widgets/aviation.tsx tests/unit/adsb.test.ts`
+`git commit -m "feat(aviation): capture ADS-B squawk → activates emergency-squawk alerts"`
+
+---
+
+### Task 2: Pure aviation ops helpers
+
+**Files:** Create `lib/planes/ops.ts`; Test `tests/unit/planes-ops.test.ts`.
+
+**Produces:** `opsSummary`, `altitudeBand`, `regionOf`, `REGION_LABELS`, `sortFlights`, `FlightSortKey`.
+
+- [ ] **Step 1: `lib/planes/ops.ts`**
+
+```ts
+// Pure aviation helpers for the airspace-console focus view. All read the plane
+// WorldObject (its meta carries the classified category/onGround/velocity), so no
+// re-classification or fetch is needed. Unit-tested; the .tsx is a dumb shell.
+import type { WorldObject } from "@/lib/world";
+import type { PlaneCategory } from "@/lib/planes/classify";
+import { ADSB_REGIONS } from "@/lib/sources/adsb";
+
+const CATEGORY_LABEL: Record<PlaneCategory, string> = {
+  airliner: "Airliner", regional: "Regional", light: "Light", helicopter: "Helicopter", ground: "Ground",
+};
+const CATEGORY_ORDER: PlaneCategory[] = ["airliner", "regional", "light", "helicopter", "ground"];
+
+function meta(o: WorldObject): Record<string, unknown> { return (o.meta ?? {}) as Record<string, unknown>; }
+function categoryOf(o: WorldObject): PlaneCategory {
+  const c = meta(o).category;
+  return (typeof c === "string" && c in CATEGORY_LABEL ? c : "light") as PlaneCategory;
+}
+function velocityOf(o: WorldObject): number | null {
+  const v = meta(o).velocityMs;
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+export interface OpsSummary {
+  total: number; airborne: number; ground: number;
+  byCategory: { category: PlaneCategory; label: string; count: number }[];
+  maxAltKm: number; maxSpeedMs: number;
+}
+
+export function opsSummary(objects: WorldObject[]): OpsSummary {
+  let airborne = 0, ground = 0, maxAltKm = 0, maxSpeedMs = 0;
+  const counts: Partial<Record<PlaneCategory, number>> = {};
+  for (const o of objects) {
+    if (meta(o).onGround) ground++; else airborne++;
+    const c = categoryOf(o);
+    counts[c] = (counts[c] ?? 0) + 1;
+    if (typeof o.altKm === "number" && o.altKm > maxAltKm) maxAltKm = o.altKm;
+    const v = velocityOf(o);
+    if (v != null && v > maxSpeedMs) maxSpeedMs = v;
+  }
+  const byCategory = CATEGORY_ORDER.filter((c) => counts[c]).map((c) => ({ category: c, label: CATEGORY_LABEL[c], count: counts[c]! }));
+  return { total: objects.length, airborne, ground, byCategory, maxAltKm, maxSpeedMs };
+}
+
+export type AltBand = "ground" | "0–1 km" | "1–3 km" | "3–7 km" | "7–11 km" | "11+ km";
+export const ALT_BANDS: AltBand[] = ["11+ km", "7–11 km", "3–7 km", "1–3 km", "0–1 km", "ground"];
+export function altitudeBand(o: WorldObject): AltBand {
+  if (meta(o).onGround) return "ground";
+  const a = typeof o.altKm === "number" ? o.altKm : 0;
+  if (a < 1) return "0–1 km";
+  if (a < 3) return "1–3 km";
+  if (a < 7) return "3–7 km";
+  if (a < 11) return "7–11 km";
+  return "11+ km";
+}
+
+// Region labels are index-matched to ADSB_REGIONS.
+export const REGION_LABELS = ["London / SE England", "California", "South Carolina"];
+/** Nearest ADS-B query region (the regions are continents apart, so squared-degree distance is enough). */
+export function regionOf(lat: number, lon: number): string {
+  let best = -1, bestD = Infinity;
+  ADSB_REGIONS.forEach((r, i) => {
+    const d = (lat - r.lat) ** 2 + (lon - r.lon) ** 2;
+    if (d < bestD) { bestD = d; best = i; }
+  });
+  return best >= 0 ? (REGION_LABELS[best] ?? `Region ${best + 1}`) : "—";
+}
+
+export type FlightSortKey = "altitude" | "speed" | "callsign" | "region";
+export function sortFlights(objects: WorldObject[], key: FlightSortKey, dir: 1 | -1): WorldObject[] {
+  const cmp = (a: WorldObject, b: WorldObject): number => {
+    if (key === "callsign") return a.label.localeCompare(b.label);
+    if (key === "region") return regionOf(a.lat, a.lon).localeCompare(regionOf(b.lat, b.lon));
+    if (key === "speed") return (velocityOf(a) ?? -Infinity) - (velocityOf(b) ?? -Infinity);
+    return (a.altKm ?? -Infinity) - (b.altKm ?? -Infinity);
+  };
+  return [...objects].sort((a, b) => dir * cmp(a, b));
+}
+```
+
+- [ ] **Step 2: `tests/unit/planes-ops.test.ts`**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { opsSummary, altitudeBand, regionOf, sortFlights } from "@/lib/planes/ops";
+import type { WorldObject } from "@/lib/world";
+
+const plane = (over: Partial<WorldObject> & { meta?: Record<string, unknown> }): WorldObject =>
+  ({ kind: "plane", id: "plane:x", lat: 51, lon: 0, label: "T", ...over } as WorldObject);
+
+describe("opsSummary", () => {
+  it("splits airborne/ground, counts categories, tracks maxima", () => {
+    const s = opsSummary([
+      plane({ altKm: 10, meta: { category: "airliner", velocityMs: 250, onGround: false } }),
+      plane({ altKm: 0, meta: { category: "ground", onGround: true, velocityMs: 5 } }),
+    ]);
+    expect(s.total).toBe(2);
+    expect(s.airborne).toBe(1);
+    expect(s.ground).toBe(1);
+    expect(s.maxAltKm).toBe(10);
+    expect(s.maxSpeedMs).toBe(250);
+    expect(s.byCategory.find((c) => c.category === "airliner")!.count).toBe(1);
+  });
+});
+
+describe("altitudeBand", () => {
+  it("bands by altitude, ground first", () => {
+    expect(altitudeBand(plane({ altKm: 9, meta: { onGround: false } }))).toBe("7–11 km");
+    expect(altitudeBand(plane({ meta: { onGround: true } }))).toBe("ground");
+  });
+});
+
+describe("regionOf", () => {
+  it("maps coords to the nearest ADS-B region label", () => {
+    expect(regionOf(51.5, -0.1)).toBe("London / SE England");
+    expect(regionOf(37, -120)).toBe("California");
+  });
+});
+
+describe("sortFlights", () => {
+  it("sorts by altitude descending with dir -1", () => {
+    const out = sortFlights([plane({ id: "a", altKm: 1 }), plane({ id: "b", altKm: 9 })], "altitude", -1);
+    expect(out[0].id).toBe("b");
+  });
+});
+```
+
+- [ ] **Step 3: Gate + commit** — green.
+`git add lib/planes/ops.ts tests/unit/planes-ops.test.ts`
+`git commit -m "feat(aviation): pure ops helpers — summary, altitude bands, region, sort"`
+
+---
+
+### Task 3: Detail skeleton — masthead + ops-summary bar + register
+
+**Files:** Create `lib/console/widgets/aviation.detail.tsx`; Modify `lib/console/widgets/aviation.tsx` (attach `detail`), `app/globals.css` (append `.tn-av*`).
+
+Mirror `signals.detail.tsx`'s skeleton. `AviationDetail(_props: WidgetDetailProps)` calls `usePlanes()`, computes `opsSummary(objects)`, and renders:
+- Masthead: title "Airspace", `<b>{total}</b> live · {airborne} airborne · {ground} ground · max {maxAltKm.toFixed(1)} km · {(maxSpeedMs*1.94384).toFixed(0)} kt`. Count sparkline via `recordSeries("av:count", total, Date.now())` + `seriesSamples`/`deltaOf` — fold in the live sample the SAME way W3 does (`signals.detail.tsx`) to avoid the one-poll delta lag.
+- Ops bar: `summary.byCategory.map(...)` chips (`label · count`).
+- Emergency banner: if any `objects` has `meta.squawk` in {7500,7600,7700}, show a `.tn-av-emg` critical row (`⚠ {callsign} squawking {code} — {hijack|radio failure|emergency}`). Reuse the reason map inline or import from `aviation.rules.ts` if exported; otherwise inline `{7500:"hijack",7600:"radio failure",7700:"emergency"}`.
+- Honest empty state when `objects.length === 0` ("No aircraft in range right now.").
+- Footer (attribution + export) is added in Task 6; a placeholder footer with attribution may exist now.
+
+Declare state used later: `const [region, setRegion] = useState<string|null>(null)`, `const [band, setBand] = useState<AltBand|null>(null)`, `const [sortKey, setSortKey] = useState<FlightSortKey>("altitude")`, `const [dir, setDir] = useState<1|-1>(-1)`, `const [openId, setOpenId] = useState<string|null>(null)`. Repo tsconfig has NO `noUnusedLocals`, so declaring these now compiles clean; Tasks 4–5 consume them.
+
+CSS `.tn-av*`: reuse the `.tn-sd*` visual language (masthead, panels grid, chips, table, emergency row in a red-tinted band, footer/actions). Theme tokens only.
+
+- [ ] **Step 1:** Write the component skeleton + emergency banner + ops bar.
+- [ ] **Step 2:** Add `detail: AviationDetail` to `AVIATION_WIDGET` and `import AviationDetail from "./aviation.detail";`.
+- [ ] **Step 3:** Append `.tn-av*` CSS.
+- [ ] **Step 4: Gate + commit** — green.
+`git commit -m "feat(aviation): focus detail skeleton — ops summary + emergency-squawk banner"`
+
+---
+
+### Task 4: Region + altitude filter rail, region map, altitude sparkline
+
+**Files:** Modify `lib/console/widgets/aviation.detail.tsx`.
+
+- Filter rail: region chips (`REGION_LABELS` + "All") toggling `region`; altitude-band chips (`ALT_BANDS` + "All") toggling `band`. Apply both filters to derive `filtered = objects.filter(o => (!region || regionOf(o.lat,o.lon)===region) && (!band || altitudeBand(o)===band))`. All downstream panels/table use `filtered`.
+- Region `InsetMap`: `points = filtered.map(o => ({ lat:o.lat, lon:o.lon, id:o.id, color:o.color, props:{ callsign:o.label } }))`, `onSelect={setOpenId}`.
+- Altitude sparkline: derive a series from `layer.trails` for the selected/overall set — simplest honest version: chart the count-of-aircraft over the recorded `av:count` series (already have it) OR an altitude histogram of `filtered` via `ALT_BANDS` counts rendered as `.tn-av-bars` (like `.tn-sd-bars`). Prefer the altitude histogram (no time series needed): bars per `ALT_BANDS` with counts.
+
+- [ ] **Step 1:** Insert the filter rail + region map + altitude histogram panels (grid), all keyed off `filtered`.
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(aviation): focus detail — region/altitude filters + region map + altitude histogram"`
+
+---
+
+### Task 5: Sortable flight table + per-flight dossier
+
+**Files:** Modify `lib/console/widgets/aviation.detail.tsx`.
+
+- Uncapped sortable table over `sortFlights(filtered, sortKey, dir)`. Columns (click header to sort where a `FlightSortKey` exists): Callsign, Type (`typeLabel` + `meta.typeCode`), Alt (`{altKm.toFixed(1)} km / {(altKm/0.0003048).toFixed(0)} ft`), Speed (`{(velocityMs*1.94384).toFixed(0)} kt` / `{(velocityMs*3.6).toFixed(0)} km/h`), Heading (`{headingDeg}° {compass}`), V/S (`meta.verticalRateMs`), Reg (`meta.registration`), Region (`regionOf`), Squawk (`meta.squawk`, red when emergency). Provide a local `headingToCompass(deg)` helper (16-point or 8-point) — the private one in `PlaneDetail.tsx` is not exported, so declare a small local copy.
+- Row click toggles `openId`; when open, render a drill row `<td colSpan=…><PlaneDetail object={o} /></td>` (import `PlaneDetail` default). This gives route/airframe enrichment for free (dormant-safe).
+
+- [ ] **Step 1:** Insert the table + dossier drill row (keyed-fragment: `import { Fragment }`, `<Fragment key={o.id}>`).
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(aviation): focus detail — sortable flight table + per-flight dossier (PlaneDetail)"`
+
+---
+
+### Task 6: Footer — attribution + CSV/GeoJSON export
+
+**Files:** Modify `lib/console/widgets/aviation.detail.tsx`.
+
+- Footer: attribution `Aircraft: adsb.lol · enrichment: adsbdb · 3 fixed regions (London / California / S.Carolina)`.
+- Export buttons (disabled when empty): CSV of the flight rows (callsign, type, altKm, speedKt, headingDeg, verticalRateMs, registration, region, squawk) via `toCsv`/`downloadText`/`exportFilename("aviation", Date.now())`; GeoJSON via `toGeoJson(filtered.map(o => ({ lat:o.lat, lon:o.lon, properties:{ callsign:o.label, ...(o.meta ?? {}) } })))`.
+
+- [ ] **Step 1:** Insert the footer + export.
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(aviation): focus detail — attribution footer + CSV/GeoJSON export"`
+
+---
+
+### Task 7: Verification
+
+- [ ] Full gate `npx tsc --noEmit && npm test` green; `git status` clean apart from `.superpowers/sdd/progress.md`.
+- [ ] Confirm the squawk thread: a raw row with `squawk:"7700"` produces `meta.squawk==="7700"` and the emergency banner + red table cell (unit test covers the parse; banner is code-review-verified).
+- [ ] If the integrator has a browser: expand the Aviation widget, confirm ops summary, filters, region map, table sort + dossier, export. Otherwise note live visual verification pending.
+
+## Self-Review
+
+- **Spec §7.4 coverage:** (1) ops summary bar → Task 3 ✓; (2) region + altitude filter rail → Task 4 ✓; (3) master flight table (sortable, uncapped, CSV/GeoJSON) → Tasks 5+6 ✓; (4) per-flight dossier via `PlaneDetail` → Task 5 ✓; (5) altitude sparkline/histogram from trails → Task 4 (altitude histogram) ✓; (6) region `InsetMap` with heading-oriented markers + trails → Task 4 (InsetMap; heading colour via `o.color`; trails are a nice-to-have, InsetMap renders anchor points) ✓; squawk parse → Task 1 ✓ (activates the pre-written `aviationAlerts`).
+- **Type consistency:** `OpsSummary`, `AltBand`/`ALT_BANDS`, `FlightSortKey`, `REGION_LABELS`, `opsSummary`/`altitudeBand`/`regionOf`/`sortFlights` names match across Tasks 2→6. `usePlanes`/`WorldObject.meta`/`PlaneDetail`/`aviationAlerts`/`Chart`/`InsetMap`/export signatures verified against source.
+- **Honesty:** squawk-emergency only fires on real 7500/7600/7700; "N live · airborne/ground"; region derived by nearest-of-3 (regions are continents apart); dormant-safe enrichment; empty states honest. Note: InsetMap renders anchor points (not full heading-rotated glyphs or trail polylines) — acceptable v1, documented.

--- a/docs/superpowers/plans/2026-07-08-focus-window-w5-cameras.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-w5-cameras.md
@@ -1,0 +1,247 @@
+# W5 — Cameras detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A traffic-camera console focus view — an honest coverage bar (live-HLS vs still vs offline, per operator), a region map, operator/region filters, still + live-HLS camera walls (concurrency-capped players), a sortable table with a per-camera dossier (live snapshot), and CSV/GeoJSON export.
+
+**Architecture:** New default-export `CamerasDetail(props: WidgetDetailProps)` registered as `detail:` on `CAMERAS_WIDGET`. Because the docked widget only reads map-loaded cameras (`loadedCamerasStore`), the detail needs a NEW `useCameras()` hook that fetches the full `/api/cameras` list (enriched this milestone). Pure coverage + HLS-concurrency logic lives in testable `lib/cameras/coverage.ts` + `lib/cameras/concurrency.ts`. Snapshots are shown ONLY through the existing `/api/proxy?id=` (still) and `/api/hls?id=` (live) routes via the existing `CameraImage`/`CameraVideo`/`CameraDetail` components — never raw upstream URLs (SSRF). Region filtering reuses `cameraFilterStore`.
+
+**Tech Stack:** Next 15 / React 19 / TS; MapLibre (InsetMap); hls.js (via existing CameraVideo); vitest.
+
+## Global Constraints
+
+- Keyless-first, dormant-safe; honest empty states. NEVER render an upstream camera URL directly — always `/api/proxy?id=<id>` (still) or `/api/hls?id=<id>` (live), which enforce the SSRF allowlist by id.
+- Native `<Chart>`; shared `<InsetMap>`; theme tokens only (`--tn-surface`/`--tn-surface-solid`/`--tn-surface-2`/`--tn-text`/`--tn-text-muted`/`--tn-text-faint`/`--tn-border`/`--tn-accent`). NO `--tn-surface-1`/`--tn-text-1`.
+- Cap concurrent live HLS players (CAP = 6) — a 50-player wall would kill the browser. Stills are cheap `<img>`; default everything to still, activate live on click.
+- Build gate (every task): `npx tsc --noEmit && npm test` → green.
+- Commits: solo `011-sam-110 <lesttech.dev.sam@gmail.com>`, **no Co-Authored-By / Claude trailer**, plain `git commit -m "..."` (never a `@'...'` heredoc).
+- Owned files only; never `git add -A`/`checkout`/`reset`/`stash`; do not touch `.superpowers/sdd/progress.md`.
+- **Verify every import path against source before use** — the interfaces below are from a research pass; confirm exact names/paths (esp. `Camera` type location, `isLiveStreamUrl`, `cameraFilterStore`, the proxy/hls routes) in the actual files.
+
+## Reference pattern
+
+`lib/console/widgets/aviation.detail.tsx` (W4) and `lib/console/widgets/signals.detail.tsx` (W3) are the canonical templates — mirror masthead+counts+sparkline (fold the live sample in, and **only stamp `updatedAt` once real data arrives** — the W4 review fix), `.tn-<x>-panels` grid, filter chips, footer with attribution + export.
+
+## Data shapes (verify, then consume)
+
+- `Camera` (`lib/types.ts`, `CameraSchema`): `{ id; source; country; region?; name; lat; lon; road?; direction?; imageUrl?; streamUrl?; mediaType:"jpeg"|"video"|"both"; refreshSeconds; license; attribution; available; lastSampledAt? }`. Derived `live = isLiveStreamUrl(streamUrl)` (`lib/proxy/hls-allowlist.ts`).
+- `/api/cameras` currently returns only `{ id, name, lat, lon, available, source, country, live }` — **Task 1 enriches it** with `region, road, refreshSeconds, attribution, license, lastSampledAt`.
+- `CAMERAS_WIDGET` — plain object in `lib/console/widgets/cameras.tsx`, `registerWidget(CAMERAS_WIDGET)`. Attach `detail: CamerasDetail`.
+- `cameraFilterStore` + `useCameraFilter()` (`lib/cameraFilter.ts`): `{ regions: Record<source,boolean>; liveOnly: boolean }`, `toggleRegion(source)`, `setLiveOnly(on)`, `passes(source, live)`, `get`, `subscribe`.
+- `components/CameraDetail.tsx` (default): `CameraDetail({ object: WorldObject })` — self-fetches `/api/camera/${id}`, renders `CameraVideo`/`CameraImage` + freshness + deep link. Build a minimal `WorldObject` (`{ kind:"camera", id, label:name, lat, lon, meta:{ available } }`) for the drill-down.
+- `components/CameraImage.tsx` / `components/CameraVideo.tsx` (defaults): props `{ id, alt, attribution, license, refreshSeconds }`; render `/api/proxy?id=` / `/api/hls?id=`.
+- `lib/cameras/freshness.ts` (pure): `msUntilRefresh`, `refreshProgress`, `formatCountdown`, `sampledAgeMs`.
+- Primitives: `Chart`/`InsetMap`/`recordSeries`+`seriesSamples`/`deltaOf`/`toCsv`+`toGeoJson`+`downloadText`+`exportFilename`/`shellLayoutStore.unfocus`/`humaniseKey` (same imports as W3/W4).
+
+## File Structure
+
+- Create `lib/cameras/coverage.ts`, `lib/cameras/concurrency.ts`, `lib/cameras/useCameras.ts`, `lib/console/widgets/cameras.detail.tsx`.
+- Create tests `tests/unit/cameras-coverage.test.ts`, `tests/unit/cameras-concurrency.test.ts`.
+- Modify `app/api/cameras/route.ts` (enrich payload), `lib/console/widgets/cameras.tsx` (attach `detail:`), `app/globals.css` (`.tn-cm*`).
+
+---
+
+### Task 1: Enrich `/api/cameras` + pure coverage + HLS-concurrency helpers
+
+**Files:** Modify `app/api/cameras/route.ts`; Create `lib/cameras/coverage.ts`, `lib/cameras/concurrency.ts`; Test `tests/unit/cameras-coverage.test.ts`, `tests/unit/cameras-concurrency.test.ts`.
+
+- [ ] **Step 1: Enrich the route.** In `app/api/cameras/route.ts`, add `region, road, refreshSeconds, attribution, license, lastSampledAt` to each mapped camera object it returns (they already exist on the full record — just include them). Keep `live` and everything already returned. Do NOT leak `imageUrl`/`streamUrl` (snapshots go through the proxy by id). If a route-shape test exists, update it.
+
+- [ ] **Step 2: `lib/cameras/coverage.ts`** (define a local minimal `CameraLite` shape so the helper is decoupled from the full zod type):
+
+```ts
+// Pure coverage/honesty maths for the Cameras focus view. A camera is offline when
+// unavailable, "live" when it exposes an allowlisted HLS stream, else a refreshing
+// still. Grouped per operator so the console can be honest about what each feed is.
+export interface CameraLite {
+  id: string; source: string; name: string; lat: number; lon: number;
+  available: boolean; live: boolean; region?: string;
+}
+
+export interface OperatorCoverage {
+  source: string; total: number; live: number; still: number; offline: number;
+}
+export interface Coverage {
+  total: number; live: number; still: number; offline: number;
+  byOperator: OperatorCoverage[];
+}
+
+export function coverage(cams: CameraLite[]): Coverage {
+  const ops = new Map<string, OperatorCoverage>();
+  let live = 0, still = 0, offline = 0;
+  for (const c of cams) {
+    const bucket: "live" | "still" | "offline" = !c.available ? "offline" : c.live ? "live" : "still";
+    if (bucket === "live") live++; else if (bucket === "still") still++; else offline++;
+    let o = ops.get(c.source);
+    if (!o) { o = { source: c.source, total: 0, live: 0, still: 0, offline: 0 }; ops.set(c.source, o); }
+    o.total++; o[bucket]++;
+  }
+  const byOperator = [...ops.values()].sort((a, b) => b.total - a.total);
+  return { total: cams.length, live, still, offline, byOperator };
+}
+```
+
+- [ ] **Step 3: `lib/cameras/concurrency.ts`** (pure eviction + a tiny store + hook):
+
+```ts
+"use client";
+// Caps how many live HLS players run at once — a wall of 50 hls.js players would
+// crush the browser, so live is click-to-activate and the oldest slot is evicted
+// past the cap. The eviction maths is pure (unit-tested); the store is a thin shell.
+import { useSyncExternalStore } from "react";
+
+export const HLS_CAP = 6;
+
+/** Pure: activate `id` in an LRU-ish active list, evicting the oldest past `cap`. */
+export function nextActive(active: string[], id: string, cap: number = HLS_CAP): string[] {
+  const without = active.filter((x) => x !== id);
+  const next = [...without, id]; // most-recent last
+  return next.length > cap ? next.slice(next.length - cap) : next;
+}
+
+let active: string[] = [];
+const listeners = new Set<() => void>();
+function emit() { for (const l of listeners) l(); }
+
+export const hlsSlots = {
+  activate(id: string) { active = nextActive(active, id); emit(); },
+  deactivate(id: string) { active = active.filter((x) => x !== id); emit(); },
+  get(): string[] { return active; },
+  subscribe(l: () => void): () => void { listeners.add(l); return () => listeners.delete(l); },
+};
+
+export function useHlsActive(id: string): boolean {
+  const list = useSyncExternalStore(hlsSlots.subscribe, hlsSlots.get, hlsSlots.get);
+  return list.includes(id);
+}
+```
+
+- [ ] **Step 4: Tests.** `tests/unit/cameras-coverage.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { coverage, type CameraLite } from "@/lib/cameras/coverage";
+
+const c = (o: Partial<CameraLite>): CameraLite =>
+  ({ id: "x", source: "tfl", name: "n", lat: 0, lon: 0, available: true, live: false, ...o });
+
+describe("coverage", () => {
+  it("buckets live / still / offline and groups per operator", () => {
+    const cov = coverage([
+      c({ source: "caltrans", live: true }),
+      c({ source: "caltrans", live: false }),
+      c({ source: "tfl", available: false }),
+    ]);
+    expect(cov.total).toBe(3);
+    expect(cov.live).toBe(1);
+    expect(cov.still).toBe(1);
+    expect(cov.offline).toBe(1);
+    const caltrans = cov.byOperator.find((o) => o.source === "caltrans")!;
+    expect(caltrans.total).toBe(2);
+    expect(caltrans.live).toBe(1);
+    const tfl = cov.byOperator.find((o) => o.source === "tfl")!;
+    expect(tfl.offline).toBe(1);
+  });
+});
+```
+
+`tests/unit/cameras-concurrency.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { nextActive } from "@/lib/cameras/concurrency";
+
+describe("nextActive", () => {
+  it("adds an id and keeps it under the cap, evicting the oldest", () => {
+    let a: string[] = [];
+    for (const id of ["a", "b", "c"]) a = nextActive(a, id, 2);
+    expect(a).toEqual(["b", "c"]); // "a" evicted
+  });
+  it("re-activating an existing id moves it to most-recent without growing", () => {
+    const a = nextActive(["a", "b"], "a", 2);
+    expect(a).toEqual(["b", "a"]);
+  });
+});
+```
+
+- [ ] **Step 5: Gate + commit** — green.
+`git add app/api/cameras/route.ts lib/cameras/coverage.ts lib/cameras/concurrency.ts tests/unit/cameras-coverage.test.ts tests/unit/cameras-concurrency.test.ts`
+`git commit -m "feat(cameras): enrich /api/cameras + pure coverage + HLS-slot concurrency helpers"`
+
+---
+
+### Task 2: `useCameras` hook + detail skeleton + register
+
+**Files:** Create `lib/cameras/useCameras.ts`, `lib/console/widgets/cameras.detail.tsx`; Modify `lib/console/widgets/cameras.tsx`, `app/globals.css`.
+
+- [ ] **Step 1: `lib/cameras/useCameras.ts`** — a shared ref-counted poller for `/api/cameras` (mirror `useSignalFeed`'s structure): return `{ cameras: CameraLite[]; status: "loading"|"idle"|"error"; updatedAt: number|null }`. Poll ~60s, keep last-good, dormant-safe (`.catch` → keep prior). The response items already match `CameraLite` (id/source/name/lat/lon/available/live/region after Task 1).
+
+- [ ] **Step 2: `lib/console/widgets/cameras.detail.tsx`** — `CamerasDetail(_props: WidgetDetailProps)`:
+  - `useCameras()` → cameras; `coverage(cameras)`.
+  - Masthead: title "Camera network", `<b>{total}</b> cameras · {live} live · {still} still · {offline} offline`, freshness from `updatedAt`, count sparkline via `recordSeries("cam:count", total, updatedAt)` + `seriesSamples`/`deltaOf` — **only record once cameras arrive** (guard like W4's fix).
+  - Honest empty state ("No cameras loaded." on empty).
+  - Declare state used later: `const [openId,setOpenId]=useState<string|null>(null)`, `const [sortKey,setSortKey]=useState<"name"|"operator"|"region">("operator")`, `const [dir,setDir]=useState<1|-1>(1)`. (No `noUnusedLocals`, so this compiles.)
+  - Placeholder footer (Task 5 fills it).
+
+- [ ] **Step 3:** Add `detail: CamerasDetail` + `import CamerasDetail from "./cameras.detail";` to `CAMERAS_WIDGET` in `cameras.tsx`.
+
+- [ ] **Step 4:** Append `.tn-cm*` CSS (reuse the `.tn-sd*`/`.tn-av*` language: masthead, panels grid, operator chips, camera-wall grid `grid-template-columns: repeat(auto-fill,minmax(200px,1fr))`, tile with caption, table, footer/actions). Theme tokens only.
+
+- [ ] **Step 5: Gate + commit** — green.
+`git commit -m "feat(cameras): useCameras hook + focus detail skeleton — coverage masthead"`
+
+---
+
+### Task 3: Coverage bar + region map + operator/region filters
+
+**Files:** Modify `lib/console/widgets/cameras.detail.tsx`.
+
+- Coverage-honesty bar: per `coverage().byOperator`, a chip per operator `{source} · {live}▶ / {still}▦ / {offline}✕` (label live vs still explicitly — TfL is stills-only; Caltrans/SCDOT carry HLS).
+- Filters: reuse `cameraFilterStore`/`useCameraFilter` — region/operator toggles + a live-only toggle. Derive `filtered = cameras.filter((c) => filter.passes(c.source, c.live))`.
+- Region `InsetMap`: `points = filtered.map((c) => ({ lat:c.lat, lon:c.lon, id:c.id, props:{ name:c.name } }))`, `onSelect={setOpenId}`.
+
+- [ ] **Step 1:** Insert coverage bar + filters + map (grid), all keyed off `filtered`.
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(cameras): focus detail — coverage bar + region map + operator/region filters"`
+
+---
+
+### Task 4: Camera walls (still + click-to-activate live) + sortable table + dossier
+
+**Files:** Modify `lib/console/widgets/cameras.detail.tsx`.
+
+- Wall grid over `filtered`, grouped by operator (or a flat grid): each tile is a `CameraImage` (still) by default. For a `live` camera, overlay a "▶ Live" button; clicking calls `hlsSlots.activate(id)` and the tile swaps to `CameraVideo`; `useHlsActive(id)` decides which render. A "◼ Stop" (or auto-evict past `HLS_CAP`) tears it back to still. Show a small "N/​6 live" counter. Every tile caption: name + operator + freshness (`formatCountdown`/`sampledAgeMs` from `freshness.ts`).
+- Sortable table (`name`/`operator`/`region`) over `filtered`; row click toggles `openId`; open → drill row rendering `<CameraDetail object={toWorldObject(c)} />` where `toWorldObject(c) = { kind:"camera", id:c.id, label:c.name, lat:c.lat, lon:c.lon, meta:{ available:c.available } } as WorldObject`.
+
+- [ ] **Step 1:** Insert the wall + table + dossier (keyed-fragment via `import { Fragment }`).
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(cameras): focus detail — still/live camera walls (HLS-capped) + table + dossier"`
+
+---
+
+### Task 5: Footer — attribution + CSV/GeoJSON export
+
+**Files:** Modify `lib/console/widgets/cameras.detail.tsx`.
+
+- Footer: attribution note (per-operator licences are on each `Camera.attribution`/`license`; summarise "Operators: <distinct sources> · see each camera for licence"). 
+- Export (disabled when empty): CSV of `filtered` (id, name, source, region, lat, lon, live, available) and GeoJSON via `toGeoJson(filtered.map((c) => ({ lat:c.lat, lon:c.lon, properties:{ name:c.name, source:c.source, live:c.live, available:c.available } })))`, using `exportFilename("cameras", Date.now())`.
+
+- [ ] **Step 1:** Insert footer + export.
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(cameras): focus detail — attribution footer + CSV/GeoJSON export"`
+
+---
+
+### Task 6: Verification
+
+- [ ] Full gate `npx tsc --noEmit && npm test` green; `git status` clean apart from `.superpowers/sdd/progress.md`.
+- [ ] Confirm no raw upstream URL is ever rendered (only `/api/proxy?id=` / `/api/hls?id=` via CameraImage/CameraVideo/CameraDetail).
+- [ ] Confirm the HLS cap: activating a 7th live tile evicts the oldest (`nextActive` unit test covers the maths; wiring is code-review-verified).
+- [ ] If the integrator has a browser: expand the Cameras widget, confirm coverage bar, filters, map, a still wall, one click-to-live tile, table + dossier, export. Otherwise note live visual verification pending.
+
+## Self-Review
+
+- **Spec §7.5 coverage:** (1) coverage-honesty bar (live/still/offline + per-operator, labelled) → Task 3 ✓; (2) live HLS wall, concurrency-capped, click-activated → Task 4 (`hlsSlots`/`useHlsActive`, CAP 6) ✓; (3) refreshing-still walls with per-feed countdowns → Task 4 (CameraImage + `freshness.ts`) ✓; (4) focus rail reusing `CameraDetail` + nearest-cameras → Task 4 dossier (CameraDetail already renders nearby) ✓; (5) filter/export reusing `cameraFilterStore` → Tasks 3+5 ✓. New work: enrich `/api/cameras` (Task 1) + HLS concurrency manager (Task 1 `concurrency.ts`) ✓.
+- **Type consistency:** `CameraLite`/`Coverage`/`OperatorCoverage`/`coverage`/`nextActive`/`hlsSlots`/`useHlsActive`/`useCameras` names match across Tasks 1→5.
+- **Safety/honesty:** snapshots strictly via proxy-by-id (no SSRF); live capped at 6 (browser safety); coverage labels each feed honestly (still vs live); offline counted; dormant-safe hook; empty states honest.
+- **Risk flagged:** the live wall is the riskiest surface — keep it click-to-activate (not viewport auto-play) to bound complexity; if `CameraVideo`'s props differ from the assumed `{id,alt,attribution,license,refreshSeconds}`, adapt to the real signature (verify in source).

--- a/docs/superpowers/plans/2026-07-08-focus-window-w6-news-video.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-w6-news-video.md
@@ -1,0 +1,146 @@
+# W6 — News-video detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A live-news-video console focus view — a hero player, a keyless channel wall grouped by category, an optional muted 2×2 mosaic, a live headline rail, and an add-custom-stream directory.
+
+**Architecture:** New default-export `NewsDetail(props: WidgetDetailProps)` registered as `detail:` on `NEWS_WIDGET`. It reuses the existing static provider catalog (`lib/console/news/providers.ts`: `NEWS_PROVIDERS`, `resolveEmbed`, `parseCustomStream`) and the existing embed mechanism (YouTube `<iframe>`, already keyless + CSP-clear; HLS via the existing `CameraVideo`/`/api/hls` path — no NEW hosts). Selection persists through `shellLayoutStore.configure(instanceId, { providerId, customProvider })`. The headline rail reuses `/api/news` (`NewsItem`) via `useJsonPoll` exactly like `headlines.detail.tsx`.
+
+**Tech Stack:** Next 15 / React 19 / TS; YouTube iframe; hls.js (via existing CameraVideo); vitest.
+
+## Global Constraints
+
+- Keyless-first (YouTube embeds + `img.youtube.com` thumbnails, no YouTube Data API). Dormant-safe; honest empty states.
+- **Do NOT expand the `/api/hls` SSRF allowlist** (`lib/proxy/hls-allowlist.ts`) to broadcaster CDNs — rotating hosts + a security surface. HLS providers already in the catalog route through the existing allowlisted path; YouTube is the primary reliable channel. (Deliberate deviation from the research's "HLS-first" — YouTube-first here.)
+- **No count-sparkline / recordSeries** in this view — the provider catalog is static, so a count trend is meaningless (avoids the W3/W4 sparkline pitfalls entirely).
+- Native primitives only; theme tokens only (`--tn-surface`/`--tn-surface-solid`/`--tn-surface-2`/`--tn-text`/`--tn-text-muted`/`--tn-text-faint`/`--tn-border`/`--tn-accent`). NO `--tn-surface-1`/`--tn-text-1`. No geo → no InsetMap.
+- Build gate (every task): `npx tsc --noEmit && npm test` → green.
+- Commits: solo `011-sam-110 <lesttech.dev.sam@gmail.com>`, **no Co-Authored-By / Claude trailer**, plain `git commit -m "..."`.
+- Owned files only; never `git add -A`/`checkout`/`reset`/`stash`; do not touch `.superpowers/sdd/progress.md`.
+- **Verify every signature against source** (the interfaces below are from a research pass): `resolveEmbed`, `parseCustomStream`, `NewsProvider`, the YouTube iframe markup in `news.tsx`, `shellLayoutStore.configure`, `useJsonPoll`, `NewsItem`, and how the docked `NEWS_WIDGET` reads `config.providerId`/`customProvider`.
+
+## Reference pattern
+
+`lib/console/widgets/headlines.detail.tsx` (W2) is the closest reference (news domain, `/api/news` rail, `useJsonPoll`, source filter chips, recency grouping, footer + export). `lib/console/widgets/news.tsx` (the docked widget) holds the existing player embed markup + config read — reuse it.
+
+## Data shapes (verify, then consume)
+
+- `NewsProvider = { id; name; category; kind: "youtube"|"hls"; ref; favorite? }` (`ref` = 11-char YouTube id OR m3u8 URL) — `lib/console/news/providers.ts`.
+- `NEWS_PROVIDERS: NewsProvider[]` (12), `resolveEmbed(p): { kind: "youtube"|"hls"; src: string }`, `parseCustomStream(url): NewsProvider|null` — same file.
+- `NEWS_WIDGET` — plain object in `lib/console/widgets/news.tsx`, `registerWidget(NEWS_WIDGET)`, `defaultConfig: { providerId: "aljazeera" }`. Attach `detail: NewsDetail`.
+- `NewsItem = { title; url; source; ts; description? }` — `lib/news.ts`; `/api/news` returns `{ generatedAt, items }`.
+- `useJsonPoll<T>(url, pollMs, initial)` — used in `headlines.detail.tsx` (confirm signature there).
+- `shellLayoutStore.configure(instanceId, patch)` + `shellLayoutStore.unfocus()` — `@/lib/console/store`. `WidgetDetailProps = { instanceId; config }`.
+- Thumbnails: `https://img.youtube.com/vi/<ref>/hqdefault.jpg` (keyless).
+
+## File Structure
+
+- Modify `lib/console/news/providers.ts` — add pure `providerThumb(p)`.
+- Create `lib/console/widgets/news.detail.tsx` — `NewsDetail`.
+- Modify `lib/console/widgets/news.tsx` — attach `detail:`.
+- Modify `tests/unit/console-news-providers.test.ts` — `providerThumb` cases.
+- Modify `app/globals.css` — append `.tn-nv*` block.
+
+---
+
+### Task 1: `providerThumb` helper
+
+**Files:** Modify `lib/console/news/providers.ts`; Test `tests/unit/console-news-providers.test.ts`.
+
+- [ ] **Step 1:** Add to `providers.ts`:
+
+```ts
+/** Keyless YouTube thumbnail for a provider, or null for HLS (no free thumbnail). */
+export function providerThumb(p: NewsProvider): string | null {
+  return p.kind === "youtube" ? `https://img.youtube.com/vi/${p.ref}/hqdefault.jpg` : null;
+}
+```
+
+- [ ] **Step 2:** Add to `tests/unit/console-news-providers.test.ts`:
+
+```ts
+import { providerThumb } from "@/lib/console/news/providers";
+// …
+it("providerThumb returns a keyless YouTube thumb for youtube, null for hls", () => {
+  expect(providerThumb({ id: "x", name: "X", category: "World", kind: "youtube", ref: "abc12345678" }))
+    .toBe("https://img.youtube.com/vi/abc12345678/hqdefault.jpg");
+  expect(providerThumb({ id: "y", name: "Y", category: "World", kind: "hls", ref: "https://h/s.m3u8" })).toBeNull();
+});
+```
+
+- [ ] **Step 3: Gate + commit** — green.
+`git add lib/console/news/providers.ts tests/unit/console-news-providers.test.ts`
+`git commit -m "feat(news-video): keyless providerThumb helper"`
+
+---
+
+### Task 2: Detail scaffold — masthead + category filter + hero player + register
+
+**Files:** Create `lib/console/widgets/news.detail.tsx`; Modify `lib/console/widgets/news.tsx`, `app/globals.css`.
+
+- [ ] **Step 1:** `NewsDetail({ instanceId, config }: WidgetDetailProps)`:
+  - Active provider: resolve from `config.providerId` (+ `config.customProvider` via `parseCustomStream`) against `NEWS_PROVIDERS`; default the catalog's first / "aljazeera". Local `useState` for the active id, seeded from config, so clicking a channel is instant; also persist via `shellLayoutStore.configure(instanceId, { providerId })`.
+  - Masthead: title "Live news" + now-playing (`{active.name} · {active.category}`) + a "← Back to map" is already provided by the WidgetDetail host, so no extra unfocus needed here (the footer add-custom is Task 5).
+  - Category filter chips: distinct `NEWS_PROVIDERS` categories + "All"; filters the wall (Task 3).
+  - Hero player: reuse the EXACT embed the docked `news.tsx` uses. For `resolveEmbed(active).kind === "youtube"` → the YouTube `<iframe>` (copy news.tsx's markup: `https://www.youtube.com/embed/<ref>?autoplay=1&mute=1&playsinline=1`, `allow="autoplay; encrypted-media; picture-in-picture"`, `allowFullScreen`); for `"hls"` → `<CameraVideo …>` or the existing HLS embed news.tsx uses. Do NOT hand-roll a new HLS path.
+  - Declare `const [category, setCategory] = useState<string|null>(null)` and `const [activeId, setActiveId] = useState<string>(<seed>)` (consumed in Task 3).
+  - Honest empty state if the catalog is somehow empty.
+
+- [ ] **Step 2:** Add `detail: NewsDetail` + `import NewsDetail from "./news.detail";` to `NEWS_WIDGET` in `news.tsx`.
+
+- [ ] **Step 3:** Append `.tn-nv*` CSS (hero 16:9 `aspect-ratio`, channel-wall grid `repeat(auto-fill,minmax(160px,1fr))`, thumb tile with caption + live dot, category chips, rail list, footer/actions). Theme tokens only. If `news.tsx` already ships a `.tn-newsw-*` stylesheet, reuse its classes where sensible rather than duplicating.
+
+- [ ] **Step 4: Gate + commit** — green.
+`git commit -m "feat(news-video): focus detail scaffold — hero player + category filter"`
+
+---
+
+### Task 3: Channel wall
+
+**Files:** Modify `lib/console/widgets/news.detail.tsx`.
+
+- Grid over `NEWS_PROVIDERS` filtered by `category`, grouped by category (or a flat grid with a category label). Each tile: `providerThumb(p)` as the `<img>` (lazy, `loading="lazy"`), a fallback coloured block when null (HLS), the channel name, a "▶ LIVE" badge, and a highlighted ring when `p.id === activeId`. Clicking a tile: `setActiveId(p.id)` + `shellLayoutStore.configure(instanceId, { providerId: p.id })` so the hero swaps and the choice persists.
+
+- [ ] **Step 1:** Insert the wall.
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(news-video): focus detail — category channel wall (keyless thumbnails)"`
+
+---
+
+### Task 4: Live headline rail + optional muted mosaic
+
+**Files:** Modify `lib/console/widgets/news.detail.tsx`.
+
+- Headline rail: `useJsonPoll<{ items: NewsItem[] }>("/api/news", 120000, { items: [] })` (mirror `headlines.detail.tsx`); render a compact scrollable list (source · relative time · title → link), honest "No headlines." empty state.
+- Optional mosaic toggle: a "▦ Mosaic" button that renders a 2×2 grid of the first 4 filtered channels as muted YouTube iframes (`mute=1`, `autoplay=1`), with the active channel unmuted; toggling back returns to the single hero. Keep it behind a toggle so the default is one player (bandwidth-honest).
+
+- [ ] **Step 1:** Insert the rail + mosaic toggle.
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(news-video): focus detail — live headline rail + optional 2×2 mosaic"`
+
+---
+
+### Task 5: Directory footer — add-custom-stream + export
+
+**Files:** Modify `lib/console/widgets/news.detail.tsx`.
+
+- Footer: an add-custom-stream input → `parseCustomStream(url)`; on a non-null result, `shellLayoutStore.configure(instanceId, { customProvider: <result or url>, providerId: <result.id> })` and set it active; show an inline error when parse returns null. Attribution note ("Channels are the broadcasters' official keyless live streams (YouTube/HLS)").
+- Export: CSV of the channel directory (`id, name, category, kind`) via `toCsv`/`downloadText`/`exportFilename("news-channels", Date.now())`.
+
+- [ ] **Step 1:** Insert footer + custom-add + export.
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(news-video): focus detail — add-custom-stream + channel directory export"`
+
+---
+
+### Task 6: Verification
+
+- [ ] Full gate `npx tsc --noEmit && npm test` green; `git status` clean apart from `.superpowers/sdd/progress.md`.
+- [ ] Confirm no new host reaches `/api/hls` and no raw m3u8 is fetched client-side outside the existing allowlisted path.
+- [ ] If the integrator has a browser: expand the News widget, confirm hero plays, channel wall thumbnails + swap-on-click + persistence, headline rail, mosaic toggle, add-custom. Otherwise note live visual verification pending.
+
+## Self-Review
+
+- **Spec §7.6 coverage:** (1) hero player (YouTube-first; HLS via existing path) → Task 2 ✓; (2) channel wall, keyless YouTube thumbnails, category-grouped → Task 3 ✓; (3) optional 2×2 muted mosaic → Task 4 ✓; (4) live headline rail (`/api/news`) → Task 4 ✓; (5) directory / add-custom + now-playing → Tasks 2+5 ✓. Deliberate scope: HLS-first hero + broadcaster-CDN allowlist expansion DEFERRED (security/reliability) — YouTube-first instead, documented.
+- **Type consistency:** `providerThumb`/`resolveEmbed`/`parseCustomStream`/`NewsProvider`/`NewsItem`/`useJsonPoll`/`shellLayoutStore.configure` names verified against source before use.
+- **Safety/honesty:** keyless throughout; no SSRF allowlist change; mosaic behind a toggle (bandwidth-honest); persistence via the same `configure` the docked widget uses; empty states honest.

--- a/docs/superpowers/specs/2026-07-08-focus-window-design.md
+++ b/docs/superpowers/specs/2026-07-08-focus-window-design.md
@@ -1,0 +1,324 @@
+# Focus Window — per-widget expand-to-center-stage detail views — Design Spec
+
+> Date: 2026-07-08 · Status: Approved (design) · Owner: Sampo
+> Part of the World Monitor (TrafficNerd-V2) build. Grounded in a read-only 8-agent
+> code scan (2026-07-08) that traced every console widget to its real data source and
+> proposed a bespoke detail view. This spec turns the main globe window into a **focus
+> surface**: any widget can be expanded onto the center stage to show much deeper,
+> genuinely useful information — while keeping the app's keyless-first, dormant-safe,
+> "computed-not-fabricated" identity.
+
+## 0. Where this sits
+
+World Monitor's center "stage" already has a small switching system: `StageHost`
+renders `map3d` (globe) / `map2d` (flat) / `clock`, toggled by `StageSwitch` via
+`shellLayoutStore.stage()`. This feature adds a **fourth kind of stage — a focused
+widget** — plus a per-widget bespoke *detail component* that fills it. The docked
+console widgets are unchanged; expanding one simply changes what the center stage shows.
+
+Every console widget participates: the 7 bespoke widgets (headlines, satellites,
+markets, aviation, events, cameras/news-video) **plus** the ~30 signal layers, which
+share one `signals` widget component and therefore get **one schema-agnostic detail
+template** parameterised by the `SignalSource` descriptor.
+
+## 1. Goals & success criteria
+
+**Goal:** every widget can expand onto the main window and present its data at real
+depth — the deep view a professional would actually use — without fabricating data or
+adding non-keyless dependencies for the default experience.
+
+**Success criteria:**
+1. A user can click an **expand** control on any docked widget and it takes over the
+   center stage; a **back** control (and the stage switch) returns to the map.
+2. The focus state persists across reload (round-trips through the saved layout) and can
+   be shared via URL.
+3. Each detail view reuses the widget's **existing data hook** — no duplicate polling.
+4. Each detail view is **dormant-safe**: on upstream failure or missing key it shows an
+   honest empty / "what unlocks this" state, never a crash or fabricated value.
+5. The Build gate stays green: `npx tsc --noEmit && npm test`, with pure logic
+   unit-tested before UI, and a Playwright screenshot per UI milestone.
+
+## 2. Decisions locked (2026-07-08)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | How focus takes the main window | **Replace the center stage** — reuse the `StageHost`/`StageSwitch`/`shellLayoutStore.stage()` seam; the globe unmounts while focused (lighter than an overlay). |
+| D2 | Widget scope this pass | **All widgets bespoke** — every widget gets a custom detail view; the ~30 signal layers share **one** parameterised template. |
+| D3 | Headlines AI summary | **Full-article fetch, on-demand** — server-side fetch of the article URL → readability extraction → freellmapi.co gateway. Dormant until `FREELLMAPI_*`; graceful fallback to the RSS `<description>` snippet on paywall/403. |
+| D4 | Satellites deep view | **Option C** — orbital detail (ground track, full elements, next-pass-over-you) as the spine **plus** a keyless NASA GIBS earth-observation imagery tile for regional context; embed real live feeds (ISS, GOES/Himawari) only where they genuinely exist. |
+| D5 | Charting primitive | **Native SVG, zero-dep** — hand-roll a `<Chart>` extending `Sparkline` (line/area/candlestick + crosshair + axes). Matches the repo's deliberate no-new-dep ethos. |
+| D6 | Inset map primitive | **One shared lightweight `<InsetMap>`** — a small single-layer MapLibre instance (the dep already exists), pooled/capped, rendering points/lines/polygons/tracks. |
+
+## 3. Architecture — the focus foundation (build once, all widgets use it)
+
+Four pieces, all extending existing seams:
+
+1. **Focus store** — `lib/console/focus.ts`. Holds `focusedWidgetId: string | null`.
+   Implemented with the external-store + `useSyncExternalStore` pattern already used by
+   `lib/overlay.ts` (the agents' recommended template). Actions: `open(id)`,
+   `close()`, `useFocus()`.
+2. **Stage integration** — extend `StageId` in `lib/console/types.ts` with a `focus`
+   kind; add a `focus` branch to `components/console/StageHost.tsx` that renders
+   `<WidgetDetail widgetId=…/>` instead of `<WorldMap/>`; `components/console/StageSwitch.tsx`
+   gains a **FOCUS** chip (shown only while focused) and a **← back** control that
+   restores the previous stage. The focused id round-trips through
+   `lib/console/sanitize.ts` and the persisted layout serialization.
+3. **Expand affordance** — one button on the `components/console/WidgetFrame.tsx`
+   header (next to the `⋯` menu — the same seam the export menu was added to). Every
+   widget inherits it. Clicking calls `focusStore.open(instance.id)`.
+4. **Detail contract** — `WidgetType` (`lib/console/registry.ts`) gains an optional
+   `detail?: ComponentType<WidgetDetailProps>` where
+   `WidgetDetailProps = { instanceId: string; config: Record<string, unknown> }`.
+   `<WidgetDetail>` looks up the focused instance's type and renders its `detail`
+   component; a widget without one falls back to a **generic detail** (a larger scroll
+   of the widget body + its export). This guarantees no expand button is ever dead.
+
+Detail components **reuse the widget's existing data hook** (`useJsonPoll`,
+`useEventFeeds`, `useSatellites`, `usePlanes`, `useSignalFeed`, …) — no duplicate fetch.
+
+## 4. Shared primitives (build once, reused across detail views)
+
+- **`components/Chart.tsx`** — native SVG, generalising `components/Sparkline.tsx`.
+  Modes: line, area, candlestick. Features: hover crosshair + tooltip, min/max markers,
+  baseline overlay, axes, up/down green(`#16a34a`)/red(`#dc2626`) tint convention. Pure
+  scale/scan maths extracted to a testable helper. **No new dependency.**
+- **`lib/widgets/buckets.ts`** — pure histogram/time-bin helpers (magnitude buckets,
+  hourly/daily time bins). Unit-tested. Feeds the events/signals distribution charts and
+  the headline volume strip.
+- **`components/InsetMap.tsx`** — one shared, single-purpose MapLibre instance rendering
+  exactly one layer's features (points sized/tinted, line geometry, H3 polygons,
+  satellite ground-tracks with antimeridian split). Auto-fit bounds; hover/click a
+  feature ↔ table row. Instances are pooled/capped so we never spawn many globes. Reuses
+  `lib/map/features.ts` (`toTrailFC`) + `lib/basemaps.ts` raster patterns.
+
+## 5. Data flow
+
+```
+[expand button on WidgetFrame]
+      → focusStore.open(instance.id)
+      → StageSwitch shows FOCUS chip; StageHost renders <WidgetDetail widgetId>
+      → WidgetDetail resolves WidgetType.detail, renders it
+      → detail view calls the SAME data hook the docked widget uses (no new fetch)
+      → renders deep panels (Chart / InsetMap / tables / dossiers)
+[back / stage switch] → focusStore.close() → StageHost restores previous stage (globe)
+```
+
+## 6. Error handling & honesty
+
+- Data hooks already degrade to empty on failure; every panel has an **honest empty
+  state** ("no active cyclones this season", "no public live feed for this object —
+  showing orbital data + region imagery instead").
+- **Key-gated** pieces (AI summary, FRED macro, ACLED / FIRMS / AISStream) render the
+  *"what unlocks this"* explainer (mirroring `components/shell/DailyBrief.tsx`), never a
+  fabricated value.
+- The **AI summary** is SSRF-guarded (fetch restricted to the existing proxy allowlist);
+  on paywall/403/empty it falls back to summarising — or just showing — the captured RSS
+  `<description>`.
+- **Never claim** more than the data supports: GDACS/cyclone "magnitude" is shown as the
+  native alert-level / wind / pressure, not a fake unified number; satellite imagery is
+  captioned as imagery *of* the ground region, not *from* that satellite.
+
+## 7. Per-widget detail views (grounded in the scan)
+
+Each is one gated milestone. Panels degrade gracefully when a field is absent.
+
+### 7.1 Events — triage board *(no new data)*
+Data: `projectEventFeed` rows joined back to raw `useEventFeeds().bySource` props
+(USGS quakes, GDACS multi-hazard, NOAA NHC cyclones — all keyless).
+Panels: (1) triage header (S0–S4 tier ribbon + type counts, click-to-filter); (2)
+grouped feed with **per-domain metrics** from raw props — quake `M + depth`; cyclone
+`category · maxWind · pressure · movement`; disaster `alertLevel · severity · country ·
+from→to · ongoing`; (3) event geo-point map (`InsetMap`, fed by the `exportGeo`
+FeatureCollection already built in `events.tsx`); (4) severity/type distribution rail
+(`buckets` + `Chart`); (5) sources & attribution footer + inline CSV/GeoJSON export.
+Reuse: `lib/widgets/eventFeed.ts`, `lib/events/*`, existing `exportRows`/`exportGeo`,
+`SignalDetail` humanise pattern. **New work: none** beyond F1/F2.
+
+### 7.2 Headlines — newsroom board *(+ AI summary)*
+Data: `/api/news` (keyless RSS: BBC/Al Jazeera/NPR/Guardian). The RSS parser currently
+**drops** `<description>` (and `media:thumbnail`/`category`) — capturing it is part of
+the win.
+Panels: (1) control bar (source chips w/ counts, sort, client search); (2) grouped
+headline list (recency buckets or by-source) with snippet + optional thumbnail; (3)
+**"also covered by"** cross-source cluster (surfaces what `mergeNews` currently
+discards); (4) **on-demand AI article summary** per headline; (5) hourly volume strip
+(`buckets`); (6) sources footer + CSV export.
+New work: extend `parseRss` to capture `description`/`image`/`category` (keep `NewsItem`
+back-compatible for `NewsTicker`); new **`/api/news/summary`** route — SSRF-allowlisted
+fetch of the article URL → readability strip → freellmapi gateway (copy the
+`app/api/brief` + `lib/geolocate/config.ts` `freellmConfig()` + `lib/geolocate/llm.ts`
+patterns) → 3–5 sentence factual summary; cache by URL; dormant-safe. Pure prompt
+builder + `parseSummaryResponse` unit-tested.
+Key: `FREELLMAPI_*` (dormant → falls back to snippet).
+
+### 7.3 Signals — one schema-agnostic template *(covers ~30 layers)*
+Data: the shared `/api/signals/<id>` → `SignalFeature[]`, parameterised by the
+`SignalSource` descriptor (`lib/signals/registry.ts`). Reuses `useSignalFeed` +
+`projectSignal`.
+Panels: (1) masthead + **count-history sparkline** (wire `lib/widgets/history.ts` /
+`lib/series.ts` — history exists but no signal records into it yet) + delta + freshness +
+"shown of total"; (2) source-only **`InsetMap`** (points/lines/H3 polygons/centroids);
+(3) **magnitude/severity distribution** (`buckets` + `Chart`; falls back to declared
+severity or an auto-detected numeric; hidden when neither exists — honest); (4) **time
+distribution** (hourly/daily; "undated" note for cables/weather/aggregated sources); (5)
+full sortable/groupable feature table with per-row **props drill-down** (reuse
+`SignalDetail` humanise + definition-list); (6) source/attribution/methodology (+ dormant
+key note for ACLED/FIRMS/AISStream/OpenAQ/ReliefWeb/ENTSOE); (7) CSV/GeoJSON export +
+"show this layer on the main map".
+New work: the template component; `buckets` helpers; wire count-history recording.
+
+### 7.4 Aviation — airspace console
+Data: `usePlanes()` → `{ objects, trails }` (keyless adsb.lol, 3 fixed regions);
+per-flight enrichment via `/api/flight` (adsbdb).
+Panels: (1) ops summary bar (airborne/ground split, per-category counts, max alt/speed);
+(2) region + altitude-band filter rail; (3) master flight table (callsign, type+ICAO,
+alt km/ft, speed km/h/kn, heading+compass, vertical rate, registration, region;
+sortable, uncapped, CSV/GeoJSON); (4) per-flight dossier (reuse `components/PlaneDetail.tsx`
++ `/api/flight` route/airframe, click-triggered only); (5) altitude sparkline from
+`trails`; (6) region **`InsetMap`** with heading-oriented markers + trails.
+New work: extend `parseAdsb()` to capture `squawk` (activates the already-written
+emergency 7500/7600/7700 alerts + a squawk column) — the field is already in the payload.
+Note: coverage is bounded to the 3 hardcoded regions; adsbdb is per-selected-flight only
+(rate limits) — both stated honestly.
+
+### 7.5 Cameras — honest live/still wall
+Data: `/api/cameras` (list) + `/api/camera/[id]` (full record + neighbours) + `/api/hls`
+(SSRF-safe HLS proxy) + `/api/proxy` (still proxy). 11 operators; only **Caltrans (CA)
+and SCDOT (SC)** yield playable HLS — everything else is refreshing stills.
+Panels: (1) coverage-honesty bar (live/still/offline counts, per-operator chips labelled
+live-HLS vs still; London/TfL explicitly stills-only pending M9's JamCam 403 fix); (2)
+live HLS wall (Caltrans + SCDOT), **concurrency-capped** (~4–6 players, activate on
+click/viewport, tear down off-screen — respects the ~6-connections-per-origin limit); (3)
+refreshing-still walls by operator/region with per-feed countdowns; (4) focus rail (reuse
+`components/CameraDetail.tsx` + nearest-cameras jump); (5) filter/export (reuse
+`cameraFilterStore`).
+New work: enrich `/api/cameras` payload (add `region`/`road`/`refreshSeconds`/
+`attribution`/`license`/`lastSampledAt` — avoids an N+1 of `/api/camera/[id]`); a
+client-side HLS concurrency manager.
+
+### 7.6 News (video) — live news video wall
+Data: `NEWS_PROVIDERS` (static catalog; all 12 currently `kind:'youtube'`) + YouTube
+embeds/thumbnails (keyless) + the shared `/api/hls` proxy + `/api/news` for a paired
+headline rail.
+Panels: (1) hero player — **HLS-first** via `/api/hls` (reuse `CameraVideo` pattern) with
+**YouTube fallback**; (2) channel wall grouped by category with keyless YouTube-thumbnail
+tiles; (3) optional 2×2 mosaic multi-view (muted, one audio-focus); (4) live headline
+rail (`/api/news`); (5) directory/add-custom-stream + now-playing status.
+New work: add optional `hlsUrl` to `NewsProvider` and populate broadcaster `.m3u8`
+(Al Jazeera/DW/France 24 publish public HLS); **route news HLS through `/api/hls`**
+(currently loads raw `.m3u8` directly → CORS-blocked); extend `lib/proxy/hls-allowlist.ts`
+for the chosen hosts. Avoid the YouTube Data API (would need a key) — keep the manual ref
+list + custom-add.
+
+### 7.7 Markets — trading terminal *(first heavy `<Chart>` user)*
+Data: `/api/markets` (keyless crypto/commodities/FX/equities; macro dormant). Deep view
+adds **real historical series**.
+Panels: (1) instrument rail grouped by asset class (mini `Sparkline` preview, biggest
+movers first); (2) **primary historical chart** — `<Chart>` line/area/candlestick with
+1M/6M/1Y range tabs, crosshair tooltip (date + OHLC + volume), period change + 52-week
+high/low; (3) instrument stats/context (market cap, currency, as-of); (4) section movers
+heat-strip (reuse alert thresholds); (5) macro panel — **VIX (`^VIX`) and 10-Year
+(`^TNX`) graph keyless via Yahoo**; Fed Funds/Unemployment stay key-gated (FRED) with the
+dormant note; (6) footer (attribution, "indicative only, not financial advice", CSV +
+per-instrument OHLC export).
+New work: **`/api/markets/chart`** route proxying the keyless **Yahoo v8 chart** endpoint
+with `range=1mo/6mo/1y` (full `timestamp[]` + `indicators.quote[0].{o,h,l,c,v}[]` +
+`adjclose[]`); extend the `YahooChart` type + a pure `parseYahooSeries()` (unit-tested,
+mirroring `markets-quote.test.ts`); a symbol-mapping table (CoinGecko id / FX pair / Yahoo
+ticker → chart symbol); FX history via keyless **Frankfurter timeseries**; crypto history
+via Yahoo `BTC-USD…` or CoinGecko `market_chart`. Add `^VIX`/`^TNX` to the keyless set.
+Risks: Yahoo v8 is unofficial (429/crumb flakiness) — stay server-side proxied + cache
+per symbol+range.
+
+### 7.8 Satellites — orbital cockpit *(the deepest)*
+Data: `/api/satellites` (CelesTrak TLE, keyless) → client SGP4 via `useSatellites` /
+`propagate.ts`; classification via `classify.ts`.
+Panels: (1) command bar (group selector + category chips w/ counts + element-set epoch
+age as an honesty signal); (2) searchable/sortable satellite roster (left spine,
+successor to today's 200-row table); (3) selected-satellite orbital vitals (NORAD, intl
+designator, inclination/ecc/RAAN/argP/mean-anomaly/mean-motion, derived apogee/perigee);
+(4) **live ground track** on the shared `InsetMap` (±1 orbital period, antimeridian split,
+sub-point + observer markers, GeoJSON export); (5) **NEXT PASS over your location**
+(OVERHEAD pill / AOS→LOS, max elevation, rise/set azimuth, a small polar sky-chart;
+graceful "enable location" fallback); (6) **region imagery** — keyless **NASA GIBS**
+(MODIS/VIIRS true-color) + the existing Esri close-up, captioned honestly; (7) **real
+live feed only where one exists** — ISS (25544) NASA live embed; GOES/Himawari full-disk
+stills for GEO weather sats; explicit "no public feed" for everything else.
+New work: pure `lib/satellites/passes.ts` (`nextPass`/`isOverhead` via satellite.js
+`ecfToLookAngles`/`geodeticToEcf`/`eciToEcf` — already installed, no new dep);
+`lib/satellites/render.ts` (ground-track GeoJSON + antimeridian split); extend the TLE
+parser for full elements; `lib/sources/gibs.ts` (keyless GIBS snapshot/tiles; allowlist
+`*.earthdata.nasa.gov`); ISS/GOES/Himawari embed URLs (+ CSP `frame-src` for the ISS
+YouTube embed); accept multiple groups + dedupe by NORAD in `/api/satellites`.
+
+## 8. Testing
+
+Pure logic unit-tested before UI (repo convention, vitest): `<Chart>` scale maths;
+`buckets` histogram/time-bin; TLE element parser; `nextPass()`; ground-track antimeridian
+split; `parseYahooSeries()`; the summary prompt builder + `parseSummaryResponse`; the RSS
+`<description>` capture (extend the existing `parseRss` fixture test). Each UI milestone
+gets a Playwright screenshot into `persona-shots/`. Gate every milestone with
+`npx tsc --noEmit && npm test`.
+
+## 9. Phased milestones (map into `ROADMAP.md`)
+
+Foundation first, then per-widget by leverage. Each is one solo-committed, gated checkpoint.
+
+- **F1 — Focus framework** (store + StageId + StageHost/StageSwitch + WidgetFrame expand
+  + `WidgetType.detail` + persisted round-trip + generic fallback detail).
+- **F2 — Shared primitives** (`<Chart>` + `buckets` + `<InsetMap>`).
+- **W1 — Events detail** (no new data — proves the primitives).
+- **W2 — Headlines detail** (+ `<description>` capture + `/api/news/summary`).
+- **W3 — Signals detail template** (covers ~30 layers).
+- **W4 — Aviation detail** (+ squawk parse).
+- **W5 — Cameras detail** (+ enriched `/api/cameras` + HLS concurrency cap).
+- **W6 — News-video detail** (+ `hlsUrl` + proxy routing + allowlist).
+- **W7 — Markets detail** (+ `/api/markets/chart`).
+- **W8 — Satellites detail** (+ passes/TLE/ground-track/GIBS).
+
+## 10. New endpoints & keyless data sources introduced
+
+| Item | Keyless | For |
+|---|---|---|
+| `/api/news/summary` (article fetch → readability → freellmapi) | key-gated (dormant, snippet fallback) | Headlines |
+| RSS `<description>`/`image`/`category` capture in `parseRss` | ✅ | Headlines |
+| `/api/markets/chart` (Yahoo v8 full OHLC arrays) | ✅ | Markets |
+| Frankfurter timeseries / CoinGecko market_chart (FX/crypto history) | ✅ | Markets |
+| `^VIX` / `^TNX` added to keyless Yahoo set | ✅ | Markets macro |
+| `lib/sources/gibs.ts` (NASA GIBS true-color imagery) | ✅ | Satellites |
+| `lib/satellites/passes.ts` + TLE element parser + `render.ts` | ✅ | Satellites |
+| Multi-group + NORAD-dedupe in `/api/satellites` | ✅ | Satellites |
+| `squawk` capture in `parseAdsb()` | ✅ | Aviation |
+| Enriched `/api/cameras` payload | ✅ | Cameras |
+| `hlsUrl` on `NewsProvider` + `/api/hls` routing + allowlist hosts | ✅ | News video |
+
+## 11. Risks
+
+- **Foundation is a prerequisite for everything** — F1 touches shared console
+  types/store/StageHost/StageSwitch + persisted layout; must not regress the 3 existing
+  stages (guard with tests).
+- **Yahoo v8 chart** is unofficial (429/crumb 401/403, host flakiness) — server-side
+  proxy + aggressive per-symbol+range cache.
+- **HLS concurrency** — all HLS shares the `/api/hls` origin; cap simultaneous players.
+- **AI summary** — paywalls/anti-bot 403s are common; snippet fallback is mandatory;
+  SSRF allowlist is mandatory.
+- **Honesty** — cyclone/GDACS "magnitude", satellite imagery provenance, camera live-vs-
+  still, and "sparklines accumulate over polls" must all be labelled truthfully.
+- **InsetMap** — pool/cap instances; do not reuse the 1379-line globe `WorldMap`.
+
+## 12. Needs from Sampo
+
+- **API keys** (all optional — keyless fallbacks exist; keys only upgrade quality):
+  `FREELLMAPI_*` (unlocks the Headlines AI summary — otherwise snippet-only),
+  `FRED_API_KEY` (Fed Funds/Unemployment history — VIX/10-Yr are keyless without it),
+  plus the already-dormant `FINNHUB_API_KEY` / `ACLED_*` / `FIRMS` / `AISSTREAM_API_KEY`.
+- No decisions outstanding — D1–D6 are locked above.
+
+## 13. Non-goals / future
+
+- Alerting/notifications, saved digests, and scenario/forecast engines are out of scope
+  (separate PRDs exist).
+- Bulk per-row flight enrichment (adsbdb rate limits) — per-selected-flight only.
+- YouTube Data API (viewer counts / auto-recovering rotated live IDs) — needs a key;
+  keep manual ref list + custom-add.
+- Global ADS-B coverage (bounded to the 3 configured regions).

--- a/lib/cameras/concurrency.ts
+++ b/lib/cameras/concurrency.ts
@@ -1,0 +1,30 @@
+"use client";
+// Caps how many live HLS players run at once — a wall of 50 hls.js players would
+// crush the browser, so live is click-to-activate and the oldest slot is evicted
+// past the cap. The eviction maths is pure (unit-tested); the store is a thin shell.
+import { useSyncExternalStore } from "react";
+
+export const HLS_CAP = 6;
+
+/** Pure: activate `id` in an LRU-ish active list, evicting the oldest past `cap`. */
+export function nextActive(active: string[], id: string, cap: number = HLS_CAP): string[] {
+  const without = active.filter((x) => x !== id);
+  const next = [...without, id]; // most-recent last
+  return next.length > cap ? next.slice(next.length - cap) : next;
+}
+
+let active: string[] = [];
+const listeners = new Set<() => void>();
+function emit() { for (const l of listeners) l(); }
+
+export const hlsSlots = {
+  activate(id: string) { active = nextActive(active, id); emit(); },
+  deactivate(id: string) { active = active.filter((x) => x !== id); emit(); },
+  get(): string[] { return active; },
+  subscribe(l: () => void): () => void { listeners.add(l); return () => listeners.delete(l); },
+};
+
+export function useHlsActive(id: string): boolean {
+  const list = useSyncExternalStore(hlsSlots.subscribe, hlsSlots.get, hlsSlots.get);
+  return list.includes(id);
+}

--- a/lib/cameras/coverage.ts
+++ b/lib/cameras/coverage.ts
@@ -27,3 +27,17 @@ export function coverage(cams: CameraLite[]): Coverage {
   const byOperator = [...ops.values()].sort((a, b) => b.total - a.total);
   return { total: cams.length, live, still, offline, byOperator };
 }
+
+/**
+ * Wall ordering comparator: working-live first, then working-still, then offline last
+ * (name-tiebroken). "live" is gated on availability — an offline feed can still carry an
+ * allowlisted stream URL (live=true, available=false), and ranking those ahead of working
+ * stills would fill a bounded wall with "Feed offline" tiles while hiding usable feeds.
+ */
+export function byWallPriority(a: CameraLite, b: CameraLite): number {
+  return (
+    Number(b.live && b.available) - Number(a.live && a.available) ||
+    Number(b.available) - Number(a.available) ||
+    a.name.localeCompare(b.name)
+  );
+}

--- a/lib/cameras/coverage.ts
+++ b/lib/cameras/coverage.ts
@@ -1,0 +1,29 @@
+// Pure coverage/honesty maths for the Cameras focus view. A camera is offline when
+// unavailable, "live" when it exposes an allowlisted HLS stream, else a refreshing
+// still. Grouped per operator so the console can be honest about what each feed is.
+export interface CameraLite {
+  id: string; source: string; name: string; lat: number; lon: number;
+  available: boolean; live: boolean; region?: string;
+}
+
+export interface OperatorCoverage {
+  source: string; total: number; live: number; still: number; offline: number;
+}
+export interface Coverage {
+  total: number; live: number; still: number; offline: number;
+  byOperator: OperatorCoverage[];
+}
+
+export function coverage(cams: CameraLite[]): Coverage {
+  const ops = new Map<string, OperatorCoverage>();
+  let live = 0, still = 0, offline = 0;
+  for (const c of cams) {
+    const bucket: "live" | "still" | "offline" = !c.available ? "offline" : c.live ? "live" : "still";
+    if (bucket === "live") live++; else if (bucket === "still") still++; else offline++;
+    let o = ops.get(c.source);
+    if (!o) { o = { source: c.source, total: 0, live: 0, still: 0, offline: 0 }; ops.set(c.source, o); }
+    o.total++; o[bucket]++;
+  }
+  const byOperator = [...ops.values()].sort((a, b) => b.total - a.total);
+  return { total: cams.length, live, still, offline, byOperator };
+}

--- a/lib/cameras/useCameras.ts
+++ b/lib/cameras/useCameras.ts
@@ -1,0 +1,94 @@
+"use client";
+// One shared, ref-counted poller for /api/cameras — mirrors useSignalFeed. The first
+// subscriber starts a ~60s poll, the last unsubscribe stops it, and the latest list
+// stays cached so a re-mounted detail shows data instantly. A fetch error keeps the
+// last good list (dormant-safe: we only surface "error" if we never had any data).
+//
+// The /api/cameras response is enriched (Task 1), so each item is a CameraRow: a
+// CameraLite (what coverage() consumes) plus the attribution / licence / refresh /
+// sample fields the camera walls and dossier need. Snapshots are still fetched by id
+// through /api/proxy + /api/hls, never a raw upstream URL — no URL is carried here.
+
+import { useMemo, useSyncExternalStore } from "react";
+import type { CameraLite } from "@/lib/cameras/coverage";
+
+export interface CameraRow extends CameraLite {
+  country: string;
+  road?: string;
+  refreshSeconds: number;
+  attribution: string;
+  license: string;
+  lastSampledAt?: string;
+}
+
+export interface CamerasFeed {
+  cameras: CameraRow[];
+  status: "loading" | "idle" | "error";
+  updatedAt: number | null;
+}
+
+interface Entry {
+  state: CamerasFeed;
+  listeners: Set<() => void>;
+  timer: ReturnType<typeof setInterval> | null;
+  refCount: number;
+}
+
+const EMPTY: CamerasFeed = { cameras: [], status: "loading", updatedAt: null };
+const REFRESH_MS = 60_000;
+
+let entry: Entry | null = null;
+function ensure(): Entry {
+  if (!entry) entry = { state: EMPTY, listeners: new Set(), timer: null, refCount: 0 };
+  return entry;
+}
+function emit(e: Entry) {
+  for (const l of e.listeners) l();
+}
+
+function load(e: Entry) {
+  fetch("/api/cameras")
+    .then((r) => r.json())
+    .then((d) => {
+      const cameras = (d?.cameras as CameraRow[]) ?? [];
+      e.state = { cameras, status: "idle", updatedAt: Date.now() };
+      emit(e);
+    })
+    .catch(() => {
+      // Keep the last good list; only show "error" if we never had any.
+      e.state = {
+        cameras: e.state.cameras,
+        status: e.state.updatedAt ? "idle" : "error",
+        updatedAt: e.state.updatedAt,
+      };
+      emit(e);
+    });
+}
+
+/** Subscribe to the shared, enriched /api/cameras feed for the focus view. */
+export function useCameras(): CamerasFeed {
+  const subscribe = useMemo(
+    () => (cb: () => void) => {
+      const e = ensure();
+      e.listeners.add(cb);
+      e.refCount += 1;
+      if (e.refCount === 1) {
+        if (!e.state.updatedAt) e.state = { ...e.state, status: "loading" };
+        load(e);
+        e.timer = setInterval(() => load(e), REFRESH_MS);
+      }
+      return () => {
+        e.listeners.delete(cb);
+        e.refCount -= 1;
+        if (e.refCount === 0 && e.timer) {
+          clearInterval(e.timer);
+          e.timer = null;
+        }
+      };
+    },
+    [],
+  );
+
+  const getSnapshot = () => ensure().state;
+  return useSyncExternalStore(subscribe, getSnapshot, () => EMPTY);
+}

--- a/lib/chart/scale.ts
+++ b/lib/chart/scale.ts
@@ -1,0 +1,16 @@
+// lib/chart/scale.ts
+// Pure 1-D scale maths shared by the native SVG charts. No DOM, node-testable.
+
+export function extent(values: number[]): [number, number] {
+  let lo = Infinity, hi = -Infinity;
+  for (const v of values) { if (v < lo) lo = v; if (v > hi) hi = v; }
+  if (!Number.isFinite(lo)) return [0, 1];
+  if (lo === hi) return [lo - 1, hi + 1];
+  return [lo, hi];
+}
+
+export function linear(domain: [number, number], range: [number, number]): (x: number) => number {
+  const [d0, d1] = domain, [r0, r1] = range;
+  const m = d1 === d0 ? 0 : (r1 - r0) / (d1 - d0);
+  return (x) => r0 + (x - d0) * m;
+}

--- a/lib/console/reducers.ts
+++ b/lib/console/reducers.ts
@@ -43,7 +43,11 @@ export function removeWidget(l: ShellLayout, id: string): ShellLayout {
   const kept = l.widgets.filter((w) => w.id !== id);
   const segSorted = kept.filter((w) => w.segment === removed.segment).sort((a, b) => a.order - b.order);
   const orderMap = new Map(segSorted.map((w, i) => [w.id, i] as const));
-  return { ...l, widgets: kept.map((w) => (orderMap.has(w.id) ? { ...w, order: orderMap.get(w.id)! } : w)) };
+  return {
+    ...l,
+    focusedWidgetId: l.focusedWidgetId === id ? null : l.focusedWidgetId,
+    widgets: kept.map((w) => (orderMap.has(w.id) ? { ...w, order: orderMap.get(w.id)! } : w)),
+  };
 }
 
 export function moveWidget(l: ShellLayout, id: string, toSegment: SegmentId, toIndex: number): ShellLayout {
@@ -81,4 +85,7 @@ export function setSegmentCollapsed(l: ShellLayout, seg: SegmentId, collapsed: b
 }
 export function setStage(l: ShellLayout, stage: StageId): ShellLayout {
   return { ...l, stage };
+}
+export function setFocus(l: ShellLayout, id: string | null): ShellLayout {
+  return { ...l, focusedWidgetId: id };
 }

--- a/lib/console/registry.ts
+++ b/lib/console/registry.ts
@@ -2,6 +2,8 @@ import type { ComponentType } from "react";
 
 export interface WidgetBodyProps { instanceId: string; config: Record<string, unknown> }
 
+export interface WidgetDetailProps { instanceId: string; config: Record<string, unknown> }
+
 export interface WidgetType {
   id: string;
   title: string;
@@ -10,6 +12,8 @@ export interface WidgetType {
   defaultHeight: number;
   defaultConfig: Record<string, unknown>;
   component: ComponentType<WidgetBodyProps>;
+  /** Optional rich "focus" view shown when the widget is expanded onto the center stage. */
+  detail?: ComponentType<WidgetDetailProps>;
   capabilities?: { filter?: boolean; sort?: boolean };
 }
 

--- a/lib/console/sanitize.ts
+++ b/lib/console/sanitize.ts
@@ -47,5 +47,8 @@ export function sanitizeLayout(raw: unknown): ShellLayout | null {
       config: o.config && typeof o.config === "object" ? (o.config as Record<string, unknown>) : {},
     });
   }
-  return { segments, stage: r.stage as StageId, widgets };
+  const ids = new Set(widgets.map((w) => w.id));
+  const focusedWidgetId =
+    typeof r.focusedWidgetId === "string" && ids.has(r.focusedWidgetId) ? r.focusedWidgetId : null;
+  return { segments, stage: r.stage as StageId, widgets, focusedWidgetId };
 }

--- a/lib/console/signals/signalDetail.ts
+++ b/lib/console/signals/signalDetail.ts
@@ -3,6 +3,7 @@
 // source actually carries numeric magnitudes, falls back to declared severity
 // counts, and reports "none" when neither exists (the caller then hides the panel).
 import type { SignalFeature } from "@/lib/signals/types";
+import { histogram } from "@/lib/widgets/buckets";
 
 /** Declared severity read from common alert-level props — only unambiguous words. */
 export function declaredSeverity(props?: Record<string, unknown>): "critical" | "warn" | null {
@@ -37,15 +38,20 @@ export function distribution(features: SignalFeature[]): Distribution {
   const mags = magnitudeValues(features);
   if (mags.length > 0) {
     const lo = Math.floor(Math.min(...mags));
-    const hi = Math.ceil(Math.max(...mags));
+    const maxV = Math.max(...mags);
+    // When the max is an exact integer, extend the top edge by one so it gets its
+    // OWN bucket instead of merging into the penultimate one (off-by-one guard).
+    const hi = Math.ceil(maxV) + (Number.isInteger(maxV) ? 1 : 0);
     const span = Math.max(1, hi - lo);
-    const step = Math.max(1, Math.ceil(span / 8)); // integer buckets, ≤8
-    const bins: { label: string; count: number }[] = [];
-    for (let edge = lo; edge < lo + step * Math.ceil(span / step); edge += step) {
-      const top = edge + step;
-      const count = mags.filter((m) => m >= edge && (top >= hi ? m <= top : m < top)).length;
-      bins.push({ label: step === 1 ? `${edge}` : `${edge}–${top}`, count });
-    }
+    const step = Math.max(1, Math.ceil(span / 8)); // ≤8 integer-width buckets
+    const edges: number[] = [];
+    for (let e = lo; e < hi; e += step) edges.push(e);
+    edges.push(hi);
+    // Reuse the node-tested histogram (last bin inclusive of the top edge).
+    const bins = histogram(mags, edges).map((count, i) => ({
+      label: step === 1 ? `${edges[i]}` : `${edges[i]}–${edges[i + 1]}`,
+      count,
+    }));
     return { kind: "magnitude", bins };
   }
   let critical = 0, warn = 0, other = 0;

--- a/lib/console/signals/signalDetail.ts
+++ b/lib/console/signals/signalDetail.ts
@@ -1,0 +1,94 @@
+// Pure projection helpers for the Signals FOCUS detail view. The distribution
+// logic is deliberately honest: it shows a magnitude histogram only when the
+// source actually carries numeric magnitudes, falls back to declared severity
+// counts, and reports "none" when neither exists (the caller then hides the panel).
+import type { SignalFeature } from "@/lib/signals/types";
+
+/** Declared severity read from common alert-level props — only unambiguous words. */
+export function declaredSeverity(props?: Record<string, unknown>): "critical" | "warn" | null {
+  if (!props) return null;
+  for (const key of ["alertlevel", "alertLevel", "severity", "level", "status"]) {
+    const v = props[key];
+    if (typeof v !== "string") continue;
+    const s = v.toLowerCase();
+    if (/red|extreme|severe|critical|emergency/.test(s)) return "critical";
+    if (/orange|warning|high|moderate/.test(s)) return "warn";
+  }
+  return null;
+}
+
+/** Finite numeric props.magnitude values. */
+export function magnitudeValues(features: SignalFeature[]): number[] {
+  const out: number[] = [];
+  for (const f of features) {
+    const m = f.props?.magnitude;
+    if (typeof m === "number" && Number.isFinite(m)) out.push(m);
+  }
+  return out;
+}
+
+export interface Distribution {
+  kind: "magnitude" | "severity" | "none";
+  bins: { label: string; count: number }[];
+}
+
+/** Honest distribution: magnitude histogram → severity counts → none. */
+export function distribution(features: SignalFeature[]): Distribution {
+  const mags = magnitudeValues(features);
+  if (mags.length > 0) {
+    const lo = Math.floor(Math.min(...mags));
+    const hi = Math.ceil(Math.max(...mags));
+    const span = Math.max(1, hi - lo);
+    const step = Math.max(1, Math.ceil(span / 8)); // integer buckets, ≤8
+    const bins: { label: string; count: number }[] = [];
+    for (let edge = lo; edge < lo + step * Math.ceil(span / step); edge += step) {
+      const top = edge + step;
+      const count = mags.filter((m) => m >= edge && (top >= hi ? m <= top : m < top)).length;
+      bins.push({ label: step === 1 ? `${edge}` : `${edge}–${top}`, count });
+    }
+    return { kind: "magnitude", bins };
+  }
+  let critical = 0, warn = 0, other = 0;
+  for (const f of features) {
+    const s = declaredSeverity(f.props);
+    if (s === "critical") critical++;
+    else if (s === "warn") warn++;
+    else other++;
+  }
+  if (critical > 0 || warn > 0) {
+    return { kind: "severity", bins: [
+      { label: "Severe", count: critical },
+      { label: "Warning", count: warn },
+      { label: "Other", count: other },
+    ] };
+  }
+  return { kind: "none", bins: [] };
+}
+
+/** Parseable ISO timestamps → ms, plus the count of undated features. */
+export function timeModel(features: SignalFeature[]): { values: number[]; undated: number } {
+  const values: number[] = [];
+  let undated = 0;
+  for (const f of features) {
+    const t = f.ts ? Date.parse(f.ts) : NaN;
+    if (Number.isFinite(t)) values.push(t);
+    else undated++;
+  }
+  return { values, undated };
+}
+
+export type SortKey = "magnitude" | "recency" | "title";
+
+/** Stable-ish sort by magnitude / recency / title. Missing values sort last. */
+export function sortFeatures(features: SignalFeature[], key: SortKey, dir: 1 | -1): SignalFeature[] {
+  const mag = (f: SignalFeature) =>
+    typeof f.props?.magnitude === "number" && Number.isFinite(f.props.magnitude) ? (f.props.magnitude as number) : -Infinity;
+  const rec = (f: SignalFeature) => (f.ts ? Date.parse(f.ts) : NaN);
+  const cmp = (a: SignalFeature, b: SignalFeature): number => {
+    if (key === "title") return a.title.localeCompare(b.title);
+    if (key === "magnitude") return mag(a) - mag(b);
+    const ra = rec(a), rb = rec(b);
+    return (Number.isFinite(ra) ? ra : -Infinity) - (Number.isFinite(rb) ? rb : -Infinity);
+  };
+  return [...features].sort((a, b) => dir * cmp(a, b));
+}

--- a/lib/console/store.ts
+++ b/lib/console/store.ts
@@ -35,6 +35,8 @@ export const shellLayoutStore = {
   setSegment(seg: SegmentId, size: number) { state = R.setSegmentSize(state, seg, size); emit(); },
   collapseSegment(seg: SegmentId, c: boolean) { state = R.setSegmentCollapsed(state, seg, c); emit(); },
   stage(s: StageId) { state = R.setStage(state, s); emit(); },
+  focus(id: string) { state = R.setFocus(state, id); emit(); },
+  unfocus() { state = R.setFocus(state, null); emit(); },
 };
 
 export function useShellLayout(): ShellLayout {

--- a/lib/console/types.ts
+++ b/lib/console/types.ts
@@ -19,6 +19,8 @@ export interface ShellLayout {
   segments: Record<SegmentId, SegmentState>;
   stage: StageId;
   widgets: WidgetInstance[];
+  /** The widget expanded onto the center stage, or null when the map is shown. */
+  focusedWidgetId: string | null;
 }
 
 export const MAX_WIDGETS = 50;
@@ -32,6 +34,7 @@ export function createDefaultLayout(): ShellLayout {
     },
     stage: "map2d",
     widgets: [],
+    focusedWidgetId: null,
   };
 }
 

--- a/lib/console/widgets/aviation.detail.tsx
+++ b/lib/console/widgets/aviation.detail.tsx
@@ -8,10 +8,15 @@
 import { useEffect, useMemo, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import { usePlanes } from "@/lib/planes/usePlanes";
-import { opsSummary, type AltBand, type FlightSortKey } from "@/lib/planes/ops";
+import {
+  opsSummary, altitudeBand, regionOf, ALT_BANDS, REGION_LABELS,
+  type AltBand, type FlightSortKey,
+} from "@/lib/planes/ops";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { deltaOf } from "@/lib/widgets/history";
 import { Chart, type ChartPoint } from "@/components/Chart";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
 
 const MS_TO_KT = 1.94384;
 const EMERGENCY_REASON: Record<string, string> = { "7500": "hijack", "7600": "radio failure", "7700": "emergency" };
@@ -64,6 +69,26 @@ export default function AviationDetail(_props: WidgetDetailProps) {
     [objects],
   );
 
+  // Region + altitude filters. Every downstream panel/table reads `filtered`.
+  const filtered = useMemo(
+    () => objects.filter((o) =>
+      (!region || regionOf(o.lat, o.lon) === region) &&
+      (!band || altitudeBand(o) === band)),
+    [objects, region, band],
+  );
+
+  const mapPoints: InsetPoint[] = useMemo(
+    () => filtered.map((o) => ({ lat: o.lat, lon: o.lon, id: o.id, color: o.color, props: { callsign: o.label } })),
+    [filtered],
+  );
+
+  const altHistogram = useMemo(() => {
+    const counts = new Map<AltBand, number>();
+    for (const o of filtered) { const b = altitudeBand(o); counts.set(b, (counts.get(b) ?? 0) + 1); }
+    return ALT_BANDS.map((b) => ({ band: b, count: counts.get(b) ?? 0 }));
+  }, [filtered]);
+  const altMax = Math.max(1, ...altHistogram.map((h) => h.count));
+
   return (
     <div className="tn-av">
       <header className="tn-av-head">
@@ -99,6 +124,51 @@ export default function AviationDetail(_props: WidgetDetailProps) {
       )}
 
       {objects.length === 0 && <p className="tn-w-empty">No aircraft in range right now.</p>}
+
+      {objects.length > 0 && (
+        <div className="tn-av-filters">
+          <div className="tn-av-filter-row">
+            <span className="tn-av-filter-label">Region</span>
+            <button className={`tn-av-fchip ${region === null ? "active" : ""}`} onClick={() => setRegion(null)}>All</button>
+            {REGION_LABELS.map((r) => (
+              <button key={r} className={`tn-av-fchip ${region === r ? "active" : ""}`} onClick={() => setRegion(region === r ? null : r)}>{r}</button>
+            ))}
+          </div>
+          <div className="tn-av-filter-row">
+            <span className="tn-av-filter-label">Altitude</span>
+            <button className={`tn-av-fchip ${band === null ? "active" : ""}`} onClick={() => setBand(null)}>All</button>
+            {ALT_BANDS.map((b) => (
+              <button key={b} className={`tn-av-fchip ${band === b ? "active" : ""}`} onClick={() => setBand(band === b ? null : b)}>{b}</button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {objects.length > 0 && (
+        <div className="tn-av-panels">
+          <div className="tn-av-panel">
+            <h3>Locations · {filtered.length}</h3>
+            {mapPoints.length > 0
+              ? <InsetMap points={mapPoints} height={220} onSelect={(id) => setOpenId(id)} />
+              : <p className="tn-w-empty">No aircraft match this filter.</p>}
+          </div>
+          <div className="tn-av-panel">
+            <h3>Altitude bands</h3>
+            {filtered.length > 0 ? (
+              <>
+                <div className="tn-av-bars">
+                  {altHistogram.map((h) => (
+                    <div key={h.band} className="tn-av-bar" style={{ height: `${(h.count / altMax) * 100}%` }} title={`${h.band}: ${h.count}`} />
+                  ))}
+                </div>
+                <div style={{ display: "flex", gap: 4 }}>
+                  {altHistogram.map((h) => <span key={h.band} className="tn-av-bar-label" style={{ flex: 1 }}>{h.band}</span>)}
+                </div>
+              </>
+            ) : <p className="tn-w-empty">No aircraft match this filter.</p>}
+          </div>
+        </div>
+      )}
 
       <footer className="tn-av-foot">
         <span className="tn-av-attr">Aircraft: adsb.lol · enrichment: adsbdb · 3 fixed regions (London / California / S.Carolina)</span>

--- a/lib/console/widgets/aviation.detail.tsx
+++ b/lib/console/widgets/aviation.detail.tsx
@@ -48,9 +48,11 @@ export default function AviationDetail(_props: WidgetDetailProps) {
 
   // usePlanes hands back a fresh objects array every poll (even when unchanged), so
   // its reference change is our per-poll clock — the stable timestamp the count
-  // sparkline needs (usePlanes exposes no updatedAt of its own).
+  // sparkline needs (usePlanes exposes no updatedAt of its own). Only stamp once REAL
+  // data has arrived: the initial mount array is empty, and stamping then would defeat
+  // the `if (updatedAt)` guard below and persist a spurious count=0 into the series.
   const [updatedAt, setUpdatedAt] = useState(0);
-  useEffect(() => { setUpdatedAt(Date.now()); }, [objects]);
+  useEffect(() => { if (objects.length > 0) setUpdatedAt(Date.now()); }, [objects]);
 
   useEffect(() => {
     if (updatedAt) recordSeries("av:count", total, updatedAt);

--- a/lib/console/widgets/aviation.detail.tsx
+++ b/lib/console/widgets/aviation.detail.tsx
@@ -18,6 +18,7 @@ import { Chart, type ChartPoint } from "@/components/Chart";
 import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
 import PlaneDetail from "@/components/PlaneDetail";
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
 
 const MS_TO_KT = 1.94384;
 const MS_TO_KMH = 3.6;
@@ -105,6 +106,29 @@ export default function AviationDetail(_props: WidgetDetailProps) {
     else { setSortKey(k); setDir(-1); }
   };
   const sortMark = (k: FlightSortKey) => (sortKey === k ? (dir === -1 ? " ↓" : " ↑") : "");
+
+  const exportRows = useMemo(
+    () => rows.map((o) => {
+      const meta = o.meta ?? {};
+      const velocityMs = typeof meta.velocityMs === "number" ? (meta.velocityMs as number) : null;
+      return {
+        callsign: o.label,
+        type: o.typeLabel ?? "",
+        altKm: typeof o.altKm === "number" ? Number(o.altKm.toFixed(2)) : "",
+        speedKt: velocityMs != null ? Number((velocityMs * MS_TO_KT).toFixed(0)) : "",
+        headingDeg: typeof meta.headingDeg === "number" ? Math.round(meta.headingDeg as number) : "",
+        verticalRateMs: typeof meta.verticalRateMs === "number" ? (meta.verticalRateMs as number) : "",
+        registration: (meta.registration as string) || "",
+        region: regionOf(o.lat, o.lon),
+        squawk: (meta.squawk as string) || "",
+      };
+    }),
+    [rows],
+  );
+  const exportGeo = useMemo(
+    () => filtered.map((o) => ({ lat: o.lat, lon: o.lon, properties: { callsign: o.label, ...(o.meta ?? {}) } })),
+    [filtered],
+  );
 
   return (
     <div className="tn-av">
@@ -241,6 +265,16 @@ export default function AviationDetail(_props: WidgetDetailProps) {
 
       <footer className="tn-av-foot">
         <span className="tn-av-attr">Aircraft: adsb.lol · enrichment: adsbdb · 3 fixed regions (London / California / S.Carolina)</span>
+        <span className="tn-av-actions">
+          <button
+            disabled={exportRows.length === 0}
+            onClick={() => downloadText(`${exportFilename("aviation", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+          >⬇ CSV</button>
+          <button
+            disabled={exportGeo.length === 0}
+            onClick={() => downloadText(`${exportFilename("aviation", Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}
+          >⬇ GeoJSON</button>
+        </span>
       </footer>
     </div>
   );

--- a/lib/console/widgets/aviation.detail.tsx
+++ b/lib/console/widgets/aviation.detail.tsx
@@ -1,0 +1,108 @@
+"use client";
+// Aviation focus view — the airspace console. Reuses the SAME live pipeline as the
+// docked widget (usePlanes → { objects, trails }) but renders deep: an ops-summary
+// masthead with a count sparkline, an emergency-squawk banner, region + altitude
+// filters, a region map and altitude histogram, a sortable uncapped flight table
+// with a per-flight PlaneDetail dossier, and an attribution footer with export.
+// All aviation maths lives in the unit-tested lib/planes/ops.ts; this is a shell.
+import { useEffect, useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import { usePlanes } from "@/lib/planes/usePlanes";
+import { opsSummary, type AltBand, type FlightSortKey } from "@/lib/planes/ops";
+import { recordSeries, seriesSamples } from "@/lib/series";
+import { deltaOf } from "@/lib/widgets/history";
+import { Chart, type ChartPoint } from "@/components/Chart";
+
+const MS_TO_KT = 1.94384;
+const EMERGENCY_REASON: Record<string, string> = { "7500": "hijack", "7600": "radio failure", "7700": "emergency" };
+
+export default function AviationDetail(_props: WidgetDetailProps) {
+  const layer = usePlanes();
+  const objects = layer.objects;
+
+  const summary = useMemo(() => opsSummary(objects), [objects]);
+  const total = summary.total;
+
+  // Filter / sort / dossier state — consumed by the panels and table added in the
+  // later tasks. Declared here as the skeleton so the component grows in place.
+  const [region, setRegion] = useState<string | null>(null);
+  const [band, setBand] = useState<AltBand | null>(null);
+  const [sortKey, setSortKey] = useState<FlightSortKey>("altitude");
+  const [dir, setDir] = useState<1 | -1>(-1);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  // usePlanes hands back a fresh objects array every poll (even when unchanged), so
+  // its reference change is our per-poll clock — the stable timestamp the count
+  // sparkline needs (usePlanes exposes no updatedAt of its own).
+  const [updatedAt, setUpdatedAt] = useState(0);
+  useEffect(() => { setUpdatedAt(Date.now()); }, [objects]);
+
+  useEffect(() => {
+    if (updatedAt) recordSeries("av:count", total, updatedAt);
+  }, [updatedAt, total]);
+
+  // Read the persisted series AND fold in the CURRENT poll's live count. recordSeries
+  // only writes in a post-commit effect and lib/series has no React subscription, so
+  // without folding it in here the delta/sparkline would trail the count beside them
+  // by one poll (exactly as signals.detail.tsx does).
+  const samples = useMemo(() => {
+    const base = seriesSamples("av:count");
+    const last = base[base.length - 1];
+    if (updatedAt && (!last || last.t !== updatedAt || last.n !== total)) {
+      return [...base, { t: updatedAt, n: total }];
+    }
+    return base;
+  }, [updatedAt, total]);
+  const spark: ChartPoint[] = useMemo(() => samples.map((s) => ({ x: s.t, y: s.n })), [samples]);
+  const delta = useMemo(() => deltaOf(samples), [samples]);
+
+  const emergencies = useMemo(
+    () => objects.filter((o) => {
+      const sq = o.meta?.squawk;
+      return typeof sq === "string" && sq in EMERGENCY_REASON;
+    }),
+    [objects],
+  );
+
+  return (
+    <div className="tn-av">
+      <header className="tn-av-head">
+        <div className="tn-av-title">Airspace</div>
+        <div className="tn-av-stat">
+          <b>{total}</b> live · {summary.airborne} airborne · {summary.ground} ground · max{" "}
+          {summary.maxAltKm.toFixed(1)} km · {(summary.maxSpeedMs * MS_TO_KT).toFixed(0)} kt
+          {delta !== 0 && (
+            <span className={`tn-av-delta ${delta > 0 ? "up" : "down"}`}> {delta > 0 ? "▲" : "▼"}{Math.abs(delta)}</span>
+          )}
+        </div>
+        {spark.length >= 2 && <div className="tn-av-spark"><Chart points={spark} height={40} up={null} /></div>}
+        {summary.byCategory.length > 0 && (
+          <div className="tn-av-ops">
+            {summary.byCategory.map((c) => (
+              <span key={c.category} className="tn-av-chip">{c.label} · {c.count}</span>
+            ))}
+          </div>
+        )}
+      </header>
+
+      {emergencies.length > 0 && (
+        <div className="tn-av-emg-list">
+          {emergencies.map((o) => {
+            const code = o.meta?.squawk as string;
+            return (
+              <div key={o.id} className="tn-av-emg">
+                ⚠ {o.label} squawking {code} — {EMERGENCY_REASON[code]}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {objects.length === 0 && <p className="tn-w-empty">No aircraft in range right now.</p>}
+
+      <footer className="tn-av-foot">
+        <span className="tn-av-attr">Aircraft: adsb.lol · enrichment: adsbdb · 3 fixed regions (London / California / S.Carolina)</span>
+      </footer>
+    </div>
+  );
+}

--- a/lib/console/widgets/aviation.detail.tsx
+++ b/lib/console/widgets/aviation.detail.tsx
@@ -5,11 +5,11 @@
 // filters, a region map and altitude histogram, a sortable uncapped flight table
 // with a per-flight PlaneDetail dossier, and an attribution footer with export.
 // All aviation maths lives in the unit-tested lib/planes/ops.ts; this is a shell.
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import { usePlanes } from "@/lib/planes/usePlanes";
 import {
-  opsSummary, altitudeBand, regionOf, ALT_BANDS, REGION_LABELS,
+  opsSummary, altitudeBand, regionOf, sortFlights, ALT_BANDS, REGION_LABELS,
   type AltBand, type FlightSortKey,
 } from "@/lib/planes/ops";
 import { recordSeries, seriesSamples } from "@/lib/series";
@@ -17,9 +17,18 @@ import { deltaOf } from "@/lib/widgets/history";
 import { Chart, type ChartPoint } from "@/components/Chart";
 import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
+import PlaneDetail from "@/components/PlaneDetail";
 
 const MS_TO_KT = 1.94384;
+const MS_TO_KMH = 3.6;
+const FT_TO_KM = 0.0003048;
 const EMERGENCY_REASON: Record<string, string> = { "7500": "hijack", "7600": "radio failure", "7700": "emergency" };
+
+// The 16-point compass copy — PlaneDetail's is private, so aviation.detail keeps its own.
+function headingToCompass(deg: number): string {
+  const dirs = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
+  return dirs[Math.round(deg / 22.5) % 16];
+}
 
 export default function AviationDetail(_props: WidgetDetailProps) {
   const layer = usePlanes();
@@ -88,6 +97,14 @@ export default function AviationDetail(_props: WidgetDetailProps) {
     return ALT_BANDS.map((b) => ({ band: b, count: counts.get(b) ?? 0 }));
   }, [filtered]);
   const altMax = Math.max(1, ...altHistogram.map((h) => h.count));
+
+  // Uncapped, sorted flight list (region/altitude filters already applied).
+  const rows = useMemo(() => sortFlights(filtered, sortKey, dir), [filtered, sortKey, dir]);
+  const toggleSort = (k: FlightSortKey) => {
+    if (sortKey === k) setDir((d) => (d === 1 ? -1 : 1));
+    else { setSortKey(k); setDir(-1); }
+  };
+  const sortMark = (k: FlightSortKey) => (sortKey === k ? (dir === -1 ? " ↓" : " ↑") : "");
 
   return (
     <div className="tn-av">
@@ -168,6 +185,58 @@ export default function AviationDetail(_props: WidgetDetailProps) {
             ) : <p className="tn-w-empty">No aircraft match this filter.</p>}
           </div>
         </div>
+      )}
+
+      {filtered.length > 0 && (
+        <table className="tn-av-table">
+          <thead>
+            <tr>
+              <th className="sortable" onClick={() => toggleSort("callsign")}>Callsign{sortMark("callsign")}</th>
+              <th>Type</th>
+              <th className="sortable" onClick={() => toggleSort("altitude")}>Alt{sortMark("altitude")}</th>
+              <th className="sortable" onClick={() => toggleSort("speed")}>Speed{sortMark("speed")}</th>
+              <th>Heading</th>
+              <th>V/S</th>
+              <th>Reg</th>
+              <th className="sortable" onClick={() => toggleSort("region")}>Region{sortMark("region")}</th>
+              <th>Squawk</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((o) => {
+              const meta = o.meta ?? {};
+              const typeCode = (meta.typeCode as string) || "";
+              const altKm = typeof o.altKm === "number" ? o.altKm : null;
+              const velocityMs = typeof meta.velocityMs === "number" ? (meta.velocityMs as number) : null;
+              const headingDeg = typeof meta.headingDeg === "number" ? (meta.headingDeg as number) : (o.heading ?? 0);
+              const vs = typeof meta.verticalRateMs === "number" ? (meta.verticalRateMs as number) : null;
+              const reg = (meta.registration as string) || "";
+              const squawk = (meta.squawk as string) || "";
+              const isEmergency = squawk in EMERGENCY_REASON;
+              const isOpen = openId === o.id;
+              return (
+                <Fragment key={o.id}>
+                  <tr className="tn-av-row" onClick={() => setOpenId(isOpen ? null : o.id)}>
+                    <td className="tn-w-strong">{o.label}</td>
+                    <td className="tn-w-muted">{o.typeLabel ?? "—"}{typeCode ? ` · ${typeCode}` : ""}</td>
+                    <td>{altKm != null ? `${altKm.toFixed(1)} km / ${(altKm / FT_TO_KM).toFixed(0)} ft` : "—"}</td>
+                    <td>{velocityMs != null ? `${(velocityMs * MS_TO_KT).toFixed(0)} kt / ${(velocityMs * MS_TO_KMH).toFixed(0)} km/h` : "—"}</td>
+                    <td>{Math.round(headingDeg)}° {headingToCompass(headingDeg)}</td>
+                    <td>{vs != null ? `${vs.toFixed(1)} m/s` : "—"}</td>
+                    <td>{reg || "—"}</td>
+                    <td>{regionOf(o.lat, o.lon)}</td>
+                    <td className={isEmergency ? "tn-av-sq-emg" : ""}>{squawk || "—"}</td>
+                  </tr>
+                  {isOpen && (
+                    <tr className="tn-av-drill">
+                      <td colSpan={9}><PlaneDetail object={o} /></td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
       )}
 
       <footer className="tn-av-foot">

--- a/lib/console/widgets/aviation.tsx
+++ b/lib/console/widgets/aviation.tsx
@@ -15,9 +15,9 @@ import { aviationAlerts, type PlaneLite } from "@/lib/console/widgets/aviation.r
  * - WorldObject.label  → callsign (adsb.ts sets label = a.callsign ?? a.hex)
  * - WorldObject.altKm  → altitude in km (NOT feet; brief used p.altitude)
  * - WorldObject.typeLabel → human type ("Airliner", "Regional / jet", etc.)
- * - NO squawk field   — adsb.lol's raw data does include squawk but parseAdsb()
- *   does not extract it; squawk will be undefined for all planes until the
- *   upstream parser is extended. Emergency alerts are spec-correct but dormant.
+ * - squawk            — parseAdsb() now captures the raw ADS-B `squawk` code and
+ *   aircraftToWorldObject() carries it on meta.squawk, so the emergency-squawk
+ *   alerts are LIVE: a plane squawking 7500/7600/7700 raises a critical alert.
  * - NO isMilitary     — classifyPlane() has no military category; the ADS-B A6
  *   "heavy military" code exists but is not mapped. isMilitary is always undefined.
  * - NO origin/destination — not present in the WorldObject/Aircraft schema.
@@ -26,10 +26,10 @@ function AviationBody({ config }: WidgetBodyProps) {
   const layer = usePlanes();
   const planes = layer.objects;
 
-  // Map to PlaneLite for alert rules. squawk + isMilitary are unavailable in
-  // the current pipeline (see notes above).
+  // Map to PlaneLite for alert rules. squawk is now threaded from meta so
+  // emergency-squawk alerts fire; isMilitary stays unavailable (see notes above).
   const lite: PlaneLite[] = useMemo(
-    () => planes.map((p) => ({ callsign: p.label })),
+    () => planes.map((p) => ({ callsign: p.label, squawk: (p.meta?.squawk as string) || undefined })),
     [planes],
   );
 

--- a/lib/console/widgets/aviation.tsx
+++ b/lib/console/widgets/aviation.tsx
@@ -5,6 +5,7 @@ import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { runAlertRule } from "@/lib/console/alerts";
 import { aviationAlerts, type PlaneLite } from "@/lib/console/widgets/aviation.rules";
+import AviationDetail from "./aviation.detail";
 
 /**
  * Aviation widget body.
@@ -78,6 +79,7 @@ export const AVIATION_WIDGET = {
   defaultHeight: 280,
   defaultConfig: { sort: "alt" },
   component: AviationBody,
+  detail: AviationDetail,
   capabilities: { filter: true, sort: true },
 };
 registerWidget(AVIATION_WIDGET);

--- a/lib/console/widgets/aviation.tsx
+++ b/lib/console/widgets/aviation.tsx
@@ -62,7 +62,7 @@ function AviationBody({ config }: WidgetBodyProps) {
             <td className="tn-w-strong">{p.label}</td>
             <td className="tn-w-muted">{p.typeLabel ?? ""}</td>
             <td className="tn-w-num">
-              {p.altKm != null ? `${p.altKm.toFixed(1)}k` : ""}
+              {p.altKm != null ? `${p.altKm.toFixed(1)} km` : ""}
             </td>
           </tr>
         ))}

--- a/lib/console/widgets/cameras.detail.tsx
+++ b/lib/console/widgets/cameras.detail.tsx
@@ -11,7 +11,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import { useCameras, type CameraRow } from "@/lib/cameras/useCameras";
-import { coverage } from "@/lib/cameras/coverage";
+import { coverage, byWallPriority } from "@/lib/cameras/coverage";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { deltaOf } from "@/lib/widgets/history";
 import { Chart, type ChartPoint } from "@/components/Chart";
@@ -52,6 +52,12 @@ function CameraTile({ camera, now }: { camera: CameraRow; now: number }) {
   const mountedAt = useRef(Date.now()).current;
   const nextFrame = isStill ? formatCountdown(msUntilRefresh(mountedAt, camera.refreshSeconds, now)) : null;
   const age = sampledAgeMs(camera.lastSampledAt, now);
+
+  // Free this camera's shared HLS slot when the tile leaves the wall (filtered out /
+  // unmounted). CameraVideo already tears down its own hls.js instance on unmount, but
+  // without this the id lingers in hlsSlots.active and the "N/6 live" honesty counter
+  // over-reports players that are no longer on screen.
+  useEffect(() => () => { hlsSlots.deactivate(camera.id); }, [camera.id]);
 
   return (
     <div className="tn-cm-tile">
@@ -113,16 +119,12 @@ export default function CamerasDetail(_props: WidgetDetailProps) {
   // Live-player count for the "N/6 live" honesty counter (shared HLS slot store).
   const liveActive = useSyncExternalStore(hlsSlots.subscribe, hlsSlots.get, hlsSlots.get);
 
-  // Wall = a bounded, most-interesting-first slice (live, then available, then name).
+  // Wall = a bounded, most-interesting-first slice: working-live, then working-still,
+  // then offline last. Gate "live" on availability — an offline feed can still carry an
+  // allowlisted stream URL (live=true, available=false), and ranking those ahead of
+  // working stills would fill the bounded wall with "Feed offline" tiles.
   const wall = useMemo(
-    () =>
-      [...filtered]
-        .sort((a, b) =>
-          Number(b.live) - Number(a.live) ||
-          Number(b.available) - Number(a.available) ||
-          a.name.localeCompare(b.name),
-        )
-        .slice(0, WALL_CAP),
+    () => [...filtered].sort(byWallPriority).slice(0, WALL_CAP),
     [filtered],
   );
 

--- a/lib/console/widgets/cameras.detail.tsx
+++ b/lib/console/widgets/cameras.detail.tsx
@@ -24,6 +24,7 @@ import { CameraDetail } from "@/components/CameraDetail";
 import { hlsSlots, useHlsActive, HLS_CAP } from "@/lib/cameras/concurrency";
 import { msUntilRefresh, formatCountdown, sampledAgeMs } from "@/lib/cameras/freshness";
 import { useNow, formatAge } from "@/lib/shell/useNow";
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
 import type { WorldObject } from "@/lib/world";
 
 type SortKey = "name" | "operator" | "region";
@@ -135,6 +136,25 @@ export default function CamerasDetail(_props: WidgetDetailProps) {
     else { setSortKey(k); setDir(1); }
   };
   const sortMark = (k: SortKey) => (sortKey === k ? (dir === 1 ? " ↑" : " ↓") : "");
+
+  // Export the FILTERED set (what's on screen). Per-operator licences ride on each
+  // Camera.attribution/license, so the footer just names the distinct operators and
+  // points to the per-camera licence (surfaced in the dossier's AttributionBadge).
+  const operators = useMemo(() => cov.byOperator.map((o) => o.source).join(", "), [cov]);
+  const exportRows = useMemo(
+    () => filtered.map((c) => ({
+      id: c.id, name: c.name, source: c.source, region: c.region ?? "",
+      lat: c.lat, lon: c.lon, live: c.live, available: c.available,
+    })),
+    [filtered],
+  );
+  const exportGeo = useMemo(
+    () => filtered.map((c) => ({
+      lat: c.lat, lon: c.lon,
+      properties: { name: c.name, source: c.source, live: c.live, available: c.available },
+    })),
+    [filtered],
+  );
 
   // Count sparkline: only stamp the series ONCE REAL DATA HAS ARRIVED (the W4 review
   // fix). The initial feed is empty and its updatedAt is null; even after a poll,
@@ -285,7 +305,21 @@ export default function CamerasDetail(_props: WidgetDetailProps) {
       )}
 
       <footer className="tn-cm-foot">
-        <span className="tn-cm-attr">Traffic cameras · see each camera for its licence.</span>
+        <span className="tn-cm-attr">
+          {operators
+            ? `Operators: ${operators} · see each camera for its licence.`
+            : "Traffic cameras · see each camera for its licence."}
+        </span>
+        <span className="tn-cm-actions">
+          <button
+            disabled={exportRows.length === 0}
+            onClick={() => downloadText(`${exportFilename("cameras", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+          >⬇ CSV</button>
+          <button
+            disabled={exportGeo.length === 0}
+            onClick={() => downloadText(`${exportFilename("cameras", Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}
+          >⬇ GeoJSON</button>
+        </span>
       </footer>
     </div>
   );

--- a/lib/console/widgets/cameras.detail.tsx
+++ b/lib/console/widgets/cameras.detail.tsx
@@ -8,9 +8,9 @@
 // export footer. All snapshots go strictly through /api/proxy?id= (still) and
 // /api/hls?id= (live) via CameraImage / CameraVideo / CameraDetail — never a raw
 // upstream URL (SSRF). Coverage + concurrency maths live in unit-tested lib/cameras/.
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
-import { useCameras } from "@/lib/cameras/useCameras";
+import { useCameras, type CameraRow } from "@/lib/cameras/useCameras";
 import { coverage } from "@/lib/cameras/coverage";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { deltaOf } from "@/lib/widgets/history";
@@ -18,8 +18,68 @@ import { Chart, type ChartPoint } from "@/components/Chart";
 import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
 import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
+import { CameraImage } from "@/components/CameraImage";
+import { CameraVideo } from "@/components/CameraVideo";
+import { CameraDetail } from "@/components/CameraDetail";
+import { hlsSlots, useHlsActive, HLS_CAP } from "@/lib/cameras/concurrency";
+import { msUntilRefresh, formatCountdown, sampledAgeMs } from "@/lib/cameras/freshness";
+import { useNow, formatAge } from "@/lib/shell/useNow";
+import type { WorldObject } from "@/lib/world";
 
 type SortKey = "name" | "operator" | "region";
+
+// The registry merges thousands of cameras (TfL ~900, Digitraffic ~2000, …). The
+// still wall renders one refreshing <img> (a /api/proxy request) per tile, so it is
+// bounded — a wall of thousands would storm the proxy and the browser. Live players
+// are capped separately (HLS_CAP). The table caps its DOM rows for the same reason;
+// both show an honest "showing N of M — refine with filters" note.
+const WALL_CAP = 18;
+const TABLE_CAP = 300;
+
+function toWorldObject(c: CameraRow): WorldObject {
+  return { kind: "camera", id: c.id, label: c.name, lat: c.lat, lon: c.lon, meta: { available: c.available } };
+}
+
+// One tile in the still/live wall. Defaults to a still <img> (CameraImage → the
+// SSRF-safe /api/proxy?id=); a live camera gets a "▶ Live" button that activates an
+// HLS slot (capped, oldest-evicted in concurrency.ts) and swaps to CameraVideo
+// (/api/hls?id=). Offline feeds show an honest placeholder — never a raw upstream URL.
+function CameraTile({ camera, now }: { camera: CameraRow; now: number }) {
+  const active = useHlsActive(camera.id);
+  const isLive = camera.live && camera.available;
+  const isStill = camera.available && !camera.live;
+  const mountedAt = useRef(Date.now()).current;
+  const nextFrame = isStill ? formatCountdown(msUntilRefresh(mountedAt, camera.refreshSeconds, now)) : null;
+  const age = sampledAgeMs(camera.lastSampledAt, now);
+
+  return (
+    <div className="tn-cm-tile">
+      <div className="tn-cm-shot">
+        {!camera.available ? (
+          <div className="tn-cm-offline">Feed offline</div>
+        ) : isLive && active ? (
+          <>
+            <button className="tn-cm-live-btn" onClick={() => hlsSlots.deactivate(camera.id)}>◼ Stop</button>
+            <CameraVideo id={camera.id} alt={camera.name} attribution={camera.attribution} license={camera.license} refreshSeconds={camera.refreshSeconds} />
+          </>
+        ) : (
+          <>
+            {isLive && <button className="tn-cm-live-btn" onClick={() => hlsSlots.activate(camera.id)}>▶ Live</button>}
+            <CameraImage id={camera.id} alt={camera.name} attribution={camera.attribution} license={camera.license} refreshSeconds={camera.refreshSeconds} />
+          </>
+        )}
+      </div>
+      <div className="tn-cm-cap">
+        <span className="tn-cm-cap-name">{camera.name}</span>
+        <span className="tn-cm-cap-sub">
+          {camera.source}
+          {isLive ? " · ▶ live" : isStill ? ` · still · next ${nextFrame}` : " · offline"}
+          {age != null && ` · sampled ${formatAge(age)} ago`}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 export default function CamerasDetail(_props: WidgetDetailProps) {
   const { cameras, status, updatedAt } = useCameras();
@@ -46,6 +106,35 @@ export default function CamerasDetail(_props: WidgetDetailProps) {
     () => filtered.map((c) => ({ lat: c.lat, lon: c.lon, id: c.id, props: { name: c.name } })),
     [filtered],
   );
+
+  // 1s tick drives the per-tile still-refresh countdowns + sampled ages.
+  const now = useNow(1000);
+  // Live-player count for the "N/6 live" honesty counter (shared HLS slot store).
+  const liveActive = useSyncExternalStore(hlsSlots.subscribe, hlsSlots.get, hlsSlots.get);
+
+  // Wall = a bounded, most-interesting-first slice (live, then available, then name).
+  const wall = useMemo(
+    () =>
+      [...filtered]
+        .sort((a, b) =>
+          Number(b.live) - Number(a.live) ||
+          Number(b.available) - Number(a.available) ||
+          a.name.localeCompare(b.name),
+        )
+        .slice(0, WALL_CAP),
+    [filtered],
+  );
+
+  // Sortable table (name / operator / region), capped for DOM sanity.
+  const rows = useMemo(() => {
+    const val = (c: CameraRow) => (sortKey === "name" ? c.name : sortKey === "operator" ? c.source : c.region ?? "");
+    return [...filtered].sort((a, b) => val(a).localeCompare(val(b)) * dir).slice(0, TABLE_CAP);
+  }, [filtered, sortKey, dir]);
+  const toggleSort = (k: SortKey) => {
+    if (sortKey === k) setDir((d) => (d === 1 ? -1 : 1));
+    else { setSortKey(k); setDir(1); }
+  };
+  const sortMark = (k: SortKey) => (sortKey === k ? (dir === 1 ? " ↑" : " ↓") : "");
 
   // Count sparkline: only stamp the series ONCE REAL DATA HAS ARRIVED (the W4 review
   // fix). The initial feed is empty and its updatedAt is null; even after a poll,
@@ -142,6 +231,57 @@ export default function CamerasDetail(_props: WidgetDetailProps) {
               : <p className="tn-w-empty">No cameras match this filter.</p>}
           </div>
         </div>
+      )}
+
+      {filtered.length > 0 && (
+        <div className="tn-cm-panel">
+          <h3>
+            Camera wall
+            <span className="tn-cm-count">
+              {liveActive.length}/{HLS_CAP} live · showing {wall.length} of {filtered.length}
+            </span>
+          </h3>
+          <div className="tn-cm-wall">
+            {wall.map((c) => <CameraTile key={c.id} camera={c} now={now} />)}
+          </div>
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <table className="tn-cm-table">
+          <thead>
+            <tr>
+              <th className="sortable" onClick={() => toggleSort("name")}>Name{sortMark("name")}</th>
+              <th className="sortable" onClick={() => toggleSort("operator")}>Operator{sortMark("operator")}</th>
+              <th className="sortable" onClick={() => toggleSort("region")}>Region{sortMark("region")}</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((c) => {
+              const isOpen = openId === c.id;
+              return (
+                <Fragment key={c.id}>
+                  <tr className="tn-cm-row" onClick={() => setOpenId(isOpen ? null : c.id)}>
+                    <td className="tn-w-strong">{c.name}</td>
+                    <td className="tn-w-muted">{c.source}</td>
+                    <td>{c.region ?? "—"}</td>
+                    <td>{!c.available ? "Offline" : c.live ? "▶ Live" : "Still"}</td>
+                  </tr>
+                  {isOpen && (
+                    <tr className="tn-cm-drill">
+                      <td colSpan={4}><CameraDetail object={toWorldObject(c)} /></td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {filtered.length > TABLE_CAP && (
+        <p className="tn-w-empty">Showing the first {TABLE_CAP} of {filtered.length} — refine with the filters above.</p>
       )}
 
       <footer className="tn-cm-foot">

--- a/lib/console/widgets/cameras.detail.tsx
+++ b/lib/console/widgets/cameras.detail.tsx
@@ -15,6 +15,9 @@ import { coverage } from "@/lib/cameras/coverage";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { deltaOf } from "@/lib/widgets/history";
 import { Chart, type ChartPoint } from "@/components/Chart";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
+import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
 
 type SortKey = "name" | "operator" | "region";
 
@@ -29,6 +32,20 @@ export default function CamerasDetail(_props: WidgetDetailProps) {
   const [openId, setOpenId] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("operator");
   const [dir, setDir] = useState<1 | -1>(1);
+
+  // Operator (per-source) + live-only filtering, reusing the SAME cameraFilterStore
+  // the globe/legend drive. NOTE: `passes` lives on the STORE (not the state object
+  // useCameraFilter returns); we read the reactive state as the memo trigger and call
+  // cameraFilterStore.passes with the current live state (mirrors WorldMap.tsx).
+  const filter = useCameraFilter();
+  const filtered = useMemo(
+    () => cameras.filter((c) => cameraFilterStore.passes(c.source, c.live)),
+    [cameras, filter],
+  );
+  const mapPoints: InsetPoint[] = useMemo(
+    () => filtered.map((c) => ({ lat: c.lat, lon: c.lon, id: c.id, props: { name: c.name } })),
+    [filtered],
+  );
 
   // Count sparkline: only stamp the series ONCE REAL DATA HAS ARRIVED (the W4 review
   // fix). The initial feed is empty and its updatedAt is null; even after a poll,
@@ -72,6 +89,60 @@ export default function CamerasDetail(_props: WidgetDetailProps) {
       {status === "loading" && cameras.length === 0 && <p className="tn-w-empty">Loading cameras…</p>}
       {status === "error" && cameras.length === 0 && <p className="tn-w-empty">Could not load cameras.</p>}
       {status === "idle" && cameras.length === 0 && <p className="tn-w-empty">No cameras loaded.</p>}
+
+      {cameras.length > 0 && (
+        <div className="tn-cm-cov">
+          {cov.byOperator.map((o) => (
+            <span
+              key={o.source}
+              className="tn-cm-cov-chip"
+              title={`${o.source}: ${o.live} live · ${o.still} still · ${o.offline} offline`}
+            >
+              <b>{o.source}</b> · {o.live}▶ / {o.still}▦ / {o.offline}✕
+            </span>
+          ))}
+        </div>
+      )}
+
+      {cameras.length > 0 && (
+        <div className="tn-cm-filters">
+          <div className="tn-cm-filter-row">
+            <span className="tn-cm-filter-label">Operators</span>
+            {cov.byOperator.map((o) => {
+              const on = filter.regions[o.source] ?? true;
+              return (
+                <button
+                  key={o.source}
+                  className={`tn-cm-fchip ${on ? "active" : "off"}`}
+                  onClick={() => cameraFilterStore.toggleRegion(o.source)}
+                >
+                  {o.source} · {o.total}
+                </button>
+              );
+            })}
+          </div>
+          <div className="tn-cm-filter-row">
+            <span className="tn-cm-filter-label">Live</span>
+            <button
+              className={`tn-cm-fchip ${filter.liveOnly ? "active" : ""}`}
+              onClick={() => cameraFilterStore.setLiveOnly(!filter.liveOnly)}
+            >
+              Live streams only
+            </button>
+          </div>
+        </div>
+      )}
+
+      {cameras.length > 0 && (
+        <div className="tn-cm-panels">
+          <div className="tn-cm-panel">
+            <h3>Locations <span className="tn-cm-count">{filtered.length} shown</span></h3>
+            {mapPoints.length > 0
+              ? <InsetMap points={mapPoints} height={240} onSelect={(id) => setOpenId(id)} />
+              : <p className="tn-w-empty">No cameras match this filter.</p>}
+          </div>
+        </div>
+      )}
 
       <footer className="tn-cm-foot">
         <span className="tn-cm-attr">Traffic cameras · see each camera for its licence.</span>

--- a/lib/console/widgets/cameras.detail.tsx
+++ b/lib/console/widgets/cameras.detail.tsx
@@ -1,0 +1,81 @@
+"use client";
+// Cameras focus view — the traffic-camera console. The docked widget only sees
+// map-loaded cameras (loadedCamerasStore); this detail fetches the full enriched
+// /api/cameras list via useCameras(), then renders deep: a coverage-honesty masthead
+// with a count sparkline, a per-operator coverage bar, operator/region filters, a
+// region map, still + click-to-activate live camera walls (HLS concurrency-capped),
+// a sortable table with a per-camera CameraDetail dossier, and an attribution +
+// export footer. All snapshots go strictly through /api/proxy?id= (still) and
+// /api/hls?id= (live) via CameraImage / CameraVideo / CameraDetail — never a raw
+// upstream URL (SSRF). Coverage + concurrency maths live in unit-tested lib/cameras/.
+import { useEffect, useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import { useCameras } from "@/lib/cameras/useCameras";
+import { coverage } from "@/lib/cameras/coverage";
+import { recordSeries, seriesSamples } from "@/lib/series";
+import { deltaOf } from "@/lib/widgets/history";
+import { Chart, type ChartPoint } from "@/components/Chart";
+
+type SortKey = "name" | "operator" | "region";
+
+export default function CamerasDetail(_props: WidgetDetailProps) {
+  const { cameras, status, updatedAt } = useCameras();
+  const cov = useMemo(() => coverage(cameras), [cameras]);
+  const total = cov.total;
+
+  // Filter / sort / dossier state — consumed by the panels + table added in the
+  // later tasks. Declared here as the skeleton (no noUnusedLocals) so the component
+  // grows in place.
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>("operator");
+  const [dir, setDir] = useState<1 | -1>(1);
+
+  // Count sparkline: only stamp the series ONCE REAL DATA HAS ARRIVED (the W4 review
+  // fix). The initial feed is empty and its updatedAt is null; even after a poll,
+  // recording a count=0 from an empty list would persist a spurious zero. `stamp` is
+  // null until cameras exist, so the `if (stamp)` guards below never fire on empties.
+  const stamp = cameras.length > 0 ? updatedAt : null;
+  useEffect(() => {
+    if (stamp) recordSeries("cam:count", total, stamp);
+  }, [stamp, total]);
+
+  // Read the persisted series AND fold in the CURRENT poll's live count — recordSeries
+  // only writes in a post-commit effect and lib/series has no React subscription, so
+  // without folding it in the delta/sparkline would trail the count beside them by one
+  // poll (exactly as signals.detail.tsx / aviation.detail.tsx do).
+  const samples = useMemo(() => {
+    const base = seriesSamples("cam:count");
+    const last = base[base.length - 1];
+    if (stamp && (!last || last.t !== stamp || last.n !== total)) {
+      return [...base, { t: stamp, n: total }];
+    }
+    return base;
+  }, [stamp, total]);
+  const spark: ChartPoint[] = useMemo(() => samples.map((s) => ({ x: s.t, y: s.n })), [samples]);
+  const delta = useMemo(() => deltaOf(samples), [samples]);
+
+  const freshAge = updatedAt ? `${Math.max(0, Math.round((Date.now() - updatedAt) / 60000))}m ago` : "—";
+
+  return (
+    <div className="tn-cm">
+      <header className="tn-cm-head">
+        <div className="tn-cm-title">Camera network</div>
+        <div className="tn-cm-stat">
+          <b>{total}</b> cameras · {cov.live} live · {cov.still} still · {cov.offline} offline · updated {freshAge}
+          {delta !== 0 && (
+            <span className={`tn-cm-delta ${delta > 0 ? "up" : "down"}`}> {delta > 0 ? "▲" : "▼"}{Math.abs(delta)}</span>
+          )}
+        </div>
+        {spark.length >= 2 && <div className="tn-cm-spark"><Chart points={spark} height={40} up={null} /></div>}
+      </header>
+
+      {status === "loading" && cameras.length === 0 && <p className="tn-w-empty">Loading cameras…</p>}
+      {status === "error" && cameras.length === 0 && <p className="tn-w-empty">Could not load cameras.</p>}
+      {status === "idle" && cameras.length === 0 && <p className="tn-w-empty">No cameras loaded.</p>}
+
+      <footer className="tn-cm-foot">
+        <span className="tn-cm-attr">Traffic cameras · see each camera for its licence.</span>
+      </footer>
+    </div>
+  );
+}

--- a/lib/console/widgets/cameras.tsx
+++ b/lib/console/widgets/cameras.tsx
@@ -20,6 +20,7 @@ import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { runAlertRule } from "@/lib/console/alerts";
 import { cameraAlerts, type CameraLite } from "@/lib/console/widgets/cameras.rules";
+import CamerasDetail from "./cameras.detail";
 
 function CamerasBody({ config }: WidgetBodyProps) {
   // Reactive: rerenders whenever WorldMap calls loadedCamerasStore.set().
@@ -68,5 +69,7 @@ export const CAMERAS_WIDGET = {
   defaultHeight: 260,
   defaultConfig: {},
   component: CamerasBody,
+  detail: CamerasDetail,
+  capabilities: { filter: true, sort: true },
 };
 registerWidget(CAMERAS_WIDGET);

--- a/lib/console/widgets/events.detail.tsx
+++ b/lib/console/widgets/events.detail.tsx
@@ -1,0 +1,93 @@
+// lib/console/widgets/events.detail.tsx
+"use client";
+// Events focus view. Reuses the SAME feed pipeline as the docked widget
+// (useEventFeeds → projectEventFeed) but renders deep: a tier/type triage header,
+// a feed grouped by event type with honest per-domain metric lines joined back to
+// the raw SignalFeature props, and (Task 10/11) a recency chart, event map and export.
+import { useMemo } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import { EVENT_SOURCES } from "@/lib/events/sources";
+import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
+import { projectEventFeed, type FeedInput } from "@/lib/widgets/eventFeed";
+import { useScope } from "@/lib/shell/scope";
+import { useTimeWindow, windowMsFor } from "@/lib/shell/timeWindow";
+import { useNow } from "@/lib/shell/useNow";
+import { SEVERITY_COLOR, type SeverityTier, type EventType } from "@/lib/events/model";
+import type { SignalFeature } from "@/lib/signals/types";
+import { countBy } from "@/lib/widgets/buckets";
+import { eventMetricLine } from "@/lib/widgets/eventMetrics";
+
+const TIERS: SeverityTier[] = ["S4", "S3", "S2", "S1", "S0"];
+const TYPE_LABEL: Partial<Record<EventType, string>> = { quake: "Quakes", disaster: "Disasters", cyclone: "Cyclones" };
+
+export default function EventsDetail({ config }: WidgetDetailProps) {
+  const scope = useScope();
+  const win = useTimeWindow();
+  const now = useNow(60_000);
+  const { bySource, status, updatedAt } = useEventFeeds();
+
+  const inputs: FeedInput[] = useMemo(
+    () => EVENT_SOURCES.map((source) => ({ source, features: bySource[source.id] ?? [] })),
+    [bySource],
+  );
+  const minTier = ((config.minTier as string) ?? "S1") as SeverityTier;
+
+  const projected = useMemo(
+    () => projectEventFeed(inputs, scope, windowMsFor(win), now, { types: null, minTier, sort: "severity" }),
+    [inputs, scope, win, now, minTier],
+  );
+
+  // Join back to raw props for per-domain metrics (lost in NormalizedEvent).
+  const featureById = useMemo(() => {
+    const m = new Map<string, SignalFeature>();
+    for (const s of EVENT_SOURCES) for (const f of bySource[s.id] ?? []) m.set(f.id, f);
+    return m;
+  }, [bySource]);
+
+  const tierCounts = useMemo(() => countBy(projected.rows, (e) => e.severity.tier), [projected.rows]);
+  const groups = useMemo(() => {
+    const by = new Map<EventType, typeof projected.rows>();
+    for (const e of projected.rows) { const g = by.get(e.type) ?? []; g.push(e); by.set(e.type, g); }
+    return [...by.entries()];
+  }, [projected.rows]);
+
+  return (
+    <div className="tn-evd">
+      <div className="tn-evd-head">
+        <div className="tn-evd-stat"><b>{projected.shown}</b> of {projected.total} events</div>
+        <div className="tn-evd-scope">{scope.label}{updatedAt ? ` · updated ${Math.round((now - updatedAt) / 60000)}m ago` : ""}</div>
+        <div className="tn-evd-tiers">
+          {TIERS.map((t) => (
+            <span key={t} className="tn-evd-tier" style={{ borderColor: SEVERITY_COLOR[t] }}>
+              <i style={{ background: SEVERITY_COLOR[t] }} /> {t} {tierCounts[t] ?? 0}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {status === "loading" && projected.shown === 0 && <p className="tn-w-empty">Loading events…</p>}
+      {projected.shown === 0 && status !== "loading" && (
+        <p className="tn-w-empty">No events above {minTier} in {scope.label}.</p>
+      )}
+
+      {groups.map(([type, rows]) => (
+        <section key={type} className="tn-evd-group">
+          <h3 className="tn-evd-group-h">{TYPE_LABEL[type] ?? type} · {rows.length}</h3>
+          <ul className="tn-evd-list">
+            {rows.map((e) => {
+              const metric = eventMetricLine(e.type, featureById.get(e.id)?.props);
+              return (
+                <li key={e.id}>
+                  <span className="tn-w-sev" style={{ background: SEVERITY_COLOR[e.severity.tier] }}>{e.severity.tier}</span>{" "}
+                  <b>{e.title}</b> <span className="tn-w-place">{e.place.name}</span>
+                  {metric && <span className="tn-evd-metric"> · {metric}</span>}
+                  {e.link && <a className="tn-evd-src" href={e.link} target="_blank" rel="noreferrer"> source ↗</a>}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/lib/console/widgets/events.detail.tsx
+++ b/lib/console/widgets/events.detail.tsx
@@ -20,6 +20,7 @@ import { timeBins } from "@/lib/widgets/buckets";
 import { Chart, type ChartPoint } from "@/components/Chart";
 import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
 
 const TIERS: SeverityTier[] = ["S4", "S3", "S2", "S1", "S0"];
 const TYPE_LABEL: Partial<Record<EventType, string>> = { quake: "Quakes", disaster: "Disasters", cyclone: "Cyclones" };
@@ -67,6 +68,24 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
       lat: e.geo.lat, lon: e.geo.lon, id: e.id, color: e.color,
       props: { title: e.title, tier: e.severity.tier },
     })),
+    [projected.rows],
+  );
+
+  const perSource = useMemo(() => {
+    const counts = countBy(projected.rows, (e) => e.source.id);
+    return EVENT_SOURCES.map((s) => ({ id: s.id, label: s.label, attribution: s.attribution, count: counts[s.id] ?? 0 }));
+  }, [projected.rows]);
+
+  const exportRows = useMemo(
+    () => projected.rows.map((e) => ({
+      tier: e.severity.tier, type: e.type, title: e.title, place: e.place.name,
+      metric: eventMetricLine(e.type, featureById.get(e.id)?.props),
+      lat: e.geo.lat, lon: e.geo.lon, occurredAt: e.occurredAt ?? "",
+    })),
+    [projected.rows, featureById],
+  );
+  const exportGeo = useMemo(
+    () => projected.rows.map((e) => ({ lat: e.geo.lat, lon: e.geo.lon, properties: { tier: e.severity.tier, type: e.type, title: e.title } })),
     [projected.rows],
   );
 
@@ -122,6 +141,24 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
           </ul>
         </section>
       ))}
+
+      <footer className="tn-evd-foot">
+        <div className="tn-evd-sources">
+          {perSource.map((s) => (
+            <span key={s.id} className="tn-evd-source">{s.label} · {s.count} <i>({s.attribution})</i></span>
+          ))}
+        </div>
+        <div className="tn-evd-export">
+          <button
+            disabled={exportRows.length === 0}
+            onClick={() => downloadText(`${exportFilename("events", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+          >⬇ CSV</button>
+          <button
+            disabled={exportGeo.length === 0}
+            onClick={() => downloadText(`${exportFilename("events", Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}
+          >⬇ GeoJSON</button>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/lib/console/widgets/events.detail.tsx
+++ b/lib/console/widgets/events.detail.tsx
@@ -16,6 +16,10 @@ import { SEVERITY_COLOR, type SeverityTier, type EventType } from "@/lib/events/
 import type { SignalFeature } from "@/lib/signals/types";
 import { countBy } from "@/lib/widgets/buckets";
 import { eventMetricLine } from "@/lib/widgets/eventMetrics";
+import { timeBins } from "@/lib/widgets/buckets";
+import { Chart, type ChartPoint } from "@/components/Chart";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
 
 const TIERS: SeverityTier[] = ["S4", "S3", "S2", "S1", "S0"];
 const TYPE_LABEL: Partial<Record<EventType, string>> = { quake: "Quakes", disaster: "Disasters", cyclone: "Cyclones" };
@@ -51,6 +55,21 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
     return [...by.entries()];
   }, [projected.rows]);
 
+  const recency: ChartPoint[] = useMemo(() => {
+    const ts = projected.rows
+      .map((e) => (e.occurredAt ? Date.parse(e.occurredAt) : NaN))
+      .filter((n) => Number.isFinite(n));
+    return timeBins(ts, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
+  }, [projected.rows, now]);
+
+  const mapPoints: InsetPoint[] = useMemo(
+    () => projected.rows.map((e) => ({
+      lat: e.geo.lat, lon: e.geo.lon, id: e.id, color: e.color,
+      props: { title: e.title, tier: e.severity.tier },
+    })),
+    [projected.rows],
+  );
+
   return (
     <div className="tn-evd">
       <div className="tn-evd-head">
@@ -62,6 +81,21 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
               <i style={{ background: SEVERITY_COLOR[t] }} /> {t} {tierCounts[t] ?? 0}
             </span>
           ))}
+        </div>
+      </div>
+
+      <div className="tn-evd-panels">
+        <div className="tn-evd-panel">
+          <h3 className="tn-evd-group-h">Events over the last 24h</h3>
+          {recency.some((p) => p.y > 0)
+            ? <Chart points={recency} height={140} up={null} />
+            : <p className="tn-w-empty">No timestamped events in the window.</p>}
+        </div>
+        <div className="tn-evd-panel">
+          <h3 className="tn-evd-group-h">Locations</h3>
+          {mapPoints.length > 0
+            ? <InsetMap points={mapPoints} height={220} />
+            : <p className="tn-w-empty">No mappable events right now.</p>}
         </div>
       </div>
 

--- a/lib/console/widgets/events.tsx
+++ b/lib/console/widgets/events.tsx
@@ -24,6 +24,7 @@ import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { runAlertRule } from "@/lib/console/alerts";
 import { eventAlerts, type EventLite } from "@/lib/console/widgets/events.rules";
 import type { SeverityTier } from "@/lib/events/model";
+import EventsDetail from "@/lib/console/widgets/events.detail";
 
 function EventsBody({ config }: WidgetBodyProps) {
   const scope = useScope();
@@ -137,6 +138,7 @@ export const EVENTS_WIDGET = {
   defaultHeight: 320,
   defaultConfig: { minTier: "S1", sort: "severity" },
   component: EventsBody,
+  detail: EventsDetail,
   capabilities: { filter: true, sort: true },
 };
 registerWidget(EVENTS_WIDGET);

--- a/lib/console/widgets/headlines.detail.tsx
+++ b/lib/console/widgets/headlines.detail.tsx
@@ -10,6 +10,7 @@ import type { NewsItem } from "@/lib/news";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { countBy, timeBins } from "@/lib/widgets/buckets";
 import { Chart, type ChartPoint } from "@/components/Chart";
+import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
 interface NewsPayload { generatedAt: number; items: NewsItem[] }
 const EMPTY: NewsPayload = { generatedAt: 0, items: [] };
@@ -85,6 +86,11 @@ export default function HeadlinesDetail({ }: WidgetDetailProps) {
       .catch(() => setSummaries((s) => ({ ...s, [it.url]: { text: it.description ?? "No preview available.", note: "Summary unavailable." } })));
   };
 
+  const exportRows = useMemo(
+    () => filtered.map((it) => ({ source: it.source, title: it.title, url: it.url, ts: it.ts, description: it.description ?? "" })),
+    [filtered],
+  );
+
   return (
     <div className="tn-hd">
       <div className="tn-hd-bar">
@@ -130,6 +136,14 @@ export default function HeadlinesDetail({ }: WidgetDetailProps) {
           </ul>
         </section>
       ))}
+
+      <footer className="tn-hd-foot">
+        <span className="tn-hd-foot-src">BBC World · Al Jazeera · NPR · The Guardian — keyless RSS</span>
+        <button className="tn-hd-export" disabled={exportRows.length === 0}
+          onClick={() => downloadText(`${exportFilename("headlines", Date.now())}.csv`, "text/csv", toCsv(exportRows))}>
+          ⬇ Export CSV
+        </button>
+      </footer>
     </div>
   );
 }

--- a/lib/console/widgets/headlines.detail.tsx
+++ b/lib/console/widgets/headlines.detail.tsx
@@ -1,0 +1,91 @@
+// lib/console/widgets/headlines.detail.tsx
+"use client";
+// Headlines focus view — a newsroom board. Reuses the SAME /api/news poll as the
+// docked widget, rendering deep: source filter + search, a recency-grouped feed with
+// snippets, an hourly volume strip (Task 6), on-demand AI summaries (Task 7), and a
+// sources footer + export (Task 8).
+import { useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import type { NewsItem } from "@/lib/news";
+import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
+import { countBy } from "@/lib/widgets/buckets";
+
+interface NewsPayload { generatedAt: number; items: NewsItem[] }
+const EMPTY: NewsPayload = { generatedAt: 0, items: [] };
+const SOURCES = ["BBC", "Al Jazeera", "NPR", "The Guardian"];
+
+function rel(ts: number, now: number): string {
+  if (!ts) return "";
+  const m = Math.max(0, Math.round((now - ts) / 60000));
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  return h < 48 ? `${h}h` : `${Math.round(h / 24)}d`;
+}
+function bucketOf(ts: number, now: number): "Last hour" | "Today" | "Earlier" {
+  const h = (now - ts) / 3_600_000;
+  if (ts && h < 1) return "Last hour";
+  if (ts && h < 24) return "Today";
+  return "Earlier";
+}
+const BUCKET_ORDER = ["Last hour", "Today", "Earlier"] as const;
+
+export default function HeadlinesDetail({ }: WidgetDetailProps) {
+  const { data, status } = useJsonPoll<NewsPayload>("/api/news", 120_000, EMPTY);
+  const items = useMemo(() => data.items ?? [], [data.items]);
+  const [srcFilter, setSrcFilter] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const now = Date.now();
+
+  const counts = useMemo(() => countBy(items, (it) => it.source), [items]);
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return items.filter(
+      (it) =>
+        (srcFilter == null || it.source === srcFilter) &&
+        (!q || it.title.toLowerCase().includes(q) || (it.description ?? "").toLowerCase().includes(q)),
+    );
+  }, [items, srcFilter, query]);
+
+  const groups = useMemo(() => {
+    const by = new Map<string, NewsItem[]>();
+    for (const it of filtered) {
+      const b = bucketOf(it.ts, now);
+      const g = by.get(b) ?? [];
+      g.push(it);
+      by.set(b, g);
+    }
+    return BUCKET_ORDER.filter((b) => by.has(b)).map((b) => [b, by.get(b)!] as const);
+  }, [filtered, now]);
+
+  return (
+    <div className="tn-hd">
+      <div className="tn-hd-bar">
+        <div className="tn-hd-chips">
+          <button className={srcFilter == null ? "is-on" : ""} onClick={() => setSrcFilter(null)}>All {items.length}</button>
+          {SOURCES.map((s) => (
+            <button key={s} className={srcFilter === s ? "is-on" : ""} onClick={() => setSrcFilter(s)}>{s} {counts[s] ?? 0}</button>
+          ))}
+        </div>
+        <input className="tn-hd-search" placeholder="Search headlines…" value={query} onChange={(e) => setQuery(e.target.value)} />
+      </div>
+
+      {status === "loading" && items.length === 0 && <p className="tn-w-empty">Loading headlines…</p>}
+      {items.length > 0 && filtered.length === 0 && <p className="tn-w-empty">No headlines match.</p>}
+
+      {groups.map(([bucket, rows]) => (
+        <section key={bucket} className="tn-hd-group">
+          <h3 className="tn-hd-group-h">{bucket} · {rows.length}</h3>
+          <ul className="tn-hd-list">
+            {rows.map((it, i) => (
+              <li key={it.url || i} className="tn-hd-item">
+                <a className="tn-hd-title" href={it.url} target="_blank" rel="noreferrer">{it.title}</a>
+                <div className="tn-hd-meta"><span className="tn-hd-src">{it.source}</span>{it.ts ? ` · ${rel(it.ts, now)}` : ""}</div>
+                {it.description && <p className="tn-hd-snippet">{it.description}</p>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/lib/console/widgets/headlines.detail.tsx
+++ b/lib/console/widgets/headlines.detail.tsx
@@ -8,7 +8,8 @@ import { useMemo, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import type { NewsItem } from "@/lib/news";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
-import { countBy } from "@/lib/widgets/buckets";
+import { countBy, timeBins } from "@/lib/widgets/buckets";
+import { Chart, type ChartPoint } from "@/components/Chart";
 
 interface NewsPayload { generatedAt: number; items: NewsItem[] }
 const EMPTY: NewsPayload = { generatedAt: 0, items: [] };
@@ -57,6 +58,11 @@ export default function HeadlinesDetail({ }: WidgetDetailProps) {
     return BUCKET_ORDER.filter((b) => by.has(b)).map((b) => [b, by.get(b)!] as const);
   }, [filtered, now]);
 
+  const volume: ChartPoint[] = useMemo(() => {
+    const ts = filtered.map((it) => it.ts).filter((n) => n > 0);
+    return timeBins(ts, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
+  }, [filtered, now]);
+
   return (
     <div className="tn-hd">
       <div className="tn-hd-bar">
@@ -68,6 +74,13 @@ export default function HeadlinesDetail({ }: WidgetDetailProps) {
         </div>
         <input className="tn-hd-search" placeholder="Search headlines…" value={query} onChange={(e) => setQuery(e.target.value)} />
       </div>
+
+      {volume.some((p) => p.y > 0) && (
+        <div className="tn-hd-vol">
+          <div className="tn-hd-group-h">Headlines per hour · last 24h</div>
+          <Chart points={volume} height={80} up={null} />
+        </div>
+      )}
 
       {status === "loading" && items.length === 0 && <p className="tn-w-empty">Loading headlines…</p>}
       {items.length > 0 && filtered.length === 0 && <p className="tn-w-empty">No headlines match.</p>}

--- a/lib/console/widgets/headlines.detail.tsx
+++ b/lib/console/widgets/headlines.detail.tsx
@@ -63,6 +63,28 @@ export default function HeadlinesDetail({ }: WidgetDetailProps) {
     return timeBins(ts, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
   }, [filtered, now]);
 
+  type SumState = { loading?: boolean; text?: string; note?: string };
+  const [summaries, setSummaries] = useState<Record<string, SumState>>({});
+  const summarize = (it: NewsItem) => {
+    if (summaries[it.url]?.loading || summaries[it.url]?.text) return;
+    setSummaries((s) => ({ ...s, [it.url]: { loading: true } }));
+    fetch("/api/news/summary", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: it.url, title: it.title, source: it.source }),
+    })
+      .then((r) => r.json())
+      .then((d: { summary: string | null; dormant: boolean; source: string | null }) => {
+        const note = d.dormant
+          ? "AI summary needs the FREELLMAPI gateway — showing the snippet."
+          : d.summary
+            ? undefined
+            : "Couldn’t read this article — showing the snippet.";
+        setSummaries((s) => ({ ...s, [it.url]: { text: d.summary ?? it.description ?? "No preview available.", note } }));
+      })
+      .catch(() => setSummaries((s) => ({ ...s, [it.url]: { text: it.description ?? "No preview available.", note: "Summary unavailable." } })));
+  };
+
   return (
     <div className="tn-hd">
       <div className="tn-hd-bar">
@@ -94,6 +116,15 @@ export default function HeadlinesDetail({ }: WidgetDetailProps) {
                 <a className="tn-hd-title" href={it.url} target="_blank" rel="noreferrer">{it.title}</a>
                 <div className="tn-hd-meta"><span className="tn-hd-src">{it.source}</span>{it.ts ? ` · ${rel(it.ts, now)}` : ""}</div>
                 {it.description && <p className="tn-hd-snippet">{it.description}</p>}
+                <button className="tn-hd-sum-btn" onClick={() => summarize(it)} disabled={!!summaries[it.url]?.loading}>
+                  {summaries[it.url]?.loading ? "Summarising…" : "✨ AI summary"}
+                </button>
+                {summaries[it.url]?.text && (
+                  <div className="tn-hd-sum">
+                    <p>{summaries[it.url]!.text}</p>
+                    {summaries[it.url]!.note && <span className="tn-hd-sum-note">{summaries[it.url]!.note}</span>}
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/lib/console/widgets/headlines.tsx
+++ b/lib/console/widgets/headlines.tsx
@@ -8,6 +8,7 @@ import { registerWidget } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
 import type { NewsItem } from "@/lib/news";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
+import HeadlinesDetail from "@/lib/console/widgets/headlines.detail";
 
 interface NewsPayload {
   generatedAt: number;
@@ -73,5 +74,6 @@ export const HEADLINES_WIDGET = {
   defaultHeight: 300,
   defaultConfig: {},
   component: HeadlinesBody,
+  detail: HeadlinesDetail,
 };
 registerWidget(HEADLINES_WIDGET);

--- a/lib/console/widgets/signals.detail.tsx
+++ b/lib/console/widgets/signals.detail.tsx
@@ -40,11 +40,20 @@ export function makeSignalDetail(source: SignalSource) {
       if (updatedAt) recordSeries(`sig:${source.id}`, scoped.length, updatedAt);
     }, [updatedAt, scoped.length]);
 
-    const spark: ChartPoint[] = useMemo(
-      () => seriesSamples(`sig:${source.id}`).map((s) => ({ x: s.t, y: s.n })),
-      [updatedAt, scoped.length],
-    );
-    const delta = useMemo(() => deltaOf(seriesSamples(`sig:${source.id}`)), [updatedAt, scoped.length]);
+    // Read the persisted series AND fold in the CURRENT poll's live count. recordSeries
+    // (above) only writes it in a post-commit effect and lib/series has no React
+    // subscription, so without folding it in here the delta/sparkline would trail the
+    // count shown beside them by one poll — and could even show a wrong-direction arrow.
+    const samples = useMemo(() => {
+      const base = seriesSamples(`sig:${source.id}`);
+      const last = base[base.length - 1];
+      if (updatedAt && (!last || last.t !== updatedAt || last.n !== scoped.length)) {
+        return [...base, { t: updatedAt, n: scoped.length }];
+      }
+      return base;
+    }, [updatedAt, scoped.length]);
+    const spark: ChartPoint[] = useMemo(() => samples.map((s) => ({ x: s.t, y: s.n })), [samples]);
+    const delta = useMemo(() => deltaOf(samples), [samples]);
 
     const rows = useMemo(() => sortFeatures(scoped, sortKey, dir), [scoped, sortKey, dir]);
     const dist = useMemo(() => distribution(scoped), [scoped]);

--- a/lib/console/widgets/signals.detail.tsx
+++ b/lib/console/widgets/signals.detail.tsx
@@ -4,7 +4,7 @@
 // live pipeline (useSignalFeed → projectSignal) but renders deep — masthead + count
 // sparkline, source map, honest magnitude/severity + time distributions, a sortable
 // feature table with per-row props drill-down, attribution, and export/show-on-map.
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import type { SignalSource } from "@/lib/signals/types";
 import { useSignalFeed } from "@/lib/console/signals/useSignalFeed";
@@ -103,7 +103,47 @@ export function makeSignalDetail(source: SignalSource) {
           </div>
         )}
 
-        {/* Feature table (Task 4) inserted below. */}
+        {scoped.length > 0 && (
+          <table className="tn-sd-table">
+            <thead>
+              <tr>
+                {(["magnitude", "title", "recency"] as SortKey[]).map((k) => (
+                  <th key={k} onClick={() => { if (sortKey === k) setDir((d) => (d === 1 ? -1 : 1)); else { setSortKey(k); setDir(-1); } }}>
+                    {k === "recency" ? "When" : humaniseKey(k)}{sortKey === k ? (dir === -1 ? " ↓" : " ↑") : ""}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((f) => {
+                const entries = Object.entries(f.props ?? {}).filter(([, v]) => v != null && v !== "");
+                const isOpen = open === f.id;
+                return (
+                  <Fragment key={f.id}>
+                    <tr className="tn-sd-row" onClick={() => setOpen(isOpen ? null : f.id)}>
+                      <td>{typeof f.props?.magnitude === "number" ? (f.props.magnitude as number) : "—"}</td>
+                      <td>{f.title}</td>
+                      <td>{f.ts ? new Date(f.ts).toISOString().slice(0, 16).replace("T", " ") : "—"}</td>
+                    </tr>
+                    {isOpen && (
+                      <tr className="tn-sd-drill">
+                        <td colSpan={3}>
+                          {entries.length > 0 ? (
+                            <dl>{entries.map(([k, v]) => (<div key={k} style={{ display: "contents" }}><dt>{humaniseKey(k)}</dt><dd>{String(v)}</dd></div>))}</dl>
+                          ) : <span className="tn-w-empty">No extra properties.</span>}
+                          <div style={{ display: "flex", gap: 10, marginTop: 4 }}>
+                            <button className="tn-sd-actions" onClick={(e) => { e.stopPropagation(); openSignalFeature(f, source.label); shellLayoutStore.unfocus(); }} style={{ background: "none", border: 0, color: "var(--tn-accent)", cursor: "pointer", padding: 0 }}>Show on globe ↗</button>
+                            {f.link && <a href={f.link} target="_blank" rel="noreferrer" style={{ color: "var(--tn-accent)" }}>Source ↗</a>}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
 
         <footer className="tn-sd-foot">
           <span className="tn-sd-attr">{source.attribution}{KEYED.has(source.id) && " · needs an API key (dormant when unset)"}</span>

--- a/lib/console/widgets/signals.detail.tsx
+++ b/lib/console/widgets/signals.detail.tsx
@@ -74,7 +74,36 @@ export function makeSignalDetail(source: SignalSource) {
         {status === "loading" && scoped.length === 0 && <p className="tn-w-empty">Loading {source.label}…</p>}
         {status !== "loading" && scoped.length === 0 && <p className="tn-w-empty">Nothing in {scope.label}.</p>}
 
-        {/* Panels (Task 3), table (Task 4), footer (Task 5) inserted below. */}
+        {scoped.length > 0 && (
+          <div className="tn-sd-panels">
+            <div className="tn-sd-panel">
+              <h3>Locations</h3>
+              {mapPoints.length > 0 ? <InsetMap points={mapPoints} height={200} onSelect={(id) => setOpen(id)} />
+                : <p className="tn-w-empty">No mappable features.</p>}
+            </div>
+            <div className="tn-sd-panel">
+              <h3>{dist.kind === "magnitude" ? "Magnitude distribution" : dist.kind === "severity" ? "Severity" : "Distribution"}</h3>
+              {dist.kind !== "none" ? (
+                <>
+                  <div className="tn-sd-bars">
+                    {dist.bins.map((b, i) => {
+                      const max = Math.max(1, ...dist.bins.map((x) => x.count));
+                      return <div key={i} className="tn-sd-bar" style={{ height: `${(b.count / max) * 100}%` }} title={`${b.label}: ${b.count}`} />;
+                    })}
+                  </div>
+                  <div style={{ display: "flex", gap: 4 }}>{dist.bins.map((b, i) => <span key={i} className="tn-sd-bar-label" style={{ flex: 1 }}>{b.label}</span>)}</div>
+                </>
+              ) : <p className="tn-w-empty">This source declares no magnitude or severity.</p>}
+            </div>
+            <div className="tn-sd-panel">
+              <h3>Over the last 24h {tm.undated > 0 && <span className="tn-sd-bar-label">· {tm.undated} undated</span>}</h3>
+              {timePoints.some((p) => p.y > 0) ? <Chart points={timePoints} height={120} up={null} />
+                : <p className="tn-w-empty">No timestamped features in the window.</p>}
+            </div>
+          </div>
+        )}
+
+        {/* Feature table (Task 4) inserted below. */}
 
         <footer className="tn-sd-foot">
           <span className="tn-sd-attr">{source.attribution}{KEYED.has(source.id) && " · needs an API key (dormant when unset)"}</span>

--- a/lib/console/widgets/signals.detail.tsx
+++ b/lib/console/widgets/signals.detail.tsx
@@ -1,0 +1,91 @@
+"use client";
+// Signals focus view — ONE parameterised template covering every registered signal
+// layer. makeSignalDetail(source) mirrors makeSignalBody(source): it reuses the SAME
+// live pipeline (useSignalFeed → projectSignal) but renders deep — masthead + count
+// sparkline, source map, honest magnitude/severity + time distributions, a sortable
+// feature table with per-row props drill-down, attribution, and export/show-on-map.
+import { useEffect, useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import type { SignalSource } from "@/lib/signals/types";
+import { useSignalFeed } from "@/lib/console/signals/useSignalFeed";
+import { useScope, withinScope } from "@/lib/shell/scope";
+import { recordSeries, seriesSamples } from "@/lib/series";
+import { deltaOf } from "@/lib/widgets/history";
+import { Chart, type ChartPoint } from "@/components/Chart";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
+import { timeBins } from "@/lib/widgets/buckets";
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
+import { signalsStore } from "@/lib/signals/store";
+import { shellLayoutStore } from "@/lib/console/store";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+import { humaniseKey } from "@/lib/text/humanise";
+import { distribution, timeModel, sortFeatures, type SortKey } from "@/lib/console/signals/signalDetail";
+
+// Sources whose upstream needs a key that may be unset — surface an honest dormant note.
+const KEYED = new Set(["acled", "firms", "aisstream", "openaq", "reliefweb", "entsoe"]);
+
+export function makeSignalDetail(source: SignalSource) {
+  function SignalDetailView(_props: WidgetDetailProps) {
+    const scope = useScope();
+    const { features, status, updatedAt } = useSignalFeed(source.id, source.refreshMs);
+    const [sortKey, setSortKey] = useState<SortKey>("magnitude");
+    const [dir, setDir] = useState<1 | -1>(-1);
+    const [open, setOpen] = useState<string | null>(null);
+
+    const scoped = useMemo(() => features.filter((f) => withinScope(f.lat, f.lon, scope)), [features, scope]);
+
+    // Wire count-history recording (spec: no signal records into the series yet).
+    useEffect(() => {
+      if (updatedAt) recordSeries(`sig:${source.id}`, scoped.length, updatedAt);
+    }, [updatedAt, scoped.length]);
+
+    const spark: ChartPoint[] = useMemo(
+      () => seriesSamples(`sig:${source.id}`).map((s) => ({ x: s.t, y: s.n })),
+      [updatedAt, scoped.length],
+    );
+    const delta = useMemo(() => deltaOf(seriesSamples(`sig:${source.id}`)), [updatedAt, scoped.length]);
+
+    const rows = useMemo(() => sortFeatures(scoped, sortKey, dir), [scoped, sortKey, dir]);
+    const dist = useMemo(() => distribution(scoped), [scoped]);
+    const tm = useMemo(() => timeModel(scoped), [scoped]);
+    const now = Date.now();
+
+    const distPoints: ChartPoint[] = dist.bins.map((b, i) => ({ x: i, y: b.count }));
+    const timePoints: ChartPoint[] = timeBins(tm.values, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
+    const mapPoints: InsetPoint[] = scoped.map((f) => ({ lat: f.lat, lon: f.lon, id: f.id, color: f.color ?? source.color, props: { title: f.title } }));
+    const freshAge = updatedAt ? `${Math.max(0, Math.round((now - updatedAt) / 60000))}m ago` : "—";
+
+    const exportRows = rows.map((f) => ({ id: f.id, title: f.title, magnitude: f.props?.magnitude ?? "", lat: f.lat, lon: f.lon, ts: f.ts ?? "", link: f.link ?? "" }));
+    const exportGeo = rows.map((f) => ({ lat: f.lat, lon: f.lon, properties: { id: f.id, title: f.title, ...(f.props ?? {}) } }));
+
+    const showOnMap = () => { signalsStore.set(source.id, true); shellLayoutStore.unfocus(); };
+
+    return (
+      <div className="tn-sd">
+        <header className="tn-sd-head">
+          <div className="tn-sd-title">{source.label}</div>
+          <div className="tn-sd-stat"><b>{scoped.length}</b> of {features.length} in {scope.label} · updated {freshAge}
+            {delta !== 0 && <span className={`tn-sd-delta ${delta > 0 ? "up" : "down"}`}> {delta > 0 ? "▲" : "▼"}{Math.abs(delta)}</span>}
+          </div>
+          {spark.length >= 2 && <div className="tn-sd-spark"><Chart points={spark} height={40} up={null} /></div>}
+        </header>
+
+        {status === "loading" && scoped.length === 0 && <p className="tn-w-empty">Loading {source.label}…</p>}
+        {status !== "loading" && scoped.length === 0 && <p className="tn-w-empty">Nothing in {scope.label}.</p>}
+
+        {/* Panels (Task 3), table (Task 4), footer (Task 5) inserted below. */}
+
+        <footer className="tn-sd-foot">
+          <span className="tn-sd-attr">{source.attribution}{KEYED.has(source.id) && " · needs an API key (dormant when unset)"}</span>
+          <span className="tn-sd-actions">
+            <button onClick={showOnMap}>🗺 Show on map</button>
+            <button disabled={!exportRows.length} onClick={() => downloadText(`${exportFilename(`signal-${source.id}`, Date.now())}.csv`, "text/csv", toCsv(exportRows))}>⬇ CSV</button>
+            <button disabled={!exportGeo.length} onClick={() => downloadText(`${exportFilename(`signal-${source.id}`, Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}>⬇ GeoJSON</button>
+          </span>
+        </footer>
+      </div>
+    );
+  }
+  return SignalDetailView;
+}

--- a/lib/console/widgets/signals.tsx
+++ b/lib/console/widgets/signals.tsx
@@ -17,6 +17,7 @@ import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { useScope } from "@/lib/shell/scope";
 import { projectSignal } from "@/lib/console/signals/signalCard";
 import { useSignalFeed } from "@/lib/console/signals/useSignalFeed";
+import { makeSignalDetail } from "./signals.detail";
 
 const GROUP_ICON: Record<string, string> = {
   Synthesis: "🧭",
@@ -115,5 +116,6 @@ for (const source of SIGNALS) {
     defaultHeight: 240,
     defaultConfig: {},
     component: makeSignalBody(source),
+    detail: makeSignalDetail(source),
   });
 }

--- a/lib/map/inset.ts
+++ b/lib/map/inset.ts
@@ -1,0 +1,34 @@
+// lib/map/inset.ts
+// Pure GeoJSON + bounds helpers for the shared <InsetMap>. Node-testable.
+
+export interface InsetPoint {
+  lat: number;
+  lon: number;
+  id?: string;
+  color?: string;
+  props?: Record<string, unknown>;
+}
+
+export function pointsToFC(points: InsetPoint[]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: points
+      .filter((p) => Number.isFinite(p.lat) && Number.isFinite(p.lon))
+      .map((p) => ({
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [p.lon, p.lat] },
+        properties: { id: p.id ?? "", color: p.color ?? "#38bdf8", ...(p.props ?? {}) },
+      })),
+  };
+}
+
+export function boundsOf(points: InsetPoint[]): [[number, number], [number, number]] | null {
+  let w = Infinity, s = Infinity, e = -Infinity, n = -Infinity;
+  for (const p of points) {
+    if (!Number.isFinite(p.lat) || !Number.isFinite(p.lon)) continue;
+    if (p.lon < w) w = p.lon; if (p.lon > e) e = p.lon;
+    if (p.lat < s) s = p.lat; if (p.lat > n) n = p.lat;
+  }
+  if (!Number.isFinite(w)) return null;
+  return [[w, s], [e, n]];
+}

--- a/lib/news.ts
+++ b/lib/news.ts
@@ -37,8 +37,10 @@ function decodeEntities(s: string): string {
 function cleanText(raw: string | undefined): string {
   if (!raw) return "";
   let s = raw.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1");
-  s = s.replace(/<[^>]+>/g, " "); // drop any stray inline markup
-  return decodeEntities(s).replace(/\s+/g, " ").trim();
+  s = s.replace(/<[^>]+>/g, " "); // drop literal inline markup (CDATA HTML)
+  s = decodeEntities(s); // entity-encoded markup (e.g. Guardian's &lt;p&gt;) becomes real tags…
+  s = s.replace(/<[^>]+>/g, " "); // …strip those too, else raw <p>/<a href> leak into the snippet
+  return s.replace(/\s+/g, " ").trim();
 }
 
 /** First inner value of <tag>…</tag> within `block`, or undefined. */

--- a/lib/news.ts
+++ b/lib/news.ts
@@ -15,6 +15,8 @@ export interface NewsItem {
   source: string;
   url: string;
   ts: number; // epoch ms (0 when the feed omits a parseable date)
+  /** Cleaned RSS <description>/<summary> snippet, when the feed provides one. */
+  description?: string;
 }
 
 const ENTITIES: Record<string, string> = {
@@ -75,7 +77,9 @@ export function parseRss(xml: string | null | undefined, source: string): NewsIt
     const title = cleanText(tag(block, "title"));
     const url = extractLink(block);
     if (!title || !url || !/^https?:\/\//i.test(url)) continue;
-    out.push({ title, source, url: url.trim(), ts: parseDate(block) });
+    const descRaw = tag(block, "description") ?? tag(block, "summary");
+    const description = cleanText(descRaw) || undefined;
+    out.push({ title, source, url: url.trim(), ts: parseDate(block), description });
   }
   return out;
 }

--- a/lib/news/article.ts
+++ b/lib/news/article.ts
@@ -1,0 +1,38 @@
+// lib/news/article.ts
+// SSRF guard + lightweight readability for the AI-summary route. Pure + node-testable.
+// The allowlist is the news PUBLISHERS behind the /api/news feeds (article links live
+// on the publisher's main domain, e.g. bbc.com — NOT the feeds.* host). This is a
+// SEPARATE list from lib/proxy/allowlist.ts (which is camera hosts only).
+
+const NEWS_DOMAINS = ["bbc.com", "bbc.co.uk", "theguardian.com", "aljazeera.com", "npr.org"];
+
+/** https + hostname is one of NEWS_DOMAINS or a subdomain of one. */
+export function isNewsArticleUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  const host = url.hostname.toLowerCase();
+  return NEWS_DOMAINS.some((d) => host === d || host.endsWith("." + d));
+}
+
+/** Strip scripts/styles/all tags, decode a few entities, collapse whitespace, cap length. */
+export function extractArticleText(html: string, maxChars = 6000): string {
+  if (!html) return "";
+  const text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.slice(0, maxChars);
+}

--- a/lib/news/summary.ts
+++ b/lib/news/summary.ts
@@ -1,0 +1,37 @@
+// lib/news/summary.ts
+// Pure prompt builder + response parser for the on-demand article summary.
+// Mirrors lib/brief.ts: honesty-guarded, node-testable; the network call lives in
+// the route. The summary is grounded ONLY in the supplied article text.
+
+export interface SummaryInput {
+  title: string;
+  source: string;
+  text: string;
+}
+
+export interface SummaryPayload {
+  summary: string | null;
+  dormant: boolean;
+  /** where the text came from: the AI over the fetched article, the RSS snippet, or nothing. */
+  source: "ai" | "snippet" | null;
+}
+
+/** Pure: article text → the chat prompt sent to the gateway. */
+export function buildSummaryPrompt(input: SummaryInput): string {
+  return [
+    "You are a neutral news editor. Summarise the article below in 3 short, factual sentences.",
+    "Use ONLY the article text provided. Do not add facts, figures, or opinions not present in it. Do not speculate.",
+    "",
+    `Headline: ${input.title}`,
+    `Source: ${input.source}`,
+    "",
+    "Article text:",
+    input.text,
+  ].join("\n");
+}
+
+/** Pure: parse the gateway's chat-completion response → summary text, or null. */
+export function parseSummaryResponse(json: unknown): string | null {
+  const content = (json as { choices?: { message?: { content?: unknown } }[] })?.choices?.[0]?.message?.content;
+  return typeof content === "string" && content.trim() ? content.trim() : null;
+}

--- a/lib/planes/classify.ts
+++ b/lib/planes/classify.ts
@@ -18,8 +18,9 @@ export interface PlaneProfile {
   category?: string;
 }
 
-// ADS-B emitter category → our coarse type (the reliable path).
-const ADSB_CATEGORY: Record<string, PlaneCategory> = {
+// ADS-B emitter category → our coarse type (the reliable path). Exported so callers
+// can tell whether a category was actually trusted (vs. fell through to the estimate).
+export const ADSB_CATEGORY: Record<string, PlaneCategory> = {
   A1: "light", // light (<15500 lbs)
   A2: "regional", // small
   A3: "airliner", // large

--- a/lib/planes/ops.ts
+++ b/lib/planes/ops.ts
@@ -1,0 +1,77 @@
+// Pure aviation helpers for the airspace-console focus view. All read the plane
+// WorldObject (its meta carries the classified category/onGround/velocity), so no
+// re-classification or fetch is needed. Unit-tested; the .tsx is a dumb shell.
+import type { WorldObject } from "@/lib/world";
+import type { PlaneCategory } from "@/lib/planes/classify";
+import { ADSB_REGIONS } from "@/lib/sources/adsb";
+
+const CATEGORY_LABEL: Record<PlaneCategory, string> = {
+  airliner: "Airliner", regional: "Regional", light: "Light", helicopter: "Helicopter", ground: "Ground",
+};
+const CATEGORY_ORDER: PlaneCategory[] = ["airliner", "regional", "light", "helicopter", "ground"];
+
+function meta(o: WorldObject): Record<string, unknown> { return (o.meta ?? {}) as Record<string, unknown>; }
+function categoryOf(o: WorldObject): PlaneCategory {
+  const c = meta(o).category;
+  return (typeof c === "string" && c in CATEGORY_LABEL ? c : "light") as PlaneCategory;
+}
+function velocityOf(o: WorldObject): number | null {
+  const v = meta(o).velocityMs;
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+export interface OpsSummary {
+  total: number; airborne: number; ground: number;
+  byCategory: { category: PlaneCategory; label: string; count: number }[];
+  maxAltKm: number; maxSpeedMs: number;
+}
+
+export function opsSummary(objects: WorldObject[]): OpsSummary {
+  let airborne = 0, ground = 0, maxAltKm = 0, maxSpeedMs = 0;
+  const counts: Partial<Record<PlaneCategory, number>> = {};
+  for (const o of objects) {
+    if (meta(o).onGround) ground++; else airborne++;
+    const c = categoryOf(o);
+    counts[c] = (counts[c] ?? 0) + 1;
+    if (typeof o.altKm === "number" && o.altKm > maxAltKm) maxAltKm = o.altKm;
+    const v = velocityOf(o);
+    if (v != null && v > maxSpeedMs) maxSpeedMs = v;
+  }
+  const byCategory = CATEGORY_ORDER.filter((c) => counts[c]).map((c) => ({ category: c, label: CATEGORY_LABEL[c], count: counts[c]! }));
+  return { total: objects.length, airborne, ground, byCategory, maxAltKm, maxSpeedMs };
+}
+
+export type AltBand = "ground" | "0–1 km" | "1–3 km" | "3–7 km" | "7–11 km" | "11+ km";
+export const ALT_BANDS: AltBand[] = ["11+ km", "7–11 km", "3–7 km", "1–3 km", "0–1 km", "ground"];
+export function altitudeBand(o: WorldObject): AltBand {
+  if (meta(o).onGround) return "ground";
+  const a = typeof o.altKm === "number" ? o.altKm : 0;
+  if (a < 1) return "0–1 km";
+  if (a < 3) return "1–3 km";
+  if (a < 7) return "3–7 km";
+  if (a < 11) return "7–11 km";
+  return "11+ km";
+}
+
+// Region labels are index-matched to ADSB_REGIONS.
+export const REGION_LABELS = ["London / SE England", "California", "South Carolina"];
+/** Nearest ADS-B query region (the regions are continents apart, so squared-degree distance is enough). */
+export function regionOf(lat: number, lon: number): string {
+  let best = -1, bestD = Infinity;
+  ADSB_REGIONS.forEach((r, i) => {
+    const d = (lat - r.lat) ** 2 + (lon - r.lon) ** 2;
+    if (d < bestD) { bestD = d; best = i; }
+  });
+  return best >= 0 ? (REGION_LABELS[best] ?? `Region ${best + 1}`) : "—";
+}
+
+export type FlightSortKey = "altitude" | "speed" | "callsign" | "region";
+export function sortFlights(objects: WorldObject[], key: FlightSortKey, dir: 1 | -1): WorldObject[] {
+  const cmp = (a: WorldObject, b: WorldObject): number => {
+    if (key === "callsign") return a.label.localeCompare(b.label);
+    if (key === "region") return regionOf(a.lat, a.lon).localeCompare(regionOf(b.lat, b.lon));
+    if (key === "speed") return (velocityOf(a) ?? -Infinity) - (velocityOf(b) ?? -Infinity);
+    return (a.altKm ?? -Infinity) - (b.altKm ?? -Infinity);
+  };
+  return [...objects].sort((a, b) => dir * cmp(a, b));
+}

--- a/lib/sources/adsb.ts
+++ b/lib/sources/adsb.ts
@@ -37,6 +37,7 @@ export interface Aircraft {
   category: string;
   typeCode: string;
   registration: string;
+  squawk: string;
 }
 
 const KT_TO_MS = 0.514444;
@@ -57,6 +58,7 @@ interface RawAircraft {
   baro_rate?: number;
   geom_rate?: number;
   category?: string;
+  squawk?: string;
 }
 
 function num(v: unknown): number | null {
@@ -89,6 +91,7 @@ export function parseAdsb(rows: RawAircraft[]): Aircraft[] {
       category: (a.category ?? "").trim(),
       typeCode: (a.t ?? "").trim(),
       registration: (a.r ?? "").trim(),
+      squawk: (a.squawk ?? "").trim(),
     });
   }
   return out;
@@ -128,6 +131,7 @@ export function aircraftToWorldObject(a: Aircraft): WorldObject {
       typeLabel: meta.label,
       // Whether the type came from a real ADS-B category vs the profile guess.
       categorySource: a.category && a.category !== "A0" ? "adsb" : "estimate",
+      squawk: a.squawk,
     },
   };
 }

--- a/lib/sources/adsb.ts
+++ b/lib/sources/adsb.ts
@@ -7,7 +7,7 @@
 // them, so planes appear wherever a viewer flies.
 
 import type { WorldObject } from "@/lib/world";
-import { classifyPlane } from "@/lib/planes/classify";
+import { classifyPlane, ADSB_CATEGORY } from "@/lib/planes/classify";
 import { PLANE_META } from "@/lib/icons/svg";
 
 export interface AdsbRegion {
@@ -129,8 +129,10 @@ export function aircraftToWorldObject(a: Aircraft): WorldObject {
       headingDeg: a.headingDeg,
       category,
       typeLabel: meta.label,
-      // Whether the type came from a real ADS-B category vs the profile guess.
-      categorySource: a.category && a.category !== "A0" ? "adsb" : "estimate",
+      // Whether the type came from a real ADS-B category vs the profile guess. Gated
+      // on the SAME map classifyPlane trusts, so codes it doesn't map (A6, B0, C*, …)
+      // are honestly reported as "estimate", not falsely as authoritative ADS-B.
+      categorySource: a.category && ADSB_CATEGORY[a.category] ? "adsb" : "estimate",
       squawk: a.squawk,
     },
   };

--- a/lib/text/humanise.ts
+++ b/lib/text/humanise.ts
@@ -1,0 +1,6 @@
+// Humanise a camelCase / snake_case / kebab key into a Title-ish label for a
+// definition-list term, e.g. "forecastFor" → "Forecast for", "alert_level" → "Alert level".
+export function humaniseKey(key: string): string {
+  const spaced = key.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}

--- a/lib/widgets/buckets.ts
+++ b/lib/widgets/buckets.ts
@@ -1,0 +1,39 @@
+// lib/widgets/buckets.ts
+// Pure bucketing helpers for the detail-view distribution/timeline charts.
+
+export function countBy<T>(items: T[], key: (t: T) => string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const it of items) { const k = key(it); out[k] = (out[k] ?? 0) + 1; }
+  return out;
+}
+
+/** edges ascending, length n+1 → n bins. Value v lands in bin i when
+ *  edges[i] <= v < edges[i+1]; the LAST bin is inclusive of the top edge. */
+export function histogram(values: number[], edges: number[]): number[] {
+  const n = Math.max(0, edges.length - 1);
+  const bins = new Array<number>(n).fill(0);
+  for (const v of values) {
+    for (let i = 0; i < n; i++) {
+      const lo = edges[i], hi = edges[i + 1];
+      const inside = i === n - 1 ? v >= lo && v <= hi : v >= lo && v < hi;
+      if (inside) { bins[i]++; break; }
+    }
+  }
+  return bins;
+}
+
+export interface TimeBin { start: number; count: number }
+
+/** n = ceil(spanMs/binMs) contiguous bins ending at `now`. Timestamps outside
+ *  [now-n*binMs, now] are ignored. */
+export function timeBins(tsList: number[], binMs: number, now: number, spanMs: number): TimeBin[] {
+  const n = Math.max(1, Math.ceil(spanMs / binMs));
+  const start0 = now - n * binMs;
+  const bins: TimeBin[] = Array.from({ length: n }, (_, i) => ({ start: start0 + i * binMs, count: 0 }));
+  for (const ts of tsList) {
+    if (ts < start0 || ts > now) continue;
+    const idx = Math.min(n - 1, Math.floor((ts - start0) / binMs));
+    bins[idx].count++;
+  }
+  return bins;
+}

--- a/lib/widgets/eventMetrics.ts
+++ b/lib/widgets/eventMetrics.ts
@@ -1,0 +1,35 @@
+// lib/widgets/eventMetrics.ts
+// Pure: RAW SignalFeature props → an honest, domain-specific metric line for the
+// Events detail feed. Only shows what the source actually provides — no fabricated
+// unified "magnitude" for cyclones/disasters (their native fields are shown instead).
+import type { EventType } from "@/lib/events/model";
+
+const str = (v: unknown): string => (typeof v === "string" && v.trim() ? v.trim() : typeof v === "number" && Number.isFinite(v) ? String(v) : "");
+
+export function eventMetricLine(type: EventType, props: Record<string, unknown> | undefined): string {
+  if (!props) return "";
+  const parts: string[] = [];
+  if (type === "quake") {
+    const m = str(props.magnitude);
+    if (m) parts.push(`M ${m}`);
+    const d = str(props.depth);
+    if (d) parts.push(`depth ${d}`);
+  } else if (type === "cyclone") {
+    for (const key of ["category", "maxWind", "pressure"] as const) {
+      const v = str(props[key]);
+      if (v) parts.push(v);
+    }
+    const mv = str(props.movement);
+    if (mv) parts.push(`moving ${mv}`);
+  } else if (type === "disaster") {
+    const al = str(props.alertLevel);
+    if (al) parts.push(`${al} alert`);
+    const c = str(props.country);
+    if (c) parts.push(c);
+    if (str(props.ongoing).toLowerCase() === "yes") parts.push("ongoing");
+  } else {
+    const m = str(props.magnitude);
+    if (m) parts.push(`M ${m}`);
+  }
+  return parts.join(" · ");
+}

--- a/tests/unit/adsb.test.ts
+++ b/tests/unit/adsb.test.ts
@@ -17,6 +17,11 @@ test("parseAdsb skips rows without a position and converts units", () => {
   expect(ac[2].onGround).toBe(true); // alt_baro "ground"
 });
 
+test("captures squawk (activates emergency-squawk alerts)", () => {
+  const [a] = parseAdsb([{ hex: "abc", flight: "TEST123", lat: 51, lon: 0, alt_baro: 30000, squawk: "7700" }] as never);
+  expect(a.squawk).toBe("7700");
+});
+
 test("aircraftToWorldObject classifies from the ADS-B category", () => {
   const [heavy, heli, ground] = parseAdsb(rows as never).map(aircraftToWorldObject);
   expect(heavy.icon).toBe("plane-airliner"); // A5 heavy

--- a/tests/unit/adsb.test.ts
+++ b/tests/unit/adsb.test.ts
@@ -30,3 +30,10 @@ test("aircraftToWorldObject classifies from the ADS-B category", () => {
   expect(heavy.meta?.categorySource).toBe("adsb");
   expect(heavy.meta?.typeCode).toBe("B77W");
 });
+
+test("categorySource is honest — an emitter code classifyPlane doesn't trust reads as 'estimate'", () => {
+  // A6 (high-performance) is a real ADS-B code but NOT in ADSB_CATEGORY, so the type is
+  // an estimate from the flight profile — the provenance flag must say so, not "adsb".
+  const [a] = parseAdsb([{ hex: "a6", flight: "FAST1", lat: 51, lon: 0, alt_baro: 35000, gs: 500, track: 90, category: "A6" }] as never).map(aircraftToWorldObject);
+  expect(a.meta?.categorySource).toBe("estimate");
+});

--- a/tests/unit/buckets.test.ts
+++ b/tests/unit/buckets.test.ts
@@ -1,0 +1,22 @@
+// tests/unit/buckets.test.ts
+import { describe, it, expect } from "vitest";
+import { countBy, histogram, timeBins } from "@/lib/widgets/buckets";
+
+describe("buckets", () => {
+  it("countBy tallies by key", () => {
+    expect(countBy(["a", "b", "a"], (s) => s)).toEqual({ a: 2, b: 1 });
+  });
+
+  it("histogram bins [lo,hi) with an inclusive last edge", () => {
+    // edges 0,2,4,6 → bins [0,2) [2,4) [4,6]
+    expect(histogram([0, 1, 2, 3, 4, 5, 6], [0, 2, 4, 6])).toEqual([2, 2, 3]);
+  });
+
+  it("timeBins buckets timestamps into fixed windows and ignores out-of-range", () => {
+    const now = 1_000_000;
+    const bins = timeBins([now - 1, now - 3500, now + 999], 1000, now, 3000);
+    expect(bins).toHaveLength(3);
+    expect(bins.reduce((a, b) => a + b.count, 0)).toBe(1); // only now-1 is inside [now-3000, now]
+    expect(bins[2].count).toBe(1);
+  });
+});

--- a/tests/unit/cameras-concurrency.test.ts
+++ b/tests/unit/cameras-concurrency.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { nextActive } from "@/lib/cameras/concurrency";
+
+describe("nextActive", () => {
+  it("adds an id and keeps it under the cap, evicting the oldest", () => {
+    let a: string[] = [];
+    for (const id of ["a", "b", "c"]) a = nextActive(a, id, 2);
+    expect(a).toEqual(["b", "c"]); // "a" evicted
+  });
+  it("re-activating an existing id moves it to most-recent without growing", () => {
+    const a = nextActive(["a", "b"], "a", 2);
+    expect(a).toEqual(["b", "a"]);
+  });
+});

--- a/tests/unit/cameras-coverage.test.ts
+++ b/tests/unit/cameras-coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { coverage, type CameraLite } from "@/lib/cameras/coverage";
+import { coverage, byWallPriority, type CameraLite } from "@/lib/cameras/coverage";
 
 const c = (o: Partial<CameraLite>): CameraLite =>
   ({ id: "x", source: "tfl", name: "n", lat: 0, lon: 0, available: true, live: false, ...o });
@@ -20,5 +20,17 @@ describe("coverage", () => {
     expect(caltrans.live).toBe(1);
     const tfl = cov.byOperator.find((o) => o.source === "tfl")!;
     expect(tfl.offline).toBe(1);
+  });
+});
+
+describe("byWallPriority", () => {
+  it("ranks working feeds above an offline-but-live feed (never fills the wall with 'offline')", () => {
+    // An out-of-service Caltrans camera still carries an allowlisted stream URL:
+    // live=true but available=false. It must NOT outrank a working still.
+    const offlineLive = c({ id: "off", source: "caltrans", name: "A", live: true, available: false });
+    const workingStill = c({ id: "still", source: "tfl", name: "B", live: false, available: true });
+    const workingLive = c({ id: "live", source: "scdot", name: "C", live: true, available: true });
+    const ordered = [offlineLive, workingStill, workingLive].sort(byWallPriority);
+    expect(ordered.map((x) => x.id)).toEqual(["live", "still", "off"]);
   });
 });

--- a/tests/unit/cameras-coverage.test.ts
+++ b/tests/unit/cameras-coverage.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { coverage, type CameraLite } from "@/lib/cameras/coverage";
+
+const c = (o: Partial<CameraLite>): CameraLite =>
+  ({ id: "x", source: "tfl", name: "n", lat: 0, lon: 0, available: true, live: false, ...o });
+
+describe("coverage", () => {
+  it("buckets live / still / offline and groups per operator", () => {
+    const cov = coverage([
+      c({ source: "caltrans", live: true }),
+      c({ source: "caltrans", live: false }),
+      c({ source: "tfl", available: false }),
+    ]);
+    expect(cov.total).toBe(3);
+    expect(cov.live).toBe(1);
+    expect(cov.still).toBe(1);
+    expect(cov.offline).toBe(1);
+    const caltrans = cov.byOperator.find((o) => o.source === "caltrans")!;
+    expect(caltrans.total).toBe(2);
+    expect(caltrans.live).toBe(1);
+    const tfl = cov.byOperator.find((o) => o.source === "tfl")!;
+    expect(tfl.offline).toBe(1);
+  });
+});

--- a/tests/unit/chart-scale.test.ts
+++ b/tests/unit/chart-scale.test.ts
@@ -1,0 +1,23 @@
+// tests/unit/chart-scale.test.ts
+import { describe, it, expect } from "vitest";
+import { extent, linear } from "@/lib/chart/scale";
+
+describe("chart scale", () => {
+  it("extent returns [min,max], padding a flat series", () => {
+    expect(extent([3, 1, 2])).toEqual([1, 3]);
+    expect(extent([5, 5])).toEqual([4, 6]);
+    expect(extent([])).toEqual([0, 1]);
+  });
+
+  it("linear maps domain onto range", () => {
+    const s = linear([0, 10], [0, 100]);
+    expect(s(0)).toBe(0);
+    expect(s(5)).toBe(50);
+    expect(s(10)).toBe(100);
+  });
+
+  it("linear is flat when the domain is degenerate", () => {
+    const s = linear([4, 4], [0, 100]);
+    expect(s(4)).toBe(0);
+  });
+});

--- a/tests/unit/event-metrics.test.ts
+++ b/tests/unit/event-metrics.test.ts
@@ -1,0 +1,21 @@
+// tests/unit/event-metrics.test.ts
+import { describe, it, expect } from "vitest";
+import { eventMetricLine } from "@/lib/widgets/eventMetrics";
+
+describe("eventMetricLine", () => {
+  it("quake: magnitude + depth", () => {
+    expect(eventMetricLine("quake", { magnitude: 5.2, depth: "12.3 km" })).toBe("M 5.2 · depth 12.3 km");
+  });
+  it("cyclone: category + wind + pressure + movement", () => {
+    expect(eventMetricLine("cyclone", { category: "Cat 3 hurricane", maxWind: "90 kt", pressure: "960 mb", movement: "315° at 12 kt" }))
+      .toBe("Cat 3 hurricane · 90 kt · 960 mb · moving 315° at 12 kt");
+  });
+  it("disaster: alert level + country + ongoing (no fake magnitude)", () => {
+    expect(eventMetricLine("disaster", { alertLevel: "Red", country: "Nigeria", ongoing: "yes" }))
+      .toBe("Red alert · Nigeria · ongoing");
+  });
+  it("returns empty string when nothing usable is present", () => {
+    expect(eventMetricLine("other", undefined)).toBe("");
+    expect(eventMetricLine("disaster", {})).toBe("");
+  });
+});

--- a/tests/unit/focus-reducer.test.ts
+++ b/tests/unit/focus-reducer.test.ts
@@ -1,0 +1,32 @@
+// tests/unit/focus-reducer.test.ts
+import { describe, it, expect } from "vitest";
+import { createDefaultLayout } from "@/lib/console/types";
+import { setFocus, addWidget, removeWidget } from "@/lib/console/reducers";
+
+describe("focus reducer", () => {
+  it("defaults to no focused widget", () => {
+    expect(createDefaultLayout().focusedWidgetId).toBeNull();
+  });
+
+  it("setFocus sets and clears the focused id", () => {
+    const l0 = createDefaultLayout();
+    const l1 = setFocus(l0, "wabc");
+    expect(l1.focusedWidgetId).toBe("wabc");
+    expect(setFocus(l1, null).focusedWidgetId).toBeNull();
+  });
+
+  it("removing the focused widget clears focus", () => {
+    let l = addWidget(createDefaultLayout(), "events", "w1");
+    l = setFocus(l, "w1");
+    l = removeWidget(l, "w1");
+    expect(l.focusedWidgetId).toBeNull();
+  });
+
+  it("removing a different widget leaves focus intact", () => {
+    let l = addWidget(createDefaultLayout(), "events", "w1");
+    l = addWidget(l, "markets", "w2");
+    l = setFocus(l, "w1");
+    l = removeWidget(l, "w2");
+    expect(l.focusedWidgetId).toBe("w1");
+  });
+});

--- a/tests/unit/humanise.test.ts
+++ b/tests/unit/humanise.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { humaniseKey } from "@/lib/text/humanise";
+
+describe("humaniseKey", () => {
+  it("camelCase → Title", () => expect(humaniseKey("forecastFor")).toBe("Forecast for"));
+  it("snake/kebab → Title", () => {
+    expect(humaniseKey("alert_level")).toBe("Alert level");
+    expect(humaniseKey("wind-speed")).toBe("Wind speed");
+  });
+});

--- a/tests/unit/map-inset.test.ts
+++ b/tests/unit/map-inset.test.ts
@@ -1,0 +1,17 @@
+// tests/unit/map-inset.test.ts
+import { describe, it, expect } from "vitest";
+import { pointsToFC, boundsOf } from "@/lib/map/inset";
+
+describe("inset map helpers", () => {
+  it("pointsToFC builds [lon,lat] point features and drops non-finite coords", () => {
+    const fc = pointsToFC([{ lat: 10, lon: 20, id: "a" }, { lat: NaN, lon: 5, id: "b" }]);
+    expect(fc.features).toHaveLength(1);
+    expect(fc.features[0].geometry).toEqual({ type: "Point", coordinates: [20, 10] });
+    expect(fc.features[0].properties).toMatchObject({ id: "a" });
+  });
+
+  it("boundsOf returns [[w,s],[e,n]] or null when empty", () => {
+    expect(boundsOf([{ lat: 10, lon: 20 }, { lat: -5, lon: 40 }])).toEqual([[20, -5], [40, 10]]);
+    expect(boundsOf([])).toBeNull();
+  });
+});

--- a/tests/unit/news-article.test.ts
+++ b/tests/unit/news-article.test.ts
@@ -1,0 +1,34 @@
+// tests/unit/news-article.test.ts
+import { describe, it, expect } from "vitest";
+import { isNewsArticleUrl, extractArticleText } from "@/lib/news/article";
+
+describe("isNewsArticleUrl", () => {
+  it("allows the known publisher domains + subdomains over https", () => {
+    expect(isNewsArticleUrl("https://www.bbc.com/news/world-123")).toBe(true);
+    expect(isNewsArticleUrl("https://www.theguardian.com/world/x")).toBe(true);
+    expect(isNewsArticleUrl("https://text.npr.org/12345")).toBe(true);
+    expect(isNewsArticleUrl("https://www.aljazeera.com/news/x")).toBe(true);
+  });
+  it("rejects other hosts, non-https, and junk", () => {
+    expect(isNewsArticleUrl("https://evil.example.com/x")).toBe(false);
+    expect(isNewsArticleUrl("http://www.bbc.com/news/x")).toBe(false); // must be https
+    expect(isNewsArticleUrl("not a url")).toBe(false);
+    expect(isNewsArticleUrl("https://notbbc.com.evil.com/x")).toBe(false);
+  });
+});
+
+describe("extractArticleText", () => {
+  it("strips scripts/styles/markup and collapses whitespace", () => {
+    const html = `<html><head><style>.x{}</style><script>bad()</script></head>
+      <body><h1>Title</h1><p>First para.</p><p>Second   para.</p></body></html>`;
+    const text = extractArticleText(html);
+    expect(text).toContain("First para.");
+    expect(text).toContain("Second para.");
+    expect(text).not.toContain("bad()");
+    expect(text).not.toContain(".x{}");
+  });
+  it("caps length and returns empty for blank input", () => {
+    expect(extractArticleText("")).toBe("");
+    expect(extractArticleText("<p>" + "a".repeat(50000) + "</p>", 100).length).toBe(100);
+  });
+});

--- a/tests/unit/news-description.test.ts
+++ b/tests/unit/news-description.test.ts
@@ -13,6 +13,11 @@ const XML = `<rss><channel>
     <title>No description here</title>
     <link>https://www.bbc.com/news/world-124</link>
   </item>
+  <item>
+    <title>Entity-encoded HTML body</title>
+    <link>https://www.theguardian.com/politics/live/2026/jul/08/story</link>
+    <description>&lt;p&gt;Lib Dems tell Reform UK leader &lt;a href="https://x.test"&gt;the game is up&lt;/a&gt;&lt;/p&gt;&lt;ul&gt;&lt;li&gt;More&lt;/li&gt;&lt;/ul&gt;</description>
+  </item>
 </channel></rss>`;
 
 describe("parseRss description", () => {
@@ -23,5 +28,12 @@ describe("parseRss description", () => {
   it("leaves description undefined when the item has none", () => {
     const items = parseRss(XML, "BBC");
     expect(items[1].description).toBeUndefined();
+  });
+  it("strips entity-encoded HTML tags (Guardian-style descriptions)", () => {
+    const items = parseRss(XML, "The Guardian");
+    // &lt;p&gt;… decodes to real <p>…</p> markup, which must not survive into the snippet.
+    expect(items[2].description).toBe("Lib Dems tell Reform UK leader the game is up More");
+    expect(items[2].description).not.toContain("<");
+    expect(items[2].description).not.toContain("href");
   });
 });

--- a/tests/unit/news-description.test.ts
+++ b/tests/unit/news-description.test.ts
@@ -1,0 +1,27 @@
+// tests/unit/news-description.test.ts
+import { describe, it, expect } from "vitest";
+import { parseRss } from "@/lib/news";
+
+const XML = `<rss><channel>
+  <item>
+    <title>Big story &amp; more</title>
+    <link>https://www.bbc.com/news/world-123</link>
+    <pubDate>Wed, 08 Jul 2026 08:00:00 GMT</pubDate>
+    <description><![CDATA[<p>A short <b>summary</b> of the story.</p>]]></description>
+  </item>
+  <item>
+    <title>No description here</title>
+    <link>https://www.bbc.com/news/world-124</link>
+  </item>
+</channel></rss>`;
+
+describe("parseRss description", () => {
+  it("captures a cleaned <description> snippet", () => {
+    const items = parseRss(XML, "BBC");
+    expect(items[0].description).toBe("A short summary of the story.");
+  });
+  it("leaves description undefined when the item has none", () => {
+    const items = parseRss(XML, "BBC");
+    expect(items[1].description).toBeUndefined();
+  });
+});

--- a/tests/unit/news-summary.test.ts
+++ b/tests/unit/news-summary.test.ts
@@ -1,0 +1,17 @@
+// tests/unit/news-summary.test.ts
+import { describe, it, expect } from "vitest";
+import { buildSummaryPrompt, parseSummaryResponse } from "@/lib/news/summary";
+
+describe("news summary", () => {
+  it("builds a grounded, non-speculative prompt containing the article text", () => {
+    const p = buildSummaryPrompt({ title: "T", source: "BBC", text: "Body of the article." });
+    expect(p).toContain("Body of the article.");
+    expect(p.toLowerCase()).toContain("do not");   // the anti-speculation guard
+  });
+  it("parses the gateway chat-completion content, or null", () => {
+    expect(parseSummaryResponse({ choices: [{ message: { content: "  A summary.  " } }] })).toBe("A summary.");
+    expect(parseSummaryResponse({ choices: [] })).toBeNull();
+    expect(parseSummaryResponse({})).toBeNull();
+    expect(parseSummaryResponse(null)).toBeNull();
+  });
+});

--- a/tests/unit/planes-ops.test.ts
+++ b/tests/unit/planes-ops.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { opsSummary, altitudeBand, regionOf, sortFlights } from "@/lib/planes/ops";
+import type { WorldObject } from "@/lib/world";
+
+const plane = (over: Partial<WorldObject> & { meta?: Record<string, unknown> }): WorldObject =>
+  ({ kind: "plane", id: "plane:x", lat: 51, lon: 0, label: "T", ...over } as WorldObject);
+
+describe("opsSummary", () => {
+  it("splits airborne/ground, counts categories, tracks maxima", () => {
+    const s = opsSummary([
+      plane({ altKm: 10, meta: { category: "airliner", velocityMs: 250, onGround: false } }),
+      plane({ altKm: 0, meta: { category: "ground", onGround: true, velocityMs: 5 } }),
+    ]);
+    expect(s.total).toBe(2);
+    expect(s.airborne).toBe(1);
+    expect(s.ground).toBe(1);
+    expect(s.maxAltKm).toBe(10);
+    expect(s.maxSpeedMs).toBe(250);
+    expect(s.byCategory.find((c) => c.category === "airliner")!.count).toBe(1);
+  });
+});
+
+describe("altitudeBand", () => {
+  it("bands by altitude, ground first", () => {
+    expect(altitudeBand(plane({ altKm: 9, meta: { onGround: false } }))).toBe("7–11 km");
+    expect(altitudeBand(plane({ meta: { onGround: true } }))).toBe("ground");
+  });
+});
+
+describe("regionOf", () => {
+  it("maps coords to the nearest ADS-B region label", () => {
+    expect(regionOf(51.5, -0.1)).toBe("London / SE England");
+    expect(regionOf(37, -120)).toBe("California");
+  });
+});
+
+describe("sortFlights", () => {
+  it("sorts by altitude descending with dir -1", () => {
+    const out = sortFlights([plane({ id: "a", altKm: 1 }), plane({ id: "b", altKm: 9 })], "altitude", -1);
+    expect(out[0].id).toBe("b");
+  });
+});

--- a/tests/unit/sanitize-focus.test.ts
+++ b/tests/unit/sanitize-focus.test.ts
@@ -1,0 +1,24 @@
+// tests/unit/sanitize-focus.test.ts
+import { describe, it, expect } from "vitest";
+import { sanitizeLayout } from "@/lib/console/sanitize";
+
+const base = {
+  segments: { left: { size: 320, collapsed: false }, right: { size: 320, collapsed: false }, bottom: { size: 240, collapsed: false } },
+  stage: "map2d",
+  widgets: [{ id: "w1", type: "events", segment: "left", order: 0, width: 12, height: 240, collapsed: false, config: {} }],
+};
+
+describe("sanitizeLayout focus", () => {
+  it("keeps a focusedWidgetId that matches a widget", () => {
+    const out = sanitizeLayout({ ...base, focusedWidgetId: "w1" });
+    expect(out?.focusedWidgetId).toBe("w1");
+  });
+  it("drops a focusedWidgetId with no matching widget", () => {
+    const out = sanitizeLayout({ ...base, focusedWidgetId: "ghost" });
+    expect(out?.focusedWidgetId).toBeNull();
+  });
+  it("defaults missing/invalid focus to null", () => {
+    expect(sanitizeLayout({ ...base })?.focusedWidgetId).toBeNull();
+    expect(sanitizeLayout({ ...base, focusedWidgetId: 42 })?.focusedWidgetId).toBeNull();
+  });
+});

--- a/tests/unit/signal-detail.test.ts
+++ b/tests/unit/signal-detail.test.ts
@@ -19,6 +19,14 @@ describe("distribution", () => {
   it("is 'none' when neither magnitude nor severity exists (honest hide)", () => {
     expect(distribution([f({ props: { note: "hi" } })]).kind).toBe("none");
   });
+  it("gives the top INTEGER magnitude its own bucket (off-by-one guard)", () => {
+    // [5,6] must render as two bars (5→1, 6→1), not one "5: 2" that swallows the max.
+    const d = distribution([f({ props: { magnitude: 5 } }), f({ props: { magnitude: 6 } })]);
+    expect(d.kind).toBe("magnitude");
+    expect(d.bins.find((b) => b.label === "5")?.count).toBe(1);
+    expect(d.bins.find((b) => b.label === "6")?.count).toBe(1);
+    expect(d.bins.reduce((n, b) => n + b.count, 0)).toBe(2);
+  });
 });
 
 describe("timeModel", () => {

--- a/tests/unit/signal-detail.test.ts
+++ b/tests/unit/signal-detail.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { distribution, timeModel, sortFeatures } from "@/lib/console/signals/signalDetail";
+import type { SignalFeature } from "@/lib/signals/types";
+
+const f = (over: Partial<SignalFeature>): SignalFeature =>
+  ({ id: "x", lat: 0, lon: 0, title: "t", signalId: "s", ...over });
+
+describe("distribution", () => {
+  it("uses a magnitude histogram when numeric magnitudes exist", () => {
+    const d = distribution([f({ props: { magnitude: 2 } }), f({ props: { magnitude: 6 } })]);
+    expect(d.kind).toBe("magnitude");
+    expect(d.bins.reduce((n, b) => n + b.count, 0)).toBe(2);
+  });
+  it("falls back to declared severity when no magnitudes", () => {
+    const d = distribution([f({ props: { alertLevel: "Red" } }), f({ props: { severity: "warning" } })]);
+    expect(d.kind).toBe("severity");
+    expect(d.bins.find((b) => b.label === "Severe")!.count).toBe(1);
+  });
+  it("is 'none' when neither magnitude nor severity exists (honest hide)", () => {
+    expect(distribution([f({ props: { note: "hi" } })]).kind).toBe("none");
+  });
+});
+
+describe("timeModel", () => {
+  it("splits dated from undated", () => {
+    const m = timeModel([f({ ts: "2026-07-08T00:00:00Z" }), f({})]);
+    expect(m.values.length).toBe(1);
+    expect(m.undated).toBe(1);
+  });
+});
+
+describe("sortFeatures", () => {
+  it("sorts by magnitude descending with dir -1", () => {
+    const out = sortFeatures([f({ id: "a", props: { magnitude: 1 } }), f({ id: "b", props: { magnitude: 9 } })], "magnitude", -1);
+    expect(out[0].id).toBe("b");
+  });
+});


### PR DESCRIPTION
## Focus Window — foundation (F1 + F2 + W1 Events)

Turns the main globe window into a **focus surface**: every console widget gets a `⤢` expand button that takes over the center stage with a deep, data-rich detail view. This PR ships the foundation + the first bespoke detail (Events), proving the mechanism end-to-end. The other seven widgets (W2–W8) follow as their own PRs.

### F1 — Focus framework
- `focusedWidgetId` on `ShellLayout` (persisted + sanitised; round-trips across reload/URL)
- `WidgetType.detail` contract + `WidgetDetail` host (generic fallback so no expand button is ever dead)
- `StageHost` focus branch, `WidgetFrame` `⤢` button, `StageSwitch` FOCUS chip + back-to-map — reuses the existing stage seam, so "back" restores the previous stage for free

### F2 — Shared primitives (zero new deps)
- `<Chart>` — native SVG line/area (+ pure `lib/chart/scale.ts`)
- `<InsetMap>` — one small single-layer MapLibre map (+ pure `lib/map/inset.ts`)
- `lib/widgets/buckets.ts` — `countBy` / `histogram` / `timeBins`

### W1 — Events detail
Triage header, feed grouped by type with **honest per-domain metrics** (quake M+depth, cyclone wind/pressure, GDACS alert-level — no fabricated unified magnitude), 24h recency chart, event-location inset map, sources/attribution footer, CSV/GeoJSON export.

### Quality
- TDD throughout; pure logic unit-tested first. **558 tests pass, `tsc` clean.**
- Verified live: expand→detail→back loop, Events detail with real data ("65 of 245 events", "M 4.7 · depth 58.2 km"), export enabled, 0 console errors.
- Keyless-first, dormant-safe, honest empty states.

Spec: `docs/superpowers/specs/2026-07-08-focus-window-design.md`
Plan: `docs/superpowers/plans/2026-07-08-focus-window-foundation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)