### PR TITLE
Focus window: news-video, markets & satellites detail views (W6–W8)

### DIFF
--- a/app/api/markets/chart/route.ts
+++ b/app/api/markets/chart/route.ts
@@ -1,0 +1,60 @@
+import { parseYahooSeries, RANGES, type Candle, type Range, type YahooChartResponse } from "@/lib/markets/chart";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/markets/chart?symbol=<yahoo>&range=1mo|6mo|1y — keyless Yahoo v8 OHLC
+// for the Markets focus view's primary historical chart. Mirrors the dormant-safe
+// pattern of /api/markets: a private getJson swallows every upstream error and a
+// small per-`symbol:range` cache shields Yahoo. It NEVER 5xxes: a bad/blocked
+// symbol, an out-of-range window, or an upstream failure all resolve to
+// `{ candles: [] }`, and the view falls back to its accumulated live series.
+
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const CACHE_TTL_MS = 5 * 60_000; // 5 min — history barely moves intraday
+// Yahoo tickers: optional leading ^ (indices), then letters/digits + . = - (e.g. BZ=F, ^VIX, BRK-B).
+const SYMBOL_RE = /^\^?[A-Za-z0-9.=-]{1,20}$/;
+
+async function getJson<T>(url: string, ms = 12_000): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": UA, Accept: "application/json" }, signal: AbortSignal.timeout(ms) });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+// Weekly bars over a year keep the point count sane; daily for the shorter windows.
+function intervalFor(range: Range): string {
+  return range === "1y" ? "1wk" : "1d";
+}
+
+const cache = new Map<string, { at: number; candles: Candle[] }>();
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const symbol = (url.searchParams.get("symbol") ?? "").trim();
+  const rangeParam = (url.searchParams.get("range") ?? "6mo").trim();
+
+  // Validate before touching the network — reject noise with an empty result, not a 5xx.
+  if (!symbol || !SYMBOL_RE.test(symbol) || !(RANGES as string[]).includes(rangeParam)) {
+    return Response.json({ candles: [] });
+  }
+  const range = rangeParam as Range;
+
+  const key = `${symbol}:${range}`;
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
+    return Response.json({ candles: hit.candles });
+  }
+
+  const yahooUrl =
+    `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}` +
+    `?range=${encodeURIComponent(range)}&interval=${intervalFor(range)}`;
+  const json = await getJson<YahooChartResponse>(yahooUrl);
+  const candles = parseYahooSeries(json);
+  // Only cache a non-empty result so a transient upstream blip doesn't pin an empty
+  // series for 5 minutes; empties simply retry next request.
+  if (candles.length > 0) cache.set(key, { at: Date.now(), candles });
+  return Response.json({ candles });
+}

--- a/app/api/markets/chart/route.ts
+++ b/app/api/markets/chart/route.ts
@@ -29,6 +29,7 @@ function intervalFor(range: Range): string {
   return range === "1y" ? "1wk" : "1d";
 }
 
+const CACHE_MAX = 200; // bound the cache so a flood of distinct attacker-supplied symbols can't grow it unbounded
 const cache = new Map<string, { at: number; candles: Candle[] }>();
 
 export async function GET(req: Request): Promise<Response> {
@@ -42,7 +43,8 @@ export async function GET(req: Request): Promise<Response> {
   }
   const range = rangeParam as Range;
 
-  const key = `${symbol}:${range}`;
+  // Yahoo tickers are case-insensitive; normalise so "aapl"/"AAPL" share one cache slot.
+  const key = `${symbol.toUpperCase()}:${range}`;
   const hit = cache.get(key);
   if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
     return Response.json({ candles: hit.candles });
@@ -55,6 +57,13 @@ export async function GET(req: Request): Promise<Response> {
   const candles = parseYahooSeries(json);
   // Only cache a non-empty result so a transient upstream blip doesn't pin an empty
   // series for 5 minutes; empties simply retry next request.
-  if (candles.length > 0) cache.set(key, { at: Date.now(), candles });
+  if (candles.length > 0) {
+    cache.set(key, { at: Date.now(), candles });
+    // Evict the oldest entry (Map preserves insertion order) once over the cap.
+    if (cache.size > CACHE_MAX) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+  }
   return Response.json({ candles });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1450,6 +1450,46 @@ a { color: var(--tn-accent); }
 .tn-cm-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
 .tn-cm-actions button:disabled { opacity: .4; cursor: default; }
 
+/* ── Satellites focus view (W8) — orbital command, mirrors the .tn-av / .tn-cm language ── */
+.tn-sat { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
+.tn-sat-head { display: flex; flex-direction: column; gap: 6px; }
+.tn-sat-title { font-size: 18px; font-weight: 700; }
+.tn-sat-stat { font-size: 12px; color: var(--tn-text-muted); }
+.tn-sat-delta.up { color: #16a34a; } .tn-sat-delta.down { color: #dc2626; }
+.tn-sat-spark { max-width: 320px; }
+.tn-sat-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.tn-sat-chip { font-size: 11px; padding: 3px 10px; border-radius: 999px; background: var(--tn-surface-2); border: 1px solid var(--tn-border); color: var(--tn-text-muted); cursor: pointer; }
+.tn-sat-chip.active { background: var(--tn-accent); border-color: var(--tn-accent); color: var(--tn-surface-solid); }
+.tn-sat-search { align-self: flex-start; min-width: 240px; max-width: 360px; width: 100%; font: inherit; font-size: 13px; padding: 6px 10px; border-radius: 8px; border: 1px solid var(--tn-border); background: var(--tn-surface-2); color: var(--tn-text); }
+.tn-sat-search::placeholder { color: var(--tn-text-faint); }
+.tn-sat-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+@media (max-width: 720px) { .tn-sat-panels { grid-template-columns: 1fr; } }
+.tn-sat-panel h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 0 0 6px; }
+.tn-sat-vitals { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px 16px; margin: 0; }
+.tn-sat-vitals > div { display: flex; flex-direction: column; gap: 2px; }
+.tn-sat-vitals dt { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); }
+.tn-sat-vitals dd { margin: 0; font-size: 14px; font-variant-numeric: tabular-nums; color: var(--tn-text); }
+.tn-sat-img-fig { margin: 0; position: relative; border-radius: 10px; overflow: hidden; background: var(--tn-surface-2); aspect-ratio: 1 / 1; }
+.tn-sat-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.tn-sat-cap { position: absolute; left: 8px; bottom: 8px; right: 8px; font-size: 11px; padding: 3px 8px; border-radius: 8px; background: var(--tn-surface); border: 1px solid var(--tn-border); color: var(--tn-text-muted); line-height: 1.4; }
+.tn-sat-live { display: flex; flex-direction: column; gap: 6px; }
+.tn-sat-live-frame { width: 100%; aspect-ratio: 16 / 9; border: 0; border-radius: 10px; background: #000; }
+.tn-sat-live .tn-sat-cap { position: static; background: transparent; border: 0; padding: 0; }
+.tn-sat-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tn-sat-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-sat-table th.sortable { cursor: pointer; }
+.tn-sat-table td { padding: 5px 8px; border-bottom: 1px solid var(--tn-border); white-space: nowrap; }
+.tn-sat-row { cursor: pointer; }
+.tn-sat-row:hover { background: var(--tn-surface-2); }
+.tn-sat-row.sel { background: var(--tn-accent-soft); }
+.tn-sat-drill { background: var(--tn-surface-2); }
+.tn-sat-drill td { padding: 12px 14px; }
+.tn-sat-foot { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; border-top: 1px solid var(--tn-border); padding-top: 8px; margin-top: auto; }
+.tn-sat-attr { font-size: 11px; color: var(--tn-text-faint); }
+.tn-sat-actions { display: flex; gap: 8px; }
+.tn-sat-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
+.tn-sat-actions button:disabled { opacity: .4; cursor: default; }
+
 /* ── Markets focus view (W7) — "for markets, it shows actual graphs" ── */
 .tn-mk { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
 .tn-mk-head { display: flex; flex-direction: column; gap: 4px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1207,6 +1207,65 @@ a { color: var(--tn-accent); }
 .tn-newsw-cat{color:#9aa6b2;font-size:9px;float:right}.tn-newsw-custom{margin:6px 9px;padding:4px;font-size:11px;border:1px solid #e1e8ef;border-radius:5px}
 
 /* ===========================================================================
+   News-video FOCUS view (W6) — prefix `tn-nv`. Theme-token chrome (dark-capable,
+   unlike the light-hardcoded `.tn-newsw-*` docked widget). Media letterboxes use a
+   dark literal (video looks correct in both themes, mirroring the docked screen).
+   =========================================================================== */
+.tn-nv{display:flex;flex-direction:column;gap:12px}
+.tn-nv-head{display:flex;align-items:baseline;justify-content:space-between;flex-wrap:wrap;gap:6px}
+.tn-nv-title{font-weight:600;font-size:15px;color:var(--tn-text)}
+.tn-nv-now{font-size:12px;color:var(--tn-text-muted)}
+.tn-nv-sec-h{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--tn-text-faint);margin:2px 0}
+
+/* Category filter chips + mosaic toggle */
+.tn-nv-chips{display:flex;flex-wrap:wrap;gap:6px}
+.tn-nv-chips button,.tn-nv-mtoggle{font:inherit;font-size:11px;border:1px solid var(--tn-border);border-radius:999px;padding:3px 11px;background:var(--tn-surface-2);color:var(--tn-text-muted);cursor:pointer}
+.tn-nv-chips button.is-on,.tn-nv-mtoggle.is-on{background:var(--tn-accent);border-color:var(--tn-accent);color:#fff}
+.tn-nv-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:space-between}
+
+/* Hero player (16:9) + mosaic (2×2) */
+.tn-nv-hero{position:relative;aspect-ratio:16/9;background:#111820;border-radius:8px;overflow:hidden}
+.tn-nv-video{position:absolute;inset:0;width:100%;height:100%;border:0}
+.tn-nv-hero-label{position:absolute;left:8px;bottom:8px;color:#fff;font-size:11px;font-weight:700;text-shadow:0 1px 2px rgba(0,0,0,.7)}
+.tn-nv-mosaic{display:grid;grid-template-columns:1fr 1fr;gap:4px}
+.tn-nv-cell{position:relative;aspect-ratio:16/9;background:#111820;border-radius:6px;overflow:hidden}
+.tn-nv-cell iframe{position:absolute;inset:0;width:100%;height:100%;border:0}
+.tn-nv-cell.is-on{outline:2px solid var(--tn-accent);outline-offset:-2px}
+.tn-nv-cell-label{position:absolute;left:5px;bottom:4px;color:#fff;font-size:9px;font-weight:700;text-shadow:0 1px 2px rgba(0,0,0,.7)}
+
+/* Channel wall — keyless thumbnail tiles */
+.tn-nv-wall{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:8px}
+.tn-nv-cat-h{grid-column:1/-1;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--tn-text-faint);margin-top:4px}
+.tn-nv-tile{position:relative;display:flex;flex-direction:column;padding:0;text-align:left;font:inherit;color:inherit;background:var(--tn-surface-2);border:1px solid var(--tn-border);border-radius:8px;overflow:hidden;cursor:pointer}
+.tn-nv-tile:hover{border-color:var(--tn-accent)}
+.tn-nv-tile.is-on{outline:2px solid var(--tn-accent);outline-offset:-2px;border-color:var(--tn-accent)}
+.tn-nv-thumb-wrap{position:relative;aspect-ratio:16/9;background:#111820}
+.tn-nv-thumb{width:100%;height:100%;object-fit:cover;display:block}
+.tn-nv-thumb-fallback{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:11px;color:var(--tn-text-faint)}
+.tn-nv-live{position:absolute;top:5px;left:5px;display:inline-flex;align-items:center;gap:4px;font-size:9px;font-weight:700;color:#fff;background:rgba(0,0,0,.55);padding:1px 6px;border-radius:4px}
+.tn-nv-live-dot{width:6px;height:6px;border-radius:50%;background:#e5484d;animation:tn-nv-pulse 1.6s ease-in-out infinite}
+@keyframes tn-nv-pulse{0%,100%{opacity:1}50%{opacity:.35}}
+.tn-nv-tile-cap{padding:5px 7px;display:flex;flex-direction:column;gap:1px;min-width:0}
+.tn-nv-tile-name{font-size:11px;color:var(--tn-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.tn-nv-tile-cat{font-size:9px;color:var(--tn-text-faint)}
+
+/* Live headline rail */
+.tn-nv-rail{display:flex;flex-direction:column;border-top:1px solid var(--tn-border)}
+.tn-nv-rail-item{display:block;padding:6px 2px;border-bottom:1px solid var(--tn-border);font-size:12px;text-decoration:none}
+.tn-nv-rail-title{color:var(--tn-text)}
+.tn-nv-rail-item:hover .tn-nv-rail-title{color:var(--tn-accent);text-decoration:underline}
+.tn-nv-rail-meta{font-size:10px;color:var(--tn-text-faint);margin-top:1px}
+
+/* Footer — add-custom-stream + export */
+.tn-nv-foot{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:8px;border-top:1px solid var(--tn-border);padding-top:10px;margin-top:2px}
+.tn-nv-foot-note{font-size:10px;color:var(--tn-text-faint);flex:1 1 220px}
+.tn-nv-add{display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.tn-nv-custom{font:inherit;font-size:11px;padding:4px 8px;border:1px solid var(--tn-border);border-radius:6px;background:var(--tn-surface-2);color:var(--tn-text);min-width:190px}
+.tn-nv-add button,.tn-nv-actions button{font:inherit;font-size:11px;padding:4px 10px;border:1px solid var(--tn-border);border-radius:6px;background:var(--tn-surface-2);color:var(--tn-text-muted);cursor:pointer}
+.tn-nv-add button:disabled,.tn-nv-actions button:disabled{opacity:.5;cursor:default}
+.tn-nv-err{font-size:10px;color:#e5484d}
+
+/* ===========================================================================
    Global capacity toast (Task 15) — calm bottom-centre pill, auto-dismisses
    =========================================================================== */
 .tn-toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%);z-index:1200;max-width:90vw;background:#2b3640;color:#fff;font:13px/1.4 -apple-system,"Segoe UI",Roboto,sans-serif;padding:9px 16px;border-radius:999px;box-shadow:0 6px 24px rgba(20,28,38,.28);animation:tn-toast-in .18s ease-out}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1449,3 +1449,71 @@ a { color: var(--tn-accent); }
 .tn-cm-actions { display: flex; gap: 8px; }
 .tn-cm-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
 .tn-cm-actions button:disabled { opacity: .4; cursor: default; }
+
+/* ── Markets focus view (W7) — "for markets, it shows actual graphs" ── */
+.tn-mk { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
+.tn-mk-head { display: flex; flex-direction: column; gap: 4px; }
+.tn-mk-title { font-size: 18px; font-weight: 700; }
+.tn-mk-stat { font-size: 12px; color: var(--tn-text-muted); }
+.tn-mk-disc { font-size: 11px; color: var(--tn-text-faint); }
+/* movers heat-strip */
+.tn-mk-heat { display: flex; flex-wrap: wrap; gap: 6px; }
+.tn-mk-heat-chip { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; font: inherit; text-align: left; border: 1px solid var(--tn-border); border-radius: 8px; padding: 4px 9px; color: var(--tn-text); cursor: pointer; }
+.tn-mk-heat-chip.is-sel { outline: 2px solid var(--tn-accent); outline-offset: -2px; }
+.tn-mk-heat-sym { font-size: 11px; font-weight: 700; }
+.tn-mk-heat-pct { font-size: 10px; color: var(--tn-text-muted); }
+/* body: instrument rail + primary panel */
+.tn-mk-body { display: grid; grid-template-columns: minmax(260px, 320px) 1fr; gap: 16px; align-items: start; }
+@media (max-width: 820px) { .tn-mk-body { grid-template-columns: 1fr; } }
+.tn-mk-rail { display: flex; flex-direction: column; gap: 12px; }
+.tn-mk-sec-h { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+.tn-mk-sec-label { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--tn-text-faint); }
+.tn-mk-sec-src { font-size: 10px; color: var(--tn-text-faint); }
+.tn-mk-sec-note { font-size: 12px; color: var(--tn-text-faint); margin: 2px 0 4px; }
+.tn-mk-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.tn-mk-row { display: grid; grid-template-columns: 1fr auto 64px; align-items: center; gap: 8px; width: 100%; font: inherit; text-align: left; background: var(--tn-surface-2); border: 1px solid transparent; border-radius: 8px; padding: 5px 8px; color: var(--tn-text); cursor: pointer; }
+.tn-mk-row:hover { border-color: var(--tn-border); }
+.tn-mk-row.is-sel { border-color: var(--tn-accent); background: var(--tn-accent-soft); }
+.tn-mk-row-main { display: flex; flex-direction: column; min-width: 0; }
+.tn-mk-row-sym { font-size: 12px; font-weight: 700; }
+.tn-mk-row-name { font-size: 10px; color: var(--tn-text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-mk-row-val { display: flex; flex-direction: column; align-items: flex-end; }
+.tn-mk-row-price { font-size: 12px; font-variant-numeric: tabular-nums; }
+.tn-mk-chg { font-size: 10px; font-variant-numeric: tabular-nums; }
+.tn-mk-chg.up { color: #16a34a; } .tn-mk-chg.down { color: #dc2626; }
+.tn-mk-row-spark { display: block; height: 28px; }
+/* primary panel */
+.tn-mk-main { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+.tn-mk-panel { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 10px; padding: 12px; }
+.tn-mk-panel-head { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 8px 12px; margin-bottom: 8px; }
+.tn-mk-panel-title { font-size: 15px; font-weight: 700; }
+.tn-mk-panel-sub { font-size: 11px; color: var(--tn-text-faint); }
+.tn-mk-tabs { display: flex; gap: 4px; }
+.tn-mk-tab { font: inherit; font-size: 11px; padding: 3px 10px; border: 1px solid var(--tn-border); border-radius: 999px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-mk-tab.active { background: var(--tn-accent); border-color: var(--tn-accent); color: #fff; }
+.tn-mk-metrics { display: flex; flex-wrap: wrap; gap: 6px 18px; margin-top: 8px; font-size: 12px; }
+.tn-mk-metric b { font-variant-numeric: tabular-nums; }
+.tn-mk-metric.up { color: #16a34a; } .tn-mk-metric.down { color: #dc2626; }
+.tn-mk-metric-label { color: var(--tn-text-faint); }
+.tn-mk-chart-note { font-size: 11px; color: var(--tn-text-faint); margin-top: 6px; }
+.tn-mk-chart-empty { display: grid; place-items: center; height: 220px; color: var(--tn-text-faint); font-size: 13px; }
+/* instrument table */
+.tn-mk-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tn-mk-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-mk-table th.sortable { cursor: pointer; }
+.tn-mk-table td { padding: 5px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-mk-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.tn-mk-trow { cursor: pointer; }
+.tn-mk-trow:hover { background: var(--tn-surface-2); }
+.tn-mk-trow.is-sel { background: var(--tn-accent-soft); }
+.tn-mk-drill { background: var(--tn-surface-2); }
+.tn-mk-drill td { padding: 10px 14px; }
+.tn-mk-drill dl { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 0; }
+.tn-mk-drill dt { color: var(--tn-accent); text-transform: uppercase; font-size: 10px; letter-spacing: .06em; font-weight: 600; }
+.tn-mk-drill dd { margin: 0; font-size: 12px; }
+/* footer */
+.tn-mk-foot { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; border-top: 1px solid var(--tn-border); padding-top: 8px; margin-top: auto; }
+.tn-mk-attr { display: flex; flex-direction: column; gap: 2px; font-size: 11px; color: var(--tn-text-faint); }
+.tn-mk-actions { display: flex; gap: 8px; }
+.tn-mk-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
+.tn-mk-actions button:disabled { opacity: .4; cursor: default; }

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -12,27 +12,61 @@ export function Chart({
   height = 200,
   area = true,
   up,
+  zeroBaseline = true,
+  markers = false,
 }: {
   points: ChartPoint[];
   width?: number;
   height?: number;
   area?: boolean;
   up?: boolean | null;
+  /** Anchor the y-scale at 0 (default, true — every existing caller). Set false so
+   *  price series that sit far from 0 auto-fit instead of squashing to a corner. */
+  zeroBaseline?: boolean;
+  /** Draw min-low / max-high / last dots with tiny value labels (price charts). */
+  markers?: boolean;
 }) {
   if (!points || points.length < 2) return null;
   const pad = 6;
   const xs = points.map((p) => p.x);
   const ys = points.map((p) => p.y);
   const sx = linear(extent(xs), [pad, width - pad]);
-  const sy = linear(extent([0, ...ys]), [height - pad, pad]); // baseline at 0
+  const sy = linear(extent(zeroBaseline === false ? ys : [0, ...ys]), [height - pad, pad]); // baseline at 0 unless opted out
   const line = points.map((p, i) => `${i === 0 ? "M" : "L"}${sx(p.x).toFixed(1)},${sy(p.y).toFixed(1)}`).join(" ");
   const stroke = up == null ? "var(--tn-accent, #38bdf8)" : up ? "#16a34a" : "#dc2626";
   const fillPath = `${line} L${sx(points[points.length - 1].x).toFixed(1)},${(height - pad).toFixed(1)} L${sx(points[0].x).toFixed(1)},${(height - pad).toFixed(1)} Z`;
+
+  // Value markers: the extremes and the latest point. Kept behind `markers` so no
+  // existing caller changes. Labels are horizontally stretched by the parent's
+  // preserveAspectRatio="none"; acceptable for the tiny annotations they are.
+  const fmtMarker = (n: number) => n.toLocaleString("en-US", { maximumFractionDigits: 2 });
+  const markerDots: { p: ChartPoint; dy: number; anchor: "start" | "middle" | "end" }[] = [];
+  if (markers) {
+    let lo = points[0], hi = points[0];
+    for (const p of points) { if (p.y < lo.y) lo = p; if (p.y > hi.y) hi = p; }
+    const last = points[points.length - 1];
+    markerDots.push({ p: hi, dy: -5, anchor: "middle" }, { p: lo, dy: 12, anchor: "middle" }, { p: last, dy: -5, anchor: "end" });
+  }
+
   return (
     <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} className="tn-chart" preserveAspectRatio="none" role="img">
       <line x1={pad} y1={height - pad} x2={width - pad} y2={height - pad} stroke="var(--tn-border, #1e293b)" strokeWidth="1" />
       {area && <path d={fillPath} fill={stroke} opacity="0.12" />}
       <path d={line} fill="none" stroke={stroke} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+      {markerDots.length > 0 && (
+        <g>
+          {markerDots.map(({ p, dy, anchor }, i) => {
+            const cx = sx(p.x), cy = sy(p.y);
+            const tx = Math.min(width - pad, Math.max(pad, cx));
+            return (
+              <g key={i}>
+                <circle cx={cx} cy={cy} r={2.5} fill={stroke} />
+                <text x={tx} y={cy + dy} fontSize={9} textAnchor={anchor} fill="var(--tn-text-faint, #94a3b8)">{fmtMarker(p.y)}</text>
+              </g>
+            );
+          })}
+        </g>
+      )}
     </svg>
   );
 }

--- a/components/InsetMap.tsx
+++ b/components/InsetMap.tsx
@@ -34,6 +34,14 @@ export default function InsetMap({
   const mapRef = useRef<maplibregl.Map | null>(null);
   const selectRef = useRef(onSelect);
   selectRef.current = onSelect;
+  // Latest props for the async 'load' handler — it is registered once, so without these
+  // it would paint the INITIAL selection if props changed during the style fetch.
+  const pointsRef = useRef(points); pointsRef.current = points;
+  const trackRef = useRef(track); trackRef.current = track;
+  // Auto-fit ONLY when the set of points changes (a new selection), not on every
+  // position update — a moving caller (satellites re-propagate every 5s) would otherwise
+  // re-snap the camera each tick and discard the user's manual pan/zoom.
+  const fitKeyRef = useRef<string>("");
 
   // Create the map once.
   useEffect(() => {
@@ -47,7 +55,7 @@ export default function InsetMap({
     });
     mapRef.current = map;
     map.on("load", () => {
-      map.addSource(SRC, { type: "geojson", data: pointsToFC(points) });
+      map.addSource(SRC, { type: "geojson", data: pointsToFC(pointsRef.current) });
       map.addLayer({
         id: LAYER,
         type: "circle",
@@ -66,8 +74,9 @@ export default function InsetMap({
       });
       map.on("mouseenter", LAYER, () => { map.getCanvas().style.cursor = "pointer"; });
       map.on("mouseleave", LAYER, () => { map.getCanvas().style.cursor = ""; });
-      syncTrack(map, track);
-      fit(map, points, track);
+      syncTrack(map, trackRef.current);
+      fit(map, pointsRef.current, trackRef.current);
+      fitKeyRef.current = pointsKey(pointsRef.current);
     });
     return () => { map.remove(); mapRef.current = null; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -78,10 +87,22 @@ export default function InsetMap({
     const map = mapRef.current;
     if (!map || !map.isStyleLoaded()) return;
     const src = map.getSource(SRC) as GeoJSONSource | undefined;
-    if (src) { src.setData(pointsToFC(points)); syncTrack(map, track); fit(map, points, track); }
+    if (src) {
+      src.setData(pointsToFC(points));
+      syncTrack(map, track);
+      // Re-fit only when the point set changes — preserves the user's pan/zoom while a
+      // moving caller updates positions in place.
+      const key = pointsKey(points);
+      if (key !== fitKeyRef.current) { fit(map, points, track); fitKeyRef.current = key; }
+    }
   }, [points, track]);
 
   return <div ref={boxRef} className="tn-inset-map" style={{ width: "100%", height }} />;
+}
+
+/** Identity of the point SET (ids, or coords when unkeyed) — used to gate auto-fit. */
+function pointsKey(points: InsetPoint[]): string {
+  return points.map((p) => p.id ?? `${p.lat.toFixed(4)},${p.lon.toFixed(4)}`).join("|");
 }
 
 function fit(map: maplibregl.Map, points: InsetPoint[], track?: [number, number][][]) {

--- a/components/InsetMap.tsx
+++ b/components/InsetMap.tsx
@@ -11,16 +11,24 @@ import { pointsToFC, boundsOf, type InsetPoint } from "@/lib/map/inset";
 
 const SRC = "inset-points";
 const LAYER = "inset-point-circles";
+const TRACK_SRC = "inset-track";
+const TRACK_LAYER = "inset-track-line";
+// Literal accent (the satellite layer's violet). Map layers use literal colours,
+// consistent with the circle layer's literal "#0b1220" stroke below.
+const TRACK_COLOR = "#7c3aed";
 const POSITRON = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
 
 export default function InsetMap({
   points,
   height = 320,
   onSelect,
+  track,
 }: {
   points: InsetPoint[];
   height?: number;
   onSelect?: (id: string) => void;
+  /** Optional ground-track polyline: [lon,lat] segments (already antimeridian-split). */
+  track?: [number, number][][];
 }) {
   const boxRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
@@ -58,7 +66,8 @@ export default function InsetMap({
       });
       map.on("mouseenter", LAYER, () => { map.getCanvas().style.cursor = "pointer"; });
       map.on("mouseleave", LAYER, () => { map.getCanvas().style.cursor = ""; });
-      fit(map, points);
+      syncTrack(map, track);
+      fit(map, points, track);
     });
     return () => { map.remove(); mapRef.current = null; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -69,13 +78,46 @@ export default function InsetMap({
     const map = mapRef.current;
     if (!map || !map.isStyleLoaded()) return;
     const src = map.getSource(SRC) as GeoJSONSource | undefined;
-    if (src) { src.setData(pointsToFC(points)); fit(map, points); }
-  }, [points]);
+    if (src) { src.setData(pointsToFC(points)); syncTrack(map, track); fit(map, points, track); }
+  }, [points, track]);
 
   return <div ref={boxRef} className="tn-inset-map" style={{ width: "100%", height }} />;
 }
 
-function fit(map: maplibregl.Map, points: InsetPoint[]) {
-  const b = boundsOf(points);
+function fit(map: maplibregl.Map, points: InsetPoint[], track?: [number, number][][]) {
+  const extra: InsetPoint[] = track ? track.flat().map(([lon, lat]) => ({ lat, lon })) : [];
+  const b = boundsOf([...points, ...extra]);
   if (b) map.fitBounds(b, { padding: 40, maxZoom: 6, duration: 0 });
+}
+
+// The optional ground-track polyline. Added LAZILY the first time a non-empty
+// track arrives, so a caller that never passes `track` gets a byte-identical
+// single-layer map (no extra source/layer registered at all).
+function trackToFC(segs: [number, number][][]): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: [{ type: "Feature", geometry: { type: "MultiLineString", coordinates: segs }, properties: {} }],
+  };
+}
+
+function syncTrack(map: maplibregl.Map, track?: [number, number][][]) {
+  const segs = (track ?? []).filter((s) => s.length >= 2);
+  const existing = map.getSource(TRACK_SRC) as GeoJSONSource | undefined;
+  if (segs.length === 0) {
+    if (existing) existing.setData({ type: "FeatureCollection", features: [] });
+    return;
+  }
+  if (existing) { existing.setData(trackToFC(segs)); return; }
+  map.addSource(TRACK_SRC, { type: "geojson", data: trackToFC(segs) });
+  // Insert BENEATH the point circles so the sub-point marker stays clickable on top.
+  map.addLayer(
+    {
+      id: TRACK_LAYER,
+      type: "line",
+      source: TRACK_SRC,
+      layout: { "line-cap": "round", "line-join": "round" },
+      paint: { "line-color": TRACK_COLOR, "line-width": 2, "line-opacity": 0.85 },
+    },
+    LAYER,
+  );
 }

--- a/docs/superpowers/plans/2026-07-08-focus-window-w7-markets.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-w7-markets.md
@@ -1,0 +1,247 @@
+# W7 — Markets detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** The milestone the user cares most about — "for markets, it shows actual graphs." A markets console focus view with real 1M/6M/1Y historical charts (keyless Yahoo v8 OHLC), an instrument rail grouped by asset class with movers-first ordering, a selected-instrument primary chart + period change + 52-week hi/lo, a sortable instrument table with a stats drill-down, and CSV export.
+
+**Architecture:** New default-export `MarketsDetail(props: WidgetDetailProps)` registered as `detail:` on `MARKETS_WIDGET`. It reuses `useJsonPoll("/api/markets")` for the live quote list (same as the docked widget) and adds a NEW keyless `/api/markets/chart` route that proxies Yahoo v8 OHLC for the selected instrument + range. Pure series parsing lives in a testable `lib/markets/chart.ts`. The shared `<Chart>` gains a `zeroBaseline` opt-out (market prices sit far from 0 and would squash against a 0 baseline). When the chart route is dormant/empty, the view honestly falls back to the accumulated live price series (`mkt:<id>` in `lib/series.ts`, ≤48 samples), clearly labelled "live session".
+
+**Tech Stack:** Next 15 / React 19 / TS; native SVG `<Chart>`; keyless Yahoo v8 finance chart; vitest.
+
+## Global Constraints
+
+- Keyless-first, dormant-safe: the chart route MUST resolve to empty (never 5xx) on upstream failure; the view falls back to the live `mkt:<id>` series. Honest labels: "delayed, keyless"; "live session" for the fallback; "indicative only — not financial advice".
+- Native `<Chart>` only (no new chart deps). Theme tokens only (`--tn-surface`/`--tn-surface-solid`/`--tn-surface-2`/`--tn-text`/`--tn-text-muted`/`--tn-text-faint`/`--tn-border`/`--tn-accent`). NO `--tn-surface-1`/`--tn-text-1`.
+- The `<Chart>` change MUST be backward-compatible: `zeroBaseline` defaults to `true` (current behaviour) so every existing caller (events/signals/aviation/cameras details) is unaffected.
+- Build gate (every task): `npx tsc --noEmit && npm test` → green.
+- Commits: solo `011-sam-110 <lesttech.dev.sam@gmail.com>`, **no Co-Authored-By / Claude trailer**, plain `git commit -m "..."`.
+- Owned files only; never `git add -A`/`checkout`/`reset`/`stash`; do not touch `.superpowers/sdd/progress.md`.
+- **Verify every signature against source** (interfaces below are from a research pass): `useJsonPoll`, `MarketsPayload`/`MarketSection`/`MarketRow` (`lib/markets.ts`), the existing Yahoo fetch helper (`getJson`) + keyless-symbol set in `app/api/markets/route.ts`, `seriesSamples`/`recordSeries`, `Chart` internals (`components/Chart.tsx`), `shellLayoutStore.configure/.unfocus`.
+
+## Reference pattern
+
+`lib/console/widgets/aviation.detail.tsx` / `signals.detail.tsx` for the detail skeleton (masthead, panels grid, table, footer, export). `app/api/signals/[id]/route.ts` and the existing `app/api/markets/route.ts` for the dormant-safe cached-route pattern (getJson swallows errors, returns last-good/empty, never 5xx).
+
+## Data shapes (verify, then consume)
+
+- `MarketsPayload = { generatedAt: number; sections: MarketSection[] }`; `MarketSection = { key; label; source: string; dormant?: boolean; note?: string; rows: MarketRow[] }`; `MarketRow = { id: string; name: string; symbol?: string; value: string; num?: number; changePct?: number|null; sub?: string; image? }` — `lib/markets.ts`.
+- `useJsonPoll<T>(url, pollMs, initial): { data, status }` — `lib/console/widgets/useJsonPoll.ts`.
+- `MARKETS_WIDGET` — plain object in `lib/console/widgets/markets.tsx`, `registerWidget(MARKETS_WIDGET)`. Attach `detail: MarketsDetail`.
+- Live series: `seriesSamples("mkt:"+row.id): CountSample[]` ({t,n}) — already recorded by the docked widget each poll.
+- `Chart({ points, width?, height?, area?, up? })` — `components/Chart.tsx`; baseline currently `extent([0, ...ys])` at line ~27.
+- Yahoo v8 chart JSON: `{ chart: { result: [ { meta, timestamp: number[] /*unix s*/, indicators: { quote: [ { open:number[], high:number[], low:number[], close:number[], volume:number[] } ], adjclose?: [ { adjclose:number[] } ] } } ], error } }`.
+
+## File Structure
+
+- Create `lib/markets/chart.ts` (pure series parsing + helpers), `app/api/markets/chart/route.ts`, `lib/console/widgets/markets.detail.tsx`, `tests/unit/markets-series.test.ts`.
+- Modify `components/Chart.tsx` (`zeroBaseline`), `app/api/markets/route.ts` (add `^VIX`/`^TNX` to the keyless set — optional macro), `lib/console/widgets/markets.tsx` (attach `detail:`), `app/globals.css` (`.tn-mk*`).
+
+---
+
+### Task 1: Pure Yahoo-series parsing + helpers
+
+**Files:** Create `lib/markets/chart.ts`; Test `tests/unit/markets-series.test.ts`.
+
+**Produces:** `Candle`, `parseYahooSeries`, `candlesToPoints`, `periodChange`, `hiLo`, `Range`, `RANGES`.
+
+- [ ] **Step 1: `lib/markets/chart.ts`**
+
+```ts
+// Pure parsing/derivation for the Markets focus charts. The chart ROUTE fetches
+// keyless Yahoo v8 OHLC; this module turns that JSON into candles + the derived
+// figures the UI shows (period change, hi/lo), and projects candles to Chart points.
+// Pure + isomorphic so it unit-tests against a captured fixture.
+
+export type Range = "1mo" | "6mo" | "1y";
+export const RANGES: Range[] = ["1mo", "6mo", "1y"];
+
+export interface Candle { t: number; o: number; h: number; l: number; c: number; v: number }
+
+interface YahooQuote { open?: (number | null)[]; high?: (number | null)[]; low?: (number | null)[]; close?: (number | null)[]; volume?: (number | null)[] }
+interface YahooResult { timestamp?: number[]; indicators?: { quote?: YahooQuote[] } }
+export interface YahooChartResponse { chart?: { result?: YahooResult[] | null; error?: unknown } }
+
+/** Pure: Yahoo v8 chart JSON → candles (drops rows with a null close). t is epoch ms. */
+export function parseYahooSeries(json: YahooChartResponse | null | undefined): Candle[] {
+  const r = json?.chart?.result?.[0];
+  const ts = r?.timestamp ?? [];
+  const q = r?.indicators?.quote?.[0] ?? {};
+  const out: Candle[] = [];
+  for (let i = 0; i < ts.length; i++) {
+    const c = q.close?.[i];
+    if (typeof c !== "number" || !Number.isFinite(c)) continue; // holidays / gaps
+    const o = q.open?.[i], h = q.high?.[i], l = q.low?.[i], v = q.volume?.[i];
+    out.push({
+      t: ts[i] * 1000,
+      o: typeof o === "number" ? o : c,
+      h: typeof h === "number" ? h : c,
+      l: typeof l === "number" ? l : c,
+      c,
+      v: typeof v === "number" ? v : 0,
+    });
+  }
+  return out;
+}
+
+export interface ChartPointLite { x: number; y: number }
+/** Close-price line points (the default "actual graph"). */
+export function candlesToPoints(candles: Candle[]): ChartPointLite[] {
+  return candles.map((k) => ({ x: k.t, y: k.c }));
+}
+
+/** Absolute + percent change from first to last close; zeros on <2 candles. */
+export function periodChange(candles: Candle[]): { abs: number; pct: number } {
+  if (candles.length < 2) return { abs: 0, pct: 0 };
+  const first = candles[0].c, last = candles[candles.length - 1].c;
+  const abs = last - first;
+  return { abs, pct: first !== 0 ? (abs / first) * 100 : 0 };
+}
+
+/** Min low / max high across the range (the "52-week" hi/lo when range=1y). */
+export function hiLo(candles: Candle[]): { hi: number; lo: number } | null {
+  if (candles.length === 0) return null;
+  let hi = -Infinity, lo = Infinity;
+  for (const k of candles) { if (k.h > hi) hi = k.h; if (k.l < lo) lo = k.l; }
+  return { hi, lo };
+}
+```
+
+- [ ] **Step 2: `tests/unit/markets-series.test.ts`**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseYahooSeries, candlesToPoints, periodChange, hiLo, type YahooChartResponse } from "@/lib/markets/chart";
+
+const json: YahooChartResponse = {
+  chart: { result: [ {
+    timestamp: [1704067200, 1704153600, 1704240000],
+    indicators: { quote: [ { open: [100, 102, null], high: [105, 106, 104], low: [99, 101, 100], close: [102, 104, null], volume: [10, 12, 0] } ] },
+  } ] },
+};
+
+describe("parseYahooSeries", () => {
+  it("zips timestamps + OHLC, drops null-close rows, converts to ms", () => {
+    const c = parseYahooSeries(json);
+    expect(c.length).toBe(2); // third row has null close → dropped
+    expect(c[0]).toEqual({ t: 1704067200000, o: 100, h: 105, l: 99, c: 102, v: 10 });
+  });
+  it("is dormant-safe on missing data", () => {
+    expect(parseYahooSeries(null)).toEqual([]);
+    expect(parseYahooSeries({ chart: { result: null } })).toEqual([]);
+  });
+});
+
+describe("derivations", () => {
+  it("periodChange first→last close", () => {
+    const c = parseYahooSeries(json);
+    expect(periodChange(c).abs).toBe(2); // 104 - 102
+    expect(Math.round(periodChange(c).pct * 100) / 100).toBe(1.96);
+  });
+  it("hiLo spans all candles", () => {
+    expect(hiLo(parseYahooSeries(json))).toEqual({ hi: 106, lo: 99 });
+  });
+  it("candlesToPoints maps close to y", () => {
+    expect(candlesToPoints(parseYahooSeries(json))[0]).toEqual({ x: 1704067200000, y: 102 });
+  });
+});
+```
+
+- [ ] **Step 3: Gate + commit** — green.
+`git add lib/markets/chart.ts tests/unit/markets-series.test.ts`
+`git commit -m "feat(markets): pure Yahoo v8 OHLC series parsing + period/hi-lo derivations"`
+
+---
+
+### Task 2: Keyless `/api/markets/chart` route
+
+**Files:** Create `app/api/markets/chart/route.ts`; optionally Modify `app/api/markets/route.ts` (add `^VIX`/`^TNX` to the keyless symbol set for a macro panel).
+
+- [ ] **Step 1:** `GET /api/markets/chart?symbol=<yahoo>&range=1mo|6mo|1y` → `{ candles: Candle[] }`. Mirror the existing markets route's dormant-safe pattern (reuse its `getJson`/fetch helper; per-`symbol:range` in-memory cache ~5 min). Fetch `https://query1.finance.yahoo.com/v8/finance/chart/<symbol>?range=<range>&interval=<1d for 1mo/6mo, 1wk for 1y>` with the same UA header the markets route uses, `parseYahooSeries(json)`, and return `{ candles }`. Validate `range ∈ RANGES` and `symbol` (non-empty, `^?[A-Za-z0-9.=\-]+`) — reject others with `{ candles: [] }`. On any upstream error return `{ candles: [] }` (never 5xx).
+
+- [ ] **Step 2 (optional macro):** In `app/api/markets/route.ts`, add `^VIX` and `^TNX` to the keyless Yahoo symbol set so the detail can show a small macro panel (VIX + US 10Y). If the set is not trivially extendable, skip and note it.
+
+- [ ] **Step 3: Gate + commit** — green (add a light route test only if the repo has route tests; otherwise the pure parse is already covered).
+`git add app/api/markets/chart/route.ts app/api/markets/route.ts`
+`git commit -m "feat(markets): keyless /api/markets/chart route (Yahoo v8 OHLC, dormant-safe)"`
+
+---
+
+### Task 3: `<Chart>` non-zero baseline + value markers
+
+**Files:** Modify `components/Chart.tsx`.
+
+- [ ] **Step 1:** Add `zeroBaseline?: boolean` (default `true`) to the props. When `true`, keep `sy = linear(extent([0, ...ys]), …)` (current). When `false`, use `sy = linear(extent(ys), …)` so price lines auto-fit. Optionally add `markers?: boolean` (default false) that, when true, draws small circles at the min-low, max-high, and last points with tiny value labels. Keep every existing prop + default identical — this is additive and backward-compatible.
+
+```tsx
+// in the props type:
+zeroBaseline?: boolean;
+// …
+const sy = linear(extent(zeroBaseline === false ? ys : [0, ...ys]), [height - pad, pad]);
+```
+
+- [ ] **Step 2:** Confirm no existing caller passes `zeroBaseline` (they rely on the default `true`) — a repo-wide grep. Gate + commit.
+`git add components/Chart.tsx`
+`git commit -m "feat(chart): opt-out zeroBaseline so price series auto-fit (backward-compatible)"`
+
+---
+
+### Task 4: Detail skeleton — masthead + instrument rail + movers heat-strip + register
+
+**Files:** Create `lib/console/widgets/markets.detail.tsx`; Modify `lib/console/widgets/markets.tsx`, `app/globals.css`.
+
+- [ ] **Step 1:** `MarketsDetail({ instanceId, config }: WidgetDetailProps)`:
+  - `useJsonPoll<MarketsPayload>("/api/markets", 120000, { generatedAt: 0, sections: [] })`.
+  - Masthead: title "Markets", section count + total instruments, freshness from `generatedAt`, "indicative only — not financial advice".
+  - Instrument rail: grouped by `section` (label + `section.source` attribution + dormant note); within each section, rows ordered biggest-mover-first (`|changePct|` desc); each row shows name/symbol, value, `changePct` (green/red), and a tiny `mkt:<id>` sparkline (`seriesSamples` → `<Chart height={28} zeroBaseline={false}>`). Clicking a row selects it (Task 5).
+  - Movers heat-strip: top gainers/losers across all sections (colour scaled by `changePct`).
+  - Selected instrument state: `const [selId, setSelId] = useState<string | null>(<first row id>)`; persist via `shellLayoutStore.configure(instanceId, { selectedId })` (optional).
+
+- [ ] **Step 2:** Add `detail: MarketsDetail` + import to `MARKETS_WIDGET` in `markets.tsx`.
+
+- [ ] **Step 3:** Append `.tn-mk*` CSS (masthead, section rail, row with sparkline, heat-strip, chart panel, range tabs, table, footer). Theme tokens only.
+
+- [ ] **Step 4: Gate + commit** — green.
+`git commit -m "feat(markets): focus detail skeleton — instrument rail + movers heat-strip"`
+
+---
+
+### Task 5: Primary historical chart + range tabs + instrument table + drill-down
+
+**Files:** Modify `lib/console/widgets/markets.detail.tsx`.
+
+- [ ] **Step 1:** Selected-instrument primary chart:
+  - `const [range, setRange] = useState<Range>("6mo")`. Fetch `/api/markets/chart?symbol=<row.symbol ?? row.id>&range=<range>` in an effect (dormant-safe; store `candles`). Render `<Chart points={candlesToPoints(candles)} height={220} zeroBaseline={false} up={periodChange(candles).abs >= 0} markers />`.
+  - **Honest fallback:** when `candles.length < 2` (route dormant / no history), chart the accumulated live series `seriesSamples("mkt:"+selId)` instead, labelled "live session (accumulating) — historical unavailable".
+  - Range tabs 1M/6M/1Y (`RANGES`), period change (`periodChange`) + hi/lo (`hiLo`, labelled "52-wk range" when range=1y).
+  - Which symbol to query: prefer `row.symbol`; some ids are crypto/FX — if the query returns empty for a symbol, fall back to the live series (already handled by the <2-candle guard). Don't invent symbols.
+  - Sortable instrument table (name / changePct / value) across all sections; row click sets `selId`; open row drill shows stats (value, changePct, `sub` = mkt cap text, section source as-of).
+
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(markets): focus detail — historical chart + 1M/6M/1Y tabs + instrument table"`
+
+---
+
+### Task 6: Footer — attribution + CSV export
+
+**Files:** Modify `lib/console/widgets/markets.detail.tsx`.
+
+- [ ] **Step 1:** Footer: per-section attribution (`section.source` strings) + "Indicative only — not financial advice." Export (disabled when empty): CSV of all instruments (section, name, symbol, value, num, changePct) via `toCsv`/`downloadText`/`exportFilename("markets", Date.now())`; and a per-selected-instrument OHLC CSV (t, o, h, l, c, v) from `candles` when present.
+
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(markets): focus detail — attribution/disclaimer footer + CSV (quotes + OHLC) export"`
+
+---
+
+### Task 7: Verification
+
+- [ ] Full gate `npx tsc --noEmit && npm test` green; `git status` clean apart from `.superpowers/sdd/progress.md`.
+- [ ] Confirm the chart route is dormant-safe (empty on bad symbol / upstream fail, never 5xx) and the view falls back to the live series honestly.
+- [ ] Confirm `zeroBaseline` default did not change any existing Chart caller.
+- [ ] If the integrator has a browser: expand the Markets widget, confirm the rail, a real 1M/6M/1Y chart for an equity/index, the fallback label for a symbol without history, table sort + drill, export. Otherwise note live visual verification pending.
+
+## Self-Review
+
+- **Spec §7.7 coverage:** (1) instrument rail grouped by asset class, mini-spark, movers-first → Task 4 ✓; (2) primary historical chart + 1M/6M/1Y tabs + period change + hi/lo → Tasks 2+5 ✓ (candlestick/crosshair deferred as spec nice-to-have — line/area with markers delivers "actual graphs"; OHLC IS fetched and exported); (3) instrument stats drill-down → Task 5 ✓; (4) movers heat-strip → Task 4 ✓; (5) macro panel VIX/10Y → Task 2 optional ✓; (6) footer attribution + disclaimer + CSV + OHLC export → Task 6 ✓. New backend `/api/markets/chart` → Task 2 ✓.
+- **Type consistency:** `Candle`/`Range`/`RANGES`/`parseYahooSeries`/`candlesToPoints`/`periodChange`/`hiLo` names match across Tasks 1→6; `zeroBaseline` prop consistent.
+- **Honesty:** real OHLC when available, explicit "live session" fallback when not; "delayed, keyless"; "not financial advice"; dormant-safe route; no invented symbols; `<Chart>` change backward-compatible.
+- **Risk flagged:** symbol mapping — `MarketRow.symbol` may not be a Yahoo ticker for crypto/FX. The <2-candle fallback to the live series keeps every instrument honest even when its symbol has no Yahoo history; do NOT hard-fail or fabricate. A full CoinGecko/Frankfurter symbol map is out of scope this pass (fallback covers it).

--- a/docs/superpowers/plans/2026-07-08-focus-window-w8-satellites.md
+++ b/docs/superpowers/plans/2026-07-08-focus-window-w8-satellites.md
@@ -1,0 +1,299 @@
+# W8 — Satellites detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A satellite command console focus view (Option C = orbital detail AND imagery): full orbital vitals parsed from the TLE, a live ±1-period ground track, NASA GIBS true-color imagery beneath each satellite's sub-point, a searchable/sortable roster with a per-satellite dossier, and export.
+
+**Architecture:** New default-export `SatellitesDetail(props: WidgetDetailProps)` registered as `detail:` on `SATELLITES_WIDGET`, reusing `useSatellites(group)`. Pure TLE-element parsing (`lib/satellites/elements.ts`), ground-track sampling with antimeridian split (`lib/satellites/groundTrack.ts`), and GIBS tile math (`lib/sources/gibs.ts`) are testable modules. `<InsetMap>` gains an OPTIONAL backward-compatible `track` line layer. The dossier reuses `components/SatelliteDetail.tsx` and adds the GIBS sub-point tile alongside its existing Esri close-up.
+
+**Tech Stack:** Next 15 / React 19 / TS; satellite.js SGP4 (already a dep, via `lib/satellites/propagate.ts`); MapLibre (InsetMap); NASA GIBS (keyless WMTS tiles); vitest.
+
+## Global Constraints
+
+- Keyless throughout (CelesTrak TLEs, GIBS imagery, Esri imagery — all already keyless or new-keyless). Dormant-safe; honest empty states.
+- **Honesty (critical for imagery):** GIBS shows NASA true-color of the REGION BENEATH the sub-point for a DATE (yesterday, for full coverage) — caption it exactly that. NEVER imply it is a live photo taken by that satellite.
+- The `<InsetMap>` change MUST be backward-compatible: `track` is optional; when absent, every existing caller (events/signals/aviation/cameras details) renders identically. Grep-verify.
+- Native primitives; theme tokens only (`--tn-surface`/`--tn-surface-solid`/`--tn-surface-2`/`--tn-text`/`--tn-text-muted`/`--tn-text-faint`/`--tn-border`/`--tn-accent`). NO `--tn-surface-1`/`--tn-text-1`.
+- Build gate (every task): `npx tsc --noEmit && npm test` → green.
+- Commits: solo `011-sam-110 <lesttech.dev.sam@gmail.com>`, **no Co-Authored-By / Claude trailer**, plain `git commit -m "..."`.
+- Owned files only; never `git add -A`/`checkout`/`reset`/`stash`; do not touch `.superpowers/sdd/progress.md`.
+- **Verify signatures against source** first: `useSatellites`, `WorldObject.meta` fields, `lib/satellites/propagate.ts` (how to build a satrec from `line1`/`line2` + `propagateAt`), `components/SatelliteDetail.tsx` props, `components/InsetMap.tsx` internals, `lib/satellites/classify.ts`.
+
+## Reference pattern
+
+`lib/console/widgets/aviation.detail.tsx` / `signals.detail.tsx` for the detail skeleton (masthead + sparkline with the W4 "only stamp once real data arrives" fix, panels grid, table, footer, export). `components/InsetMap.tsx` for how a MapLibre source/layer is added (add the line layer the same way the circle layer is added).
+
+## Data shapes (verify, then consume)
+
+- `useSatellites(group = "visual", stepMs = 1000): WorldObject[]` — `lib/satellites/useSatellites.ts`. Objects: `{ kind:"satellite", id:"sat:<norad>", lat, lon, altKm, label, color, icon, typeLabel, meta:{ noradId, objectName, line1, line2, altKm, velocityKmS, periodMin, typeLabel } }`.
+- `lib/satellites/propagate.ts`: a satrec builder from a TLE (confirm the export — likely `satellite.twoline2satrec(line1, line2)` re-exported or an internal helper) + `propagateAt(satrec, date: Date): { lat, lon, altKm, velocityKmS }`.
+- `components/SatelliteDetail.tsx` (default): `SatelliteDetail({ object: WorldObject })` — renders Esri sub-point imagery + a vitals `<dl>`.
+- `SATELLITES_WIDGET` — plain object in `lib/console/widgets/satellites.tsx`, `registerWidget(...)`. Attach `detail: SatellitesDetail` + `capabilities: { filter: true, sort: true }`.
+- `InsetMap({ points, height?, onSelect? })` — extend with optional `track`.
+- Primitives: `Chart`, `recordSeries`/`seriesSamples`/`deltaOf`, `toCsv`/`toGeoJson`/`downloadText`/`exportFilename`, `shellLayoutStore.unfocus`, `humaniseKey`.
+
+## File Structure
+
+- Create `lib/satellites/elements.ts`, `lib/satellites/groundTrack.ts`, `lib/sources/gibs.ts`, `lib/console/widgets/satellites.detail.tsx`.
+- Create tests `tests/unit/satellite-elements.test.ts`, `tests/unit/ground-track.test.ts`, `tests/unit/gibs.test.ts`.
+- Modify `components/InsetMap.tsx` (optional `track`), `lib/console/widgets/satellites.tsx` (attach `detail:` + capabilities), `app/globals.css` (`.tn-sat*`).
+
+---
+
+### Task 1: Pure TLE orbital-element parsing
+
+**Files:** Create `lib/satellites/elements.ts`; Test `tests/unit/satellite-elements.test.ts`.
+
+- [ ] **Step 1: `lib/satellites/elements.ts`** — parse the fixed-column TLE format (1-indexed columns per the TLE spec) and derive apogee/perigee.
+
+```ts
+// Pure TLE (two-line element) parsing → the orbital vitals the console shows.
+// Fixed-column format (1-indexed cols per the NORAD spec); eccentricity has an
+// implied leading decimal. Derived apogee/perigee from mean motion + eccentricity.
+export interface OrbitalElements {
+  inclinationDeg: number;
+  raanDeg: number;          // right ascension of the ascending node
+  eccentricity: number;
+  argPerigeeDeg: number;
+  meanAnomalyDeg: number;
+  meanMotionRevPerDay: number;
+  periodMin: number;
+  semiMajorAxisKm: number;
+  apogeeKm: number;         // above Earth's surface
+  perigeeKm: number;
+}
+
+const GM_EARTH = 398600.4418; // km^3 / s^2
+const R_EARTH = 6378.137;     // km (equatorial)
+
+function n(s: string): number { const v = Number(s.trim()); return Number.isFinite(v) ? v : 0; }
+
+/** Parse TLE line 2 into orbital elements (line 1 gives epoch/drag, not needed here). */
+export function parseElements(line1: string, line2: string): OrbitalElements | null {
+  if (!line2 || line2.length < 63 || line2[0] !== "2") return null;
+  const inclinationDeg = n(line2.slice(8, 16));
+  const raanDeg = n(line2.slice(17, 25));
+  const eccentricity = n(`0.${line2.slice(26, 33).trim()}`); // implied leading "0."
+  const argPerigeeDeg = n(line2.slice(34, 42));
+  const meanAnomalyDeg = n(line2.slice(43, 51));
+  const meanMotionRevPerDay = n(line2.slice(52, 63));
+  const periodMin = meanMotionRevPerDay > 0 ? 1440 / meanMotionRevPerDay : 0;
+  const nRadPerSec = (meanMotionRevPerDay * 2 * Math.PI) / 86400;
+  const semiMajorAxisKm = nRadPerSec > 0 ? Math.cbrt(GM_EARTH / (nRadPerSec * nRadPerSec)) : 0;
+  const apogeeKm = semiMajorAxisKm * (1 + eccentricity) - R_EARTH;
+  const perigeeKm = semiMajorAxisKm * (1 - eccentricity) - R_EARTH;
+  return { inclinationDeg, raanDeg, eccentricity, argPerigeeDeg, meanAnomalyDeg, meanMotionRevPerDay, periodMin, semiMajorAxisKm, apogeeKm, perigeeKm };
+}
+```
+
+- [ ] **Step 2: `tests/unit/satellite-elements.test.ts`** (ISS TLE — stable reference values):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseElements } from "@/lib/satellites/elements";
+
+// A real ISS (ZARYA) TLE. Mean motion ~15.5 rev/day → ~92-93 min, LEO ~400-420 km.
+const L1 = "1 25544U 98067A   24001.50000000  .00016717  00000-0  10270-3 0  9005";
+const L2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.50377579  1234";
+
+describe("parseElements", () => {
+  it("parses inclination / eccentricity / mean motion and derives period + apogee/perigee", () => {
+    const e = parseElements(L1, L2)!;
+    expect(e).not.toBeNull();
+    expect(Math.round(e.inclinationDeg * 10) / 10).toBe(51.6);
+    expect(e.eccentricity).toBeCloseTo(0.0006703, 6);
+    expect(Math.round(e.meanMotionRevPerDay)).toBe(16); // ~15.5 → rounds to 16
+    expect(Math.round(e.periodMin)).toBe(93);           // 1440 / 15.50 ≈ 92.9
+    expect(e.perigeeKm).toBeGreaterThan(380);
+    expect(e.apogeeKm).toBeLessThan(430);
+  });
+  it("returns null on a malformed line", () => {
+    expect(parseElements("", "garbage")).toBeNull();
+  });
+});
+```
+
+> If the test's rounded expectations are slightly off from the real column slicing, ADJUST the expected numbers to the actual parsed values (the column offsets are the source of truth) — do NOT loosen them to meaninglessness. Keep inclination ≈ 51.6 and period ≈ 93 as the anchors.
+
+- [ ] **Step 3: Gate + commit** — green.
+`git add lib/satellites/elements.ts tests/unit/satellite-elements.test.ts`
+`git commit -m "feat(satellites): pure TLE orbital-element parsing + apogee/perigee derivation"`
+
+---
+
+### Task 2: GIBS tile math (keyless imagery by sub-point)
+
+**Files:** Create `lib/sources/gibs.ts`; Test `tests/unit/gibs.test.ts`.
+
+- [ ] **Step 1: `lib/sources/gibs.ts`**
+
+```ts
+// NASA GIBS keyless true-color imagery. We show the tile covering a satellite's
+// sub-point for a date (default: yesterday UTC, which has full global coverage).
+// Web-Mercator (EPSG:3857) slippy tiles — the same z/x/y scheme MapLibre/OSM use.
+const LAYER = "MODIS_Terra_CorrectedReflectance_TrueColor";
+const MATRIX = "GoogleMapsCompatible_Level9";
+
+/** lon/lat + zoom → slippy tile {x,y} (Web-Mercator). */
+export function lonLatToTile(lon: number, lat: number, z: number): { x: number; y: number } {
+  const nTiles = 2 ** z;
+  const x = Math.floor(((lon + 180) / 360) * nTiles);
+  const latRad = (lat * Math.PI) / 180;
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * nTiles);
+  const clamp = (v: number) => Math.max(0, Math.min(nTiles - 1, v));
+  return { x: clamp(x), y: clamp(y) };
+}
+
+/** UTC yesterday as YYYY-MM-DD (GIBS lags ~1 day; yesterday is reliably covered). */
+export function gibsDate(nowMs: number): string {
+  return new Date(nowMs - 24 * 3600_000).toISOString().slice(0, 10);
+}
+
+/** A keyless GIBS true-color tile URL covering (lat, lon) at zoom `z` for a date. */
+export function gibsTileUrl(lat: number, lon: number, z: number, date: string): string {
+  const { x, y } = lonLatToTile(lon, lat, z);
+  return `https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/${LAYER}/default/${date}/${MATRIX}/${z}/${y}/${x}.jpg`;
+}
+```
+
+- [ ] **Step 2: `tests/unit/gibs.test.ts`**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { lonLatToTile, gibsTileUrl, gibsDate } from "@/lib/sources/gibs";
+
+describe("gibs tile math", () => {
+  it("maps (0,0) to the centre tile at each zoom", () => {
+    expect(lonLatToTile(0, 0, 1)).toEqual({ x: 1, y: 1 });
+    expect(lonLatToTile(-180, 85, 2)).toEqual({ x: 0, y: 0 });
+  });
+  it("clamps out-of-range into valid tile indices", () => {
+    const t = lonLatToTile(200, -95, 1); // beyond bounds
+    expect(t.x).toBeGreaterThanOrEqual(0); expect(t.x).toBeLessThanOrEqual(1);
+    expect(t.y).toBeGreaterThanOrEqual(0); expect(t.y).toBeLessThanOrEqual(1);
+  });
+  it("builds a keyless GIBS URL for a sub-point", () => {
+    const url = gibsTileUrl(51.5, -0.1, 3, "2026-07-07");
+    expect(url).toContain("gibs.earthdata.nasa.gov");
+    expect(url).toContain("/2026-07-07/");
+    expect(url).toMatch(/\/3\/\d+\/\d+\.jpg$/);
+  });
+  it("gibsDate is UTC yesterday", () => {
+    expect(gibsDate(Date.parse("2026-07-08T00:00:00Z"))).toBe("2026-07-07");
+  });
+});
+```
+
+- [ ] **Step 3: Gate + commit** — green.
+`git add lib/sources/gibs.ts tests/unit/gibs.test.ts`
+`git commit -m "feat(satellites): keyless NASA GIBS true-color tile math (sub-point imagery)"`
+
+---
+
+### Task 3: Ground-track sampling with antimeridian split
+
+**Files:** Create `lib/satellites/groundTrack.ts`; Test `tests/unit/ground-track.test.ts`. May reuse `propagate.ts` (satrec builder + `propagateAt`).
+
+- [ ] **Step 1:** `lib/satellites/groundTrack.ts` — pure antimeridian split + a track builder.
+
+```ts
+// Pure: split a sequence of [lon, lat] points into segments wherever consecutive
+// longitudes jump more than 180° (an antimeridian crossing), so a polyline renderer
+// draws separate strokes instead of one horizontal streak across the whole map.
+export function splitAntimeridian(points: [number, number][]): [number, number][][] {
+  const segs: [number, number][][] = [];
+  let cur: [number, number][] = [];
+  for (let i = 0; i < points.length; i++) {
+    if (i > 0 && Math.abs(points[i][0] - points[i - 1][0]) > 180) { segs.push(cur); cur = []; }
+    cur.push(points[i]);
+  }
+  if (cur.length) segs.push(cur);
+  return segs;
+}
+```
+
+- [ ] **Step 2:** Add `groundTrack(line1, line2, atMs, periodMin, stepSec = 60): [number, number][][]` that builds a satrec from the TLE (reuse the `propagate.ts` builder — confirm its export; if none, use `satellite.twoline2satrec(line1, line2)` from the already-installed `satellite.js`), propagates `propagateAt(satrec, new Date(t))` across `[atMs − P/2, atMs + P/2]` at `stepSec`, collects `[lon, lat]`, and returns `splitAntimeridian(points)`. It MUST resolve to `[]` on any propagation error (dormant-safe; wrap in try/catch).
+
+- [ ] **Step 3:** Test `tests/unit/ground-track.test.ts` — test `splitAntimeridian` purely (full SGP4 propagation is already covered by existing satellite tests; don't re-test satellite.js):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { splitAntimeridian } from "@/lib/satellites/groundTrack";
+
+describe("splitAntimeridian", () => {
+  it("splits at a dateline crossing", () => {
+    const segs = splitAntimeridian([[170, 0], [179, 0], [-179, 0], [-170, 0]]);
+    expect(segs.length).toBe(2);
+    expect(segs[0].length).toBe(2);
+    expect(segs[1].length).toBe(2);
+  });
+  it("keeps a non-crossing track as one segment", () => {
+    expect(splitAntimeridian([[0, 0], [10, 5], [20, 10]]).length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 4: Gate + commit** — green.
+`git add lib/satellites/groundTrack.ts tests/unit/ground-track.test.ts`
+`git commit -m "feat(satellites): ±1-period ground-track sampling + antimeridian split"`
+
+---
+
+### Task 4: InsetMap optional track line (backward-compatible)
+
+**Files:** Modify `components/InsetMap.tsx`.
+
+- [ ] **Step 1:** Add an OPTIONAL prop `track?: [number, number][][]` (array of `[lon,lat]` segments). When present + non-empty, add a GeoJSON source + a `line` layer (a MultiLineString from the segments) the same way the existing circle source/layer is added; update it in the same effect that updates points; fit bounds to include the track. When `track` is undefined, behave EXACTLY as today. Style the line with a literal accent hex (consistent with how the circle layer uses literals).
+
+- [ ] **Step 2:** Grep every existing `<InsetMap` caller (aviation/cameras/events/signals details) — confirm none passes `track`, so all render identically. Gate + commit.
+`git add components/InsetMap.tsx`
+`git commit -m "feat(map): InsetMap optional track polyline layer (backward-compatible)"`
+
+---
+
+### Task 5: Detail — command bar, roster, orbital vitals, ground-track map, GIBS imagery, dossier
+
+**Files:** Create `lib/console/widgets/satellites.detail.tsx`; Modify `lib/console/widgets/satellites.tsx`, `app/globals.css`.
+
+- [ ] **Step 1:** `SatellitesDetail(_props: WidgetDetailProps)` reusing `useSatellites(group)`:
+  - Command bar: group fixed by the docked config (`config.group`); category chips with counts (from `classify.ts`/`meta.typeLabel`); a search box filtering the roster; count sparkline (`recordSeries("sat:count", n, tick)` — only stamp once objects arrive, per the W4 fix). Masthead shows count + "TLEs via CelesTrak · SGP4".
+  - Selected satellite state: `const [selId, setSelId] = useState<string|null>(<first object id>)`; `const [q, setQ] = useState("")`.
+  - Orbital vitals panel: `parseElements(meta.line1, meta.line2)` → a `<dl>` (inclination, ecc, RAAN, argP, mean anomaly, mean motion, period, apogee/perigee) using `humaniseKey`-style labels; plus live sub-point lat/lon/alt/velocity from the object.
+  - Ground-track map: `<InsetMap points={[selected sub-point + neighbours]} track={groundTrack(meta.line1, meta.line2, Date.now(), meta.periodMin)} height={240} />`. Honest empty state if the track is `[]`.
+  - GIBS imagery panel: `<img src={gibsTileUrl(sel.lat, sel.lon, 4, gibsDate(Date.now()))}>` captioned "NASA GIBS true-color · <date> · region beneath the sub-point (not a live satellite photo)". Optionally a second, higher-zoom tile.
+  - Roster: searchable/sortable table (name, NORAD, category, altKm, periodMin) over the filtered objects; row click sets `selId`; drill row renders `<SatelliteDetail object={obj} />` (its Esri close-up complements the GIBS regional tile).
+  - Optional live-feed note: for NORAD 25544 (ISS) show a keyless NASA ISS live YouTube embed; every other satellite shows "No public live feed" (honest).
+
+- [ ] **Step 2:** Add `detail: SatellitesDetail` + `capabilities: { filter: true, sort: true }` + import to `SATELLITES_WIDGET` in `satellites.tsx`.
+
+- [ ] **Step 3:** Append `.tn-sat*` CSS (masthead, chips, panels grid, vitals dl, imagery tile + caption, roster table, dossier row). Theme tokens only.
+
+- [ ] **Step 4: Gate + commit** — green.
+`git commit -m "feat(satellites): focus detail — orbital vitals + ground track + GIBS imagery + roster dossier"`
+
+---
+
+### Task 6: Footer — attribution + export
+
+**Files:** Modify `lib/console/widgets/satellites.detail.tsx`.
+
+- [ ] **Step 1:** Footer: attribution "TLEs: CelesTrak · propagation: SGP4 (satellite.js) · imagery: NASA GIBS + Esri World Imagery". Export (disabled when empty): CSV of the roster (name, norad, category, altKm, periodMin, lat, lon) and GeoJSON of the current sub-points via `toGeoJson(objects.map(o => ({ lat:o.lat, lon:o.lon, properties:{ name:o.label, norad:o.meta?.noradId } })))`, using `exportFilename("satellites", Date.now())`.
+
+- [ ] **Step 2: Gate + commit** — green.
+`git commit -m "feat(satellites): focus detail — attribution footer + CSV/GeoJSON export"`
+
+---
+
+### Task 7: Verification
+
+- [ ] Full gate `npx tsc --noEmit && npm test` green; `git status` clean apart from `.superpowers/sdd/progress.md`.
+- [ ] Confirm the InsetMap `track` addition did not change any existing caller's render (grep + the full test suite).
+- [ ] Confirm the GIBS caption never claims a live satellite photo; imagery is keyless.
+- [ ] If the integrator has a browser: expand the Satellites widget, confirm vitals, a ground-track line on the map, a GIBS tile, roster search/sort + dossier, export. Otherwise note live visual verification pending.
+
+## Self-Review
+
+- **Spec §7.8 coverage:** (1) command bar (group/category/search + TLE-source honesty) → Task 5 ✓; (2) searchable/sortable roster → Task 5 ✓; (3) orbital vitals (incl/ecc/RAAN/argP/mean-anom/mean-motion + derived apogee/perigee) → Tasks 1+5 ✓; (4) live ground track on InsetMap (±1 period, antimeridian split) → Tasks 3+4+5 ✓; (5) next-pass/sky-chart → DEFERRED (needs geolocation + new math; spec-optional) — noted, not silently dropped; (6) region imagery (GIBS true-color + Esri close-up) → Tasks 2+5 ✓; (7) live feed only where it exists (ISS embed, else "no public feed") → Task 5 ✓.
+- **Type consistency:** `parseElements`/`OrbitalElements`/`lonLatToTile`/`gibsTileUrl`/`gibsDate`/`splitAntimeridian`/`groundTrack` names match across Tasks 1→6; InsetMap `track` prop consistent.
+- **Honesty:** GIBS captioned as regional true-color for a date, never a live satellite photo; apogee/perigee derived transparently; ground track resolves to [] on propagation error; deferred next-pass flagged, not hidden.
+- **Risk flagged:** the ground track (Task 3) needs a satrec from the TLE — reuse `propagate.ts`'s builder if exported, else `satellite.twoline2satrec` directly; keep it dormant-safe ([] on error). The InsetMap change is the shared-component risk — keep `track` strictly optional + grep-verify callers (same discipline as the W7 Chart `zeroBaseline` change).

--- a/lib/console/news/providers.ts
+++ b/lib/console/news/providers.ts
@@ -40,3 +40,8 @@ export function resolveEmbed(p: NewsProvider): { kind: "youtube" | "hls"; src: s
   if (p.kind === "youtube") return { kind: "youtube", src: `https://www.youtube.com/embed/${p.ref}?autoplay=1&mute=1&playsinline=1` };
   return { kind: "hls", src: /^https?:\/\//i.test(p.ref) ? p.ref : "" };
 }
+
+/** Keyless YouTube thumbnail for a provider, or null for HLS (no free thumbnail). */
+export function providerThumb(p: NewsProvider): string | null {
+  return p.kind === "youtube" ? `https://img.youtube.com/vi/${p.ref}/hqdefault.jpg` : null;
+}

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -1,0 +1,171 @@
+"use client";
+// Markets focus view — the milestone the spec centres on: "for markets, it shows
+// actual graphs." Reuses the SAME live pipeline as the docked widget
+// (useJsonPoll("/api/markets")) for the quote list, and adds a keyless
+// /api/markets/chart fetch for the selected instrument's real 1M/6M/1Y history.
+// Honest throughout: real OHLC when Yahoo has it, an explicit "live session"
+// fallback to the accumulated mkt:<id> series when it doesn't, and an
+// "indicative only — not financial advice" disclaimer. Pure series maths live in
+// the unit-tested lib/markets/chart.ts; this is the shell.
+import { useEffect, useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import type { MarketsPayload, MarketRow, MarketSection } from "@/lib/markets";
+import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
+import { recordSeries, seriesSamples } from "@/lib/series";
+import { Chart, type ChartPoint } from "@/components/Chart";
+import { shellLayoutStore } from "@/lib/console/store";
+
+const EMPTY: MarketsPayload = { generatedAt: 0, sections: [] };
+
+/** Signed magnitude used for movers-first ordering; nulls sort last. */
+function absMove(r: MarketRow): number {
+  return r.changePct == null ? -1 : Math.abs(r.changePct);
+}
+
+/** Heat-strip / change colour scaled by move magnitude (green up, red down). */
+function moverBg(pct: number): string {
+  const mag = Math.min(1, Math.abs(pct) / 8);
+  const a = 0.15 + mag * 0.6;
+  return pct >= 0 ? `rgba(22,163,74,${a})` : `rgba(220,38,38,${a})`;
+}
+
+function freshLabel(generatedAt: number, now: number): string {
+  if (!generatedAt) return "—";
+  const m = Math.max(0, Math.round((now - generatedAt) / 60000));
+  return m === 0 ? "just now" : `${m}m ago`;
+}
+
+export default function MarketsDetail({ instanceId, config }: WidgetDetailProps) {
+  const { data, status } = useJsonPoll<MarketsPayload>("/api/markets", 120_000, EMPTY);
+
+  // Keep dormant (key-gated) sections too — surfaced as a "needs key" note rather
+  // than hidden, so the capability is discoverable (mirrors the docked widget).
+  const sections = useMemo<MarketSection[]>(
+    () => (data.sections ?? []).filter((s) => s.rows.length || s.dormant),
+    [data.sections],
+  );
+  // Movers-first ordering within each section.
+  const railSections = useMemo(
+    () => sections.map((s) => ({ ...s, rows: [...s.rows].sort((a, b) => absMove(b) - absMove(a)) })),
+    [sections],
+  );
+  const allRows = useMemo(() => railSections.flatMap((s) => s.rows), [railSections]);
+
+  // Record each row's raw value into the PERSISTED mkt:<id> series so the rail
+  // sparklines accumulate AND the honest "live session" chart fallback has data;
+  // bump a tick so a fresh sample shows this render.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!data.generatedAt) return;
+    for (const r of allRows) if (typeof r.num === "number") recordSeries(`mkt:${r.id}`, r.num, data.generatedAt);
+    setTick((t) => t + 1);
+  }, [data.generatedAt, allRows]);
+
+  // Selected instrument — seeded from persisted config, then the first (biggest) mover.
+  const [selId, setSelId] = useState<string | null>(
+    () => (typeof config.selectedId === "string" ? config.selectedId : null),
+  );
+  useEffect(() => {
+    if (selId && allRows.some((r) => r.id === selId)) return;
+    const first = allRows[0];
+    if (first) setSelId(first.id);
+  }, [allRows, selId]);
+  const selectRow = (id: string) => {
+    setSelId(id);
+    shellLayoutStore.configure(instanceId, { selectedId: id });
+  };
+
+  // Top movers across every section (biggest absolute move first), for the heat-strip.
+  const movers = useMemo(
+    () => allRows.filter((r) => r.changePct != null).sort((a, b) => absMove(b) - absMove(a)).slice(0, 8),
+    [allRows],
+  );
+
+  const now = Date.now();
+
+  if (status === "loading" && allRows.length === 0) return <p className="tn-w-empty">Loading markets…</p>;
+
+  return (
+    <div className="tn-mk">
+      <header className="tn-mk-head">
+        <div className="tn-mk-title">Markets</div>
+        <div className="tn-mk-stat">
+          <b>{allRows.length}</b> instruments · {sections.length} asset {sections.length === 1 ? "class" : "classes"} · updated {freshLabel(data.generatedAt, now)}
+        </div>
+        <div className="tn-mk-disc">Indicative only — not financial advice. Quotes delayed, keyless.</div>
+      </header>
+
+      {allRows.length === 0 && <p className="tn-w-empty">Markets unavailable.</p>}
+
+      {movers.length > 0 && (
+        <div className="tn-mk-heat" aria-label="Biggest movers">
+          {movers.map((r) => (
+            <button
+              key={r.id}
+              className={`tn-mk-heat-chip ${selId === r.id ? "is-sel" : ""}`}
+              style={{ background: moverBg(r.changePct as number) }}
+              onClick={() => selectRow(r.id)}
+              title={`${r.name} ${(r.changePct as number) >= 0 ? "+" : ""}${r.changePct}%`}
+            >
+              <span className="tn-mk-heat-sym">{r.symbol ?? r.name}</span>
+              <span className="tn-mk-heat-pct">{(r.changePct as number) >= 0 ? "+" : ""}{r.changePct}%</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {allRows.length > 0 && (
+        <div className="tn-mk-body">
+          <aside className="tn-mk-rail" aria-label="Instruments">
+            {railSections.map((sec) => (
+              <div key={sec.key} className="tn-mk-sec">
+                <div className="tn-mk-sec-h">
+                  <span className="tn-mk-sec-label">{sec.label}</span>
+                  <span className="tn-mk-sec-src">{sec.source}</span>
+                </div>
+                {sec.dormant ? (
+                  <p className="tn-mk-sec-note">🔒 {sec.note ?? "Needs an API key."}</p>
+                ) : (
+                  <ul className="tn-mk-rows">
+                    {sec.rows.map((r) => {
+                      const spark: ChartPoint[] = seriesSamples(`mkt:${r.id}`).map((s) => ({ x: s.t, y: s.n }));
+                      return (
+                        <li key={r.id}>
+                          <button
+                            className={`tn-mk-row ${selId === r.id ? "is-sel" : ""}`}
+                            onClick={() => selectRow(r.id)}
+                            aria-pressed={selId === r.id}
+                          >
+                            <span className="tn-mk-row-main">
+                              <span className="tn-mk-row-sym">{r.symbol ?? r.name}</span>
+                              <span className="tn-mk-row-name">{r.name}</span>
+                            </span>
+                            <span className="tn-mk-row-val">
+                              <span className="tn-mk-row-price">{r.value}</span>
+                              {r.changePct != null && (
+                                <span className={`tn-mk-chg ${r.changePct >= 0 ? "up" : "down"}`}>
+                                  {r.changePct >= 0 ? "+" : ""}{r.changePct}%
+                                </span>
+                              )}
+                            </span>
+                            <span className="tn-mk-row-spark">
+                              <Chart points={spark} height={28} area={false} zeroBaseline={false} up={r.changePct == null ? null : r.changePct >= 0} />
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </aside>
+
+          <main className="tn-mk-main">
+            <p className="tn-w-empty">Select an instrument to see its chart.</p>
+          </main>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -103,6 +103,10 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
   const [chartLoading, setChartLoading] = useState(false);
   useEffect(() => {
     if (!selSym) { setCandles([]); return; }
+    // Clear the previous instrument's candles immediately so a symbol/range switch never
+    // renders — or exports — stale OHLC under the new header while the new fetch is in
+    // flight (hasHistory drops to false → loading/live-series fallback + export disabled).
+    setCandles([]);
     let alive = true;
     setChartLoading(true);
     fetch(`/api/markets/chart?symbol=${encodeURIComponent(selSym)}&range=${range}`)

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -15,6 +15,7 @@ import { recordSeries, seriesSamples } from "@/lib/series";
 import { Chart, type ChartPoint } from "@/components/Chart";
 import { shellLayoutStore } from "@/lib/console/store";
 import { candlesToPoints, hiLo, periodChange, RANGES, type Candle, type Range } from "@/lib/markets/chart";
+import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
 const EMPTY: MarketsPayload = { generatedAt: 0, sections: [] };
 const RANGE_LABEL: Record<Range, string> = { "1mo": "1M", "6mo": "6M", "1y": "1Y" };
@@ -146,6 +147,21 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
   };
   const sortMark = (k: TableSortKey) => (sortKey === k ? (sortDir === -1 ? " ↓" : " ↑") : "");
   const onTableRow = (id: string) => { selectRow(id); setOpenTid((o) => (o === id ? null : id)); };
+
+  // Exports: a full quotes CSV (every instrument) + a per-selected-instrument OHLC
+  // CSV built from the real candles (only when history is present — no fabrication).
+  const exportRows = useMemo(
+    () => railSections.flatMap((s) => s.rows.map((r) => ({
+      section: s.label, name: r.name, symbol: r.symbol ?? "", value: r.value, num: r.num ?? "", changePct: r.changePct ?? "",
+    }))),
+    [railSections],
+  );
+  const sources = useMemo(() => Array.from(new Set(sections.map((s) => s.source))), [sections]);
+  const exportOhlc = () => {
+    if (!hasHistory || !selRow) return;
+    const rows = candles.map((k) => ({ t: new Date(k.t).toISOString(), o: k.o, h: k.h, l: k.l, c: k.c, v: k.v }));
+    downloadText(`${exportFilename(`markets-${selSym}-${range}`, Date.now())}.csv`, "text/csv", toCsv(rows));
+  };
 
   const now = Date.now();
 
@@ -317,6 +333,26 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
             </table>
           </main>
         </div>
+      )}
+
+      {sections.length > 0 && (
+        <footer className="tn-mk-foot">
+          <span className="tn-mk-attr">
+            {sources.map((src) => <span key={src}>{src}</span>)}
+            <span>Indicative only — not financial advice.</span>
+          </span>
+          <span className="tn-mk-actions">
+            <button
+              disabled={exportRows.length === 0}
+              onClick={() => downloadText(`${exportFilename("markets", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+            >⬇ CSV (quotes)</button>
+            <button
+              disabled={!hasHistory}
+              onClick={exportOhlc}
+              title={hasHistory ? `Export OHLC for ${selSym}` : "No history to export"}
+            >⬇ OHLC{selSym ? ` (${selSym})` : ""}</button>
+          </span>
+        </footer>
       )}
     </div>
   );

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -7,15 +7,25 @@
 // fallback to the accumulated mkt:<id> series when it doesn't, and an
 // "indicative only — not financial advice" disclaimer. Pure series maths live in
 // the unit-tested lib/markets/chart.ts; this is the shell.
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import type { MarketsPayload, MarketRow, MarketSection } from "@/lib/markets";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { Chart, type ChartPoint } from "@/components/Chart";
 import { shellLayoutStore } from "@/lib/console/store";
+import { candlesToPoints, hiLo, periodChange, RANGES, type Candle, type Range } from "@/lib/markets/chart";
 
 const EMPTY: MarketsPayload = { generatedAt: 0, sections: [] };
+const RANGE_LABEL: Record<Range, string> = { "1mo": "1M", "6mo": "6M", "1y": "1Y" };
+type TableSortKey = "name" | "changePct" | "value";
+
+/** Adaptive-precision number formatting for prices/levels (large → 2dp, tiny → 6dp). */
+function fmtNum(n: number): string {
+  const abs = Math.abs(n);
+  const d = abs >= 1 ? 2 : abs >= 0.01 ? 4 : 6;
+  return n.toLocaleString("en-US", { maximumFractionDigits: d });
+}
 
 /** Signed magnitude used for movers-first ordering; nulls sort last. */
 function absMove(r: MarketRow): number {
@@ -80,6 +90,62 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
     () => allRows.filter((r) => r.changePct != null).sort((a, b) => absMove(b) - absMove(a)).slice(0, 8),
     [allRows],
   );
+
+  const selRow = useMemo(() => allRows.find((r) => r.id === selId) ?? null, [allRows, selId]);
+  const selSym = selRow ? (selRow.symbol ?? selRow.id) : null;
+
+  // Primary historical chart: keyless Yahoo v8 OHLC for the selected instrument +
+  // range. Dormant-safe — the route never 5xxes, and a <2-candle result (dormant /
+  // no history / crypto-FX symbol Yahoo doesn't chart) falls back to the live series.
+  const [range, setRange] = useState<Range>("6mo");
+  const [candles, setCandles] = useState<Candle[]>([]);
+  const [chartLoading, setChartLoading] = useState(false);
+  useEffect(() => {
+    if (!selSym) { setCandles([]); return; }
+    let alive = true;
+    setChartLoading(true);
+    fetch(`/api/markets/chart?symbol=${encodeURIComponent(selSym)}&range=${range}`)
+      .then((r) => r.json())
+      .then((d: { candles?: Candle[] }) => { if (alive) setCandles(Array.isArray(d.candles) ? d.candles : []); })
+      .catch(() => { if (alive) setCandles([]); })
+      .finally(() => { if (alive) setChartLoading(false); });
+    return () => { alive = false; };
+  }, [selSym, range]);
+
+  const hasHistory = candles.length >= 2;
+  const chg = useMemo(() => periodChange(candles), [candles]);
+  const range52 = useMemo(() => hiLo(candles), [candles]);
+  // Honest fallback: chart the accumulated live mkt:<id> series when there's no
+  // real history. Read in render (folds in the latest recorded sample via tick).
+  const livePoints: ChartPoint[] = useMemo(
+    () => (selId ? seriesSamples(`mkt:${selId}`).map((s) => ({ x: s.t, y: s.n })) : []),
+    [selId, data.generatedAt],
+  );
+  const chartPoints = hasHistory ? candlesToPoints(candles) : livePoints;
+  const chartUp = hasHistory
+    ? chg.abs >= 0
+    : selRow?.changePct == null ? null : selRow.changePct >= 0;
+
+  // Sortable instrument table across every section (with its section attribution).
+  const [sortKey, setSortKey] = useState<TableSortKey>("changePct");
+  const [sortDir, setSortDir] = useState<1 | -1>(-1);
+  const [openTid, setOpenTid] = useState<string | null>(null);
+  const tableRows = useMemo(() => {
+    const arr = railSections.flatMap((s) => s.rows.map((r) => ({ r, secLabel: s.label, secSrc: s.source })));
+    return arr.sort((a, b) => {
+      let d: number;
+      if (sortKey === "name") d = (a.r.symbol ?? a.r.name).localeCompare(b.r.symbol ?? b.r.name);
+      else if (sortKey === "changePct") d = (a.r.changePct ?? -Infinity) - (b.r.changePct ?? -Infinity);
+      else d = (a.r.num ?? -Infinity) - (b.r.num ?? -Infinity);
+      return d * sortDir;
+    });
+  }, [railSections, sortKey, sortDir]);
+  const toggleSort = (k: TableSortKey) => {
+    if (sortKey === k) setSortDir((d) => (d === 1 ? -1 : 1));
+    else { setSortKey(k); setSortDir(k === "name" ? 1 : -1); }
+  };
+  const sortMark = (k: TableSortKey) => (sortKey === k ? (sortDir === -1 ? " ↓" : " ↑") : "");
+  const onTableRow = (id: string) => { selectRow(id); setOpenTid((o) => (o === id ? null : id)); };
 
   const now = Date.now();
 
@@ -162,7 +228,93 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
           </aside>
 
           <main className="tn-mk-main">
-            <p className="tn-w-empty">Select an instrument to see its chart.</p>
+            {selRow ? (
+              <div className="tn-mk-panel">
+                <div className="tn-mk-panel-head">
+                  <div>
+                    <div className="tn-mk-panel-title">{selRow.name}{selRow.symbol ? ` · ${selRow.symbol}` : ""}</div>
+                    <div className="tn-mk-panel-sub">{selRow.value}{selRow.sub ? ` · ${selRow.sub}` : ""}</div>
+                  </div>
+                  <div className="tn-mk-tabs" role="tablist" aria-label="Chart range">
+                    {RANGES.map((rg) => (
+                      <button key={rg} role="tab" aria-selected={range === rg} className={`tn-mk-tab ${range === rg ? "active" : ""}`} onClick={() => setRange(rg)}>
+                        {RANGE_LABEL[rg]}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {chartPoints.length >= 2 ? (
+                  <>
+                    <Chart points={chartPoints} height={220} zeroBaseline={false} up={chartUp} markers />
+                    {hasHistory ? (
+                      <>
+                        <div className="tn-mk-metrics">
+                          <span className={`tn-mk-metric ${chg.abs >= 0 ? "up" : "down"}`}>
+                            <span className="tn-mk-metric-label">Change ({RANGE_LABEL[range]})</span>{" "}
+                            <b>{chg.abs >= 0 ? "+" : ""}{fmtNum(chg.abs)} ({chg.pct >= 0 ? "+" : ""}{chg.pct.toFixed(2)}%)</b>
+                          </span>
+                          {range52 && (
+                            <span className="tn-mk-metric">
+                              <span className="tn-mk-metric-label">{range === "1y" ? "52-wk range" : "Range"}</span>{" "}
+                              <b>{fmtNum(range52.lo)} – {fmtNum(range52.hi)}</b>
+                            </span>
+                          )}
+                          <span className="tn-mk-metric"><span className="tn-mk-metric-label">{candles.length} bars · Yahoo v8, delayed</span></span>
+                        </div>
+                      </>
+                    ) : (
+                      <div className="tn-mk-chart-note">Live session (accumulating) — historical unavailable for this symbol.</div>
+                    )}
+                  </>
+                ) : (
+                  <div className="tn-mk-chart-empty">{chartLoading ? "Loading chart…" : "No history yet — accumulating a live session series."}</div>
+                )}
+              </div>
+            ) : (
+              <p className="tn-w-empty">Select an instrument to see its chart.</p>
+            )}
+
+            <table className="tn-mk-table">
+              <thead>
+                <tr>
+                  <th className="sortable" onClick={() => toggleSort("name")}>Instrument{sortMark("name")}</th>
+                  <th className="sortable num" onClick={() => toggleSort("changePct")}>Change{sortMark("changePct")}</th>
+                  <th className="sortable num" onClick={() => toggleSort("value")}>Value{sortMark("value")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tableRows.map(({ r, secLabel, secSrc }) => {
+                  const isOpen = openTid === r.id;
+                  return (
+                    <Fragment key={r.id}>
+                      <tr className={`tn-mk-trow ${selId === r.id ? "is-sel" : ""}`} onClick={() => onTableRow(r.id)}>
+                        <td><span className="tn-mk-row-sym">{r.symbol ?? r.name}</span> <span className="tn-mk-row-name">{r.name}</span></td>
+                        <td className="num">
+                          {r.changePct != null
+                            ? <span className={`tn-mk-chg ${r.changePct >= 0 ? "up" : "down"}`}>{r.changePct >= 0 ? "+" : ""}{r.changePct}%</span>
+                            : <span className="tn-mk-row-name">—</span>}
+                        </td>
+                        <td className="num">{r.value}</td>
+                      </tr>
+                      {isOpen && (
+                        <tr className="tn-mk-drill">
+                          <td colSpan={3}>
+                            <dl>
+                              <dt>Value</dt><dd>{r.value}</dd>
+                              {r.changePct != null && (<><dt>Change</dt><dd className={`tn-mk-chg ${r.changePct >= 0 ? "up" : "down"}`}>{r.changePct >= 0 ? "+" : ""}{r.changePct}%</dd></>)}
+                              {r.sub && (<><dt>Detail</dt><dd>{r.sub}</dd></>)}
+                              <dt>Class</dt><dd>{secLabel}</dd>
+                              <dt>Source</dt><dd>{secSrc}</dd>
+                            </dl>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
           </main>
         </div>
       )}

--- a/lib/console/widgets/markets.tsx
+++ b/lib/console/widgets/markets.tsx
@@ -12,6 +12,7 @@ import type { MarketsPayload } from "@/lib/markets";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { recordSeries, seriesTrend } from "@/lib/series";
 import { Sparkline } from "@/components/Sparkline";
+import MarketsDetail from "./markets.detail";
 
 const EMPTY: MarketsPayload = { generatedAt: 0, sections: [] };
 const RANK: Record<AlertSeverity, number> = { info: 0, warn: 1, critical: 2 };
@@ -116,5 +117,6 @@ export const MARKETS_WIDGET = {
   defaultHeight: 300,
   defaultConfig: {},
   component: MarketsBody,
+  detail: MarketsDetail,
 };
 registerWidget(MARKETS_WIDGET);

--- a/lib/console/widgets/news.detail.tsx
+++ b/lib/console/widgets/news.detail.tsx
@@ -6,10 +6,10 @@
 // Selection persists via shellLayoutStore.configure(instanceId, { providerId }),
 // exactly like the docked NEWS_WIDGET. Keyless throughout (YouTube embeds +
 // img.youtube.com thumbnails); HLS routes through the existing inline hls.js path.
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import { shellLayoutStore } from "@/lib/console/store";
-import { NEWS_PROVIDERS, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+import { NEWS_PROVIDERS, providerThumb, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
 
 export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
   // Seed the active channel from persisted config (providerId + optional customProvider),
@@ -28,6 +28,25 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
   );
   // Distinct catalog categories for the filter chips (+ "All").
   const categories = useMemo(() => Array.from(new Set(NEWS_PROVIDERS.map((p) => p.category))), []);
+
+  // Channel wall: the (category-filtered) catalog, grouped by category with headers.
+  const wallGroups = useMemo(() => {
+    const shown = category == null ? NEWS_PROVIDERS : NEWS_PROVIDERS.filter((p) => p.category === category);
+    const by = new Map<string, NewsProvider[]>();
+    for (const p of shown) {
+      const g = by.get(p.category) ?? [];
+      g.push(p);
+      by.set(p.category, g);
+    }
+    return [...by.entries()];
+  }, [category]);
+
+  // Select a catalog channel: instant hero swap (local state) + persist the choice,
+  // exactly the { providerId } patch the docked NewsBody writes.
+  const selectChannel = (p: NewsProvider) => {
+    setActiveId(p.id);
+    shellLayoutStore.configure(instanceId, { providerId: p.id });
+  };
 
   const embed = active ? resolveEmbed(active) : null;
 
@@ -79,6 +98,38 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
           ? <iframe className="tn-nv-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
           : <video ref={videoRef} className="tn-nv-video" muted autoPlay playsInline controls />}
         <span className="tn-nv-hero-label">{active.name} · LIVE</span>
+      </div>
+
+      <div className="tn-nv-sec-h">Channels</div>
+      <div className="tn-nv-wall">
+        {wallGroups.map(([cat, ps]) => (
+          <Fragment key={cat}>
+            <div className="tn-nv-cat-h">{cat}</div>
+            {ps.map((p) => {
+              const thumb = providerThumb(p);
+              const on = p.id === activeId;
+              return (
+                <button
+                  key={p.id}
+                  className={`tn-nv-tile${on ? " is-on" : ""}`}
+                  onClick={() => selectChannel(p)}
+                  aria-pressed={on}
+                >
+                  <div className="tn-nv-thumb-wrap">
+                    {thumb
+                      ? <img className="tn-nv-thumb" src={thumb} alt="" loading="lazy" />
+                      : <span className="tn-nv-thumb-fallback">{p.name}</span>}
+                    <span className="tn-nv-live"><span className="tn-nv-live-dot" />LIVE</span>
+                  </div>
+                  <span className="tn-nv-tile-cap">
+                    <span className="tn-nv-tile-name">{p.name}</span>
+                    <span className="tn-nv-tile-cat">{p.category}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </Fragment>
+        ))}
       </div>
     </div>
   );

--- a/lib/console/widgets/news.detail.tsx
+++ b/lib/console/widgets/news.detail.tsx
@@ -39,6 +39,14 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
   const [customUrl, setCustomUrl] = useState("");
   const [customErr, setCustomErr] = useState(false);
 
+  // Config is the source of truth. Re-sync the local channel when it changes externally
+  // (e.g. the user switches channels on the still-visible docked copy) so the focused
+  // detail never diverges from the dock. Keyed on primitives to avoid ref-churn re-fires.
+  useEffect(() => {
+    if (typeof config.providerId === "string") setActiveId(config.providerId);
+    setCustom(config.customProvider as NewsProvider | undefined);
+  }, [config.providerId, (config.customProvider as NewsProvider | undefined)?.id]);
+
   const active = useMemo<NewsProvider | undefined>(
     () => (custom?.id === activeId ? custom : NEWS_PROVIDERS.find((p) => p.id === activeId) ?? NEWS_PROVIDERS[0]),
     [activeId, custom],
@@ -115,7 +123,9 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
       h.attachMedia(v);
     })();
     return () => { cancelled = true; hls?.destroy(); };
-  }, [embed?.kind, embed?.src]);
+    // `mosaic` is a dep: toggling it unmounts/remounts the hero <video>, so the effect
+    // must re-run to destroy the old hls.js instance and re-attach to the new element.
+  }, [embed?.kind, embed?.src, mosaic]);
 
   if (!active || !embed) {
     return (

--- a/lib/console/widgets/news.detail.tsx
+++ b/lib/console/widgets/news.detail.tsx
@@ -11,7 +11,8 @@ import type { WidgetDetailProps } from "@/lib/console/registry";
 import type { NewsItem } from "@/lib/news";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { shellLayoutStore } from "@/lib/console/store";
-import { NEWS_PROVIDERS, providerThumb, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+import { NEWS_PROVIDERS, parseCustomStream, providerThumb, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
 /** Compact relative age (mirrors headlines.detail). */
 function rel(ts: number, now: number): string {
@@ -34,6 +35,9 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
   const [category, setCategory] = useState<string | null>(null);
   // Optional muted 2×2 mosaic (default off — one hero is bandwidth-honest).
   const [mosaic, setMosaic] = useState(false);
+  // Add-custom-stream input (Task 5).
+  const [customUrl, setCustomUrl] = useState("");
+  const [customErr, setCustomErr] = useState(false);
 
   const active = useMemo<NewsProvider | undefined>(
     () => (custom?.id === activeId ? custom : NEWS_PROVIDERS.find((p) => p.id === activeId) ?? NEWS_PROVIDERS[0]),
@@ -60,6 +64,22 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
     setActiveId(p.id);
     shellLayoutStore.configure(instanceId, { providerId: p.id });
   };
+
+  // Add a custom stream: parse (YouTube URL / .m3u8), then activate + persist the full
+  // provider as customProvider (exactly what the docked NewsBody stores). Honest inline
+  // error when the URL is neither a YouTube link nor an .m3u8.
+  const addCustom = () => {
+    const p = parseCustomStream(customUrl);
+    if (!p) { setCustomErr(true); return; }
+    setCustomErr(false);
+    setCustom(p);
+    setActiveId(p.id);
+    setCustomUrl("");
+    shellLayoutStore.configure(instanceId, { providerId: p.id, customProvider: p });
+  };
+
+  // Export the static channel directory (id, name, category, kind) as CSV.
+  const exportRows = NEWS_PROVIDERS.map((p) => ({ id: p.id, name: p.name, category: p.category, kind: p.kind }));
 
   // First 4 (category-filtered) YouTube channels for the muted 2×2 mosaic.
   const mosaicCells = useMemo(
@@ -195,6 +215,29 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
           ))
         )}
       </div>
+
+      <footer className="tn-nv-foot">
+        <span className="tn-nv-foot-note">
+          Channels are the broadcasters&apos; official keyless live streams (YouTube/HLS).
+        </span>
+        <span className="tn-nv-add">
+          <input
+            className="tn-nv-custom"
+            placeholder="Add stream URL (YouTube / .m3u8)…"
+            value={customUrl}
+            onChange={(e) => { setCustomUrl(e.target.value); if (customErr) setCustomErr(false); }}
+            onKeyDown={(e) => { if (e.key === "Enter") addCustom(); }}
+          />
+          <button onClick={addCustom} disabled={!customUrl.trim()}>＋ Add</button>
+          {customErr && <span className="tn-nv-err">Not a YouTube or .m3u8 URL.</span>}
+        </span>
+        <span className="tn-nv-actions">
+          <button
+            disabled={exportRows.length === 0}
+            onClick={() => downloadText(`${exportFilename("news-channels", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+          >⬇ Channels CSV</button>
+        </span>
+      </footer>
     </div>
   );
 }

--- a/lib/console/widgets/news.detail.tsx
+++ b/lib/console/widgets/news.detail.tsx
@@ -1,0 +1,85 @@
+"use client";
+// News-video focus view — a live-news console. A hero player (YouTube iframe / the
+// docked NewsBody's inline HLS <video>, reused verbatim — no new player), a keyless
+// channel wall grouped by category (Task 3), a live headline rail + optional muted
+// 2×2 mosaic (Task 4), and an add-custom-stream directory + CSV export (Task 5).
+// Selection persists via shellLayoutStore.configure(instanceId, { providerId }),
+// exactly like the docked NEWS_WIDGET. Keyless throughout (YouTube embeds +
+// img.youtube.com thumbnails); HLS routes through the existing inline hls.js path.
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import { shellLayoutStore } from "@/lib/console/store";
+import { NEWS_PROVIDERS, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+
+export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
+  // Seed the active channel from persisted config (providerId + optional customProvider),
+  // mirroring how the docked NewsBody resolves it. Local state makes clicking a channel
+  // instant; every change also persists via shellLayoutStore.configure (below / Task 3).
+  const seedId = (config.providerId as string) ?? NEWS_PROVIDERS[0]?.id ?? "";
+  const seedCustom = config.customProvider as NewsProvider | undefined;
+  const [activeId, setActiveId] = useState<string>(seedId);
+  const [custom, setCustom] = useState<NewsProvider | undefined>(seedCustom);
+  // Category filter for the channel wall (Task 3); null = All.
+  const [category, setCategory] = useState<string | null>(null);
+
+  const active = useMemo<NewsProvider | undefined>(
+    () => (custom?.id === activeId ? custom : NEWS_PROVIDERS.find((p) => p.id === activeId) ?? NEWS_PROVIDERS[0]),
+    [activeId, custom],
+  );
+  // Distinct catalog categories for the filter chips (+ "All").
+  const categories = useMemo(() => Array.from(new Set(NEWS_PROVIDERS.map((p) => p.category))), []);
+
+  const embed = active ? resolveEmbed(active) : null;
+
+  // HLS hero: reuse the docked NewsBody's inline hls.js loader verbatim (no new player,
+  // no /api/hls host change). YouTube heroes use the keyless <iframe> below. Since the
+  // static catalog is YouTube-only, HLS only arises from a user-added custom .m3u8.
+  const videoRef = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (!embed || embed.kind !== "hls" || !videoRef.current) return;
+    const v = videoRef.current;
+    let hls: { destroy(): void } | null = null;
+    let cancelled = false;
+    if (v.canPlayType("application/vnd.apple.mpegurl")) { v.src = embed.src; return; }
+    (async () => {
+      const Hls = (await import("hls.js")).default;
+      if (cancelled || !Hls.isSupported()) return;
+      const h = new Hls();
+      hls = h;
+      h.loadSource(embed.src);
+      h.attachMedia(v);
+    })();
+    return () => { cancelled = true; hls?.destroy(); };
+  }, [embed?.kind, embed?.src]);
+
+  if (!active || !embed) {
+    return (
+      <div className="tn-nv">
+        <p className="tn-w-empty">No live channels configured.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tn-nv">
+      <header className="tn-nv-head">
+        <div className="tn-nv-title">Live news</div>
+        <div className="tn-nv-now">▶ {active.name} · {active.category}</div>
+      </header>
+
+      <div className="tn-nv-chips">
+        <button className={category == null ? "is-on" : ""} onClick={() => setCategory(null)}>All</button>
+        {categories.map((c) => (
+          <button key={c} className={category === c ? "is-on" : ""} onClick={() => setCategory(c)}>{c}</button>
+        ))}
+      </div>
+
+      <div className="tn-nv-hero">
+        {embed.kind === "youtube"
+          ? <iframe className="tn-nv-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
+          : <video ref={videoRef} className="tn-nv-video" muted autoPlay playsInline controls />}
+        <span className="tn-nv-hero-label">{active.name} · LIVE</span>
+      </div>
+    </div>
+  );
+}

--- a/lib/console/widgets/news.detail.tsx
+++ b/lib/console/widgets/news.detail.tsx
@@ -8,8 +8,19 @@
 // img.youtube.com thumbnails); HLS routes through the existing inline hls.js path.
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
+import type { NewsItem } from "@/lib/news";
+import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { shellLayoutStore } from "@/lib/console/store";
 import { NEWS_PROVIDERS, providerThumb, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+
+/** Compact relative age (mirrors headlines.detail). */
+function rel(ts: number, now: number): string {
+  if (!ts) return "";
+  const m = Math.max(0, Math.round((now - ts) / 60000));
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  return h < 48 ? `${h}h` : `${Math.round(h / 24)}d`;
+}
 
 export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
   // Seed the active channel from persisted config (providerId + optional customProvider),
@@ -21,6 +32,8 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
   const [custom, setCustom] = useState<NewsProvider | undefined>(seedCustom);
   // Category filter for the channel wall (Task 3); null = All.
   const [category, setCategory] = useState<string | null>(null);
+  // Optional muted 2×2 mosaic (default off — one hero is bandwidth-honest).
+  const [mosaic, setMosaic] = useState(false);
 
   const active = useMemo<NewsProvider | undefined>(
     () => (custom?.id === activeId ? custom : NEWS_PROVIDERS.find((p) => p.id === activeId) ?? NEWS_PROVIDERS[0]),
@@ -47,6 +60,19 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
     setActiveId(p.id);
     shellLayoutStore.configure(instanceId, { providerId: p.id });
   };
+
+  // First 4 (category-filtered) YouTube channels for the muted 2×2 mosaic.
+  const mosaicCells = useMemo(
+    () => (category == null ? NEWS_PROVIDERS : NEWS_PROVIDERS.filter((p) => p.category === category))
+      .filter((p) => p.kind === "youtube")
+      .slice(0, 4),
+    [category],
+  );
+
+  // Live headline rail — the SAME keyless /api/news poll the docked headlines widget uses.
+  const { data: newsData } = useJsonPoll<{ items: NewsItem[] }>("/api/news", 120_000, { items: [] });
+  const headlines = newsData.items ?? [];
+  const now = Date.now();
 
   const embed = active ? resolveEmbed(active) : null;
 
@@ -86,19 +112,43 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
         <div className="tn-nv-now">▶ {active.name} · {active.category}</div>
       </header>
 
-      <div className="tn-nv-chips">
-        <button className={category == null ? "is-on" : ""} onClick={() => setCategory(null)}>All</button>
-        {categories.map((c) => (
-          <button key={c} className={category === c ? "is-on" : ""} onClick={() => setCategory(c)}>{c}</button>
-        ))}
+      <div className="tn-nv-tools">
+        <div className="tn-nv-chips">
+          <button className={category == null ? "is-on" : ""} onClick={() => setCategory(null)}>All</button>
+          {categories.map((c) => (
+            <button key={c} className={category === c ? "is-on" : ""} onClick={() => setCategory(c)}>{c}</button>
+          ))}
+        </div>
+        <button className={`tn-nv-mtoggle${mosaic ? " is-on" : ""}`} onClick={() => setMosaic((m) => !m)} aria-pressed={mosaic}>
+          ▦ Mosaic
+        </button>
       </div>
 
-      <div className="tn-nv-hero">
-        {embed.kind === "youtube"
-          ? <iframe className="tn-nv-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
-          : <video ref={videoRef} className="tn-nv-video" muted autoPlay playsInline controls />}
-        <span className="tn-nv-hero-label">{active.name} · LIVE</span>
-      </div>
+      {mosaic && mosaicCells.length > 0 ? (
+        <div className="tn-nv-mosaic">
+          {mosaicCells.map((p) => {
+            const on = p.id === activeId;
+            return (
+              <div key={p.id} className={`tn-nv-cell${on ? " is-on" : ""}`}>
+                <iframe
+                  src={`https://www.youtube.com/embed/${p.ref}?autoplay=1&mute=${on ? 0 : 1}&playsinline=1`}
+                  title={p.name}
+                  allow="autoplay; encrypted-media; picture-in-picture"
+                  allowFullScreen
+                />
+                <span className="tn-nv-cell-label">{p.name}{on ? " · 🔊" : ""}</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="tn-nv-hero">
+          {embed.kind === "youtube"
+            ? <iframe className="tn-nv-video" src={embed.src} title={active.name} allow="autoplay; encrypted-media; picture-in-picture" allowFullScreen />
+            : <video ref={videoRef} className="tn-nv-video" muted autoPlay playsInline controls />}
+          <span className="tn-nv-hero-label">{active.name} · LIVE</span>
+        </div>
+      )}
 
       <div className="tn-nv-sec-h">Channels</div>
       <div className="tn-nv-wall">
@@ -130,6 +180,20 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
             })}
           </Fragment>
         ))}
+      </div>
+
+      <div className="tn-nv-sec-h">Latest headlines</div>
+      <div className="tn-nv-rail">
+        {headlines.length === 0 ? (
+          <p className="tn-w-empty">No headlines.</p>
+        ) : (
+          headlines.slice(0, 12).map((it, i) => (
+            <a key={it.url || i} className="tn-nv-rail-item" href={it.url} target="_blank" rel="noreferrer">
+              <div className="tn-nv-rail-title">{it.title}</div>
+              <div className="tn-nv-rail-meta">{it.source}{it.ts ? ` · ${rel(it.ts, now)}` : ""}</div>
+            </a>
+          ))
+        )}
       </div>
     </div>
   );

--- a/lib/console/widgets/news.tsx
+++ b/lib/console/widgets/news.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+import NewsDetail from "./news.detail";
 
 function NewsBody({ instanceId, config }: WidgetBodyProps) {
   const report = useWidgetReport();
@@ -57,6 +58,6 @@ function NewsBody({ instanceId, config }: WidgetBodyProps) {
 
 export const NEWS_WIDGET = {
   id: "news", title: "Live News", icon: "📺", category: "News",
-  defaultHeight: 240, defaultConfig: { providerId: "aljazeera" }, component: NewsBody,
+  defaultHeight: 240, defaultConfig: { providerId: "aljazeera" }, component: NewsBody, detail: NewsDetail,
 };
 registerWidget(NEWS_WIDGET);

--- a/lib/console/widgets/satellites.detail.tsx
+++ b/lib/console/widgets/satellites.detail.tsx
@@ -1,0 +1,310 @@
+"use client";
+// Satellites focus view — the orbital command console (spec §7.8, Option C: orbital
+// detail AND imagery). Reuses the SAME live pipeline as the docked widget
+// (useSatellites → locally-propagated WorldObject[]), then renders deep: a masthead
+// with a count sparkline + TLE-source honesty, category chips + a roster search,
+// full orbital vitals parsed from the TLE (lib/satellites/elements), a live ±1-period
+// ground track on the shared <InsetMap>, NASA GIBS true-color imagery of the region
+// beneath the sub-point (honestly captioned — NOT a live satellite photo), and a
+// searchable/sortable roster whose rows drill into the existing <SatelliteDetail>
+// dossier (its Esri close-up complements the GIBS regional tile).
+import { Fragment, useEffect, useMemo, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import type { WorldObject } from "@/lib/world";
+import { useSatellites } from "@/lib/satellites/useSatellites";
+import { parseElements } from "@/lib/satellites/elements";
+import { groundTrack } from "@/lib/satellites/groundTrack";
+import { gibsTileUrl, gibsDate } from "@/lib/sources/gibs";
+import { recordSeries, seriesSamples } from "@/lib/series";
+import { deltaOf } from "@/lib/widgets/history";
+import { Chart, type ChartPoint } from "@/components/Chart";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
+import SatelliteDetail from "@/components/SatelliteDetail";
+
+// The satellite meta the propagation hook attaches (see lib/satellites/useSatellites).
+// meta is Record<string, unknown> on WorldObject, so we narrow it here.
+interface SatMeta {
+  noradId?: string;
+  objectName?: string;
+  line1?: string;
+  line2?: string;
+  altKm?: number;
+  velocityKmS?: number;
+  periodMin?: number;
+  typeLabel?: string;
+}
+const metaOf = (o: WorldObject | undefined): SatMeta => (o?.meta ?? {}) as SatMeta;
+
+// NASA's official YouTube channel — the live_stream embed form resolves to whatever
+// the channel is broadcasting (the ISS onboard/external HD cameras), keyless.
+const NASA_CHANNEL = "UCLA_DiR1FfKNvjuUpBHmylQ";
+const ISS_NORAD = "25544";
+
+const TABLE_CAP = 300;
+
+type SatSortKey = "name" | "norad" | "category" | "altKm" | "periodMin";
+
+export default function SatellitesDetail(props: WidgetDetailProps) {
+  const group = (props.config?.group as string) ?? "visual";
+  const objects = useSatellites(group, 5000);
+  const total = objects.length;
+
+  const [selId, setSelId] = useState<string | null>(null);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [q, setQ] = useState("");
+  const [cat, setCat] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SatSortKey>("altKm");
+  const [dir, setDir] = useState<1 | -1>(-1);
+
+  // Count sparkline: only stamp the series ONCE REAL DATA HAS ARRIVED (the W4 fix).
+  // useSatellites hands back a fresh array every propagation tick, so its reference
+  // change is our per-poll clock; the initial mount array is empty, and stamping then
+  // would persist a spurious count=0 into the series.
+  const [updatedAt, setUpdatedAt] = useState(0);
+  useEffect(() => { if (objects.length > 0) setUpdatedAt(Date.now()); }, [objects]);
+  useEffect(() => { if (updatedAt) recordSeries("sat:count", total, updatedAt); }, [updatedAt, total]);
+
+  // Read the persisted series AND fold in the CURRENT poll's live count — recordSeries
+  // only writes in a post-commit effect and lib/series has no React subscription, so
+  // without folding it in the delta/sparkline would trail the count beside them by one
+  // poll (exactly as aviation.detail.tsx / cameras.detail.tsx do).
+  const samples = useMemo(() => {
+    const base = seriesSamples("sat:count");
+    const last = base[base.length - 1];
+    if (updatedAt && (!last || last.t !== updatedAt || last.n !== total)) {
+      return [...base, { t: updatedAt, n: total }];
+    }
+    return base;
+  }, [updatedAt, total]);
+  const spark: ChartPoint[] = useMemo(() => samples.map((s) => ({ x: s.t, y: s.n })), [samples]);
+  const delta = useMemo(() => deltaOf(samples), [samples]);
+
+  // Category chips (counts by human type label).
+  const categories = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const o of objects) {
+      const label = o.typeLabel ?? "Other";
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    }
+    return [...counts.entries()].map(([label, count]) => ({ label, count })).sort((a, b) => b.count - a.count);
+  }, [objects]);
+
+  // Roster filter (category chip + search over name / NORAD id).
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return objects.filter((o) => {
+      if (cat && (o.typeLabel ?? "Other") !== cat) return false;
+      if (!needle) return true;
+      const m = metaOf(o);
+      return o.label.toLowerCase().includes(needle) || (m.noradId ?? "").toLowerCase().includes(needle);
+    });
+  }, [objects, q, cat]);
+
+  // Selected satellite — resolved from the full set so a selection survives filtering
+  // and per-poll array churn; falls back to the first object.
+  const sel = useMemo(() => objects.find((o) => o.id === selId) ?? objects[0], [objects, selId]);
+  const selMeta = metaOf(sel);
+  const elements = useMemo(
+    () => (sel ? parseElements(selMeta.line1 ?? "", selMeta.line2 ?? "") : null),
+    // Recompute only when the underlying TLE changes, not on every propagation poll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selMeta.line1, selMeta.line2],
+  );
+
+  // Live ±1-period ground track (dormant-safe: [] on any propagation error). Keyed on
+  // the TLE identity so it computes once per selection, not every 5s poll.
+  const track = useMemo(
+    () => (sel ? groundTrack(selMeta.line1 ?? "", selMeta.line2 ?? "", Date.now(), selMeta.periodMin ?? NaN) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selMeta.line1, selMeta.line2, selMeta.periodMin],
+  );
+
+  const mapPoints: InsetPoint[] = useMemo(
+    () => (sel ? [{ lat: sel.lat, lon: sel.lon, id: sel.id, color: sel.color, props: { name: sel.label } }] : []),
+    [sel],
+  );
+
+  const gibsUrl = sel ? gibsTileUrl(sel.lat, sel.lon, 4, gibsDate(Date.now())) : "";
+  const gibsWhen = gibsDate(Date.now());
+
+  // Sortable roster (capped for DOM sanity).
+  const rows = useMemo(() => {
+    const val = (o: WorldObject): string | number => {
+      const m = metaOf(o);
+      switch (sortKey) {
+        case "name": return o.label.toLowerCase();
+        case "norad": return Number(m.noradId ?? 0);
+        case "category": return (o.typeLabel ?? "").toLowerCase();
+        case "altKm": return o.altKm ?? 0;
+        case "periodMin": return m.periodMin ?? 0;
+      }
+    };
+    return [...filtered]
+      .sort((a, b) => {
+        const va = val(a), vb = val(b);
+        if (typeof va === "number" && typeof vb === "number") return (va - vb) * dir;
+        return String(va).localeCompare(String(vb)) * dir;
+      })
+      .slice(0, TABLE_CAP);
+  }, [filtered, sortKey, dir]);
+  const toggleSort = (k: SatSortKey) => {
+    if (sortKey === k) setDir((d) => (d === 1 ? -1 : 1));
+    else { setSortKey(k); setDir(k === "name" || k === "category" ? 1 : -1); }
+  };
+  const sortMark = (k: SatSortKey) => (sortKey === k ? (dir === 1 ? " ↑" : " ↓") : "");
+
+  const liveAlt = selMeta.altKm ?? sel?.altKm ?? 0;
+
+  return (
+    <div className="tn-sat">
+      <header className="tn-sat-head">
+        <div className="tn-sat-title">Orbital command</div>
+        <div className="tn-sat-stat">
+          <b>{total}</b> tracked · propagated locally · TLEs via CelesTrak · SGP4
+          {delta !== 0 && (
+            <span className={`tn-sat-delta ${delta > 0 ? "up" : "down"}`}> {delta > 0 ? "▲" : "▼"}{Math.abs(delta)}</span>
+          )}
+        </div>
+        {spark.length >= 2 && <div className="tn-sat-spark"><Chart points={spark} height={40} up={null} /></div>}
+        {categories.length > 0 && (
+          <div className="tn-sat-chips">
+            <button className={`tn-sat-chip ${cat === null ? "active" : ""}`} onClick={() => setCat(null)}>All · {total}</button>
+            {categories.map((c) => (
+              <button
+                key={c.label}
+                className={`tn-sat-chip ${cat === c.label ? "active" : ""}`}
+                onClick={() => setCat(cat === c.label ? null : c.label)}
+              >
+                {c.label} · {c.count}
+              </button>
+            ))}
+          </div>
+        )}
+        <input
+          className="tn-sat-search"
+          placeholder="Search name or NORAD id…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+      </header>
+
+      {total === 0 && <p className="tn-w-empty">Loading satellites…</p>}
+
+      {sel && (
+        <div className="tn-sat-panels">
+          <div className="tn-sat-panel">
+            <h3>Orbital vitals · {sel.label}</h3>
+            {elements ? (
+              <dl className="tn-sat-vitals">
+                <div><dt>Inclination</dt><dd>{elements.inclinationDeg.toFixed(2)}°</dd></div>
+                <div><dt>Eccentricity</dt><dd>{elements.eccentricity.toFixed(7)}</dd></div>
+                <div><dt>RAAN</dt><dd>{elements.raanDeg.toFixed(2)}°</dd></div>
+                <div><dt>Arg. of perigee</dt><dd>{elements.argPerigeeDeg.toFixed(2)}°</dd></div>
+                <div><dt>Mean anomaly</dt><dd>{elements.meanAnomalyDeg.toFixed(2)}°</dd></div>
+                <div><dt>Mean motion</dt><dd>{elements.meanMotionRevPerDay.toFixed(4)} rev/day</dd></div>
+                <div><dt>Period</dt><dd>{elements.periodMin.toFixed(1)} min</dd></div>
+                <div><dt>Semi-major axis</dt><dd>{elements.semiMajorAxisKm.toFixed(0)} km</dd></div>
+                <div><dt>Apogee</dt><dd>{elements.apogeeKm.toFixed(0)} km</dd></div>
+                <div><dt>Perigee</dt><dd>{elements.perigeeKm.toFixed(0)} km</dd></div>
+                <div><dt>Sub-point</dt><dd>{sel.lat.toFixed(2)}, {sel.lon.toFixed(2)}</dd></div>
+                <div><dt>Altitude (live)</dt><dd>{liveAlt.toFixed(0)} km</dd></div>
+                <div><dt>Velocity (live)</dt><dd>{(selMeta.velocityKmS ?? 0).toFixed(2)} km/s</dd></div>
+                <div><dt>NORAD id</dt><dd>{selMeta.noradId ?? "—"}</dd></div>
+              </dl>
+            ) : (
+              <p className="tn-w-empty">No orbital elements for this object.</p>
+            )}
+          </div>
+
+          <div className="tn-sat-panel">
+            <h3>Ground track · ±1 orbit</h3>
+            {track.length > 0
+              ? <InsetMap points={mapPoints} track={track} height={240} />
+              : <p className="tn-w-empty">No ground track (propagation unavailable for this TLE).</p>}
+          </div>
+
+          <div className="tn-sat-panel">
+            <h3>Imagery beneath the sub-point</h3>
+            <figure className="tn-sat-img-fig">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                className="tn-sat-img"
+                src={gibsUrl}
+                alt={`NASA true-color imagery of the region beneath ${sel.label}`}
+                loading="lazy"
+              />
+              <figcaption className="tn-sat-cap">
+                NASA GIBS true-color · {gibsWhen} · region beneath the sub-point (not a live satellite photo)
+              </figcaption>
+            </figure>
+          </div>
+
+          <div className="tn-sat-panel">
+            <h3>Live feed</h3>
+            {selMeta.noradId === ISS_NORAD ? (
+              <div className="tn-sat-live">
+                <iframe
+                  className="tn-sat-live-frame"
+                  src={`https://www.youtube.com/embed/live_stream?channel=${NASA_CHANNEL}`}
+                  title="NASA live — ISS onboard/external cameras"
+                  allow="encrypted-media; picture-in-picture"
+                  allowFullScreen
+                />
+                <p className="tn-sat-cap">
+                  NASA live stream (ISS onboard/external cameras) — a real feed from the station when NASA is broadcasting.
+                </p>
+              </div>
+            ) : (
+              <p className="tn-w-empty">No public live feed for this satellite.</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <table className="tn-sat-table">
+          <thead>
+            <tr>
+              <th className="sortable" onClick={() => toggleSort("name")}>Name{sortMark("name")}</th>
+              <th className="sortable" onClick={() => toggleSort("norad")}>NORAD{sortMark("norad")}</th>
+              <th className="sortable" onClick={() => toggleSort("category")}>Category{sortMark("category")}</th>
+              <th className="sortable" onClick={() => toggleSort("altKm")}>Alt{sortMark("altKm")}</th>
+              <th className="sortable" onClick={() => toggleSort("periodMin")}>Period{sortMark("periodMin")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((o) => {
+              const m = metaOf(o);
+              const isOpen = openId === o.id;
+              const isSel = sel?.id === o.id;
+              return (
+                <Fragment key={o.id}>
+                  <tr
+                    className={`tn-sat-row ${isSel ? "sel" : ""}`}
+                    onClick={() => { setSelId(o.id); setOpenId(isOpen ? null : o.id); }}
+                  >
+                    <td className="tn-w-strong">{o.label}</td>
+                    <td className="tn-w-muted">{m.noradId ?? "—"}</td>
+                    <td>{o.typeLabel ?? "—"}</td>
+                    <td>{o.altKm != null ? `${Math.round(o.altKm)} km` : "—"}</td>
+                    <td>{m.periodMin && Number.isFinite(m.periodMin) ? `${m.periodMin.toFixed(1)} min` : "—"}</td>
+                  </tr>
+                  {isOpen && (
+                    <tr className="tn-sat-drill">
+                      <td colSpan={5}><SatelliteDetail object={o} /></td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {filtered.length > TABLE_CAP && (
+        <p className="tn-w-empty">Showing the first {TABLE_CAP} of {filtered.length} — refine with the search or category chips above.</p>
+      )}
+    </div>
+  );
+}

--- a/lib/console/widgets/satellites.detail.tsx
+++ b/lib/console/widgets/satellites.detail.tsx
@@ -21,6 +21,7 @@ import { Chart, type ChartPoint } from "@/components/Chart";
 import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
 import SatelliteDetail from "@/components/SatelliteDetail";
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
 
 // The satellite meta the propagation hook attaches (see lib/satellites/useSatellites).
 // meta is Record<string, unknown> on WorldObject, so we narrow it here.
@@ -155,6 +156,28 @@ export default function SatellitesDetail(props: WidgetDetailProps) {
   const sortMark = (k: SatSortKey) => (sortKey === k ? (dir === 1 ? " ↑" : " ↓") : "");
 
   const liveAlt = selMeta.altKm ?? sel?.altKm ?? 0;
+
+  // Export the FILTERED roster (what's on screen) as CSV, and the current sub-points
+  // of the filtered set as GeoJSON.
+  const exportRows = useMemo(
+    () => filtered.map((o) => {
+      const m = metaOf(o);
+      return {
+        name: o.label,
+        norad: m.noradId ?? "",
+        category: o.typeLabel ?? "",
+        altKm: typeof o.altKm === "number" ? Number(o.altKm.toFixed(1)) : "",
+        periodMin: m.periodMin && Number.isFinite(m.periodMin) ? Number(m.periodMin.toFixed(1)) : "",
+        lat: Number(o.lat.toFixed(4)),
+        lon: Number(o.lon.toFixed(4)),
+      };
+    }),
+    [filtered],
+  );
+  const exportGeo = useMemo(
+    () => filtered.map((o) => ({ lat: o.lat, lon: o.lon, properties: { name: o.label, norad: metaOf(o).noradId } })),
+    [filtered],
+  );
 
   return (
     <div className="tn-sat">
@@ -305,6 +328,22 @@ export default function SatellitesDetail(props: WidgetDetailProps) {
       {filtered.length > TABLE_CAP && (
         <p className="tn-w-empty">Showing the first {TABLE_CAP} of {filtered.length} — refine with the search or category chips above.</p>
       )}
+
+      <footer className="tn-sat-foot">
+        <span className="tn-sat-attr">
+          TLEs: CelesTrak · propagation: SGP4 (satellite.js) · imagery: NASA GIBS + Esri World Imagery
+        </span>
+        <span className="tn-sat-actions">
+          <button
+            disabled={exportRows.length === 0}
+            onClick={() => downloadText(`${exportFilename("satellites", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+          >⬇ CSV</button>
+          <button
+            disabled={exportGeo.length === 0}
+            onClick={() => downloadText(`${exportFilename("satellites", Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}
+          >⬇ GeoJSON</button>
+        </span>
+      </footer>
     </div>
   );
 }

--- a/lib/console/widgets/satellites.detail.tsx
+++ b/lib/console/widgets/satellites.detail.tsx
@@ -37,8 +37,9 @@ interface SatMeta {
 }
 const metaOf = (o: WorldObject | undefined): SatMeta => (o?.meta ?? {}) as SatMeta;
 
-// NASA's official YouTube channel — the live_stream embed form resolves to whatever
-// the channel is broadcasting (the ISS onboard/external HD cameras), keyless.
+// NASA's official (main) YouTube channel — the live_stream embed resolves to whatever
+// that channel is currently broadcasting: the ISS HD cameras when they're live, other
+// NASA programming otherwise. Keyless. The caption is honest about this (not ISS-only).
 const NASA_CHANNEL = "UCLA_DiR1FfKNvjuUpBHmylQ";
 const ISS_NORAD = "25544";
 
@@ -256,6 +257,11 @@ export default function SatellitesDetail(props: WidgetDetailProps) {
                 src={gibsUrl}
                 alt={`NASA true-color imagery of the region beneath ${sel.label}`}
                 loading="lazy"
+                // Gracefully hide a failed/unavailable NASA tile (outage/404) instead of the
+                // browser's broken-image glyph; self-heals when the sub-point crosses to a
+                // new (working) tile and the src changes.
+                onError={(e) => { e.currentTarget.style.display = "none"; }}
+                onLoad={(e) => { e.currentTarget.style.display = ""; }}
               />
               <figcaption className="tn-sat-cap">
                 NASA GIBS true-color · {gibsWhen} · region beneath the sub-point (not a live satellite photo)
@@ -270,12 +276,12 @@ export default function SatellitesDetail(props: WidgetDetailProps) {
                 <iframe
                   className="tn-sat-live-frame"
                   src={`https://www.youtube.com/embed/live_stream?channel=${NASA_CHANNEL}`}
-                  title="NASA live — ISS onboard/external cameras"
+                  title="NASA live channel"
                   allow="encrypted-media; picture-in-picture"
                   allowFullScreen
                 />
                 <p className="tn-sat-cap">
-                  NASA live stream (ISS onboard/external cameras) — a real feed from the station when NASA is broadcasting.
+                  NASA&apos;s live channel — carries the ISS HD cameras when NASA is broadcasting them (other NASA programming otherwise).
                 </p>
               </div>
             ) : (

--- a/lib/console/widgets/satellites.tsx
+++ b/lib/console/widgets/satellites.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from "react";
 import { useSatellites } from "@/lib/satellites/useSatellites";
 import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
+import SatellitesDetail from "./satellites.detail";
 
 function SatellitesBody({ config }: WidgetBodyProps) {
   const group = (config.group as string) ?? "visual";
@@ -48,5 +49,7 @@ export const SATELLITES_WIDGET = {
   defaultHeight: 280,
   defaultConfig: { group: "visual" },
   component: SatellitesBody,
+  detail: SatellitesDetail,
+  capabilities: { filter: true, sort: true },
 };
 registerWidget(SATELLITES_WIDGET);

--- a/lib/markets/chart.ts
+++ b/lib/markets/chart.ts
@@ -1,0 +1,57 @@
+// Pure parsing/derivation for the Markets focus charts. The chart ROUTE fetches
+// keyless Yahoo v8 OHLC; this module turns that JSON into candles + the derived
+// figures the UI shows (period change, hi/lo), and projects candles to Chart points.
+// Pure + isomorphic so it unit-tests against a captured fixture.
+
+export type Range = "1mo" | "6mo" | "1y";
+export const RANGES: Range[] = ["1mo", "6mo", "1y"];
+
+export interface Candle { t: number; o: number; h: number; l: number; c: number; v: number }
+
+interface YahooQuote { open?: (number | null)[]; high?: (number | null)[]; low?: (number | null)[]; close?: (number | null)[]; volume?: (number | null)[] }
+interface YahooResult { timestamp?: number[]; indicators?: { quote?: YahooQuote[] } }
+export interface YahooChartResponse { chart?: { result?: YahooResult[] | null; error?: unknown } }
+
+/** Pure: Yahoo v8 chart JSON → candles (drops rows with a null close). t is epoch ms. */
+export function parseYahooSeries(json: YahooChartResponse | null | undefined): Candle[] {
+  const r = json?.chart?.result?.[0];
+  const ts = r?.timestamp ?? [];
+  const q = r?.indicators?.quote?.[0] ?? {};
+  const out: Candle[] = [];
+  for (let i = 0; i < ts.length; i++) {
+    const c = q.close?.[i];
+    if (typeof c !== "number" || !Number.isFinite(c)) continue; // holidays / gaps
+    const o = q.open?.[i], h = q.high?.[i], l = q.low?.[i], v = q.volume?.[i];
+    out.push({
+      t: ts[i] * 1000,
+      o: typeof o === "number" ? o : c,
+      h: typeof h === "number" ? h : c,
+      l: typeof l === "number" ? l : c,
+      c,
+      v: typeof v === "number" ? v : 0,
+    });
+  }
+  return out;
+}
+
+export interface ChartPointLite { x: number; y: number }
+/** Close-price line points (the default "actual graph"). */
+export function candlesToPoints(candles: Candle[]): ChartPointLite[] {
+  return candles.map((k) => ({ x: k.t, y: k.c }));
+}
+
+/** Absolute + percent change from first to last close; zeros on <2 candles. */
+export function periodChange(candles: Candle[]): { abs: number; pct: number } {
+  if (candles.length < 2) return { abs: 0, pct: 0 };
+  const first = candles[0].c, last = candles[candles.length - 1].c;
+  const abs = last - first;
+  return { abs, pct: first !== 0 ? (abs / first) * 100 : 0 };
+}
+
+/** Min low / max high across the range (the "52-week" hi/lo when range=1y). */
+export function hiLo(candles: Candle[]): { hi: number; lo: number } | null {
+  if (candles.length === 0) return null;
+  let hi = -Infinity, lo = Infinity;
+  for (const k of candles) { if (k.h > hi) hi = k.h; if (k.l < lo) lo = k.l; }
+  return { hi, lo };
+}

--- a/lib/satellites/elements.ts
+++ b/lib/satellites/elements.ts
@@ -1,0 +1,37 @@
+// Pure TLE (two-line element) parsing → the orbital vitals the console shows.
+// Fixed-column format (1-indexed cols per the NORAD spec); eccentricity has an
+// implied leading decimal. Derived apogee/perigee from mean motion + eccentricity.
+export interface OrbitalElements {
+  inclinationDeg: number;
+  raanDeg: number;          // right ascension of the ascending node
+  eccentricity: number;
+  argPerigeeDeg: number;
+  meanAnomalyDeg: number;
+  meanMotionRevPerDay: number;
+  periodMin: number;
+  semiMajorAxisKm: number;
+  apogeeKm: number;         // above Earth's surface
+  perigeeKm: number;
+}
+
+const GM_EARTH = 398600.4418; // km^3 / s^2
+const R_EARTH = 6378.137;     // km (equatorial)
+
+function n(s: string): number { const v = Number(s.trim()); return Number.isFinite(v) ? v : 0; }
+
+/** Parse TLE line 2 into orbital elements (line 1 gives epoch/drag, not needed here). */
+export function parseElements(line1: string, line2: string): OrbitalElements | null {
+  if (!line2 || line2.length < 63 || line2[0] !== "2") return null;
+  const inclinationDeg = n(line2.slice(8, 16));
+  const raanDeg = n(line2.slice(17, 25));
+  const eccentricity = n(`0.${line2.slice(26, 33).trim()}`); // implied leading "0."
+  const argPerigeeDeg = n(line2.slice(34, 42));
+  const meanAnomalyDeg = n(line2.slice(43, 51));
+  const meanMotionRevPerDay = n(line2.slice(52, 63));
+  const periodMin = meanMotionRevPerDay > 0 ? 1440 / meanMotionRevPerDay : 0;
+  const nRadPerSec = (meanMotionRevPerDay * 2 * Math.PI) / 86400;
+  const semiMajorAxisKm = nRadPerSec > 0 ? Math.cbrt(GM_EARTH / (nRadPerSec * nRadPerSec)) : 0;
+  const apogeeKm = semiMajorAxisKm * (1 + eccentricity) - R_EARTH;
+  const perigeeKm = semiMajorAxisKm * (1 - eccentricity) - R_EARTH;
+  return { inclinationDeg, raanDeg, eccentricity, argPerigeeDeg, meanAnomalyDeg, meanMotionRevPerDay, periodMin, semiMajorAxisKm, apogeeKm, perigeeKm };
+}

--- a/lib/satellites/groundTrack.ts
+++ b/lib/satellites/groundTrack.ts
@@ -1,0 +1,48 @@
+// Ground-track sampling for the satellites focus view. Two pure-ish pieces:
+//  1. splitAntimeridian — pure geometry, unit-tested below.
+//  2. groundTrack — reuses lib/satellites/propagate.ts (buildSatrec + propagateAt,
+//     the SAME SGP4 path the globe/API use) to sample ±½ period of sub-points.
+//     Dormant-safe: ANY propagation error (or a non-finite period) yields [].
+import { buildSatrec, propagateAt } from "@/lib/satellites/propagate";
+
+// Pure: split a sequence of [lon, lat] points into segments wherever consecutive
+// longitudes jump more than 180° (an antimeridian crossing), so a polyline renderer
+// draws separate strokes instead of one horizontal streak across the whole map.
+export function splitAntimeridian(points: [number, number][]): [number, number][][] {
+  const segs: [number, number][][] = [];
+  let cur: [number, number][] = [];
+  for (let i = 0; i < points.length; i++) {
+    if (i > 0 && Math.abs(points[i][0] - points[i - 1][0]) > 180) { segs.push(cur); cur = []; }
+    cur.push(points[i]);
+  }
+  if (cur.length) segs.push(cur);
+  return segs;
+}
+
+/**
+ * Sample a satellite's ground track across ±½ orbit centred on `atMs`, split at
+ * the antimeridian. Returns [] on any propagation error or a non-finite period
+ * (dormant-safe — a decayed/garbage TLE must never throw into the render tree).
+ */
+export function groundTrack(
+  line1: string,
+  line2: string,
+  atMs: number,
+  periodMin: number,
+  stepSec = 60,
+): [number, number][][] {
+  try {
+    if (!Number.isFinite(periodMin) || periodMin <= 0) return [];
+    const satrec = buildSatrec(line1, line2);
+    const halfMs = (periodMin * 60_000) / 2;
+    const stepMs = stepSec * 1000;
+    const points: [number, number][] = [];
+    for (let t = atMs - halfMs; t <= atMs + halfMs; t += stepMs) {
+      const sp = propagateAt(satrec, new Date(t));
+      if (sp) points.push([sp.lon, sp.lat]);
+    }
+    return splitAntimeridian(points);
+  } catch {
+    return [];
+  }
+}

--- a/lib/sources/gibs.ts
+++ b/lib/sources/gibs.ts
@@ -1,0 +1,31 @@
+// NASA GIBS keyless true-color imagery. We show the tile covering a satellite's
+// sub-point for a date (default: yesterday UTC, which has full global coverage).
+// Web-Mercator (EPSG:3857) slippy tiles — the same z/x/y scheme MapLibre/OSM use.
+const LAYER = "MODIS_Terra_CorrectedReflectance_TrueColor";
+const MATRIX = "GoogleMapsCompatible_Level9";
+
+// Web-Mercator is only defined up to ~±85.0511°; the log() below returns NaN past
+// the poles, so clamp latitude into the valid band before projecting.
+const MERCATOR_MAX_LAT = 85.05112878;
+
+/** lon/lat + zoom → slippy tile {x,y} (Web-Mercator). */
+export function lonLatToTile(lon: number, lat: number, z: number): { x: number; y: number } {
+  const nTiles = 2 ** z;
+  const latC = Math.max(-MERCATOR_MAX_LAT, Math.min(MERCATOR_MAX_LAT, lat));
+  const x = Math.floor(((lon + 180) / 360) * nTiles);
+  const latRad = (latC * Math.PI) / 180;
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * nTiles);
+  const clamp = (v: number) => Math.max(0, Math.min(nTiles - 1, Number.isFinite(v) ? v : 0));
+  return { x: clamp(x), y: clamp(y) };
+}
+
+/** UTC yesterday as YYYY-MM-DD (GIBS lags ~1 day; yesterday is reliably covered). */
+export function gibsDate(nowMs: number): string {
+  return new Date(nowMs - 24 * 3600_000).toISOString().slice(0, 10);
+}
+
+/** A keyless GIBS true-color tile URL covering (lat, lon) at zoom `z` for a date. */
+export function gibsTileUrl(lat: number, lon: number, z: number, date: string): string {
+  const { x, y } = lonLatToTile(lon, lat, z);
+  return `https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/${LAYER}/default/${date}/${MATRIX}/${z}/${y}/${x}.jpg`;
+}

--- a/tests/unit/console-news-providers.test.ts
+++ b/tests/unit/console-news-providers.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed } from "@/lib/console/news/providers";
+import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed, providerThumb } from "@/lib/console/news/providers";
 
 test("seeds at least 10 free providers with valid kinds", () => {
   expect(NEWS_PROVIDERS.length).toBeGreaterThanOrEqual(10);
@@ -30,4 +30,10 @@ test("resolveEmbed rejects a non-http(s) hls ref", () => {
   const e = resolveEmbed({ id: "x", name: "X", category: "Custom", kind: "hls", ref: "javascript:alert(1)" });
   expect(e.kind).toBe("hls");
   expect(e.src).toBeFalsy();
+});
+
+test("providerThumb returns a keyless YouTube thumb for youtube, null for hls", () => {
+  expect(providerThumb({ id: "x", name: "X", category: "World", kind: "youtube", ref: "abc12345678" }))
+    .toBe("https://img.youtube.com/vi/abc12345678/hqdefault.jpg");
+  expect(providerThumb({ id: "y", name: "Y", category: "World", kind: "hls", ref: "https://h/s.m3u8" })).toBeNull();
 });

--- a/tests/unit/gibs.test.ts
+++ b/tests/unit/gibs.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { lonLatToTile, gibsTileUrl, gibsDate } from "@/lib/sources/gibs";
+
+describe("gibs tile math", () => {
+  it("maps (0,0) to the centre tile at each zoom", () => {
+    expect(lonLatToTile(0, 0, 1)).toEqual({ x: 1, y: 1 });
+    expect(lonLatToTile(-180, 85, 2)).toEqual({ x: 0, y: 0 });
+  });
+  it("clamps out-of-range into valid tile indices", () => {
+    const t = lonLatToTile(200, -95, 1); // beyond bounds
+    expect(t.x).toBeGreaterThanOrEqual(0); expect(t.x).toBeLessThanOrEqual(1);
+    expect(t.y).toBeGreaterThanOrEqual(0); expect(t.y).toBeLessThanOrEqual(1);
+  });
+  it("builds a keyless GIBS URL for a sub-point", () => {
+    const url = gibsTileUrl(51.5, -0.1, 3, "2026-07-07");
+    expect(url).toContain("gibs.earthdata.nasa.gov");
+    expect(url).toContain("/2026-07-07/");
+    expect(url).toMatch(/\/3\/\d+\/\d+\.jpg$/);
+  });
+  it("gibsDate is UTC yesterday", () => {
+    expect(gibsDate(Date.parse("2026-07-08T00:00:00Z"))).toBe("2026-07-07");
+  });
+});

--- a/tests/unit/ground-track.test.ts
+++ b/tests/unit/ground-track.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { splitAntimeridian } from "@/lib/satellites/groundTrack";
+
+describe("splitAntimeridian", () => {
+  it("splits at a dateline crossing", () => {
+    const segs = splitAntimeridian([[170, 0], [179, 0], [-179, 0], [-170, 0]]);
+    expect(segs.length).toBe(2);
+    expect(segs[0].length).toBe(2);
+    expect(segs[1].length).toBe(2);
+  });
+  it("keeps a non-crossing track as one segment", () => {
+    expect(splitAntimeridian([[0, 0], [10, 5], [20, 10]]).length).toBe(1);
+  });
+});

--- a/tests/unit/markets-series.test.ts
+++ b/tests/unit/markets-series.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { parseYahooSeries, candlesToPoints, periodChange, hiLo, type YahooChartResponse } from "@/lib/markets/chart";
+
+const json: YahooChartResponse = {
+  chart: { result: [ {
+    timestamp: [1704067200, 1704153600, 1704240000],
+    indicators: { quote: [ { open: [100, 102, null], high: [105, 106, 104], low: [99, 101, 100], close: [102, 104, null], volume: [10, 12, 0] } ] },
+  } ] },
+};
+
+describe("parseYahooSeries", () => {
+  it("zips timestamps + OHLC, drops null-close rows, converts to ms", () => {
+    const c = parseYahooSeries(json);
+    expect(c.length).toBe(2); // third row has null close → dropped
+    expect(c[0]).toEqual({ t: 1704067200000, o: 100, h: 105, l: 99, c: 102, v: 10 });
+  });
+  it("is dormant-safe on missing data", () => {
+    expect(parseYahooSeries(null)).toEqual([]);
+    expect(parseYahooSeries({ chart: { result: null } })).toEqual([]);
+  });
+});
+
+describe("derivations", () => {
+  it("periodChange first→last close", () => {
+    const c = parseYahooSeries(json);
+    expect(periodChange(c).abs).toBe(2); // 104 - 102
+    expect(Math.round(periodChange(c).pct * 100) / 100).toBe(1.96);
+  });
+  it("hiLo spans all candles", () => {
+    expect(hiLo(parseYahooSeries(json))).toEqual({ hi: 106, lo: 99 });
+  });
+  it("candlesToPoints maps close to y", () => {
+    expect(candlesToPoints(parseYahooSeries(json))[0]).toEqual({ x: 1704067200000, y: 102 });
+  });
+});

--- a/tests/unit/satellite-elements.test.ts
+++ b/tests/unit/satellite-elements.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { parseElements } from "@/lib/satellites/elements";
+
+// A real ISS (ZARYA) TLE. Mean motion ~15.5 rev/day → ~92-93 min, LEO ~400-420 km.
+const L1 = "1 25544U 98067A   24001.50000000  .00016717  00000-0  10270-3 0  9005";
+const L2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.50377579  1234";
+
+describe("parseElements", () => {
+  it("parses inclination / eccentricity / mean motion and derives period + apogee/perigee", () => {
+    const e = parseElements(L1, L2)!;
+    expect(e).not.toBeNull();
+    expect(Math.round(e.inclinationDeg * 10) / 10).toBe(51.6);
+    expect(e.eccentricity).toBeCloseTo(0.0006703, 6);
+    expect(Math.round(e.meanMotionRevPerDay)).toBe(16); // ~15.5 → rounds to 16
+    expect(Math.round(e.periodMin)).toBe(93);           // 1440 / 15.50 ≈ 92.9
+    expect(e.perigeeKm).toBeGreaterThan(380);
+    expect(e.apogeeKm).toBeLessThan(430);
+  });
+  it("returns null on a malformed line", () => {
+    expect(parseElements("", "garbage")).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-on to #41. Adds the final three expand-to-stage detail views, completing the 8-view focus-window feature.

## What
- **W6 news-video** — hero player + category channel wall (keyless thumbnails) + live headline rail + optional 2×2 mosaic + add-custom-stream + directory export
- **W7 markets** — historical OHLC chart (keyless Yahoo v8, dormant-safe `/api/markets/chart`) with 1M/6M/1Y tabs + instrument console + movers heat-strip + CSV export
- **W8 satellites** — orbital vitals (pure TLE parse + apogee/perigee) + ±1-period ground track (antimeridian-split) + NASA GIBS true-color sub-point imagery + roster dossier + export

## Shared primitives touched (backward-compatible)
- `components/Chart.tsx` — opt-out `zeroBaseline` so price series auto-fit
- `components/InsetMap.tsx` — optional `track` polyline layer; auto-fit gated on point-set change; load-race refs

## Verification
- Gate: `tsc --noEmit` clean, **599 passed (599)** across 145 files
- Each view adversarially reviewed (3 lenses → verify); all confirmed defects fixed with regression tests

Note: W6–W8 verified via gate + adversarial code review; live browser pass still pending (Playwright MCP dropped mid-run).