### PR TITLE
feat(console): lay the ⌘K palette out as a side-by-side mega-menu

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -294,7 +294,7 @@ a { color: var(--tn-accent); }
 .tn-palette-root { position: fixed; inset: 0; z-index: 60; display: grid; place-items: start center; padding-top: 12vh; }
 .tn-palette-backdrop { position: absolute; inset: 0; background: rgba(15, 23, 42, 0.28); backdrop-filter: blur(2px); }
 .tn-palette {
-  position: relative; z-index: 1; width: min(560px, 92vw);
+  position: relative; z-index: 1; width: min(980px, 95vw);
   background: var(--tn-surface-solid); border: 1px solid var(--tn-border-strong); border-radius: 14px;
   box-shadow: var(--tn-shadow); overflow: hidden; color: var(--tn-text);
   animation: tn-pop 0.16s ease;
@@ -305,15 +305,20 @@ a { color: var(--tn-accent); }
   background: transparent; color: var(--tn-text); font: inherit; font-size: 15px; padding: 15px 16px; outline: none;
 }
 .tn-palette-input::placeholder { color: var(--tn-text-faint); }
-.tn-palette-list { list-style: none; margin: 0; padding: 6px; max-height: 46vh; overflow: auto; }
+/* Mega-menu: sections sit side by side as columns, divided by a hairline rule. */
+.tn-palette-cols { display: flex; align-items: flex-start; margin: 0; padding: 6px; max-height: 60vh; overflow-y: auto; }
+.tn-palette-col { flex: 1 1 0; min-width: 0; padding: 0 6px; }
+.tn-palette-col + .tn-palette-col { border-left: 1px solid var(--tn-border); }
+.tn-palette-seclist { list-style: none; margin: 0 0 6px; padding: 0; }
 .tn-palette-group {
   padding: 10px 11px 4px; font-size: 10px; font-weight: 700; text-transform: uppercase;
   letter-spacing: 0.09em; color: var(--tn-text-muted); pointer-events: none;
 }
-.tn-palette-group:first-child { padding-top: 4px; }
-.tn-palette-item { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 11px; border-radius: 9px; cursor: pointer; font-size: 13.5px; color: var(--tn-text); }
+.tn-palette-col > .tn-palette-group:first-child { padding-top: 4px; }
+.tn-palette-item { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-width: 0; padding: 9px 11px; border-radius: 9px; cursor: pointer; font-size: 13.5px; color: var(--tn-text); }
 .tn-palette-item.is-active { background: var(--tn-accent-soft); color: var(--tn-accent-strong); }
-.tn-palette-hint { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--tn-text-faint); }
+.tn-palette-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-palette-hint { flex: none; font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--tn-text-faint); white-space: nowrap; }
 .tn-palette-empty { padding: 16px; text-align: center; color: var(--tn-text-faint); font-size: 13px; }
 .tn-palette-foot { display: flex; gap: 14px; padding: 8px 14px; border-top: 1px solid var(--tn-border); color: var(--tn-text-faint); font-size: 11px; }
 .tn-palette-foot .tn-kbd { background: var(--tn-chip-bg); border-radius: 5px; padding: 1px 5px; margin-right: 4px; }

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -22,7 +22,7 @@ import { langStore } from "@/lib/i18n/store";
 import { LANGS } from "@/lib/i18n/catalog";
 import { variantStore } from "@/lib/variants/store";
 import { BUILTIN_VARIANTS } from "@/lib/variants/builtins";
-import { groupCommands, GROUP_ORDER, type Command } from "@/lib/console/paletteGroups";
+import { groupCommands, columnize, GROUP_ORDER, type Command } from "@/lib/console/paletteGroups";
 import type { GeocodeResult } from "@/lib/geo/geocode";
 
 // Pick a fly-to zoom from a geocode result's extent (wider areas frame out).
@@ -189,9 +189,20 @@ function buildCommands(close: () => void): Command[] {
 export default function CommandPalette({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
+  const [vw, setVw] = useState(1280);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const commands = useMemo(() => buildCommands(onClose), [onClose]);
+
+  // Column count for the mega-menu layout — sections sit side by side, more of
+  // them the wider the viewport. Tracked in state so a resize reflows the palette.
+  useEffect(() => {
+    const onResize = () => setVw(window.innerWidth);
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  const colCount = vw >= 1080 ? 3 : vw >= 680 ? 2 : 1;
 
   // Live place search: any query ≥2 chars also geocodes (keyless Photon via
   // /api/geocode) so you can fly to ANY place (Kyiv, Gaza…), not just the
@@ -233,14 +244,26 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
       .map((g) => ({ group: g, commands: byGroup.get(g)! }));
   }, [commands, query, geoCmds]);
 
-  // Flattened visual order (groups in fixed order, commands within) — the single
-  // index space the ↑/↓ highlight moves through.
-  const flat = useMemo(() => grouped.flatMap((g) => g.commands), [grouped]);
+  // Sections laid out into side-by-side columns (the mega-menu). The flat index
+  // space is column-major — down a column, then on to the next — so ↑/↓ walk a
+  // column and ←/→ hop columns.
+  const columns = useMemo(() => columnize(grouped, colCount), [grouped, colCount]);
+  const flat = useMemo(() => columns.flat().flatMap((sec) => sec.commands), [columns]);
   const indexById = useMemo(() => {
     const m = new Map<string, number>();
     flat.forEach((c, i) => m.set(c.id, i));
     return m;
   }, [flat]);
+  // Each column's start offset + length in the flat index space — drives ←/→.
+  const colMeta = useMemo(() => {
+    let start = 0;
+    return columns.map((col) => {
+      const len = col.reduce((s, sec) => s + sec.commands.length, 0);
+      const m = { start, len };
+      start += len;
+      return m;
+    });
+  }, [columns]);
 
   const activeRef = useRef<HTMLLIElement | null>(null);
   useEffect(() => { activeRef.current?.scrollIntoView({ block: "nearest" }); }, [active]);
@@ -271,6 +294,17 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setActive((a) => Math.max(a - 1, 0));
+    } else if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      const delta = e.key === "ArrowRight" ? 1 : -1;
+      setActive((a) => {
+        const ci = colMeta.findIndex((m) => a >= m.start && a < m.start + m.len);
+        if (ci < 0) return a;
+        const target = Math.min(Math.max(ci + delta, 0), colMeta.length - 1);
+        if (target === ci) return a;
+        const offset = a - colMeta[ci].start; // keep the same row when hopping columns
+        return colMeta[target].start + Math.min(offset, colMeta[target].len - 1);
+      });
     } else if (e.key === "Enter") {
       e.preventDefault();
       flat[active]?.run();
@@ -289,36 +323,43 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Command search"
         />
-        <ul className="tn-palette-list" role="listbox">
-          {flat.length === 0 ? (
-            <li className="tn-palette-empty">No matching commands</li>
-          ) : (
-            grouped.map((g) => (
-              <Fragment key={g.group}>
-                <li className="tn-palette-group" role="presentation" aria-hidden="true">{g.group}</li>
-                {g.commands.map((c) => {
-                  const i = indexById.get(c.id)!;
-                  return (
-                    <li
-                      key={c.id}
-                      ref={i === active ? activeRef : undefined}
-                      role="option"
-                      aria-selected={i === active}
-                      className={`tn-palette-item${i === active ? " is-active" : ""}`}
-                      onMouseEnter={() => setActive(i)}
-                      onClick={() => c.run()}
-                    >
-                      <span>{c.label}</span>
-                      <span className="tn-palette-hint">{c.hint}</span>
-                    </li>
-                  );
-                })}
-              </Fragment>
-            ))
-          )}
-        </ul>
+        {flat.length === 0 ? (
+          <div className="tn-palette-empty">No matching commands</div>
+        ) : (
+          <div className="tn-palette-cols" role="listbox">
+            {columns.map((col, ci) => (
+              <div className="tn-palette-col" key={ci}>
+                {col.map((g) => (
+                  <Fragment key={g.group}>
+                    <div className="tn-palette-group" aria-hidden="true">{g.group}</div>
+                    <ul className="tn-palette-seclist" role="presentation">
+                      {g.commands.map((c) => {
+                        const i = indexById.get(c.id)!;
+                        return (
+                          <li
+                            key={c.id}
+                            ref={i === active ? activeRef : undefined}
+                            role="option"
+                            aria-selected={i === active}
+                            className={`tn-palette-item${i === active ? " is-active" : ""}`}
+                            onMouseEnter={() => setActive(i)}
+                            onClick={() => c.run()}
+                          >
+                            <span className="tn-palette-label">{c.label}</span>
+                            <span className="tn-palette-hint">{c.hint}</span>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </Fragment>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
         <div className="tn-palette-foot">
-          <span><span className="tn-kbd">↑↓</span> navigate</span>
+          <span><span className="tn-kbd">↑↓</span> in column</span>
+          <span><span className="tn-kbd">←→</span> columns</span>
           <span><span className="tn-kbd">↵</span> run</span>
           <span><span className="tn-kbd">esc</span> close</span>
         </div>

--- a/lib/console/paletteGroups.ts
+++ b/lib/console/paletteGroups.ts
@@ -77,3 +77,36 @@ export function groupCommands(commands: Command[], query: string): GroupedComman
   }
   return out;
 }
+
+/**
+ * Lay the (already ordered) sections out across `columnCount` side-by-side columns
+ * for the mega-menu palette — sections stay whole (never split) and keep GROUP_ORDER,
+ * flowing left-to-right. Each section lands in the column its running "centre of mass"
+ * falls into, then clamped so columns fill sequentially with no gaps and no backwards
+ * jumps. The result reads column-major (top of col 0 → bottom, then col 1 …), which is
+ * exactly the order ↑/↓ walks in the palette. Columns beyond the section count collapse
+ * away, so a 2-section filter never renders 3 empty columns.
+ */
+export function columnize(sections: GroupedCommands[], columnCount: number): GroupedCommands[][] {
+  if (sections.length === 0) return [];
+  const n = Math.max(1, Math.min(columnCount, sections.length));
+  const cols: GroupedCommands[][] = Array.from({ length: n }, () => []);
+  const total = sections.reduce((s, g) => s + g.commands.length, 0);
+  const target = total / n; // items per column, on average
+  let col = 0;
+  let colWeight = 0;
+  for (let i = 0; i < sections.length; i++) {
+    const remaining = sections.length - i; // sections still to place, incl. this one
+    if (col < n - 1 && colWeight > 0) {
+      const emptyAfter = n - 1 - col; // columns after the current one still needing content
+      // Forced: keeping this section here would strand a trailing column empty.
+      const forced = remaining - 1 < emptyAfter;
+      // Balanced: current column has met its share and advancing won't strand columns.
+      const balanced = colWeight >= target && remaining - 1 >= emptyAfter;
+      if (forced || balanced) { col += 1; colWeight = 0; }
+    }
+    cols[col].push(sections[i]);
+    colWeight += sections[i].commands.length;
+  }
+  return cols;
+}

--- a/tests/unit/palette-groups.test.ts
+++ b/tests/unit/palette-groups.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { groupCommands, GROUP_ORDER, type Command } from "@/lib/console/paletteGroups";
+import { groupCommands, columnize, GROUP_ORDER, type Command, type GroupedCommands } from "@/lib/console/paletteGroups";
 
 const cmd = (id: string, label: string, hint: string, group: Command["group"]): Command =>
   ({ id, label, hint, group, run: () => {} });
@@ -72,4 +72,48 @@ test("partial matches across groups keep only the non-empty groups, in order", (
   const g = groupCommands(cmds, "wor");
   // "wor" hits World (Profiles) + Worthing (Go to) + world (Layer sets), in GROUP_ORDER.
   expect(g.map((x) => x.group)).toEqual(["Profiles", "Go to", "Layer sets"]);
+});
+
+// ── columnize: lay ordered sections into side-by-side mega-menu columns ──────
+const sec = (group: Command["group"], n: number): GroupedCommands =>
+  ({ group, commands: Array.from({ length: n }, (_, i) => cmd(`${group}-${i}`, `${group} ${i}`, "", group)) });
+
+test("columnize preserves section order when read column-major", () => {
+  const sections = [sec("Profiles", 4), sec("Go to", 4), sec("Add widget", 4), sec("Stage", 4)];
+  const cols = columnize(sections, 2);
+  const order = cols.flat().map((s) => s.group);
+  expect(order).toEqual(["Profiles", "Go to", "Add widget", "Stage"]);
+});
+
+test("columnize fills columns with no gaps and never splits a section", () => {
+  const sections = [sec("Profiles", 40), sec("Go to", 2), sec("Stage", 2)]; // one huge section
+  const cols = columnize(sections, 3);
+  expect(cols.every((c) => c.length > 0)).toBe(true); // no empty column
+  // every section appears exactly once, intact
+  const groups = cols.flat().map((s) => s.group).sort();
+  expect(groups).toEqual(["Go to", "Profiles", "Stage"]);
+});
+
+test("columnize caps the column count at the number of sections", () => {
+  const cols = columnize([sec("Profiles", 3), sec("Go to", 3)], 5);
+  expect(cols).toHaveLength(2);
+});
+
+test("columnize with one column keeps everything in a single column", () => {
+  const sections = [sec("Profiles", 3), sec("Go to", 3), sec("Stage", 3)];
+  const cols = columnize(sections, 1);
+  expect(cols).toHaveLength(1);
+  expect(cols[0].map((s) => s.group)).toEqual(["Profiles", "Go to", "Stage"]);
+});
+
+test("columnize returns no columns for no sections", () => {
+  expect(columnize([], 3)).toEqual([]);
+});
+
+test("columnize roughly balances even sections across columns", () => {
+  const sections = [sec("Profiles", 3), sec("Go to", 3), sec("Add widget", 3), sec("Stage", 3), sec("Scenarios", 3), sec("Appearance", 3)];
+  const cols = columnize(sections, 3);
+  expect(cols).toHaveLength(3);
+  // 6 equal sections into 3 columns → 2 sections each
+  expect(cols.map((c) => c.length)).toEqual([2, 2, 2]);
 });


### PR DESCRIPTION
Sections now render as columns (Profiles | Go to | Add widget ...) divided by hairline rules, instead of one tall scrolling list — so several sections are visible at once.

- New pure `columnize(sections, n)` in paletteGroups: balances the ordered sections into n contiguous, non-empty columns (never splits a section, no gaps, column-major reading order). Unit-tested.
- Responsive column count (3 / 2 / 1) from viewport width, reflowed on resize; palette widened to min(980px, 95vw).
- Keyboard model is now 2D: up/down walk a column, left/right hop columns keeping the same row; Enter/Esc unchanged. Footer legend updated.
- Long labels ellipsize so they stay tidy in a narrow column.