### PR TITLE
Country dossier: live Instability index (composite conflict/displacement/outage)

### DIFF
--- a/components/CountryDetail.tsx
+++ b/components/CountryDetail.tsx
@@ -1,19 +1,169 @@
 "use client";
-// In-overlay body for a clicked country (placeholder).
+// In-overlay body for a clicked country.
 //
 // The country layer is a base reference today: borders + names + a click target.
 // This dossier shows the identity we already know (flag, ISO, region, rough
-// population) and reserves clearly-labelled slots for the live data that will be
-// wired in later (travel advisory, the Country Instability Index, active events
-// in-country). It deliberately says "coming soon" rather than faking numbers.
+// population). The "Instability index" slot is now LIVE — it reads the per-country
+// Composite Instability Index (CII) we already compute and shows the score, its
+// top drivers and the factor breakdown, presented honestly as a composite estimate
+// (not an official government figure). "Travel advisory" and "Active events" stay
+// clearly-labelled "coming soon" slots rather than faking numbers.
 
+import type { CSSProperties } from "react";
 import type { WorldObject } from "@/lib/world";
+import { useSignalFeatures } from "@/lib/widgets/useSignalFeatures";
+import { resolveCountryInstability } from "@/lib/geo/countryInstability";
 
 const COMING_SOON: { title: string; note: string }[] = [
   { title: "Travel advisory", note: "Government advisory level + summary" },
-  { title: "Instability index", note: "Composite conflict / displacement / outage score" },
   { title: "Active events", note: "Live signals currently inside this country" },
 ];
+
+// Shared card + chip styling (matches the existing reserved-slot look, theme vars only).
+const CARD_STYLE: CSSProperties = {
+  padding: "10px",
+  borderRadius: 8,
+  background: "var(--tn-surface-2, rgba(148,163,184,0.10))",
+};
+const SLOT_TITLE_STYLE: CSSProperties = { fontSize: 13, fontWeight: 600, color: "var(--tn-text)" };
+const SLOT_NOTE_STYLE: CSSProperties = { fontSize: 11, color: "var(--tn-text-muted)" };
+const CHIP_STYLE: CSSProperties = {
+  fontSize: 10,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  fontWeight: 700,
+  border: "1px solid var(--tn-border)",
+  borderRadius: 999,
+  padding: "2px 7px",
+  whiteSpace: "nowrap",
+};
+
+/** An inert "coming soon" reserved slot (Travel advisory / Active events). */
+function ComingSoonSlot({ title, note }: { title: string; note: string }) {
+  return (
+    <div
+      style={{
+        ...CARD_STYLE,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+      }}
+    >
+      <div>
+        <div style={SLOT_TITLE_STYLE}>{title}</div>
+        <div style={SLOT_NOTE_STYLE}>{note}</div>
+      </div>
+      <span style={{ ...CHIP_STYLE, color: "var(--tn-text-faint)" }}>Coming soon</span>
+    </div>
+  );
+}
+
+/** A single-line instability slot (loading / below-threshold / dormant / error). */
+function InstabilityStatusSlot({ note, chip, chipColor }: { note: string; chip: string; chipColor: string }) {
+  return (
+    <div
+      style={{
+        ...CARD_STYLE,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+      }}
+    >
+      <div>
+        <div style={SLOT_TITLE_STYLE}>Instability index</div>
+        <div style={SLOT_NOTE_STYLE}>{note}</div>
+      </div>
+      <span style={{ ...CHIP_STYLE, color: chipColor }}>{chip}</span>
+    </div>
+  );
+}
+
+/** LIVE Country Instability Index slot for the clicked country. */
+function InstabilitySlot({ iso3, label }: { iso3: string | undefined; label: string }) {
+  const { features, status } = useSignalFeatures("instability", true);
+  const state = resolveCountryInstability(features, status, iso3, label);
+
+  if (state.kind === "loading")
+    return <InstabilityStatusSlot note="Assessing instability…" chip="Loading" chipColor="var(--tn-text-faint)" />;
+  if (state.kind === "error")
+    return <InstabilityStatusSlot note="Instability data is unavailable right now." chip="Unavailable" chipColor="var(--tn-text-faint)" />;
+  if (state.kind === "empty")
+    return <InstabilityStatusSlot note="Monitoring inputs are dormant right now." chip="No data" chipColor="var(--tn-text-faint)" />;
+  if (state.kind === "below")
+    return <InstabilityStatusSlot note="Stable — below the monitoring threshold." chip="Stable" chipColor="var(--tn-live)" />;
+
+  const { view } = state;
+  return (
+    <div style={{ ...CARD_STYLE, display: "flex", flexDirection: "column", gap: 10 }}>
+      {/* Title + score */}
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
+        <div>
+          <div style={SLOT_TITLE_STYLE}>Instability index</div>
+          <div style={SLOT_NOTE_STYLE}>
+            Composite estimate{view.coverage ? ` · ${view.coverage}` : ""}
+          </div>
+        </div>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 2, color: view.color }}>
+          <span className="tn-num" style={{ fontSize: 22, fontWeight: 700, lineHeight: 1 }}>{view.score}</span>
+          <span style={{ fontSize: 11, color: "var(--tn-text-muted)" }}>/100</span>
+        </div>
+      </div>
+
+      {/* Top drivers */}
+      {view.drivers.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {view.drivers.map((d) => (
+            <span
+              key={d}
+              style={{
+                fontSize: 11,
+                padding: "2px 8px",
+                borderRadius: 999,
+                background: "var(--tn-accent-soft)",
+                color: "var(--tn-accent-strong)",
+                border: "1px solid var(--tn-border)",
+                textTransform: "capitalize",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {d}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Factor breakdown */}
+      {view.factors.length > 0 && (
+        <div style={{ display: "grid", gap: 7 }}>
+          {view.factors.map((f) => (
+            <div key={f.label}>
+              <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11, marginBottom: 3 }}>
+                <span style={{ color: "var(--tn-text-muted)", textTransform: "capitalize" }}>{f.label}</span>
+                <span className="tn-num" style={{ color: "var(--tn-text)" }}>{f.value}</span>
+              </div>
+              <div style={{ height: 5, borderRadius: 999, background: "var(--tn-border)", overflow: "hidden" }}>
+                <div
+                  style={{
+                    height: "100%",
+                    width: `${Math.min(100, Math.max(0, f.pct))}%`,
+                    background: view.color,
+                    borderRadius: 999,
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div style={{ fontSize: 10, color: "var(--tn-text-faint)", lineHeight: 1.4 }}>
+        Composite estimate from ACLED · WFP · UNHCR · IODA — not an official government figure.
+      </div>
+    </div>
+  );
+}
 
 export default function CountryDetail({ object }: { object: WorldObject }) {
   const meta = object.meta ?? {};
@@ -29,6 +179,8 @@ export default function CountryDetail({ object }: { object: WorldObject }) {
   if (region) facts.push(["Region", region]);
   if (continent && continent !== region) facts.push(["Continent", continent]);
   if (population) facts.push(["Population", `≈ ${population.toLocaleString("en-US")}`]);
+
+  const [travelAdvisory, activeEvents] = COMING_SOON;
 
   return (
     <div style={{ color: "var(--tn-text)", fontFamily: "var(--tn-sans)" }}>
@@ -74,7 +226,7 @@ export default function CountryDetail({ object }: { object: WorldObject }) {
         </dl>
       )}
 
-      {/* ── Reserved live-data slots (honest placeholder) ── */}
+      {/* ── Live + reserved data slots ── */}
       <div
         style={{
           marginTop: 16,
@@ -84,40 +236,9 @@ export default function CountryDetail({ object }: { object: WorldObject }) {
           gap: 8,
         }}
       >
-        {COMING_SOON.map((s) => (
-          <div
-            key={s.title}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 12,
-              padding: "8px 10px",
-              borderRadius: 8,
-              background: "var(--tn-surface-2, rgba(148,163,184,0.10))",
-            }}
-          >
-            <div>
-              <div style={{ fontSize: 13, fontWeight: 600, color: "var(--tn-text)" }}>{s.title}</div>
-              <div style={{ fontSize: 11, color: "var(--tn-text-muted)" }}>{s.note}</div>
-            </div>
-            <span
-              style={{
-                fontSize: 10,
-                textTransform: "uppercase",
-                letterSpacing: "0.06em",
-                fontWeight: 700,
-                color: "var(--tn-text-faint)",
-                border: "1px solid var(--tn-border)",
-                borderRadius: 999,
-                padding: "2px 7px",
-                whiteSpace: "nowrap",
-              }}
-            >
-              Coming soon
-            </span>
-          </div>
-        ))}
+        <ComingSoonSlot title={travelAdvisory.title} note={travelAdvisory.note} />
+        <InstabilitySlot iso3={iso3} label={object.label} />
+        <ComingSoonSlot title={activeEvents.title} note={activeEvents.note} />
       </div>
 
       <div style={{ marginTop: 12, fontSize: 12, color: "var(--tn-text-muted)" }}>

--- a/lib/geo/countryInstability.ts
+++ b/lib/geo/countryInstability.ts
@@ -1,0 +1,130 @@
+// Pure helpers for the country dossier's "Instability index" section.
+//
+// The Country Instability Index (CII) is already computed per-country by
+// lib/signals/instability.ts and served via /api/signals/instability. Each
+// feature has id `cii:<ISO3>` and props carrying { country, score, drivers,
+// coverage, magnitude, ...per-factor breakdown }. This module's only job is to
+// match a clicked country to its CII feature and shape it for display — no DOM,
+// no fetching, so it is fully unit-testable.
+
+import type { SignalFeature } from "@/lib/signals/types";
+import type { FeedStatus } from "@/lib/widgets/useSignalFeatures";
+
+// The CII source spreads a per-factor breakdown (label → "NN%") straight into
+// props alongside these fixed keys. Everything NOT in this set (and shaped like a
+// percentage) is a factor contribution.
+const RESERVED_PROP_KEYS = new Set(["country", "score", "drivers", "coverage", "magnitude"]);
+
+export interface InstabilityFactor {
+  /** Human factor label, e.g. "armed conflict". */
+  label: string;
+  /** Raw display value from the source, e.g. "80%". */
+  value: string;
+  /** Parsed 0..100 magnitude for the mini bar (0 if unparseable). */
+  pct: number;
+}
+
+export interface CountryInstabilityView {
+  /** Composite score 0..100. */
+  score: number;
+  /** Ramp colour the source assigned to this score. */
+  color: string;
+  /** Top drivers, ordered by weighted contribution (densest first). */
+  drivers: string[];
+  /** Per-factor breakdown, ordered to match the drivers. */
+  factors: InstabilityFactor[];
+  /** Factor coverage, e.g. "3/4 factors". */
+  coverage: string;
+}
+
+/** The ISO-3 embedded in a CII feature id ("cii:SYR" → "SYR"), else null. */
+export function featureIso3(feature: SignalFeature): string | null {
+  const [ns, code] = String(feature?.id ?? "").split(":");
+  return ns === "cii" && code ? code.toUpperCase() : null;
+}
+
+/**
+ * Find the CII feature for a clicked country: by ISO-3 first (via the `cii:<ISO3>`
+ * id), then falling back to a case-insensitive country-name === label match.
+ * Returns null when nothing matches (e.g. the country is below the CII threshold).
+ */
+export function findInstabilityFeature(
+  features: SignalFeature[],
+  iso3: string | undefined,
+  label: string | undefined,
+): SignalFeature | null {
+  if (!Array.isArray(features) || features.length === 0) return null;
+
+  const wantIso = iso3?.trim().toUpperCase() || null;
+  if (wantIso) {
+    const byIso = features.find((f) => featureIso3(f) === wantIso);
+    if (byIso) return byIso;
+  }
+
+  const wantLabel = label?.trim().toLowerCase() || null;
+  if (wantLabel) {
+    const byName = features.find(
+      (f) => String(f.props?.country ?? "").trim().toLowerCase() === wantLabel,
+    );
+    if (byName) return byName;
+  }
+
+  return null;
+}
+
+/** Shape a matched CII feature into the dossier view-model. Pure. */
+export function deriveInstabilityView(feature: SignalFeature): CountryInstabilityView {
+  const props = feature.props ?? {};
+  const score = Number(props.score ?? 0);
+
+  const drivers = String(props.drivers ?? "")
+    .split("›")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Order the breakdown to mirror the drivers (weighted contribution) ordering.
+  const rank = new Map(drivers.map((d, i) => [d, i] as const));
+  const factors: InstabilityFactor[] = Object.entries(props)
+    .filter(([k, v]) => !RESERVED_PROP_KEYS.has(k) && typeof v === "string" && /%\s*$/.test(v))
+    .map(([label, v]) => ({
+      label,
+      value: String(v),
+      pct: Number(String(v).replace(/[^0-9.]/g, "")) || 0,
+    }))
+    .sort((a, b) => (rank.get(a.label) ?? 99) - (rank.get(b.label) ?? 99));
+
+  return {
+    score,
+    color: feature.color ?? "#dc2626",
+    drivers,
+    factors,
+    coverage: String(props.coverage ?? ""),
+  };
+}
+
+/** The rendering state for the country dossier's instability slot. */
+export type CountryInstabilityState =
+  | { kind: "loading" }
+  | { kind: "error" }
+  | { kind: "empty" }
+  | { kind: "below" }
+  | { kind: "scored"; view: CountryInstabilityView };
+
+/**
+ * Resolve what the instability slot should show. Honest about the difference
+ * between "this country is genuinely below the threshold" (feed has data, no
+ * match) and "we have no data right now" (feed empty / errored), so we never
+ * fake a "Stable" verdict when the monitor is simply dormant.
+ */
+export function resolveCountryInstability(
+  features: SignalFeature[],
+  status: FeedStatus,
+  iso3: string | undefined,
+  label: string | undefined,
+): CountryInstabilityState {
+  const match = findInstabilityFeature(features, iso3, label);
+  if (match) return { kind: "scored", view: deriveInstabilityView(match) };
+  if (status === "error") return { kind: "error" };
+  if (features.length === 0) return status === "loading" ? { kind: "loading" } : { kind: "empty" };
+  return { kind: "below" };
+}

--- a/tests/unit/geo-country-instability.test.ts
+++ b/tests/unit/geo-country-instability.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "vitest";
+import { computeInstability, type CountryInput } from "@/lib/signals/instability";
+import {
+  featureIso3,
+  findInstabilityFeature,
+  deriveInstabilityView,
+  resolveCountryInstability,
+} from "@/lib/geo/countryInstability";
+import type { SignalFeature } from "@/lib/signals/types";
+
+// A real CII feature, produced by the actual source, so the test is pinned to the
+// exact prop shape INSTABILITY_SOURCE emits (id `cii:<ISO3>`, props.score/drivers
+// + spread per-factor breakdown + coverage).
+const SYR_INPUT: CountryInput = {
+  iso3: "SYR",
+  factors: { conflict: 1000, food: 0.45, displacement: 6_000_000, outages: 50_000 },
+};
+const [syr] = computeInstability([SYR_INPUT]);
+// The CII source names countries from the centroid set ("Syrian Arab Republic"),
+// which need NOT equal Natural Earth's clicked-polygon label ("Syria") — exactly
+// why iso3-first matching matters and the name path is only a fallback.
+const syrName = String(syr.props?.country);
+
+test("featureIso3 extracts the ISO-3 from a cii:<ISO3> id", () => {
+  expect(featureIso3(syr)).toBe("SYR");
+  expect(featureIso3({ ...syr, id: "usgs:nc123" })).toBeNull();
+  expect(featureIso3({ ...syr, id: "" })).toBeNull();
+});
+
+test("matches by iso3 (case-insensitive), regardless of label", () => {
+  const found = findInstabilityFeature([syr], "syr", "Totally Different Name");
+  expect(found?.id).toBe("cii:SYR");
+});
+
+test("falls back to props.country === label when iso3 is absent/unknown", () => {
+  const byName = findInstabilityFeature([syr], undefined, syrName);
+  expect(byName?.id).toBe("cii:SYR");
+  const byNameCase = findInstabilityFeature([syr], "ZZZ", `  ${syrName.toLowerCase()}  `);
+  expect(byNameCase?.id).toBe("cii:SYR");
+});
+
+test("returns null when the country is below threshold (no matching feature)", () => {
+  // Germany is dropped by computeInstability (below CII_MIN_SCORE), so the feed
+  // simply doesn't contain it.
+  expect(findInstabilityFeature([syr], "DEU", "Germany")).toBeNull();
+  expect(findInstabilityFeature([], "SYR", "Syria")).toBeNull();
+});
+
+test("deriveInstabilityView exposes score, ordered drivers and factor breakdown", () => {
+  const view = deriveInstabilityView(syr);
+  expect(view.score).toBe(Number(syr.props?.score));
+  expect(view.color).toBe(syr.color);
+  expect(view.coverage).toBe("4/4 factors");
+  // Drivers ordered by weighted contribution — armed conflict (w=0.40) leads.
+  expect(view.drivers[0]).toBe("armed conflict");
+  // Breakdown mirrors the drivers ordering and parses the "NN%" values.
+  expect(view.factors[0].label).toBe("armed conflict");
+  expect(view.factors.map((f) => f.label).sort()).toEqual(
+    ["armed conflict", "displacement", "food insecurity", "internet outages"],
+  );
+  const food = view.factors.find((f) => f.label === "food insecurity")!;
+  expect(food.value).toBe("90%");
+  expect(food.pct).toBe(90);
+  // Reserved keys never leak into the breakdown.
+  expect(view.factors.some((f) => ["country", "score", "coverage"].includes(f.label))).toBe(false);
+});
+
+test("resolveCountryInstability: scored when a feature matches", () => {
+  const state = resolveCountryInstability([syr], "idle", "SYR", "Syria");
+  expect(state.kind).toBe("scored");
+  if (state.kind === "scored") expect(state.view.score).toBe(Number(syr.props?.score));
+});
+
+test("resolveCountryInstability: below-threshold when feed has data but no match", () => {
+  expect(resolveCountryInstability([syr], "idle", "DEU", "Germany").kind).toBe("below");
+});
+
+test("resolveCountryInstability: honest empty vs loading vs error when nothing matches", () => {
+  // Feed returned nothing and we're still fetching → loading.
+  expect(resolveCountryInstability([], "loading", "SYR", "Syria").kind).toBe("loading");
+  // Feed settled empty (dormant inputs) → empty, NOT a fake "Stable".
+  expect(resolveCountryInstability([], "idle", "SYR", "Syria").kind).toBe("empty");
+  // Fetch failed with no cached match → error.
+  expect(resolveCountryInstability([], "error", "SYR", "Syria").kind).toBe("error");
+});
+
+test("resolveCountryInstability: a match wins even during a background refresh", () => {
+  const nonMatch: SignalFeature = { ...syr, id: "cii:SDN", props: { ...syr.props, country: "Sudan" } };
+  const state = resolveCountryInstability([syr, nonMatch], "loading", "SYR", "Syria");
+  expect(state.kind).toBe("scored");
+});


### PR DESCRIPTION
Completes the **Instability index** section of the country detail panel (the one that was 'Coming soon'). Travel advisory + Active events stay Coming soon (separate work).

## What
The composite instability score was already computed per-country by `INSTABILITY_SOURCE` (`/api/signals/instability`, keyed `cii:<ISO3>`) but never shown. Now the country dossier fetches it and renders the matching country's **score (0–100)**, its **drivers**, and a **per-factor breakdown** (armed conflict · food insecurity · displacement · internet outages).

- New pure `lib/geo/countryInstability.ts` — `findInstabilityFeature` (ISO3-first match, name fallback — Natural Earth says 'Syria', the CII centroid says 'Syrian Arab Republic'), `deriveInstabilityView`, and a discriminated `resolveCountryInstability` state.
- Honest states: **scored** / **below** ('Stable — below the monitoring threshold', never a fake 0) / **loading** / **empty** ('inputs dormant') / **error**. The card labels the number a *'Composite estimate · N/4 factors'* with a footnote crediting ACLED · WFP · UNHCR · IODA — 'not an official government figure'.

## Verify
- Gate: `tsc --noEmit` clean, **608 passed (146 files)**; 9 new unit tests
- All theme tokens used confirmed present (light + dark)
- Live click-through render still pending (no browser this session)