### PR TITLE
⌘K palette: organised, grouped command sections

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -306,6 +306,11 @@ a { color: var(--tn-accent); }
 }
 .tn-palette-input::placeholder { color: var(--tn-text-faint); }
 .tn-palette-list { list-style: none; margin: 0; padding: 6px; max-height: 46vh; overflow: auto; }
+.tn-palette-group {
+  padding: 10px 11px 4px; font-size: 10px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.09em; color: var(--tn-text-muted); pointer-events: none;
+}
+.tn-palette-group:first-child { padding-top: 4px; }
 .tn-palette-item { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 11px; border-radius: 9px; cursor: pointer; font-size: 13.5px; color: var(--tn-text); }
 .tn-palette-item.is-active { background: var(--tn-accent-soft); color: var(--tn-accent-strong); }
 .tn-palette-hint { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--tn-text-faint); }

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -3,7 +3,7 @@
 // keyboard-first way to compose the view: toggle a layer, apply a preset, switch
 // basemap, or fly to a covered region. Open/close is owned by ConsoleShell.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { layersStore, LAYER_PRESETS, ACTIVE_LAYERS, type LayerKey } from "@/lib/layers";
 import { mapViewStore } from "@/lib/mapView";
 import { BASEMAPS, type BasemapKey } from "@/lib/basemaps";
@@ -12,19 +12,18 @@ import { cinematic } from "@/lib/cinematic/store";
 import { pickLiveCamera } from "@/lib/cinematic/livePick";
 import { loadedCamerasStore } from "@/lib/cameras/loaded";
 import "@/lib/console/widgets";
-import { widgetsByCategory } from "@/lib/console/registry";
+import { widgetsByCategory, getWidgetType } from "@/lib/console/registry";
 import { shellLayoutStore } from "@/lib/console/store";
 import type { StageId } from "@/lib/console/types";
 import { listPresets, applyPreset, saveCustomPreset } from "@/lib/console/presets";
 import { encodeLayout } from "@/lib/console/share";
+import { uiStore } from "@/lib/shell/ui";
+import { langStore } from "@/lib/i18n/store";
+import { LANGS } from "@/lib/i18n/catalog";
+import { variantStore } from "@/lib/variants/store";
+import { BUILTIN_VARIANTS } from "@/lib/variants/builtins";
+import { groupCommands, GROUP_ORDER, type Command } from "@/lib/console/paletteGroups";
 import type { GeocodeResult } from "@/lib/geo/geocode";
-
-interface Command {
-  id: string;
-  label: string;
-  hint: string;
-  run: () => void;
-}
 
 // Pick a fly-to zoom from a geocode result's extent (wider areas frame out).
 function zoomForResult(r: GeocodeResult): number {
@@ -55,11 +54,13 @@ function alertCapacity() {
 function buildCommands(close: () => void): Command[] {
   const cmds: Command[] = [];
 
+  // ── Layers: toggles, layer presets, basemaps ────────────────────────────
   for (const k of ACTIVE_LAYERS) {
     cmds.push({
       id: `toggle-${k}`,
       label: `Toggle ${LAYER_NAMES[k]}`,
       hint: "layer",
+      group: "Layers",
       run: () => {
         layersStore.toggle(k);
         close();
@@ -72,6 +73,7 @@ function buildCommands(close: () => void): Command[] {
       id: `preset-${p.id}`,
       label: `Preset: ${p.label}`,
       hint: "preset",
+      group: "Layers",
       run: () => {
         layersStore.applyPreset(p.id);
         close();
@@ -83,7 +85,8 @@ function buildCommands(close: () => void): Command[] {
     cmds.push({
       id: `basemap-${k}`,
       label: `Basemap: ${BASEMAPS[k].label}`,
-      hint: "view",
+      hint: "basemap",
+      group: "Layers",
       run: () => {
         mapViewStore.setBasemap(k);
         close();
@@ -91,6 +94,7 @@ function buildCommands(close: () => void): Command[] {
     });
   }
 
+  // ── Navigate: fly to a covered region, dive to a live feed ──────────────
   for (const r of CAMERA_REGIONS) {
     if (!r.view) continue;
     const view = r.view;
@@ -98,6 +102,7 @@ function buildCommands(close: () => void): Command[] {
       id: `jump-${r.source}`,
       label: `Fly to ${r.label}`,
       hint: "jump",
+      group: "Navigate",
       run: () => {
         mapViewStore.flyTo(view);
         close();
@@ -109,6 +114,7 @@ function buildCommands(close: () => void): Command[] {
     id: "dive-live",
     label: "Dive to a live feed",
     hint: "live",
+    group: "Navigate",
     run: () => {
       const cam = pickLiveCamera(loadedCamerasStore.get());
       if (cam) {
@@ -125,6 +131,7 @@ function buildCommands(close: () => void): Command[] {
     },
   });
 
+  // ── Widgets: add one of each type, or focus an already-open one ─────────
   for (const group of widgetsByCategory()) {
     for (const t of group.types) {
       const openCount = shellLayoutStore.get().widgets.filter((w) => w.type === t.id).length;
@@ -132,17 +139,44 @@ function buildCommands(close: () => void): Command[] {
         id: `add-${t.id}`,
         label: `Add ${t.title}${openCount ? ` (${openCount} open)` : ""}`,
         hint: group.category.toLowerCase(),
+        group: "Widgets",
         run: () => { const r = shellLayoutStore.add(t.id, { config: { ...t.defaultConfig }, height: t.defaultHeight }); if (!r.ok) alertCapacity(); close(); },
       });
     }
   }
 
-  const STAGES: { id: StageId; label: string }[] = [{ id: "map3d", label: "3D map" }, { id: "map2d", label: "2D map" }, { id: "clock", label: "World clock" }];
-  for (const s of STAGES) cmds.push({ id: `stage-${s.id}`, label: `Stage → ${s.label}`, hint: "stage", run: () => { shellLayoutStore.stage(s.id); close(); } });
+  const openWidgets = shellLayoutStore.get().widgets;
+  const typeSeen = new Map<string, number>();
+  for (const w of openWidgets) {
+    const title = getWidgetType(w.type)?.title ?? w.type;
+    const total = openWidgets.filter((x) => x.type === w.type).length;
+    const n = (typeSeen.get(w.type) ?? 0) + 1;
+    typeSeen.set(w.type, n);
+    cmds.push({
+      id: `focus-${w.id}`,
+      label: `Focus ${title}${total > 1 ? ` #${n}` : ""}`,
+      hint: "widget",
+      group: "Widgets",
+      run: () => { shellLayoutStore.focus(w.id); close(); },
+    });
+  }
 
-  for (const p of listPresets()) cmds.push({ id: `cpreset-${p.id}`, label: `Preset: ${p.title}`, hint: "preset", run: () => { applyPreset(p.id); close(); } });
-  cmds.push({ id: "save-preset", label: "Save layout as preset…", hint: "preset", run: () => { const t = window.prompt("Preset name?"); if (t) saveCustomPreset(t); close(); } });
-  cmds.push({ id: "share-layout", label: "Copy shareable link", hint: "share", run: () => { const url = `${location.origin}${location.pathname}?c=${encodeLayout(shellLayoutStore.get())}`; navigator.clipboard?.writeText(url); close(); } });
+  // ── Views: stage, theme, language, scenario (variant) ───────────────────
+  const STAGES: { id: StageId; label: string }[] = [{ id: "map3d", label: "3D map" }, { id: "map2d", label: "2D map" }, { id: "clock", label: "World clock" }];
+  for (const s of STAGES) cmds.push({ id: `stage-${s.id}`, label: `Stage → ${s.label}`, hint: "stage", group: "Views", run: () => { shellLayoutStore.stage(s.id); close(); } });
+
+  cmds.push({ id: "theme-toggle", label: "Toggle light / dark theme", hint: "theme", group: "Views", run: () => { uiStore.toggleTheme(); close(); } });
+
+  for (const l of LANGS) cmds.push({ id: `lang-${l.code}`, label: `Language: ${l.name}`, hint: "language", group: "Views", run: () => { langStore.set(l.code); close(); } });
+
+  for (const v of BUILTIN_VARIANTS) cmds.push({ id: `variant-${v.id}`, label: `Scenario: ${v.title}`, hint: "scenario", group: "Views", run: () => { variantStore.setActive(v.id); close(); } });
+
+  // ── Layouts: console layout presets, save current as preset ─────────────
+  for (const p of listPresets()) cmds.push({ id: `cpreset-${p.id}`, label: `Layout: ${p.title}`, hint: "layout", group: "Layouts", run: () => { applyPreset(p.id); close(); } });
+  cmds.push({ id: "save-preset", label: "Save layout as preset…", hint: "layout", group: "Layouts", run: () => { const t = window.prompt("Preset name?"); if (t) saveCustomPreset(t); close(); } });
+
+  // ── Share: copy a shareable link to the composed view ───────────────────
+  cmds.push({ id: "share-layout", label: "Copy shareable link", hint: "share", group: "Share", run: () => { const url = `${location.origin}${location.pathname}?c=${encodeLayout(shellLayoutStore.get())}`; navigator.clipboard?.writeText(url); close(); } });
 
   return cmds;
 }
@@ -171,17 +205,40 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
     return () => { alive = false; clearTimeout(t); };
   }, [query]);
 
-  const results = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    const base = q ? commands.filter((c) => c.label.toLowerCase().includes(q) || c.hint.includes(q)) : commands;
-    const geoCmds: Command[] = geo.map((r) => ({
-      id: `geo-${r.lat},${r.lon}`,
-      label: `Fly to ${r.name}`,
-      hint: r.type || "place",
-      run: () => { mapViewStore.flyToPoint({ lat: r.lat, lon: r.lon, zoom: zoomForResult(r) }); onClose(); },
-    }));
-    return [...base, ...geoCmds];
-  }, [commands, query, geo, onClose]);
+  // Live place results are the product of the query itself — surface them under
+  // Navigate unfiltered (never re-filtered by the substring), matching the prior
+  // "append to the list" behaviour, just now grouped.
+  const geoCmds = useMemo<Command[]>(() => geo.map((r) => ({
+    id: `geo-${r.lat},${r.lon}`,
+    label: `Fly to ${r.name}`,
+    hint: r.type || "place",
+    group: "Navigate",
+    run: () => { mapViewStore.flyToPoint({ lat: r.lat, lon: r.lon, zoom: zoomForResult(r) }); onClose(); },
+  })), [geo, onClose]);
+
+  // Grouped, query-filtered sections in the fixed GROUP_ORDER; live geocode
+  // results fold into Navigate (added even when the static Navigate group filtered empty).
+  const grouped = useMemo(() => {
+    const base = groupCommands(commands, query);
+    if (geoCmds.length === 0) return base;
+    const byGroup = new Map(base.map((g) => [g.group, g.commands]));
+    byGroup.set("Navigate", [...(byGroup.get("Navigate") ?? []), ...geoCmds]);
+    return GROUP_ORDER
+      .filter((g) => (byGroup.get(g)?.length ?? 0) > 0)
+      .map((g) => ({ group: g, commands: byGroup.get(g)! }));
+  }, [commands, query, geoCmds]);
+
+  // Flattened visual order (groups in fixed order, commands within) — the single
+  // index space the ↑/↓ highlight moves through.
+  const flat = useMemo(() => grouped.flatMap((g) => g.commands), [grouped]);
+  const indexById = useMemo(() => {
+    const m = new Map<string, number>();
+    flat.forEach((c, i) => m.set(c.id, i));
+    return m;
+  }, [flat]);
+
+  const activeRef = useRef<HTMLLIElement | null>(null);
+  useEffect(() => { activeRef.current?.scrollIntoView({ block: "nearest" }); }, [active]);
 
   useEffect(() => {
     if (open) {
@@ -205,13 +262,13 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
       onClose();
     } else if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActive((a) => Math.min(a + 1, results.length - 1));
+      setActive((a) => Math.min(a + 1, flat.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setActive((a) => Math.max(a - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      results[active]?.run();
+      flat[active]?.run();
     }
   };
 
@@ -228,21 +285,30 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
           aria-label="Command search"
         />
         <ul className="tn-palette-list" role="listbox">
-          {results.length === 0 ? (
+          {flat.length === 0 ? (
             <li className="tn-palette-empty">No matching commands</li>
           ) : (
-            results.map((c, i) => (
-              <li
-                key={c.id}
-                role="option"
-                aria-selected={i === active}
-                className={`tn-palette-item${i === active ? " is-active" : ""}`}
-                onMouseEnter={() => setActive(i)}
-                onClick={() => c.run()}
-              >
-                <span>{c.label}</span>
-                <span className="tn-palette-hint">{c.hint}</span>
-              </li>
+            grouped.map((g) => (
+              <Fragment key={g.group}>
+                <li className="tn-palette-group" role="presentation" aria-hidden="true">{g.group}</li>
+                {g.commands.map((c) => {
+                  const i = indexById.get(c.id)!;
+                  return (
+                    <li
+                      key={c.id}
+                      ref={i === active ? activeRef : undefined}
+                      role="option"
+                      aria-selected={i === active}
+                      className={`tn-palette-item${i === active ? " is-active" : ""}`}
+                      onMouseEnter={() => setActive(i)}
+                      onClick={() => c.run()}
+                    >
+                      <span>{c.label}</span>
+                      <span className="tn-palette-hint">{c.hint}</span>
+                    </li>
+                  );
+                })}
+              </Fragment>
             ))
           )}
         </ul>

--- a/lib/console/paletteGroups.ts
+++ b/lib/console/paletteGroups.ts
@@ -1,0 +1,42 @@
+// Pure grouping + filter for the ⌘K command palette. Deliberately import-light —
+// no React, no stores — so the palette component stays thin and this logic unit-tests
+// fast. CommandPalette.tsx owns the command definitions and rendering; this owns the
+// shape (Command), the fixed section order, and how a query slices commands into groups.
+
+/** The palette's fixed sections, in display order. */
+export type CommandGroup = "Navigate" | "Layers" | "Views" | "Widgets" | "Layouts" | "Share";
+
+export interface Command {
+  id: string;
+  label: string;
+  hint: string;
+  group: CommandGroup;
+  run: () => void;
+}
+
+export interface GroupedCommands {
+  group: CommandGroup;
+  commands: Command[];
+}
+
+/** Fixed display order of the palette's sections. Groups always render in this order. */
+export const GROUP_ORDER: CommandGroup[] = ["Navigate", "Layers", "Views", "Widgets", "Layouts", "Share"];
+
+/**
+ * Slice commands into the fixed section order, applying a case-insensitive substring
+ * filter over each command's label + hint. A blank query keeps every command. Groups
+ * that end up empty are dropped; the surviving groups keep GROUP_ORDER, and within a
+ * group the incoming command order is preserved.
+ */
+export function groupCommands(commands: Command[], query: string): GroupedCommands[] {
+  const q = query.trim().toLowerCase();
+  const matches = (c: Command) =>
+    !q || c.label.toLowerCase().includes(q) || c.hint.toLowerCase().includes(q);
+
+  const out: GroupedCommands[] = [];
+  for (const group of GROUP_ORDER) {
+    const inGroup = commands.filter((c) => c.group === group && matches(c));
+    if (inGroup.length > 0) out.push({ group, commands: inGroup });
+  }
+  return out;
+}

--- a/tests/unit/palette-groups.test.ts
+++ b/tests/unit/palette-groups.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "vitest";
+import { groupCommands, GROUP_ORDER, type Command } from "@/lib/console/paletteGroups";
+
+const cmd = (id: string, label: string, hint: string, group: Command["group"]): Command =>
+  ({ id, label, hint, group, run: () => {} });
+
+// One command per group, deliberately pushed OUT of display order so the tests
+// prove groupCommands re-orders into GROUP_ORDER rather than echoing input order.
+const sample: Command[] = [
+  cmd("share-1", "Copy shareable link", "share", "Share"),
+  cmd("nav-1", "Fly to Kyiv", "jump", "Navigate"),
+  cmd("nav-2", "Dive to a live feed", "live", "Navigate"),
+  cmd("layer-1", "Toggle Cameras", "layer", "Layers"),
+  cmd("view-1", "Toggle light / dark theme", "theme", "Views"),
+  cmd("widget-1", "Add Aviation", "aviation", "Widgets"),
+  cmd("layout-1", "Save layout as preset…", "layout", "Layouts"),
+];
+
+test("blank query keeps every command, groups render in the fixed order", () => {
+  const g = groupCommands(sample, "");
+  expect(g.map((x) => x.group)).toEqual(["Navigate", "Layers", "Views", "Widgets", "Layouts", "Share"]);
+  expect(g.flatMap((x) => x.commands)).toHaveLength(sample.length);
+});
+
+test("fixed order is independent of input order", () => {
+  const shuffled = [...sample].reverse();
+  const g = groupCommands(shuffled, "");
+  expect(g.map((x) => x.group)).toEqual(GROUP_ORDER);
+});
+
+test("within a group, incoming command order is preserved", () => {
+  const g = groupCommands(sample, "");
+  const nav = g.find((x) => x.group === "Navigate")!;
+  expect(nav.commands.map((c) => c.id)).toEqual(["nav-1", "nav-2"]);
+});
+
+test("filter matches the label (case-insensitive) and drops empty groups", () => {
+  const g = groupCommands(sample, "FLY");
+  expect(g.map((x) => x.group)).toEqual(["Navigate"]);
+  expect(g[0].commands.map((c) => c.id)).toEqual(["nav-1"]);
+});
+
+test("filter matches the hint too", () => {
+  const g = groupCommands(sample, "theme");
+  expect(g.map((x) => x.group)).toEqual(["Views"]);
+  expect(g[0].commands.map((c) => c.id)).toEqual(["view-1"]);
+});
+
+test("filter matches the hint case-insensitively", () => {
+  const g = groupCommands(sample, "Share");
+  expect(g.map((x) => x.group)).toEqual(["Share"]);
+});
+
+test("a query that matches nothing yields an empty array", () => {
+  expect(groupCommands(sample, "zzz-no-match")).toEqual([]);
+});
+
+test("partial matches across groups keep only the non-empty groups, in order", () => {
+  const cmds: Command[] = [
+    cmd("a", "Preset: World", "preset", "Layers"),
+    cmd("b", "Layout: World", "layout", "Layouts"),
+    cmd("c", "Fly to Worthing", "jump", "Navigate"),
+  ];
+  const g = groupCommands(cmds, "wor");
+  // "wor" hits Worthing (Navigate) + World (Layers, Layouts); Views/Widgets/Share drop out.
+  expect(g.map((x) => x.group)).toEqual(["Navigate", "Layers", "Layouts"]);
+});


### PR DESCRIPTION
Refactors the flat ⌘K command list into an organised palette with grouped sections.

## What
- New pure helper `lib/console/paletteGroups.ts` — `Command` shape, `CommandGroup` union, `GROUP_ORDER`, and `groupCommands(commands, query)` (case-insensitive label+hint filter; empty groups dropped; fixed order + within-group order preserved). Unit-tested (8 cases).
- `CommandPalette.tsx` rewritten to render grouped sections (**Navigate · Layers · Views · Widgets · Layouts · Share**) with per-group headers, a single flat index space for ↑/↓ highlight, Enter-to-run, hover-to-highlight, and `scrollIntoView` on the active row.
- **New actions surfaced** that weren't in the palette before: theme toggle, language (EN/ES/FR), scenario/variant switch, and *focus an already-open widget* (one per open widget).
- Live `/api/geocode` fly-to results fold into Navigate unfiltered (unchanged behaviour, now grouped).
- `app/globals.css`: `.tn-palette-group` header style (existing `--tn-text-muted` token; `.is-active` row style already existed).

## Verify
- Gate: `tsc --noEmit` clean, **607 passed (146 files)**
- Live keyboard-nav pass still pending (no browser this session).