### PR TITLE
Console: fix navbar overlap + worldwide aircraft grid (shared store-and-serve cache)

### DIFF
--- a/app/api/planes/route.ts
+++ b/app/api/planes/route.ts
@@ -3,13 +3,14 @@ import { fetchAircraft } from "@/lib/sources/adsb";
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/planes — live aircraft (keyless, from adsb.lol) across the camera
- * regions as classified WorldObjects. fetchAircraft handles caching + failure
- * (serves stale/empty), so this route never throws.
+ * GET /api/planes — live aircraft (keyless, from adsb.lol) across a coarse global
+ * grid as classified WorldObjects. fetchAircraft serves a shared, stored snapshot
+ * (Next Data Cache) and handles failure (empty), so this route never throws and
+ * users never trigger their own upstream pull.
  *
  * Response: { count: number, planes: WorldObject[] }
  */
 export async function GET() {
-  const planes = await fetchAircraft(Date.now());
+  const planes = await fetchAircraft();
   return Response.json({ count: planes.length, planes });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1147,7 +1147,7 @@ a { color: var(--tn-accent); }
 /* ===========================================================================
    ConsoleWorkspace + Segment — Task 7
    =========================================================================== */
-.tn-cw-shell{position:absolute;inset:0;display:flex;min-height:0}
+.tn-cw-shell{position:absolute;inset:var(--tn-topbar-h) 0 0 0;display:flex;min-height:0}
 .tn-cw-col{flex:none;overflow:hidden;display:flex}
 .tn-cw-center{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0}
 .tn-cw-stage{flex:1;position:relative;min-height:0}

--- a/lib/console/widgets/aviation.detail.tsx
+++ b/lib/console/widgets/aviation.detail.tsx
@@ -266,7 +266,7 @@ export default function AviationDetail(_props: WidgetDetailProps) {
       )}
 
       <footer className="tn-av-foot">
-        <span className="tn-av-attr">Aircraft: adsb.lol · enrichment: adsbdb · 3 fixed regions (London / California / S.Carolina)</span>
+        <span className="tn-av-attr">Aircraft: adsb.lol · enrichment: adsbdb · worldwide grid (cached snapshot)</span>
         <span className="tn-av-actions">
           <button
             disabled={exportRows.length === 0}

--- a/lib/planes/ops.ts
+++ b/lib/planes/ops.ts
@@ -3,7 +3,6 @@
 // re-classification or fetch is needed. Unit-tested; the .tsx is a dumb shell.
 import type { WorldObject } from "@/lib/world";
 import type { PlaneCategory } from "@/lib/planes/classify";
-import { ADSB_REGIONS } from "@/lib/sources/adsb";
 
 const CATEGORY_LABEL: Record<PlaneCategory, string> = {
   airliner: "Airliner", regional: "Regional", light: "Light", helicopter: "Helicopter", ground: "Ground",
@@ -53,16 +52,29 @@ export function altitudeBand(o: WorldObject): AltBand {
   return "11+ km";
 }
 
-// Region labels are index-matched to ADSB_REGIONS.
-export const REGION_LABELS = ["London / SE England", "California", "South Carolina"];
-/** Nearest ADS-B query region (the regions are continents apart, so squared-degree distance is enough). */
+// Coarse continent buckets for the region filter/column. Derived purely from
+// lat/lon — the aircraft grid is now worldwide, so "region" means the continent a
+// flight is over, independent of which harvest cells fetched it.
+export const REGION_LABELS = [
+  "North America", "South America", "Europe", "Middle East", "Africa", "Asia", "Oceania",
+];
+// Ordered bounding boxes; the first box that contains the point wins, so overlaps
+// (Europe/Middle East/Africa around the Mediterranean) resolve by this priority.
+const CONTINENT_BOXES: { label: string; latMin: number; latMax: number; lonMin: number; lonMax: number }[] = [
+  { label: "North America", latMin: 7, latMax: 84, lonMin: -170, lonMax: -50 },
+  { label: "South America", latMin: -56, latMax: 13, lonMin: -82, lonMax: -34 },
+  { label: "Europe", latMin: 36, latMax: 72, lonMin: -25, lonMax: 40 },
+  { label: "Middle East", latMin: 12, latMax: 42, lonMin: 34, lonMax: 63 },
+  { label: "Africa", latMin: -35, latMax: 37, lonMin: -18, lonMax: 52 },
+  { label: "Asia", latMin: 5, latMax: 78, lonMin: 40, lonMax: 180 },
+  { label: "Oceania", latMin: -50, latMax: 0, lonMin: 110, lonMax: 180 },
+];
+/** Coarse continent for a coordinate (first matching box), or "—" if unclassified. */
 export function regionOf(lat: number, lon: number): string {
-  let best = -1, bestD = Infinity;
-  ADSB_REGIONS.forEach((r, i) => {
-    const d = (lat - r.lat) ** 2 + (lon - r.lon) ** 2;
-    if (d < bestD) { bestD = d; best = i; }
-  });
-  return best >= 0 ? (REGION_LABELS[best] ?? `Region ${best + 1}`) : "—";
+  for (const b of CONTINENT_BOXES) {
+    if (lat >= b.latMin && lat <= b.latMax && lon >= b.lonMin && lon <= b.lonMax) return b.label;
+  }
+  return "—";
 }
 
 export type FlightSortKey = "altitude" | "speed" | "callsign" | "region";

--- a/lib/sources/adsb.ts
+++ b/lib/sources/adsb.ts
@@ -3,8 +3,17 @@
 // continuous polling (429s). adsb.lol also broadcasts the ADS-B emitter
 // `category` + type code, so planes are classified accurately (not guessed).
 //
-// We query a few point+radius regions (matching the camera regions) and merge
-// them, so planes appear wherever a viewer flies.
+// COVERAGE: adsb.lol's endpoint is point+radius (max 250 nm), with no global
+// query. We sweep a coarse worldwide grid of ~25 busy-airspace centres and merge
+// the results, so cross-border / intercontinental flights show up. (Mid-ocean is
+// inherently sparse — these are ground-receiver feeds, not satellite ADS-B.)
+//
+// STORE-AND-SERVE: the whole sweep runs inside Next's Data Cache
+// (`unstable_cache`), a store shared across every serverless instance. Upstream is
+// therefore hit at most once per REVALIDATE_S for the ENTIRE deployment, and every
+// visitor is served the same stored snapshot rather than triggering their own
+// live pull. The result is capped (MAX_AIRCRAFT) so the cached entry stays under
+// the Data Cache 2 MB limit and the client payload stays reasonable.
 
 import type { WorldObject } from "@/lib/world";
 import { classifyPlane, ADSB_CATEGORY } from "@/lib/planes/classify";
@@ -16,12 +25,44 @@ export interface AdsbRegion {
   distNm: number;
 }
 
-// Centred on the camera regions. Radii kept moderate so dense airspace stays
-// legible (individual planes + trails readable) rather than blobbing together.
-export const ADSB_REGIONS: AdsbRegion[] = [
-  { lat: 51.5, lon: -0.12, distNm: 90 }, // London / SE England
-  { lat: 36.8, lon: -119.7, distNm: 160 }, // California
-  { lat: 33.9, lon: -80.9, distNm: 140 }, // South Carolina
+// A coarse worldwide grid of busy-airspace centres, each a 250 nm (adsb.lol max)
+// point+radius query. Kept to ~25 cells so one sweep is ~25 upstream calls total —
+// shared across all users via the Data Cache below, not per visitor. Overlaps are
+// deduped by hex; "region" chips in the UI are derived from lat/lon, not these.
+const NM = 250;
+export const ADSB_GRID: AdsbRegion[] = [
+  // North America
+  { lat: 34.0, lon: -118.2, distNm: NM }, // Los Angeles
+  { lat: 39.7, lon: -104.9, distNm: NM }, // Denver
+  { lat: 41.9, lon: -87.9, distNm: NM }, // Chicago
+  { lat: 40.7, lon: -74.0, distNm: NM }, // New York
+  { lat: 25.8, lon: -80.3, distNm: NM }, // Miami
+  { lat: 19.4, lon: -99.1, distNm: NM }, // Mexico City
+  // South America
+  { lat: 4.7, lon: -74.1, distNm: NM }, // Bogotá
+  { lat: -23.5, lon: -46.6, distNm: NM }, // São Paulo
+  { lat: -34.6, lon: -58.4, distNm: NM }, // Buenos Aires
+  // Europe
+  { lat: 51.5, lon: -0.1, distNm: NM }, // London
+  { lat: 50.0, lon: 8.6, distNm: NM }, // Frankfurt
+  { lat: 40.4, lon: -3.7, distNm: NM }, // Madrid
+  { lat: 41.0, lon: 28.9, distNm: NM }, // Istanbul
+  { lat: 55.7, lon: 37.6, distNm: NM }, // Moscow
+  // Middle East
+  { lat: 25.2, lon: 55.3, distNm: NM }, // Dubai
+  // Africa
+  { lat: 30.0, lon: 31.2, distNm: NM }, // Cairo
+  { lat: 6.5, lon: 3.4, distNm: NM }, // Lagos
+  { lat: -26.2, lon: 28.0, distNm: NM }, // Johannesburg
+  // Asia
+  { lat: 28.6, lon: 77.2, distNm: NM }, // Delhi
+  { lat: 13.7, lon: 100.5, distNm: NM }, // Bangkok
+  { lat: 1.35, lon: 103.8, distNm: NM }, // Singapore
+  { lat: 22.3, lon: 114.2, distNm: NM }, // Hong Kong
+  { lat: 31.2, lon: 121.5, distNm: NM }, // Shanghai
+  { lat: 35.6, lon: 139.8, distNm: NM }, // Tokyo
+  // Oceania
+  { lat: -33.9, lon: 151.2, distNm: NM }, // Sydney
 ];
 
 export interface Aircraft {
@@ -138,9 +179,15 @@ export function aircraftToWorldObject(a: Aircraft): WorldObject {
   };
 }
 
-// Short server-side cache so rapid client polls don't hammer adsb.lol.
-const CACHE_TTL_MS = 8_000;
-let cache: { objects: WorldObject[]; at: number } | null = null;
+// How long a stored global sweep is served before the next visitor triggers a
+// refresh. Planes move, but ~25 s staleness is invisible on a world map and keeps
+// upstream load predictable regardless of traffic.
+const REVALIDATE_S = 25;
+// Cap the served set so the cached entry stays under the Data Cache's 2 MB limit
+// and the client payload stays reasonable. Airborne aircraft are kept before ground.
+export const MAX_AIRCRAFT = 3000;
+// Grid cells fetched at once — friendly to the community API, no 25-request herd.
+const CONCURRENCY = 6;
 
 async function fetchRegion(r: AdsbRegion): Promise<RawAircraft[]> {
   const url = `https://api.adsb.lol/v2/lat/${r.lat}/lon/${r.lon}/dist/${r.distNm}`;
@@ -153,25 +200,53 @@ async function fetchRegion(r: AdsbRegion): Promise<RawAircraft[]> {
   return json.ac ?? json.aircraft ?? [];
 }
 
-/**
- * Live aircraft across all regions as WorldObjects, deduped by hex, with an
- * 8 s cache. Returns the stale cache (or empty) if every region fails.
- */
-export async function fetchAircraft(nowMs: number): Promise<WorldObject[]> {
-  if (cache && nowMs - cache.at < CACHE_TTL_MS) return cache.objects;
-
-  const results = await Promise.allSettled(ADSB_REGIONS.map(fetchRegion));
-  const rows = results
-    .filter((r): r is PromiseFulfilledResult<RawAircraft[]> => r.status === "fulfilled")
-    .flatMap((r) => r.value);
-
-  if (rows.length === 0 && results.every((r) => r.status === "rejected")) {
-    return cache?.objects ?? [];
+/** Keep at most `cap` aircraft, preferring airborne over ground. Pure/testable. */
+export function capAircraft(objects: WorldObject[], cap: number): WorldObject[] {
+  if (objects.length <= cap) return objects;
+  const airborne: WorldObject[] = [];
+  const ground: WorldObject[] = [];
+  for (const o of objects) {
+    ((o.meta as { onGround?: boolean } | undefined)?.onGround ? ground : airborne).push(o);
   }
+  return [...airborne, ...ground].slice(0, cap);
+}
+
+/**
+ * Sweep the whole grid (batched by CONCURRENCY), dedupe by hex, and cap. Throws
+ * only if EVERY cell fails — that way the Data Cache keeps serving the last good
+ * snapshot instead of overwriting it with an empty one.
+ */
+async function pullAircraft(): Promise<WorldObject[]> {
+  const rows: RawAircraft[] = [];
+  let ok = 0;
+  for (let i = 0; i < ADSB_GRID.length; i += CONCURRENCY) {
+    const settled = await Promise.allSettled(ADSB_GRID.slice(i, i + CONCURRENCY).map(fetchRegion));
+    for (const s of settled) {
+      if (s.status === "fulfilled") {
+        ok++;
+        rows.push(...s.value);
+      }
+    }
+  }
+  if (ok === 0) throw new Error("all adsb.lol grid cells failed");
 
   const byHex = new Map<string, Aircraft>();
-  for (const a of parseAdsb(rows)) byHex.set(a.hex, a); // dedupe overlapping regions
+  for (const a of parseAdsb(rows)) byHex.set(a.hex, a); // dedupe overlapping cells
   const objects = [...byHex.values()].map(aircraftToWorldObject);
-  cache = { objects, at: nowMs };
-  return objects;
+  return capAircraft(objects, MAX_AIRCRAFT);
+}
+
+/**
+ * Live aircraft worldwide as WorldObjects. The sweep is wrapped in Next's Data
+ * Cache, so upstream is polled at most once per REVALIDATE_S for the whole
+ * deployment and every visitor is served the shared stored snapshot. Returns []
+ * only on a cold total failure (or outside the Next runtime, e.g. unit tests).
+ */
+export async function fetchAircraft(): Promise<WorldObject[]> {
+  try {
+    const { unstable_cache } = await import("next/cache");
+    return await unstable_cache(pullAircraft, ["aircraft-global-v1"], { revalidate: REVALIDATE_S })();
+  } catch {
+    return [];
+  }
 }

--- a/tests/unit/adsb-grid.test.ts
+++ b/tests/unit/adsb-grid.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { ADSB_GRID, capAircraft } from "@/lib/sources/adsb";
+import type { WorldObject } from "@/lib/world";
+
+describe("ADSB_GRID", () => {
+  it("is a coarse worldwide grid within adsb.lol's point+radius limits", () => {
+    expect(ADSB_GRID.length).toBeGreaterThanOrEqual(20);
+    for (const c of ADSB_GRID) {
+      expect(c.distNm).toBeLessThanOrEqual(250); // adsb.lol max radius
+      expect(c.lat).toBeGreaterThanOrEqual(-90);
+      expect(c.lat).toBeLessThanOrEqual(90);
+      expect(c.lon).toBeGreaterThanOrEqual(-180);
+      expect(c.lon).toBeLessThanOrEqual(180);
+    }
+  });
+
+  it("spans multiple continents (not clustered in one hemisphere)", () => {
+    expect(ADSB_GRID.some((c) => c.lon < -50)).toBe(true); // Americas
+    expect(ADSB_GRID.some((c) => c.lon > 90)).toBe(true); // Asia/Oceania
+    expect(ADSB_GRID.some((c) => c.lat < 0)).toBe(true); // southern hemisphere
+  });
+});
+
+describe("capAircraft", () => {
+  const mk = (id: string, onGround: boolean): WorldObject =>
+    ({ kind: "plane", id, lat: 0, lon: 0, label: id, meta: { onGround } } as unknown as WorldObject);
+
+  it("returns everything when under the cap", () => {
+    const objs = [mk("a", false), mk("b", true)];
+    expect(capAircraft(objs, 10)).toHaveLength(2);
+  });
+
+  it("caps to the limit and drops ground aircraft before airborne", () => {
+    const objs = [mk("g1", true), mk("a1", false), mk("a2", false), mk("g2", true)];
+    const out = capAircraft(objs, 2);
+    expect(out).toHaveLength(2);
+    expect(out.every((o) => (o.meta as { onGround?: boolean }).onGround === false)).toBe(true);
+  });
+});

--- a/tests/unit/planes-ops.test.ts
+++ b/tests/unit/planes-ops.test.ts
@@ -28,9 +28,13 @@ describe("altitudeBand", () => {
 });
 
 describe("regionOf", () => {
-  it("maps coords to the nearest ADS-B region label", () => {
-    expect(regionOf(51.5, -0.1)).toBe("London / SE England");
-    expect(regionOf(37, -120)).toBe("California");
+  it("maps coords to a coarse continent bucket", () => {
+    expect(regionOf(51.5, -0.1)).toBe("Europe"); // London
+    expect(regionOf(37, -120)).toBe("North America"); // California
+    expect(regionOf(35.6, 139.8)).toBe("Asia"); // Tokyo
+    expect(regionOf(-33.9, 151.2)).toBe("Oceania"); // Sydney
+    expect(regionOf(25.2, 55.3)).toBe("Middle East"); // Dubai
+    expect(regionOf(-23.5, -46.6)).toBe("South America"); // São Paulo
   });
 });
 


### PR DESCRIPTION
Two independent console fixes.

## 1. Navbar overlapping widgets
The workspace (`.tn-cw-shell`) was pinned `inset:0`, starting at y=0 *under* the `position:fixed` topbar, so the top row of widgets had their title bars hidden behind the navbar. Offset the top by the existing `--tn-topbar-h` variable.

## 2. Airspace: worldwide grid + store-and-serve
Coverage was **3 fixed point-radius circles** (London/California/S.Carolina) — so only aircraft over those three spots ever appeared; cross-border/intercontinental flights were never fetched. Now a coarse **~25-cell worldwide grid** over busy-airspace centres (still adsb.lol's 250nm point+radius, deduped by hex).

**Store-and-serve:** the whole sweep runs inside Next's **Data Cache** (`unstable_cache`) — a store shared across every serverless instance. Upstream is hit **at most once per 25s for the entire deployment**; every visitor is served the same stored snapshot instead of triggering their own live pull. Served set capped at 3000 (airborne first) to stay under the Data Cache 2MB limit and keep the client payload sane. Region filter/column now derives a coarse continent from lat/lon.

## Verify
- Gate: `tsc --noEmit` clean, **589 passed (142 files)**
- New tests: worldwide-grid validity + `capAircraft` priority; continent-bucket `regionOf`