### PR TITLE
feat(console): section the ⌘K palette, retarget presets to personas, …

### DIFF
--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -15,7 +15,7 @@ import "@/lib/console/widgets";
 import { widgetsByCategory, getWidgetType } from "@/lib/console/registry";
 import { shellLayoutStore } from "@/lib/console/store";
 import type { StageId } from "@/lib/console/types";
-import { listPresets, applyPreset, saveCustomPreset } from "@/lib/console/presets";
+import { listPresets, applyPreset, saveCustomPreset, DEFAULT_PRESET_ID } from "@/lib/console/presets";
 import { encodeLayout } from "@/lib/console/share";
 import { uiStore } from "@/lib/shell/ui";
 import { langStore } from "@/lib/i18n/store";
@@ -54,55 +54,18 @@ function alertCapacity() {
 function buildCommands(close: () => void): Command[] {
   const cmds: Command[] = [];
 
-  // ── Layers: toggles, layer presets, basemaps ────────────────────────────
-  for (const k of ACTIVE_LAYERS) {
-    cmds.push({
-      id: `toggle-${k}`,
-      label: `Toggle ${LAYER_NAMES[k]}`,
-      hint: "layer",
-      group: "Layers",
-      run: () => {
-        layersStore.toggle(k);
-        close();
-      },
-    });
-  }
+  // ── Profiles: apply a persona workspace (the fast path to a full board) ──
+  for (const p of listPresets()) cmds.push({ id: `cpreset-${p.id}`, label: `${p.icon} ${p.title}`, hint: p.blurb, group: "Profiles", run: () => { applyPreset(p.id); close(); } });
 
-  for (const p of LAYER_PRESETS) {
-    cmds.push({
-      id: `preset-${p.id}`,
-      label: `Preset: ${p.label}`,
-      hint: "preset",
-      group: "Layers",
-      run: () => {
-        layersStore.applyPreset(p.id);
-        close();
-      },
-    });
-  }
-
-  for (const k of Object.keys(BASEMAPS) as BasemapKey[]) {
-    cmds.push({
-      id: `basemap-${k}`,
-      label: `Basemap: ${BASEMAPS[k].label}`,
-      hint: "basemap",
-      group: "Layers",
-      run: () => {
-        mapViewStore.setBasemap(k);
-        close();
-      },
-    });
-  }
-
-  // ── Navigate: fly to a covered region, dive to a live feed ──────────────
+  // ── Go to: fly to a covered region, dive to a live feed ─────────────────
   for (const r of CAMERA_REGIONS) {
     if (!r.view) continue;
     const view = r.view;
     cmds.push({
       id: `jump-${r.source}`,
       label: `Fly to ${r.label}`,
-      hint: "jump",
-      group: "Navigate",
+      hint: "region",
+      group: "Go to",
       run: () => {
         mapViewStore.flyTo(view);
         close();
@@ -114,7 +77,7 @@ function buildCommands(close: () => void): Command[] {
     id: "dive-live",
     label: "Dive to a live feed",
     hint: "live",
-    group: "Navigate",
+    group: "Go to",
     run: () => {
       const cam = pickLiveCamera(loadedCamerasStore.get());
       if (cam) {
@@ -131,7 +94,7 @@ function buildCommands(close: () => void): Command[] {
     },
   });
 
-  // ── Widgets: add one of each type, or focus an already-open one ─────────
+  // ── Add widget: one command per registered type (hint = its category) ───
   for (const group of widgetsByCategory()) {
     for (const t of group.types) {
       const openCount = shellLayoutStore.get().widgets.filter((w) => w.type === t.id).length;
@@ -139,12 +102,13 @@ function buildCommands(close: () => void): Command[] {
         id: `add-${t.id}`,
         label: `Add ${t.title}${openCount ? ` (${openCount} open)` : ""}`,
         hint: group.category.toLowerCase(),
-        group: "Widgets",
+        group: "Add widget",
         run: () => { const r = shellLayoutStore.add(t.id, { config: { ...t.defaultConfig }, height: t.defaultHeight }); if (!r.ok) alertCapacity(); close(); },
       });
     }
   }
 
+  // ── Open widgets: jump focus to a card that's already on the workspace ──
   const openWidgets = shellLayoutStore.get().widgets;
   const typeSeen = new Map<string, number>();
   for (const w of openWidgets) {
@@ -156,27 +120,68 @@ function buildCommands(close: () => void): Command[] {
       id: `focus-${w.id}`,
       label: `Focus ${title}${total > 1 ? ` #${n}` : ""}`,
       hint: "widget",
-      group: "Widgets",
+      group: "Open widgets",
       run: () => { shellLayoutStore.focus(w.id); close(); },
     });
   }
 
-  // ── Views: stage, theme, language, scenario (variant) ───────────────────
+  // ── Map layers: toggle an individual globe layer ────────────────────────
+  for (const k of ACTIVE_LAYERS) {
+    cmds.push({
+      id: `toggle-${k}`,
+      label: `Toggle ${LAYER_NAMES[k]}`,
+      hint: "layer",
+      group: "Map layers",
+      run: () => {
+        layersStore.toggle(k);
+        close();
+      },
+    });
+  }
+
+  // ── Layer sets: apply a curated bundle of layers ────────────────────────
+  for (const p of LAYER_PRESETS) {
+    cmds.push({
+      id: `preset-${p.id}`,
+      label: `${p.label}`,
+      hint: "layer set",
+      group: "Layer sets",
+      run: () => {
+        layersStore.applyPreset(p.id);
+        close();
+      },
+    });
+  }
+
+  // ── Basemap: swap the underlying map style ──────────────────────────────
+  for (const k of Object.keys(BASEMAPS) as BasemapKey[]) {
+    cmds.push({
+      id: `basemap-${k}`,
+      label: `${BASEMAPS[k].label}`,
+      hint: "basemap",
+      group: "Basemap",
+      run: () => {
+        mapViewStore.setBasemap(k);
+        close();
+      },
+    });
+  }
+
+  // ── Stage: what the centre stage shows ──────────────────────────────────
   const STAGES: { id: StageId; label: string }[] = [{ id: "map3d", label: "3D map" }, { id: "map2d", label: "2D map" }, { id: "clock", label: "World clock" }];
-  for (const s of STAGES) cmds.push({ id: `stage-${s.id}`, label: `Stage → ${s.label}`, hint: "stage", group: "Views", run: () => { shellLayoutStore.stage(s.id); close(); } });
+  for (const s of STAGES) cmds.push({ id: `stage-${s.id}`, label: `Stage → ${s.label}`, hint: "stage", group: "Stage", run: () => { shellLayoutStore.stage(s.id); close(); } });
 
-  cmds.push({ id: "theme-toggle", label: "Toggle light / dark theme", hint: "theme", group: "Views", run: () => { uiStore.toggleTheme(); close(); } });
+  // ── Scenarios: switch the top-left monitor variant ──────────────────────
+  for (const v of BUILTIN_VARIANTS) cmds.push({ id: `variant-${v.id}`, label: `${v.title}`, hint: "scenario", group: "Scenarios", run: () => { variantStore.setActive(v.id); close(); } });
 
-  for (const l of LANGS) cmds.push({ id: `lang-${l.code}`, label: `Language: ${l.name}`, hint: "language", group: "Views", run: () => { langStore.set(l.code); close(); } });
+  // ── Appearance: theme + language ────────────────────────────────────────
+  cmds.push({ id: "theme-toggle", label: "Toggle light / dark theme", hint: "theme", group: "Appearance", run: () => { uiStore.toggleTheme(); close(); } });
+  for (const l of LANGS) cmds.push({ id: `lang-${l.code}`, label: `Language: ${l.name}`, hint: "language", group: "Appearance", run: () => { langStore.set(l.code); close(); } });
 
-  for (const v of BUILTIN_VARIANTS) cmds.push({ id: `variant-${v.id}`, label: `Scenario: ${v.title}`, hint: "scenario", group: "Views", run: () => { variantStore.setActive(v.id); close(); } });
-
-  // ── Layouts: console layout presets, save current as preset ─────────────
-  for (const p of listPresets()) cmds.push({ id: `cpreset-${p.id}`, label: `Layout: ${p.title}`, hint: "layout", group: "Layouts", run: () => { applyPreset(p.id); close(); } });
-  cmds.push({ id: "save-preset", label: "Save layout as preset…", hint: "layout", group: "Layouts", run: () => { const t = window.prompt("Preset name?"); if (t) saveCustomPreset(t); close(); } });
-
-  // ── Share: copy a shareable link to the composed view ───────────────────
-  cmds.push({ id: "share-layout", label: "Copy shareable link", hint: "share", group: "Share", run: () => { const url = `${location.origin}${location.pathname}?c=${encodeLayout(shellLayoutStore.get())}`; navigator.clipboard?.writeText(url); close(); } });
+  // ── Workspace: reset / save / share the current composition ─────────────
+  cmds.push({ id: "reset-layout", label: "Reset to default layout", hint: "reset", group: "Workspace", run: () => { applyPreset(DEFAULT_PRESET_ID); close(); } });
+  cmds.push({ id: "save-preset", label: "Save layout as preset…", hint: "save", group: "Workspace", run: () => { const t = window.prompt("Preset name?"); if (t) saveCustomPreset(t); close(); } });
+  cmds.push({ id: "share-layout", label: "Copy shareable link", hint: "share", group: "Workspace", run: () => { const url = `${location.origin}${location.pathname}?c=${encodeLayout(shellLayoutStore.get())}`; navigator.clipboard?.writeText(url); close(); } });
 
   return cmds;
 }
@@ -206,23 +211,23 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
   }, [query]);
 
   // Live place results are the product of the query itself — surface them under
-  // Navigate unfiltered (never re-filtered by the substring), matching the prior
+  // "Go to" unfiltered (never re-filtered by the substring), matching the prior
   // "append to the list" behaviour, just now grouped.
   const geoCmds = useMemo<Command[]>(() => geo.map((r) => ({
     id: `geo-${r.lat},${r.lon}`,
     label: `Fly to ${r.name}`,
     hint: r.type || "place",
-    group: "Navigate",
+    group: "Go to",
     run: () => { mapViewStore.flyToPoint({ lat: r.lat, lon: r.lon, zoom: zoomForResult(r) }); onClose(); },
   })), [geo, onClose]);
 
   // Grouped, query-filtered sections in the fixed GROUP_ORDER; live geocode
-  // results fold into Navigate (added even when the static Navigate group filtered empty).
+  // results fold into "Go to" (added even when the static Go-to group filtered empty).
   const grouped = useMemo(() => {
     const base = groupCommands(commands, query);
     if (geoCmds.length === 0) return base;
     const byGroup = new Map(base.map((g) => [g.group, g.commands]));
-    byGroup.set("Navigate", [...(byGroup.get("Navigate") ?? []), ...geoCmds]);
+    byGroup.set("Go to", [...(byGroup.get("Go to") ?? []), ...geoCmds]);
     return GROUP_ORDER
       .filter((g) => (byGroup.get(g)?.length ?? 0) > 0)
       .map((g) => ({ group: g, commands: byGroup.get(g)! }));
@@ -279,7 +284,7 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
         <input
           ref={inputRef}
           className="tn-palette-input"
-          placeholder="Search layers, presets, basemaps — or fly to any place…"
+          placeholder="Search actions — switch profile, add a widget, fly to any place…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Command search"

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -23,7 +23,7 @@ import { scopeStore } from "@/lib/shell/scope";
 import { viewModeStore } from "@/lib/shell/viewMode";
 import ConsoleWorkspace from "@/components/console/ConsoleWorkspace";
 import { shellLayoutStore } from "@/lib/console/store";
-import { applyPreset } from "@/lib/console/presets";
+import { applyPreset, DEFAULT_PRESET_ID } from "@/lib/console/presets";
 import { decodeLayout } from "@/lib/console/share";
 import "@/lib/console/widgets";
 
@@ -47,7 +47,7 @@ export default function ConsoleShell() {
     shellLayoutStore.hydrate();
     const c = new URLSearchParams(window.location.search).get("c");
     if (c) { const l = decodeLayout(c); if (l) shellLayoutStore.replace(l); }
-    else if (shellLayoutStore.get().widgets.length === 0) applyPreset("world"); // first-run seed
+    else if (shellLayoutStore.get().widgets.length === 0) applyPreset(DEFAULT_PRESET_ID); // first-run seed
     registerServiceWorker(); // production-only; a no-op under `next dev`
   }, []);
 

--- a/lib/console/paletteGroups.ts
+++ b/lib/console/paletteGroups.ts
@@ -3,8 +3,33 @@
 // fast. CommandPalette.tsx owns the command definitions and rendering; this owns the
 // shape (Command), the fixed section order, and how a query slices commands into groups.
 
-/** The palette's fixed sections, in display order. */
-export type CommandGroup = "Navigate" | "Layers" | "Views" | "Widgets" | "Layouts" | "Share";
+/**
+ * The palette's fixed sections, in display order. Kept fine-grained on purpose:
+ * one job per section so a glance (or a filtered query) lands you in the right place.
+ *   • Profiles      — apply a persona workspace (the fast path to a full board)
+ *   • Go to         — fly to a place / region, or dive into a live feed
+ *   • Add widget    — drop a new card onto the workspace
+ *   • Open widgets  — jump focus to a card that's already open
+ *   • Map layers    — toggle an individual globe layer on/off
+ *   • Layer sets    — apply a curated bundle of layers
+ *   • Basemap       — swap the underlying map style
+ *   • Stage         — what the centre stage shows (3D / 2D / clock)
+ *   • Scenarios     — switch the top-left monitor variant
+ *   • Appearance    — theme + language
+ *   • Workspace     — save / reset / share the current composition
+ */
+export type CommandGroup =
+  | "Profiles"
+  | "Go to"
+  | "Add widget"
+  | "Open widgets"
+  | "Map layers"
+  | "Layer sets"
+  | "Basemap"
+  | "Stage"
+  | "Scenarios"
+  | "Appearance"
+  | "Workspace";
 
 export interface Command {
   id: string;
@@ -20,7 +45,19 @@ export interface GroupedCommands {
 }
 
 /** Fixed display order of the palette's sections. Groups always render in this order. */
-export const GROUP_ORDER: CommandGroup[] = ["Navigate", "Layers", "Views", "Widgets", "Layouts", "Share"];
+export const GROUP_ORDER: CommandGroup[] = [
+  "Profiles",
+  "Go to",
+  "Add widget",
+  "Open widgets",
+  "Map layers",
+  "Layer sets",
+  "Basemap",
+  "Stage",
+  "Scenarios",
+  "Appearance",
+  "Workspace",
+];
 
 /**
  * Slice commands into the fixed section order, applying a case-insensitive substring

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -4,7 +4,19 @@ import { addWidget, setStage } from "@/lib/console/reducers";
 import { shellLayoutStore } from "@/lib/console/store";
 import { loadPersisted, savePersisted } from "@/lib/shell/persist";
 
-export interface ConsolePreset { id: string; title: string; icon: string; build(): ShellLayout }
+// A preset is a persona: a curated workspace aimed at ONE kind of user. `blurb` is the
+// short "who it's for" tag surfaced next to the title in the ⌘K Profiles section, so the
+// list reads as an audience menu rather than a pile of domains.
+export interface ConsolePreset {
+  id: string;
+  title: string;
+  icon: string;
+  blurb: string;
+  build(): ShellLayout;
+}
+
+/** The board a fresh visitor lands on (ConsoleShell first-run seed + "Reset to default"). */
+export const DEFAULT_PRESET_ID = "intelligence";
 
 let seed = 0;
 const id = () => `p${(seed += 1).toString(36)}`;
@@ -14,71 +26,90 @@ function compose(stage: ShellLayout["stage"], specs: { type: string; segment: Se
   return l;
 }
 
-// Each preset is a curated profile: a stage + a set of widgets all relevant to
-// one field, spread across the left / right / bottom segments. Widget `type`s are
-// the registered widget ids — core layers (events, cameras, aviation, satellites,
-// markets, headlines, news) and per-signal cards (`signal:<sourceId>`).
+// Each preset drops a curated set of widgets across the left / right / bottom segments.
+// Widget `type`s are the registered widget ids — core layers (events, cameras, aviation,
+// satellites, markets, headlines, news) and per-signal cards (`signal:<sourceId>`).
 export const BUILTIN_PRESETS: ConsolePreset[] = [
-  // A balanced cross-domain overview — the default landing profile.
-  { id: "world", title: "World", icon: "🌐", build: () => compose("map2d", [
-      { type: "events", segment: "left" }, { type: "aviation", segment: "left" },
+  // ── Generalist ──────────────────────────────────────────────────────────
+  // World Overview — a calm bit-of-everything board for a first look.
+  { id: "world", title: "World Overview", icon: "🌐", blurb: "generalist", build: () => compose("map2d", [
+      { type: "signal:instability", segment: "left" }, { type: "events", segment: "left" },
       { type: "cameras", segment: "right" }, { type: "markets", segment: "right" },
       { type: "headlines", segment: "bottom" },
   ]) },
 
-  // Aviation — live traffic, military movements, and what threatens flight.
-  { id: "aviation-ops", title: "Aviation Ops", icon: "✈", build: () => compose("map2d", [
-      { type: "aviation", segment: "left" }, { type: "signal:gpsJamming", segment: "left" },
-      { type: "signal:military-air", segment: "right" }, { type: "cameras", segment: "right" },
-      { type: "events", segment: "bottom" },
+  // ── Newsroom — journalists / news followers ─────────────────────────────
+  // Breaking events, live headlines and streaming video.
+  { id: "newsroom", title: "Newsroom", icon: "📰", blurb: "for journalists", build: () => compose("map2d", [
+      { type: "events", segment: "left" }, { type: "signal:conflict", segment: "left" },
+      { type: "headlines", segment: "right" }, { type: "cameras", segment: "right" },
+      { type: "news", segment: "bottom" },
   ]) },
 
-  // Natural disasters — earthquakes, fires, storms, multi-hazard GDACS alerts.
-  { id: "disaster-response", title: "Disaster Response", icon: "🆘", build: () => compose("map2d", [
-      { type: "events", segment: "left" }, { type: "signal:earthquakes", segment: "left" },
-      { type: "signal:wildfires", segment: "right" }, { type: "signal:tropical-cyclones", segment: "right" },
-      { type: "signal:gdacs", segment: "bottom" },
+  // ── Intelligence — OSINT / conflict analysts (the default landing board) ─
+  // Instability synthesis, geolocated conflict/protests, verified ACLED, military air.
+  { id: "intelligence", title: "Intelligence", icon: "🔎", blurb: "for analysts", build: () => compose("map2d", [
+      { type: "signal:instability", segment: "left" }, { type: "signal:conflict", segment: "left" },
+      { type: "signal:acled", segment: "right" }, { type: "signal:protests", segment: "right" },
+      { type: "signal:military-air", segment: "bottom" },
   ]) },
 
-  // Security & conflict — events, protests, military air, world headlines.
-  { id: "security", title: "Security & Conflict", icon: "⚔", build: () => compose("map2d", [
-      { type: "signal:conflict", segment: "left" }, { type: "signal:acled", segment: "left" },
-      { type: "signal:protests", segment: "right" }, { type: "signal:military-air", segment: "right" },
-      { type: "headlines", segment: "bottom" },
-  ]) },
-
-  // Cyber & critical infrastructure — botnets, ransomware, outages, grid, cables.
-  { id: "cyber-infra", title: "Cyber & Infrastructure", icon: "🛡", build: () => compose("map2d", [
-      { type: "signal:cyber-c2", segment: "left" }, { type: "signal:cyber-ransomware", segment: "left" },
-      { type: "signal:internet-outages", segment: "right" }, { type: "signal:cables", segment: "right" },
-      { type: "signal:grid-load", segment: "bottom" },
-  ]) },
-
-  // Climate & environment — weather, fires, air quality, floods, cyclones.
-  { id: "climate", title: "Climate & Environment", icon: "🌿", build: () => compose("map2d", [
-      { type: "signal:weather", segment: "left" }, { type: "signal:wildfires", segment: "left" },
-      { type: "signal:airquality", segment: "right" }, { type: "signal:floods", segment: "right" },
+  // ── Emergency Response — disaster & relief teams ────────────────────────
+  // Multi-hazard GDACS alerts plus the live earthquake / fire / flood / storm layers.
+  { id: "emergency", title: "Emergency Response", icon: "🆘", blurb: "for responders", build: () => compose("map2d", [
+      { type: "signal:gdacs", segment: "left" }, { type: "signal:earthquakes", segment: "left" },
+      { type: "signal:wildfires", segment: "right" }, { type: "signal:floods", segment: "right" },
       { type: "signal:tropical-cyclones", segment: "bottom" },
   ]) },
 
-  // Space & orbital — satellites, launches, aurora and space-weather (globe stage).
-  { id: "space", title: "Space & Orbital", icon: "🛰", build: () => compose("map3d", [
+  // ── Aviation — spotters & flight ops ────────────────────────────────────
+  // Live traffic, military movements, airports, and what threatens navigation.
+  { id: "aviation-ops", title: "Aviation", icon: "✈", blurb: "for aviation", build: () => compose("map2d", [
+      { type: "aviation", segment: "left" }, { type: "signal:gpsJamming", segment: "left" },
+      { type: "signal:military-air", segment: "right" }, { type: "signal:airports", segment: "right" },
+      { type: "cameras", segment: "bottom" },
+  ]) },
+
+  // ── Markets Desk — traders / economists ─────────────────────────────────
+  // Crypto/FX, macro headlines, and the supply-chain / energy risk that moves them.
+  { id: "markets-desk", title: "Markets Desk", icon: "📈", blurb: "for traders", build: () => compose("map2d", [
+      { type: "markets", segment: "left" }, { type: "headlines", segment: "left" },
+      { type: "signal:conflict", segment: "right" }, { type: "signal:grid-load", segment: "right" },
+      { type: "signal:ports", segment: "bottom" },
+  ]) },
+
+  // ── Space & Orbital — space watchers (globe stage) ──────────────────────
+  { id: "space", title: "Space & Orbital", icon: "🛰", blurb: "for space fans", build: () => compose("map3d", [
       { type: "satellites", segment: "left" }, { type: "signal:launches", segment: "left" },
       { type: "signal:aurora", segment: "right" }, { type: "signal:space-weather", segment: "right" },
       { type: "signal:gpsJamming", segment: "bottom" },
   ]) },
 
-  // Markets & newsroom — crypto/FX, world headlines, live video news.
-  { id: "markets-news", title: "Markets & Newsroom", icon: "📈", build: () => compose("map2d", [
-      { type: "markets", segment: "left" }, { type: "signal:conflict", segment: "left" },
-      { type: "headlines", segment: "right" }, { type: "news", segment: "bottom" },
-  ]) },
-
-  // Maritime — vessel traffic, ports, undersea cables, cyclones at sea.
-  { id: "maritime", title: "Maritime", icon: "🚢", build: () => compose("map2d", [
+  // ── Maritime — shipping & logistics ─────────────────────────────────────
+  { id: "maritime", title: "Maritime", icon: "🚢", blurb: "for logistics", build: () => compose("map2d", [
       { type: "signal:ais", segment: "left" }, { type: "signal:ports", segment: "left" },
       { type: "signal:cables", segment: "right" }, { type: "signal:tropical-cyclones", segment: "right" },
       { type: "cameras", segment: "bottom" },
+  ]) },
+
+  // ── Climate & Environment — environment watchers ────────────────────────
+  { id: "climate", title: "Climate & Environment", icon: "🌿", blurb: "for climate", build: () => compose("map2d", [
+      { type: "signal:weather", segment: "left" }, { type: "signal:wildfires", segment: "left" },
+      { type: "signal:airquality", segment: "right" }, { type: "signal:floods", segment: "right" },
+      { type: "signal:tropical-cyclones", segment: "bottom" },
+  ]) },
+
+  // ── Cyber & Infrastructure — security teams ─────────────────────────────
+  { id: "cyber-infra", title: "Cyber & Infrastructure", icon: "🛡", blurb: "for security", build: () => compose("map2d", [
+      { type: "signal:cyber-c2", segment: "left" }, { type: "signal:cyber-ransomware", segment: "left" },
+      { type: "signal:internet-outages", segment: "right" }, { type: "signal:cables", segment: "right" },
+      { type: "signal:grid-load", segment: "bottom" },
+  ]) },
+
+  // ── Explorer — relaxed, casual browsing ─────────────────────────────────
+  { id: "explorer", title: "Explorer", icon: "🧭", blurb: "casual", build: () => compose("map2d", [
+      { type: "cameras", segment: "left" }, { type: "events", segment: "left" },
+      { type: "news", segment: "right" }, { type: "headlines", segment: "bottom" },
   ]) },
 ];
 
@@ -101,7 +132,7 @@ export function saveCustomPreset(title: string): void {
   savePersisted(KEY, VERSION, list);
 }
 
-export function listPresets(): { id: string; title: string; icon: string }[] {
-  return [...BUILTIN_PRESETS.map((p) => ({ id: p.id, title: p.title, icon: p.icon })),
-          ...loadCustom().map((p) => ({ id: p.id, title: p.title, icon: "★" }))];
+export function listPresets(): { id: string; title: string; icon: string; blurb: string }[] {
+  return [...BUILTIN_PRESETS.map((p) => ({ id: p.id, title: p.title, icon: p.icon, blurb: p.blurb })),
+          ...loadCustom().map((p) => ({ id: p.id, title: p.title, icon: "★", blurb: "saved" }))];
 }

--- a/tests/unit/console-presets.test.ts
+++ b/tests/unit/console-presets.test.ts
@@ -1,15 +1,20 @@
 import { expect, test } from "vitest";
-import { BUILTIN_PRESETS } from "@/lib/console/presets";
+import { BUILTIN_PRESETS, DEFAULT_PRESET_ID } from "@/lib/console/presets";
 import { SIGNALS } from "@/lib/signals/registry";
 
 const CORE_WIDGETS = new Set(["events", "news", "cameras", "aviation", "satellites", "markets", "headlines"]);
 const SIGNAL_WIDGETS = new Set(SIGNALS.map((s) => `signal:${s.id}`));
 
-test("built-ins are non-empty and within the cap", () => {
+// The persona lineup: one preset per major user type. Ids are stable (used by the
+// first-run seed, the ⌘K Profiles section, and shared layout URLs).
+const PERSONA_IDS = [
+  "world", "newsroom", "intelligence", "emergency", "aviation-ops",
+  "markets-desk", "space", "maritime", "climate", "cyber-infra", "explorer",
+];
+
+test("the full persona lineup is present, non-empty, and within the cap", () => {
   const ids = BUILTIN_PRESETS.map((p) => p.id);
-  expect(ids).toContain("world");
-  expect(ids).toContain("aviation-ops");
-  expect(ids).toContain("disaster-response");
+  for (const id of PERSONA_IDS) expect(ids).toContain(id);
   for (const p of BUILTIN_PRESETS) {
     const l = p.build();
     expect(l.widgets.length).toBeGreaterThan(0);
@@ -17,17 +22,22 @@ test("built-ins are non-empty and within the cap", () => {
   }
 });
 
+test("the default landing preset exists and seeds a real board", () => {
+  const def = BUILTIN_PRESETS.find((p) => p.id === DEFAULT_PRESET_ID);
+  expect(def, `DEFAULT_PRESET_ID "${DEFAULT_PRESET_ID}" must be a built-in`).toBeDefined();
+  expect(def!.build().widgets.length).toBeGreaterThan(0);
+});
+
+test("every preset carries a persona blurb (who it's for)", () => {
+  for (const p of BUILTIN_PRESETS) {
+    expect(p.blurb.length, `preset "${p.id}" needs a blurb`).toBeGreaterThan(0);
+  }
+});
+
 test("aviation-ops puts an aviation widget on the canvas with a stage", () => {
   const l = BUILTIN_PRESETS.find((p) => p.id === "aviation-ops")!.build();
   expect(l.widgets.some((w) => w.type === "aviation")).toBe(true);
   expect(["map2d", "map3d", "clock"]).toContain(l.stage);
-});
-
-test("the field profiles are all present", () => {
-  const ids = BUILTIN_PRESETS.map((p) => p.id);
-  for (const id of ["security", "cyber-infra", "climate", "space", "markets-news", "maritime"]) {
-    expect(ids).toContain(id);
-  }
 });
 
 test("every preset references only real core widgets or registered signal widgets", () => {

--- a/tests/unit/console-share.test.ts
+++ b/tests/unit/console-share.test.ts
@@ -4,7 +4,7 @@ import { BUILTIN_PRESETS } from "@/lib/console/presets";
 import { createDefaultLayout, type ShellLayout } from "@/lib/console/types";
 
 test("encode→decode round-trips a layout", () => {
-  const l = BUILTIN_PRESETS.find((p) => p.id === "disaster-response")!.build();
+  const l = BUILTIN_PRESETS.find((p) => p.id === "emergency")!.build();
   const round = decodeLayout(encodeLayout(l));
   expect(round?.stage).toBe(l.stage);
   expect(round?.widgets.map((w) => w.type)).toEqual(l.widgets.map((w) => w.type));

--- a/tests/unit/palette-groups.test.ts
+++ b/tests/unit/palette-groups.test.ts
@@ -7,18 +7,26 @@ const cmd = (id: string, label: string, hint: string, group: Command["group"]): 
 // One command per group, deliberately pushed OUT of display order so the tests
 // prove groupCommands re-orders into GROUP_ORDER rather than echoing input order.
 const sample: Command[] = [
-  cmd("share-1", "Copy shareable link", "share", "Share"),
-  cmd("nav-1", "Fly to Kyiv", "jump", "Navigate"),
-  cmd("nav-2", "Dive to a live feed", "live", "Navigate"),
-  cmd("layer-1", "Toggle Cameras", "layer", "Layers"),
-  cmd("view-1", "Toggle light / dark theme", "theme", "Views"),
-  cmd("widget-1", "Add Aviation", "aviation", "Widgets"),
-  cmd("layout-1", "Save layout as preset…", "layout", "Layouts"),
+  cmd("work-1", "Copy shareable link", "share", "Workspace"),
+  cmd("appear-1", "Toggle light / dark theme", "theme", "Appearance"),
+  cmd("scen-1", "Middle East", "scenario", "Scenarios"),
+  cmd("stage-1", "Stage → 2D map", "stage", "Stage"),
+  cmd("base-1", "Satellite", "basemap", "Basemap"),
+  cmd("set-1", "Everything", "layer set", "Layer sets"),
+  cmd("map-1", "Toggle Cameras", "layer", "Map layers"),
+  cmd("open-1", "Focus Aviation", "widget", "Open widgets"),
+  cmd("add-1", "Add Aviation", "aviation", "Add widget"),
+  cmd("go-1", "Fly to Kyiv", "region", "Go to"),
+  cmd("go-2", "Dive to a live feed", "live", "Go to"),
+  cmd("prof-1", "🔎 Intelligence", "for analysts", "Profiles"),
 ];
 
 test("blank query keeps every command, groups render in the fixed order", () => {
   const g = groupCommands(sample, "");
-  expect(g.map((x) => x.group)).toEqual(["Navigate", "Layers", "Views", "Widgets", "Layouts", "Share"]);
+  expect(g.map((x) => x.group)).toEqual([
+    "Profiles", "Go to", "Add widget", "Open widgets", "Map layers",
+    "Layer sets", "Basemap", "Stage", "Scenarios", "Appearance", "Workspace",
+  ]);
   expect(g.flatMap((x) => x.commands)).toHaveLength(sample.length);
 });
 
@@ -30,25 +38,25 @@ test("fixed order is independent of input order", () => {
 
 test("within a group, incoming command order is preserved", () => {
   const g = groupCommands(sample, "");
-  const nav = g.find((x) => x.group === "Navigate")!;
-  expect(nav.commands.map((c) => c.id)).toEqual(["nav-1", "nav-2"]);
+  const go = g.find((x) => x.group === "Go to")!;
+  expect(go.commands.map((c) => c.id)).toEqual(["go-1", "go-2"]);
 });
 
 test("filter matches the label (case-insensitive) and drops empty groups", () => {
   const g = groupCommands(sample, "FLY");
-  expect(g.map((x) => x.group)).toEqual(["Navigate"]);
-  expect(g[0].commands.map((c) => c.id)).toEqual(["nav-1"]);
+  expect(g.map((x) => x.group)).toEqual(["Go to"]);
+  expect(g[0].commands.map((c) => c.id)).toEqual(["go-1"]);
 });
 
 test("filter matches the hint too", () => {
   const g = groupCommands(sample, "theme");
-  expect(g.map((x) => x.group)).toEqual(["Views"]);
-  expect(g[0].commands.map((c) => c.id)).toEqual(["view-1"]);
+  expect(g.map((x) => x.group)).toEqual(["Appearance"]);
+  expect(g[0].commands.map((c) => c.id)).toEqual(["appear-1"]);
 });
 
 test("filter matches the hint case-insensitively", () => {
-  const g = groupCommands(sample, "Share");
-  expect(g.map((x) => x.group)).toEqual(["Share"]);
+  const g = groupCommands(sample, "Analysts");
+  expect(g.map((x) => x.group)).toEqual(["Profiles"]);
 });
 
 test("a query that matches nothing yields an empty array", () => {
@@ -57,11 +65,11 @@ test("a query that matches nothing yields an empty array", () => {
 
 test("partial matches across groups keep only the non-empty groups, in order", () => {
   const cmds: Command[] = [
-    cmd("a", "Preset: World", "preset", "Layers"),
-    cmd("b", "Layout: World", "layout", "Layouts"),
-    cmd("c", "Fly to Worthing", "jump", "Navigate"),
+    cmd("a", "🌐 World Overview", "generalist", "Profiles"),
+    cmd("b", "Fly to Worthing", "region", "Go to"),
+    cmd("c", "Everything (world)", "layer set", "Layer sets"),
   ];
   const g = groupCommands(cmds, "wor");
-  // "wor" hits Worthing (Navigate) + World (Layers, Layouts); Views/Widgets/Share drop out.
-  expect(g.map((x) => x.group)).toEqual(["Navigate", "Layers", "Layouts"]);
+  // "wor" hits World (Profiles) + Worthing (Go to) + world (Layer sets), in GROUP_ORDER.
+  expect(g.map((x) => x.group)).toEqual(["Profiles", "Go to", "Layer sets"]);
 });


### PR DESCRIPTION
…default to Intelligence

Palette: split the 6 broad groups into 11 single-purpose sections (Profiles, Go to, Add widget, Open widgets, Map layers, Layer sets, Basemap, Stage, Scenarios, Appearance, Workspace) — pure reshuffle of each command.group + expanded GROUP_ORDER; filter/keyboard logic untouched. Geocode results fold into "Go to".

Presets: reframed as user personas with a "who it's for" blurb shown as the palette hint (generalist / for journalists / for analysts...). Added Newsroom, Intelligence and Explorer; renamed disaster-response to emergency and markets-news to markets-desk. World Overview kept as the generalist profile.

Default: first-run seed and "Reset to default layout" now share DEFAULT_PRESET_ID (Intelligence) — instability + conflict + ACLED + protests + military air.

Tests updated (palette-groups, console-presets, console-share).