### PR TITLE
feat(markets): professional trading-chart overhaul (candles, indicators, ATH%, alerts, live rates)

### DIFF
--- a/app/api/markets/ath/route.ts
+++ b/app/api/markets/ath/route.ts
@@ -1,0 +1,54 @@
+import { parseYahooSeries, type YahooChartResponse } from "@/lib/markets/chart";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/markets/ath?symbols=BTC-USD,SPY,BZ=F — keyless all-time-high per symbol,
+// from Yahoo v8 monthly candles over range=max (the max monthly high ≈ ATH; honest
+// monthly resolution, labelled as such in the UI). Dormant-safe: any failure /
+// unknown symbol is simply omitted from the map, never a 5xx. Hard-cached per
+// symbol (ATH barely moves) so the table can enrich itself without hammering Yahoo.
+
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const CACHE_TTL_MS = 6 * 60 * 60_000; // 6h — an all-time high changes rarely
+const SYMBOL_RE = /^\^?[A-Za-z0-9.=-]{1,20}$/;
+const MAX_SYMBOLS = 40;
+const CACHE_MAX = 300;
+const cache = new Map<string, { at: number; ath: number }>();
+
+async function getJson<T>(url: string, ms = 12_000): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { "User-Agent": UA, Accept: "application/json" }, signal: AbortSignal.timeout(ms) });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function athFor(symbol: string): Promise<number | null> {
+  const hit = cache.get(symbol);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.ath;
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?range=max&interval=1mo`;
+  const candles = parseYahooSeries(await getJson<YahooChartResponse>(url));
+  if (candles.length === 0) return null;
+  let hi = -Infinity;
+  for (const k of candles) if (k.h > hi) hi = k.h;
+  if (!Number.isFinite(hi)) return null;
+  cache.set(symbol, { at: Date.now(), ath: hi });
+  if (cache.size > CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  return hi;
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const symbols = Array.from(
+    new Set((url.searchParams.get("symbols") ?? "").split(",").map((s) => s.trim().toUpperCase()).filter((s) => SYMBOL_RE.test(s))),
+  ).slice(0, MAX_SYMBOLS);
+  const entries = await Promise.all(symbols.map(async (s) => [s, await athFor(s)] as const));
+  const ath: Record<string, number> = {};
+  for (const [s, v] of entries) if (v != null) ath[s] = v;
+  return Response.json({ ath });
+}

--- a/app/api/markets/chart/route.ts
+++ b/app/api/markets/chart/route.ts
@@ -1,4 +1,4 @@
-import { parseYahooSeries, RANGES, type Candle, type Range, type YahooChartResponse } from "@/lib/markets/chart";
+import { parseYahooSeries, sliceRecent, yahooParamsFor, RANGES, type Candle, type Range, type YahooChartResponse } from "@/lib/markets/chart";
 
 export const dynamic = "force-dynamic";
 
@@ -24,11 +24,6 @@ async function getJson<T>(url: string, ms = 12_000): Promise<T | null> {
   }
 }
 
-// Weekly bars over a year keep the point count sane; daily for the shorter windows.
-function intervalFor(range: Range): string {
-  return range === "1y" ? "1wk" : "1d";
-}
-
 const CACHE_MAX = 200; // bound the cache so a flood of distinct attacker-supplied symbols can't grow it unbounded
 const cache = new Map<string, { at: number; candles: Candle[] }>();
 
@@ -50,11 +45,14 @@ export async function GET(req: Request): Promise<Response> {
     return Response.json({ candles: hit.candles });
   }
 
+  // Map our timeframe → Yahoo (range, interval); intraday windows over-fetch a day
+  // and are trimmed to their trailing span (Yahoo has no native "last hour" range).
+  const { range: yRange, interval, sliceMs } = yahooParamsFor(range);
   const yahooUrl =
     `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}` +
-    `?range=${encodeURIComponent(range)}&interval=${intervalFor(range)}`;
+    `?range=${encodeURIComponent(yRange)}&interval=${encodeURIComponent(interval)}`;
   const json = await getJson<YahooChartResponse>(yahooUrl);
-  const candles = parseYahooSeries(json);
+  const candles = sliceRecent(parseYahooSeries(json), sliceMs);
   // Only cache a non-empty result so a transient upstream blip doesn't pin an empty
   // series for 5 minutes; empties simply retry next request.
   if (candles.length > 0) {

--- a/app/api/markets/route.ts
+++ b/app/api/markets/route.ts
@@ -76,9 +76,14 @@ async function getJson<T>(url: string, ms = 12_000): Promise<T | null> {
   }
 }
 
-/** Fetch each Yahoo symbol in parallel and keep the rows that resolve. */
+/** Fetch each Yahoo symbol in parallel and keep the rows that resolve. Carries the
+ *  Yahoo ticker as chartSymbol so the focus view can pull real OHLC history even
+ *  when the display symbol differs (e.g. Brent→BZ=F). */
 async function yahooRows(specs: { y: string; symbol: string; name: string }[]): Promise<MarketSection["rows"]> {
-  const rows = await Promise.all(specs.map(async (spec) => parseYahooChart(await getJson<YahooChart>(yahooUrl(spec.y)), spec)));
+  const rows = await Promise.all(specs.map(async (spec) => {
+    const row = parseYahooChart(await getJson<YahooChart>(yahooUrl(spec.y)), spec);
+    return row ? { ...row, chartSymbol: spec.y } : null;
+  }));
   return rows.filter((r): r is NonNullable<typeof r> => r != null);
 }
 
@@ -109,7 +114,8 @@ async function equitiesSection(): Promise<MarketSection> {
       return { symbol: e.symbol, name: e.name, c: q?.c, dp: q?.dp };
     }),
   );
-  return { key: "equities", label: "Equities", source: "Finnhub", rows: parseEquities(quotes) };
+  // Finnhub tickers match Yahoo's, so charts pull real OHLC under the same symbol.
+  return { key: "equities", label: "Equities", source: "Finnhub", rows: parseEquities(quotes).map((r) => ({ ...r, chartSymbol: r.symbol })) };
 }
 
 async function macroSection(): Promise<MarketSection> {

--- a/app/api/markets/route.ts
+++ b/app/api/markets/route.ts
@@ -5,6 +5,7 @@ import {
   parseEquities,
   parseMacro,
   parseYahooChart,
+  macroRowFromYahoo,
   type CoinGeckoMarket,
   type MarketsPayload,
   type MarketSection,
@@ -60,6 +61,15 @@ const YAHOO_EQUITIES: { y: string; symbol: string; name: string }[] = [
   { y: "AAPL", symbol: "AAPL", name: "Apple" },
   { y: "MSFT", symbol: "MSFT", name: "Microsoft" },
   { y: "NVDA", symbol: "NVDA", name: "Nvidia" },
+];
+// Keyless macro fallback: Yahoo's rate/vol indices quote the figure directly
+// (^TNX/^FVX/^TYX = the Treasury yield in %; ^VIX = the volatility level), so the
+// Macro panel is live without a FRED key. FRED (real series) is used when keyed.
+const YAHOO_MACRO: { y: string; symbol: string; name: string; unit: string }[] = [
+  { y: "^TNX", symbol: "US 10Y", name: "US 10-Yr Treasury Yield", unit: "%" },
+  { y: "^FVX", symbol: "US 5Y", name: "US 5-Yr Treasury Yield", unit: "%" },
+  { y: "^TYX", symbol: "US 30Y", name: "US 30-Yr Treasury Yield", unit: "%" },
+  { y: "^VIX", symbol: "VIX", name: "Volatility (VIX)", unit: "" },
 ];
 const yahooUrl = (sym: string) =>
   `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(sym)}?interval=1d&range=1d`;
@@ -121,7 +131,9 @@ async function equitiesSection(): Promise<MarketSection> {
 async function macroSection(): Promise<MarketSection> {
   const key = (process.env.FRED_API_KEY ?? "").trim();
   if (!key) {
-    return { key: "macro", label: "Macro / rates", source: "FRED (St. Louis Fed)", dormant: true, note: "Set FRED_API_KEY to enable.", rows: [] };
+    // Keyless: live Treasury yields + VIX from Yahoo instead of a dormant panel.
+    const rows = await Promise.all(YAHOO_MACRO.map(async (s) => macroRowFromYahoo(await getJson<YahooChart>(yahooUrl(s.y)), s)));
+    return { key: "macro", label: "Macro / rates", source: "Yahoo Finance · delayed, keyless", rows: rows.filter((r): r is NonNullable<typeof r> => r != null) };
   }
   const series = await Promise.all(
     FRED_SERIES.map(async (s) => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1586,6 +1586,13 @@ a { color: var(--tn-accent); }
 .tn-mk-ohlc-t { color: var(--tn-text-faint); }
 .tn-mk-rsi { margin-top: 4px; }
 .tn-mk-rsi-label { font-size: 10px; color: var(--tn-text-faint); text-transform: uppercase; letter-spacing: .05em; }
+/* 52-week range slider */
+.tn-mk-rangebar { display: flex; align-items: center; gap: 8px; margin-top: 8px; font-size: 11px; color: var(--tn-text-faint); font-variant-numeric: tabular-nums; }
+.tn-mk-rb-end { flex: none; }
+.tn-mk-rb-track { position: relative; flex: 1 1 auto; height: 5px; border-radius: 999px; background: var(--tn-surface-2); }
+.tn-mk-rb-fill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 999px; background: linear-gradient(90deg, var(--tn-border), var(--tn-accent)); }
+.tn-mk-rb-dot { position: absolute; top: 50%; width: 9px; height: 9px; border-radius: 50%; background: #fff; border: 2px solid var(--tn-accent); transform: translate(-50%, -50%); }
+.tn-mk-ath { color: var(--tn-text-muted); font-variant-numeric: tabular-nums; }
 /* instrument table */
 .tn-mk-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .tn-mk-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1593,6 +1593,16 @@ a { color: var(--tn-accent); }
 .tn-mk-rb-fill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 999px; background: linear-gradient(90deg, var(--tn-border), var(--tn-accent)); }
 .tn-mk-rb-dot { position: absolute; top: 50%; width: 9px; height: 9px; border-radius: 50%; background: #fff; border: 2px solid var(--tn-accent); transform: translate(-50%, -50%); }
 .tn-mk-ath { color: var(--tn-text-muted); font-variant-numeric: tabular-nums; }
+/* price alerts */
+.tn-mk-ctrls-l { display: flex; align-items: center; gap: 8px; }
+.tn-mk-bell { font: inherit; font-size: 12px; line-height: 1; padding: 3px 8px; border: 1px solid var(--tn-border); border-radius: 999px; background: transparent; cursor: pointer; filter: grayscale(1); opacity: .7; }
+.tn-mk-bell.on { filter: none; opacity: 1; border-color: var(--tn-accent); background: var(--tn-surface-2); }
+.tn-candle.is-armed { cursor: crosshair; }
+.tn-mk-arm-hint { font-size: 11px; color: var(--tn-accent); margin: 2px 0; }
+.tn-mk-alerts { display: flex; flex-wrap: wrap; gap: 6px; margin: 4px 0; }
+.tn-mk-alert { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; padding: 1px 4px 1px 7px; border-radius: 999px; border: 1px solid var(--tn-border); font-variant-numeric: tabular-nums; }
+.tn-mk-alert.above { color: #16a34a; } .tn-mk-alert.below { color: #dc2626; }
+.tn-mk-alert button { border: 0; background: none; cursor: pointer; color: var(--tn-text-faint); font-size: 13px; line-height: 1; padding: 0 2px; }
 /* instrument table */
 .tn-mk-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .tn-mk-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1569,6 +1569,23 @@ a { color: var(--tn-accent); }
 .tn-mk-metric-label { color: var(--tn-text-faint); }
 .tn-mk-chart-note { font-size: 11px; color: var(--tn-text-faint); margin-top: 6px; }
 .tn-mk-chart-empty { display: grid; place-items: center; height: 220px; color: var(--tn-text-faint); font-size: 13px; }
+/* chart controls: candle/line segmented switch + technical-overlay chips */
+.tn-mk-chart-ctrls { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 6px 12px; margin-bottom: 6px; }
+.tn-mk-seg { display: inline-flex; border: 1px solid var(--tn-border); border-radius: 999px; overflow: hidden; }
+.tn-mk-seg button { font: inherit; font-size: 11px; padding: 3px 12px; border: 0; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-mk-seg button.active { background: var(--tn-accent); color: #fff; }
+.tn-mk-inds { display: flex; flex-wrap: wrap; gap: 4px; }
+.tn-mk-ind { font: inherit; font-size: 10.5px; padding: 2px 8px; border: 1px solid var(--tn-border); border-radius: 999px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-mk-ind.on { background: var(--tn-surface-2); border-color: var(--tn-accent); color: var(--tn-text); }
+/* candle canvas + the top-left OHLC hover read-out */
+.tn-mk-canvas { position: relative; }
+.tn-candle { display: block; touch-action: none; }
+.tn-mk-ohlc { position: absolute; top: 4px; left: 6px; z-index: 2; display: flex; flex-wrap: wrap; gap: 2px 10px; font-size: 11px; font-variant-numeric: tabular-nums; color: var(--tn-text-muted); background: rgba(255,255,255,.72); backdrop-filter: blur(4px); border-radius: 6px; padding: 2px 7px; pointer-events: none; }
+.tn-mk-ohlc b { color: var(--tn-text); font-weight: 600; }
+.tn-mk-ohlc b.up { color: #16a34a; } .tn-mk-ohlc b.down { color: #dc2626; }
+.tn-mk-ohlc-t { color: var(--tn-text-faint); }
+.tn-mk-rsi { margin-top: 4px; }
+.tn-mk-rsi-label { font-size: 10px; color: var(--tn-text-faint); text-transform: uppercase; letter-spacing: .05em; }
 /* instrument table */
 .tn-mk-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .tn-mk-table th { text-align: left; color: var(--tn-text-faint); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }

--- a/components/CandleChart.tsx
+++ b/components/CandleChart.tsx
@@ -1,0 +1,185 @@
+"use client";
+// Dependency-free SVG candlestick chart — the Markets focus view's primary chart.
+// Deliberately NOT a charting library (keeps the app's zero-dep, calm identity):
+// candles + wicks, index-spaced (no weekend gaps), with optional index-aligned
+// overlays (moving averages, Bollinger band, benchmark shape), a volume-by-price
+// profile, data-driven anomaly anchors, and a hover crosshair that reports the
+// candle under the cursor so the caller can render an OHLC read-out.
+//
+// All maths (SMA / Bollinger / RSI / volume profile / anomalies / rescale) live in
+// the unit-tested lib/markets/indicators.ts; this file is pure projection to SVG.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { extent, linear } from "@/lib/chart/scale";
+import type { Candle } from "@/lib/markets/chart";
+import type { VolBin, Anomaly } from "@/lib/markets/indicators";
+
+/** An index-aligned overlay line (same length as candles; nulls break the path). */
+export interface OverlayLine { values: (number | null)[]; color: string; width?: number; dash?: boolean }
+/** An index-aligned band (Bollinger): a faint fill + edges between upper and lower. */
+export interface BandOverlay { upper: (number | null)[]; lower: (number | null)[]; color: string }
+
+const UP = "#16a34a", DOWN = "#dc2626";
+
+export function CandleChart({
+  candles,
+  height = 240,
+  up = null,
+  overlays = [],
+  band = null,
+  volume = null,
+  anomalies = [],
+  onHover,
+}: {
+  candles: Candle[];
+  height?: number;
+  up?: boolean | null;
+  overlays?: OverlayLine[];
+  band?: BandOverlay | null;
+  volume?: VolBin[] | null;
+  anomalies?: Anomaly[];
+  onHover?: (candle: Candle | null, idx: number) => void;
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(640);
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => setW(el.clientWidth || 640));
+    ro.observe(el);
+    setW(el.clientWidth || 640);
+    return () => ro.disconnect();
+  }, []);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  const padX = 8, padT = 8;
+  const padB = anomalies.length > 0 ? 16 : 8;
+
+  const geom = useMemo(() => {
+    const n = candles.length;
+    if (n < 1) return null;
+    const bandW = (w - 2 * padX) / n;
+    const bodyW = Math.max(1, Math.min(14, bandW * 0.62));
+    // y-domain spans candle extremes plus every overlay/band value so nothing clips.
+    const ys: number[] = [];
+    for (const k of candles) { ys.push(k.h, k.l); }
+    for (const o of overlays) for (const v of o.values) if (v != null && Number.isFinite(v)) ys.push(v);
+    if (band) for (const arr of [band.upper, band.lower]) for (const v of arr) if (v != null && Number.isFinite(v)) ys.push(v);
+    const sy = linear(extent(ys), [height - padB, padT]);
+    const cx = (i: number) => padX + (i + 0.5) * bandW;
+    return { n, bandW, bodyW, sy, cx };
+  }, [candles, overlays, band, w, height, padB]);
+
+  if (!geom || candles.length < 1) return <div ref={wrapRef} style={{ width: "100%", height }} />;
+  const { n, bandW, bodyW, sy, cx } = geom;
+
+  // Index-aligned overlay → an SVG path, broken at nulls.
+  const linePath = (values: (number | null)[]): string => {
+    let d = "", pen = false;
+    for (let i = 0; i < values.length; i++) {
+      const v = values[i];
+      if (v == null || !Number.isFinite(v)) { pen = false; continue; }
+      d += `${pen ? "L" : "M"}${cx(i).toFixed(1)},${sy(v).toFixed(1)} `;
+      pen = true;
+    }
+    return d.trim();
+  };
+
+  // Bollinger band fill (only across the contiguous window where both edges exist).
+  let bandFill = "";
+  if (band) {
+    const fwd: string[] = [], back: string[] = [];
+    for (let i = 0; i < n; i++) {
+      const u = band.upper[i], l = band.lower[i];
+      if (u != null && l != null && Number.isFinite(u) && Number.isFinite(l)) {
+        fwd.push(`${cx(i).toFixed(1)},${sy(u).toFixed(1)}`);
+        back.unshift(`${cx(i).toFixed(1)},${sy(l).toFixed(1)}`);
+      }
+    }
+    if (fwd.length > 1) bandFill = `M${fwd.join(" L")} L${back.join(" L")} Z`;
+  }
+
+  // Volume-by-price bars, faint, anchored to the right edge; POC bin stands out.
+  const maxVol = volume ? Math.max(1, ...volume.map((b) => b.volume)) : 1;
+  const profileW = (w - 2 * padX) * 0.2;
+
+  const hovered = hoverIdx != null && hoverIdx >= 0 && hoverIdx < n ? candles[hoverIdx] : null;
+
+  const onMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const px = (e.clientX - rect.left) * (rect.width ? w / rect.width : 1);
+    let idx = Math.floor((px - padX) / bandW);
+    if (idx < 0) idx = 0; if (idx >= n) idx = n - 1;
+    if (idx !== hoverIdx) { setHoverIdx(idx); onHover?.(candles[idx], idx); }
+  };
+  const onLeave = () => { setHoverIdx(null); onHover?.(null, -1); };
+
+  return (
+    <div ref={wrapRef} style={{ width: "100%", height }}>
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${w} ${height}`}
+        preserveAspectRatio="none"
+        className="tn-candle"
+        role="img"
+        onMouseMove={onMove}
+        onMouseLeave={onLeave}
+      >
+        {/* Volume-by-price profile (behind everything) */}
+        {volume?.map((b, i) => {
+          const y0 = sy(b.hi), y1 = sy(b.lo);
+          const bw = (b.volume / maxVol) * profileW;
+          const isPoc = b.volume === maxVol;
+          return (
+            <rect key={`v${i}`} x={w - padX - bw} y={Math.min(y0, y1)} width={Math.max(0, bw)} height={Math.max(0.5, Math.abs(y1 - y0))}
+              fill={isPoc ? "#4a78c9" : "#8aa0b8"} opacity={isPoc ? 0.28 : 0.14} />
+          );
+        })}
+
+        {/* Bollinger fill + edges */}
+        {bandFill && <path d={bandFill} fill={band!.color} opacity="0.08" />}
+        {band && <path d={linePath(band.upper)} fill="none" stroke={band.color} strokeWidth="1" opacity="0.5" strokeDasharray="3 3" />}
+        {band && <path d={linePath(band.lower)} fill="none" stroke={band.color} strokeWidth="1" opacity="0.5" strokeDasharray="3 3" />}
+
+        {/* Candles: wick + body */}
+        {candles.map((k, i) => {
+          const green = k.c >= k.o;
+          const col = green ? UP : DOWN;
+          const x = cx(i);
+          const yHi = sy(k.h), yLo = sy(k.l);
+          const yO = sy(k.o), yC = sy(k.c);
+          const top = Math.min(yO, yC), bot = Math.max(yO, yC);
+          const isHover = i === hoverIdx;
+          return (
+            <g key={k.t} opacity={hoverIdx == null || isHover ? 1 : 0.72}>
+              <line x1={x} y1={yHi} x2={x} y2={yLo} stroke={col} strokeWidth="1" />
+              <rect x={x - bodyW / 2} y={top} width={bodyW} height={Math.max(1, bot - top)} fill={col} />
+            </g>
+          );
+        })}
+
+        {/* Overlay lines (moving averages, benchmark shape) */}
+        {overlays.map((o, i) => (
+          <path key={`o${i}`} d={linePath(o.values)} fill="none" stroke={o.color}
+            strokeWidth={o.width ?? 1.4} strokeDasharray={o.dash ? "5 4" : undefined}
+            opacity={o.dash ? 0.7 : 0.95} strokeLinejoin="round" />
+        ))}
+
+        {/* Anomaly anchors on the time axis */}
+        {anomalies.map((a) => (
+          <g key={`a${a.idx}`}>
+            <line x1={cx(a.idx)} y1={height - padB} x2={cx(a.idx)} y2={height - padB + 5} stroke={a.up ? UP : DOWN} strokeWidth="1" />
+            <path d={`M${cx(a.idx)},${height - 2} l-3.5,-6 l7,0 Z`} fill={a.up ? UP : DOWN} opacity="0.85">
+              <title>{`${a.up ? "+" : ""}${a.pct.toFixed(1)}% — ${new Date(a.t).toLocaleDateString()}`}</title>
+            </path>
+          </g>
+        ))}
+
+        {/* Hover crosshair */}
+        {hovered && (
+          <line x1={cx(hoverIdx!)} y1={padT} x2={cx(hoverIdx!)} y2={height - padB} stroke="var(--tn-text-faint, #94a3b8)" strokeWidth="1" strokeDasharray="2 3" opacity="0.7" />
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/components/CandleChart.tsx
+++ b/components/CandleChart.tsx
@@ -20,6 +20,9 @@ export interface BandOverlay { upper: (number | null)[]; lower: (number | null)[
 
 const UP = "#16a34a", DOWN = "#dc2626";
 
+/** A persistent horizontal price guide (e.g. an armed alert level). */
+export interface PriceGuide { price: number; color: string; label?: string }
+
 export function CandleChart({
   candles,
   height = 240,
@@ -28,7 +31,10 @@ export function CandleChart({
   band = null,
   volume = null,
   anomalies = [],
+  guides = [],
+  armed = false,
   onHover,
+  onPriceClick,
 }: {
   candles: Candle[];
   height?: number;
@@ -37,7 +43,10 @@ export function CandleChart({
   band?: BandOverlay | null;
   volume?: VolBin[] | null;
   anomalies?: Anomaly[];
+  guides?: PriceGuide[];
+  armed?: boolean;
   onHover?: (candle: Candle | null, idx: number) => void;
+  onPriceClick?: (price: number) => void;
 }) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const [w, setW] = useState(640);
@@ -64,13 +73,18 @@ export function CandleChart({
     for (const k of candles) { ys.push(k.h, k.l); }
     for (const o of overlays) for (const v of o.values) if (v != null && Number.isFinite(v)) ys.push(v);
     if (band) for (const arr of [band.upper, band.lower]) for (const v of arr) if (v != null && Number.isFinite(v)) ys.push(v);
-    const sy = linear(extent(ys), [height - padB, padT]);
+    const [yLo, yHi] = extent(ys);
+    const sy = linear([yLo, yHi], [height - padB, padT]);
     const cx = (i: number) => padX + (i + 0.5) * bandW;
-    return { n, bandW, bodyW, sy, cx };
+    return { n, bandW, bodyW, sy, cx, yLo, yHi };
   }, [candles, overlays, band, w, height, padB]);
 
+  const [armPrice, setArmPrice] = useState<number | null>(null);
+
   if (!geom || candles.length < 1) return <div ref={wrapRef} style={{ width: "100%", height }} />;
-  const { n, bandW, bodyW, sy, cx } = geom;
+  const { n, bandW, bodyW, sy, cx, yLo, yHi } = geom;
+  // Inverse of sy: pixel-y → price (yLo maps to the axis bottom, yHi to the top).
+  const priceAtY = (pix: number) => yLo + (pix - (height - padB)) * ((yHi - yLo) / (padT - (height - padB)));
 
   // Index-aligned overlay → an SVG path, broken at nulls.
   const linePath = (values: (number | null)[]): string => {
@@ -110,8 +124,19 @@ export function CandleChart({
     let idx = Math.floor((px - padX) / bandW);
     if (idx < 0) idx = 0; if (idx >= n) idx = n - 1;
     if (idx !== hoverIdx) { setHoverIdx(idx); onHover?.(candles[idx], idx); }
+    if (armed) {
+      const py = (e.clientY - rect.top) * (rect.height ? height / rect.height : 1);
+      setArmPrice(priceAtY(py));
+    }
   };
-  const onLeave = () => { setHoverIdx(null); onHover?.(null, -1); };
+  const onLeave = () => { setHoverIdx(null); setArmPrice(null); onHover?.(null, -1); };
+  const onClick = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (!armed || !onPriceClick) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const py = (e.clientY - rect.top) * (rect.height ? height / rect.height : 1);
+    onPriceClick(priceAtY(py));
+  };
+  const fmtP = (n: number) => n.toLocaleString("en-US", { maximumFractionDigits: n >= 1 ? 2 : 6 });
 
   return (
     <div ref={wrapRef} style={{ width: "100%", height }}>
@@ -120,10 +145,11 @@ export function CandleChart({
         height={height}
         viewBox={`0 0 ${w} ${height}`}
         preserveAspectRatio="none"
-        className="tn-candle"
+        className={`tn-candle${armed ? " is-armed" : ""}`}
         role="img"
         onMouseMove={onMove}
         onMouseLeave={onLeave}
+        onClick={onClick}
       >
         {/* Volume-by-price profile (behind everything) */}
         {volume?.map((b, i) => {
@@ -174,6 +200,26 @@ export function CandleChart({
             </path>
           </g>
         ))}
+
+        {/* Persistent price guides (armed alert levels) */}
+        {guides.map((g, i) => {
+          const gy = sy(g.price);
+          if (!Number.isFinite(gy)) return null;
+          return (
+            <g key={`g${i}`}>
+              <line x1={padX} y1={gy} x2={w - padX} y2={gy} stroke={g.color} strokeWidth="1" strokeDasharray="4 3" opacity="0.85" />
+              <text x={padX + 3} y={gy - 3} fontSize={10} fill={g.color}>{g.label ?? fmtP(g.price)}</text>
+            </g>
+          );
+        })}
+
+        {/* Armed cursor guide: the price the next click would set an alert at */}
+        {armed && armPrice != null && (
+          <g>
+            <line x1={padX} y1={sy(armPrice)} x2={w - padX} y2={sy(armPrice)} stroke="var(--tn-accent, #38bdf8)" strokeWidth="1" strokeDasharray="2 2" />
+            <text x={w - padX - 3} y={sy(armPrice) - 3} fontSize={10} textAnchor="end" fill="var(--tn-accent, #38bdf8)">🔔 {fmtP(armPrice)}</text>
+          </g>
+        )}
 
         {/* Hover crosshair */}
         {hovered && (

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -2,6 +2,7 @@
 // Native SVG line/area chart — the shared, dependency-free charting primitive
 // (generalises Sparkline). Presentational: caller supplies {x,y} points already
 // in data space. Renders nothing below 2 points. up tints the stroke green/red.
+import { useId } from "react";
 import { extent, linear } from "@/lib/chart/scale";
 
 export interface ChartPoint { x: number; y: number }
@@ -14,6 +15,7 @@ export function Chart({
   up,
   zeroBaseline = true,
   markers = false,
+  gradient = false,
 }: {
   points: ChartPoint[];
   width?: number;
@@ -25,7 +27,11 @@ export function Chart({
   zeroBaseline?: boolean;
   /** Draw min-low / max-high / last dots with tiny value labels (price charts). */
   markers?: boolean;
+  /** Soft performance-tinted gradient beneath the line (green up / red down),
+   *  fading to transparent at the baseline. Replaces the flat area tint. */
+  gradient?: boolean;
 }) {
+  const gradId = useId();
   if (!points || points.length < 2) return null;
   const pad = 6;
   const xs = points.map((p) => p.x);
@@ -50,8 +56,16 @@ export function Chart({
 
   return (
     <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} className="tn-chart" preserveAspectRatio="none" role="img">
+      {gradient && (
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={stroke} stopOpacity="0.34" />
+            <stop offset="100%" stopColor={stroke} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+      )}
       <line x1={pad} y1={height - pad} x2={width - pad} y2={height - pad} stroke="var(--tn-border, #1e293b)" strokeWidth="1" />
-      {area && <path d={fillPath} fill={stroke} opacity="0.12" />}
+      {area && <path d={fillPath} fill={gradient ? `url(#${gradId})` : stroke} opacity={gradient ? 1 : 0.12} />}
       <path d={line} fill="none" stroke={stroke} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
       {markerDots.length > 0 && (
         <g>

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -14,11 +14,10 @@ import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { Chart, type ChartPoint } from "@/components/Chart";
 import { shellLayoutStore } from "@/lib/console/store";
-import { candlesToPoints, hiLo, periodChange, RANGES, type Candle, type Range } from "@/lib/markets/chart";
+import { candlesToPoints, hiLo, periodChange, RANGES, RANGE_LABEL, type Candle, type Range } from "@/lib/markets/chart";
 import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
 const EMPTY: MarketsPayload = { generatedAt: 0, sections: [] };
-const RANGE_LABEL: Record<Range, string> = { "1mo": "1M", "6mo": "6M", "1y": "1Y" };
 type TableSortKey = "name" | "changePct" | "value";
 
 /** Adaptive-precision number formatting for prices/levels (large → 2dp, tiny → 6dp). */

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -20,7 +20,7 @@ import { sma, bollinger, rsi, volumeProfile, rescaleShape, anomalyFlags } from "
 import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
 const EMPTY: MarketsPayload = { generatedAt: 0, sections: [] };
-type TableSortKey = "name" | "changePct" | "value";
+type TableSortKey = "name" | "changePct" | "value" | "ath";
 type ChartType = "candles" | "line";
 type IndKey = "ma" | "boll" | "vol" | "rsi" | "bench" | "anom";
 const IND_CHIPS: [IndKey, string][] = [["ma", "MA 50/200"], ["boll", "Bollinger"], ["vol", "Volume"], ["rsi", "RSI"], ["bench", "Benchmark"], ["anom", "Events"]];
@@ -43,6 +43,27 @@ function resample(src: number[], n: number): number[] {
   const span = src.length - 1, denom = n - 1 || 1;
   for (let i = 0; i < n; i++) out.push(src[Math.min(span, Math.max(0, Math.round((i * span) / denom)))]);
   return out;
+}
+
+/** Percent below the all-time high (0 = at ATH, −40 = 40% down). null if unknown. */
+function athPct(cur: number | undefined, ath: number | undefined): number | null {
+  if (cur == null || ath == null || !(ath > 0)) return null;
+  return (cur / ath - 1) * 100;
+}
+
+/** A 52-week (or period) range slider: where the current price sits between lo/hi. */
+function RangeBar({ lo, hi, cur }: { lo: number; hi: number; cur: number }) {
+  const pct = hi > lo ? Math.min(100, Math.max(0, ((cur - lo) / (hi - lo)) * 100)) : 50;
+  return (
+    <div className="tn-mk-rangebar" title={`low ${fmtNum(lo)} · now ${fmtNum(cur)} · high ${fmtNum(hi)}`}>
+      <span className="tn-mk-rb-end">{fmtNum(lo)}</span>
+      <span className="tn-mk-rb-track">
+        <span className="tn-mk-rb-fill" style={{ width: `${pct}%` }} />
+        <span className="tn-mk-rb-dot" style={{ left: `${pct}%` }} />
+      </span>
+      <span className="tn-mk-rb-end">{fmtNum(hi)}</span>
+    </div>
+  );
 }
 
 /** Adaptive-precision number formatting for prices/levels (large → 2dp, tiny → 6dp). */
@@ -123,6 +144,25 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
     () => railSections.find((s) => s.rows.some((r) => r.id === selId))?.key,
     [railSections, selId],
   );
+
+  // All-time-high enrichment for the "ATH %" column: batched, keyless, hard-cached
+  // server-side. Keyed by upper-cased chartSymbol (Yahoo ticker) so the table can
+  // show how far each asset trades below its historical peak.
+  const [athMap, setAthMap] = useState<Record<string, number>>({});
+  const athSyms = useMemo(
+    () => Array.from(new Set(allRows.map((r) => r.chartSymbol?.toUpperCase()).filter((s): s is string => !!s))),
+    [allRows],
+  );
+  useEffect(() => {
+    if (athSyms.length === 0) return;
+    let alive = true;
+    fetch(`/api/markets/ath?symbols=${encodeURIComponent(athSyms.join(","))}`)
+      .then((r) => r.json())
+      .then((d: { ath?: Record<string, number> }) => { if (alive) setAthMap(d.ath ?? {}); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [athSyms.join(",")]); // eslint-disable-line react-hooks/exhaustive-deps
+  const athOf = (r: MarketRow) => athPct(r.num, r.chartSymbol ? athMap[r.chartSymbol.toUpperCase()] : undefined);
 
   // Primary historical chart: keyless Yahoo v8 OHLC for the selected instrument +
   // range. Dormant-safe — the route never 5xxes, and a <2-candle result (dormant /
@@ -224,10 +264,11 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
       let d: number;
       if (sortKey === "name") d = (a.r.symbol ?? a.r.name).localeCompare(b.r.symbol ?? b.r.name);
       else if (sortKey === "changePct") d = (a.r.changePct ?? -Infinity) - (b.r.changePct ?? -Infinity);
+      else if (sortKey === "ath") d = (athOf(a.r) ?? -Infinity) - (athOf(b.r) ?? -Infinity);
       else d = (a.r.num ?? -Infinity) - (b.r.num ?? -Infinity);
       return d * sortDir;
     });
-  }, [railSections, sortKey, sortDir]);
+  }, [railSections, sortKey, sortDir, athMap]); // eslint-disable-line react-hooks/exhaustive-deps
   const toggleSort = (k: TableSortKey) => {
     if (sortKey === k) setSortDir((d) => (d === 1 ? -1 : 1));
     else { setSortKey(k); setSortDir(k === "name" ? 1 : -1); }
@@ -399,11 +440,18 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
                         <b>{fmtNum(range52.lo)} – {fmtNum(range52.hi)}</b>
                       </span>
                     )}
+                    {(() => { const a = selRow ? athOf(selRow) : null; return a == null ? null : (
+                      <span className="tn-mk-metric"><span className="tn-mk-metric-label">From ATH</span> <b>{a >= -0.05 ? "at high" : `${a.toFixed(1)}%`}</b></span>
+                    ); })()}
                     <span className="tn-mk-metric"><span className="tn-mk-metric-label">{candles.length} bars · Yahoo v8, delayed</span></span>
                   </div>
                 ) : chartPoints.length >= 2 ? (
                   <div className="tn-mk-chart-note">Live session (accumulating) — historical unavailable for this symbol.</div>
                 ) : null}
+
+                {hasHistory && range52 && candles.length > 0 && (
+                  <RangeBar lo={range52.lo} hi={range52.hi} cur={candles[candles.length - 1].c} />
+                )}
               </div>
             ) : (
               <p className="tn-w-empty">Select an instrument to see its chart.</p>
@@ -414,6 +462,7 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
                 <tr>
                   <th className="sortable" onClick={() => toggleSort("name")}>Instrument{sortMark("name")}</th>
                   <th className="sortable num" onClick={() => toggleSort("changePct")}>Change{sortMark("changePct")}</th>
+                  <th className="sortable num" onClick={() => toggleSort("ath")} title="Percent below all-time high">ATH %{sortMark("ath")}</th>
                   <th className="sortable num" onClick={() => toggleSort("value")}>Value{sortMark("value")}</th>
                 </tr>
               </thead>
@@ -429,11 +478,14 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
                             ? <span className={`tn-mk-chg ${r.changePct >= 0 ? "up" : "down"}`}>{r.changePct >= 0 ? "+" : ""}{r.changePct}%</span>
                             : <span className="tn-mk-row-name">—</span>}
                         </td>
+                        <td className="num">
+                          {(() => { const a = athOf(r); return a == null ? <span className="tn-mk-row-name">—</span> : <span className="tn-mk-ath">{a >= -0.05 ? "at high" : `${a.toFixed(1)}%`}</span>; })()}
+                        </td>
                         <td className="num">{r.value}</td>
                       </tr>
                       {isOpen && (
                         <tr className="tn-mk-drill">
-                          <td colSpan={3}>
+                          <td colSpan={4}>
                             <dl>
                               <dt>Value</dt><dd>{r.value}</dd>
                               {r.changePct != null && (<><dt>Change</dt><dd className={`tn-mk-chg ${r.changePct >= 0 ? "up" : "down"}`}>{r.changePct >= 0 ? "+" : ""}{r.changePct}%</dd></>)}

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -13,12 +13,37 @@ import type { MarketsPayload, MarketRow, MarketSection } from "@/lib/markets";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { Chart, type ChartPoint } from "@/components/Chart";
+import { CandleChart, type OverlayLine, type BandOverlay } from "@/components/CandleChart";
 import { shellLayoutStore } from "@/lib/console/store";
 import { candlesToPoints, hiLo, periodChange, RANGES, RANGE_LABEL, type Candle, type Range } from "@/lib/markets/chart";
+import { sma, bollinger, rsi, volumeProfile, rescaleShape, anomalyFlags } from "@/lib/markets/indicators";
 import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
 const EMPTY: MarketsPayload = { generatedAt: 0, sections: [] };
 type TableSortKey = "name" | "changePct" | "value";
+type ChartType = "candles" | "line";
+type IndKey = "ma" | "boll" | "vol" | "rsi" | "bench" | "anom";
+const IND_CHIPS: [IndKey, string][] = [["ma", "MA 50/200"], ["boll", "Bollinger"], ["vol", "Volume"], ["rsi", "RSI"], ["bench", "Benchmark"], ["anom", "Events"]];
+
+/** Compact non-currency magnitude for volume, e.g. "1.2B", "845.0M", "12.3K". */
+function fmtVol(n: number): string {
+  const a = Math.abs(n);
+  if (a >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (a >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (a >= 1e3) return `${(n / 1e3).toFixed(1)}K`;
+  return `${Math.round(n)}`;
+}
+
+/** Resample a series to `n` points by index (a faint benchmark shape need not be
+ *  time-exact — it maps the other asset's contour onto this instrument's window). */
+function resample(src: number[], n: number): number[] {
+  if (src.length === 0 || n <= 0) return [];
+  if (src.length === n) return src;
+  const out: number[] = [];
+  const span = src.length - 1, denom = n - 1 || 1;
+  for (let i = 0; i < n; i++) out.push(src[Math.min(span, Math.max(0, Math.round((i * span) / denom)))]);
+  return out;
+}
 
 /** Adaptive-precision number formatting for prices/levels (large → 2dp, tiny → 6dp). */
 function fmtNum(n: number): string {
@@ -92,7 +117,12 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
   );
 
   const selRow = useMemo(() => allRows.find((r) => r.id === selId) ?? null, [allRows, selId]);
-  const selSym = selRow ? (selRow.symbol ?? selRow.id) : null;
+  // Yahoo history ticker (crypto/commodity display symbols aren't Yahoo tickers).
+  const selSym = selRow ? (selRow.chartSymbol ?? selRow.symbol ?? selRow.id) : null;
+  const selSectionKey = useMemo(
+    () => railSections.find((s) => s.rows.some((r) => r.id === selId))?.key,
+    [railSections, selId],
+  );
 
   // Primary historical chart: keyless Yahoo v8 OHLC for the selected instrument +
   // range. Dormant-safe — the route never 5xxes, and a <2-candle result (dormant /
@@ -100,12 +130,18 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
   const [range, setRange] = useState<Range>("6mo");
   const [candles, setCandles] = useState<Candle[]>([]);
   const [chartLoading, setChartLoading] = useState(false);
+  // Chart presentation: candlestick vs gradient line, technical overlays, and the
+  // candle under the cursor (drives the OHLC read-out).
+  const [chartType, setChartType] = useState<ChartType>("candles");
+  const [ind, setInd] = useState<Record<IndKey, boolean>>({ ma: false, boll: false, vol: false, rsi: false, bench: false, anom: true });
+  const toggleInd = (k: IndKey) => setInd((s) => ({ ...s, [k]: !s[k] }));
+  const [hover, setHover] = useState<Candle | null>(null);
   useEffect(() => {
-    if (!selSym) { setCandles([]); return; }
+    if (!selSym) { setCandles([]); setHover(null); return; }
     // Clear the previous instrument's candles immediately so a symbol/range switch never
     // renders — or exports — stale OHLC under the new header while the new fetch is in
     // flight (hasHistory drops to false → loading/live-series fallback + export disabled).
-    setCandles([]);
+    setCandles([]); setHover(null);
     let alive = true;
     setChartLoading(true);
     fetch(`/api/markets/chart?symbol=${encodeURIComponent(selSym)}&range=${range}`)
@@ -117,6 +153,54 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
   }, [selSym, range]);
 
   const hasHistory = candles.length >= 2;
+
+  // Benchmark correlation overlay: crypto compares against BTC (ETH if BTC is
+  // selected); everything else against SPY (QQQ if SPY is selected). Fetched only
+  // while the toggle is on; overlaid as a faint, rescaled SHAPE line (not a price).
+  const benchSym = useMemo(() => {
+    if (!ind.bench || !selSym) return null;
+    const crypto = selSectionKey === "crypto";
+    const pick = crypto ? (selSym === "BTC-USD" ? "ETH-USD" : "BTC-USD") : (selSym === "SPY" ? "QQQ" : "SPY");
+    return pick === selSym ? null : pick;
+  }, [ind.bench, selSym, selSectionKey]);
+  const [benchCandles, setBenchCandles] = useState<Candle[]>([]);
+  useEffect(() => {
+    if (!benchSym) { setBenchCandles([]); return; }
+    let alive = true;
+    fetch(`/api/markets/chart?symbol=${encodeURIComponent(benchSym)}&range=${range}`)
+      .then((r) => r.json())
+      .then((d: { candles?: Candle[] }) => { if (alive) setBenchCandles(Array.isArray(d.candles) ? d.candles : []); })
+      .catch(() => { if (alive) setBenchCandles([]); });
+    return () => { alive = false; };
+  }, [benchSym, range]);
+
+  // Technical overlays, all derived from the real candles via the unit-tested maths.
+  const closes = useMemo(() => candles.map((k) => k.c), [candles]);
+  const overlays = useMemo<OverlayLine[]>(() => {
+    const out: OverlayLine[] = [];
+    if (ind.ma) {
+      out.push({ values: sma(closes, 50), color: "#d9882f", width: 1.3 });
+      out.push({ values: sma(closes, 200), color: "#4a78c9", width: 1.3 });
+    }
+    if (ind.bench && benchCandles.length >= 2 && candles.length >= 2) {
+      let lo = Infinity, hi = -Infinity;
+      for (const k of candles) { if (k.l < lo) lo = k.l; if (k.h > hi) hi = k.h; }
+      const shaped = rescaleShape(resample(benchCandles.map((k) => k.c), candles.length), lo, hi);
+      out.push({ values: shaped, color: "#7c5cbf", width: 1.2, dash: true });
+    }
+    return out;
+  }, [ind.ma, ind.bench, closes, benchCandles, candles]);
+  const band = useMemo<BandOverlay | null>(() => {
+    if (!ind.boll) return null;
+    const b = bollinger(closes, 20, 2);
+    return { upper: b.map((x) => x.upper), lower: b.map((x) => x.lower), color: "#4a78c9" };
+  }, [ind.boll, closes]);
+  const volProfile = useMemo(() => (ind.vol ? volumeProfile(candles, 24) : null), [ind.vol, candles]);
+  const anomalies = useMemo(() => (ind.anom ? anomalyFlags(candles, 2.5) : []), [ind.anom, candles]);
+  const rsiPoints = useMemo<ChartPoint[]>(() => {
+    if (!ind.rsi) return [];
+    return rsi(closes, 14).map((v, i) => (v == null ? null : { x: candles[i].t, y: v })).filter((p): p is ChartPoint => p != null);
+  }, [ind.rsi, closes, candles]);
   const chg = useMemo(() => periodChange(candles), [candles]);
   const range52 = useMemo(() => hiLo(candles), [candles]);
   // Honest fallback: chart the accumulated live mkt:<id> series when there's no
@@ -263,32 +347,63 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
                   </div>
                 </div>
 
-                {chartPoints.length >= 2 ? (
-                  <>
-                    <Chart points={chartPoints} height={220} zeroBaseline={false} up={chartUp} markers />
-                    {hasHistory ? (
-                      <>
-                        <div className="tn-mk-metrics">
-                          <span className={`tn-mk-metric ${chg.abs >= 0 ? "up" : "down"}`}>
-                            <span className="tn-mk-metric-label">Change ({RANGE_LABEL[range]})</span>{" "}
-                            <b>{chg.abs >= 0 ? "+" : ""}{fmtNum(chg.abs)} ({chg.pct >= 0 ? "+" : ""}{chg.pct.toFixed(2)}%)</b>
-                          </span>
-                          {range52 && (
-                            <span className="tn-mk-metric">
-                              <span className="tn-mk-metric-label">{range === "1y" ? "52-wk range" : "Range"}</span>{" "}
-                              <b>{fmtNum(range52.lo)} – {fmtNum(range52.hi)}</b>
-                            </span>
-                          )}
-                          <span className="tn-mk-metric"><span className="tn-mk-metric-label">{candles.length} bars · Yahoo v8, delayed</span></span>
-                        </div>
-                      </>
-                    ) : (
-                      <div className="tn-mk-chart-note">Live session (accumulating) — historical unavailable for this symbol.</div>
+                <div className="tn-mk-chart-ctrls">
+                  <div className="tn-mk-seg" role="tablist" aria-label="Chart type">
+                    <button role="tab" aria-selected={chartType === "candles"} className={chartType === "candles" ? "active" : ""} onClick={() => setChartType("candles")}>Candles</button>
+                    <button role="tab" aria-selected={chartType === "line"} className={chartType === "line" ? "active" : ""} onClick={() => setChartType("line")}>Line</button>
+                  </div>
+                  {hasHistory && chartType === "candles" && (
+                    <div className="tn-mk-inds" role="group" aria-label="Technical overlays">
+                      {IND_CHIPS.map(([k, label]) => (
+                        <button key={k} className={`tn-mk-ind ${ind[k] ? "on" : ""}`} aria-pressed={ind[k]} onClick={() => toggleInd(k)}>{label}</button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {hasHistory && chartType === "candles" ? (
+                  <div className="tn-mk-canvas">
+                    {hover && (
+                      <div className="tn-mk-ohlc" aria-hidden>
+                        <span>O <b>{fmtNum(hover.o)}</b></span>
+                        <span>H <b className="up">{fmtNum(hover.h)}</b></span>
+                        <span>L <b className="down">{fmtNum(hover.l)}</b></span>
+                        <span>C <b>{fmtNum(hover.c)}</b></span>
+                        {hover.v > 0 && <span>V <b>{fmtVol(hover.v)}</b></span>}
+                        <span className="tn-mk-ohlc-t">{new Date(hover.t).toLocaleString()}</span>
+                      </div>
                     )}
-                  </>
+                    <CandleChart candles={candles} height={240} up={chartUp} overlays={overlays} band={band} volume={volProfile} anomalies={anomalies} onHover={(c) => setHover(c)} />
+                    {ind.rsi && rsiPoints.length >= 2 && (
+                      <div className="tn-mk-rsi">
+                        <span className="tn-mk-rsi-label">RSI 14</span>
+                        <Chart points={rsiPoints} height={52} area={false} zeroBaseline={false} up={null} />
+                      </div>
+                    )}
+                  </div>
+                ) : chartPoints.length >= 2 ? (
+                  <Chart points={chartPoints} height={240} zeroBaseline={false} up={chartUp} markers gradient />
                 ) : (
                   <div className="tn-mk-chart-empty">{chartLoading ? "Loading chart…" : "No history yet — accumulating a live session series."}</div>
                 )}
+
+                {hasHistory ? (
+                  <div className="tn-mk-metrics">
+                    <span className={`tn-mk-metric ${chg.abs >= 0 ? "up" : "down"}`}>
+                      <span className="tn-mk-metric-label">Change ({RANGE_LABEL[range]})</span>{" "}
+                      <b>{chg.abs >= 0 ? "+" : ""}{fmtNum(chg.abs)} ({chg.pct >= 0 ? "+" : ""}{chg.pct.toFixed(2)}%)</b>
+                    </span>
+                    {range52 && (
+                      <span className="tn-mk-metric">
+                        <span className="tn-mk-metric-label">{range === "1y" ? "52-wk range" : "Range"}</span>{" "}
+                        <b>{fmtNum(range52.lo)} – {fmtNum(range52.hi)}</b>
+                      </span>
+                    )}
+                    <span className="tn-mk-metric"><span className="tn-mk-metric-label">{candles.length} bars · Yahoo v8, delayed</span></span>
+                  </div>
+                ) : chartPoints.length >= 2 ? (
+                  <div className="tn-mk-chart-note">Live session (accumulating) — historical unavailable for this symbol.</div>
+                ) : null}
               </div>
             ) : (
               <p className="tn-w-empty">Select an instrument to see its chart.</p>

--- a/lib/console/widgets/markets.detail.tsx
+++ b/lib/console/widgets/markets.detail.tsx
@@ -7,13 +7,14 @@
 // fallback to the accumulated mkt:<id> series when it doesn't, and an
 // "indicative only — not financial advice" disclaimer. Pure series maths live in
 // the unit-tested lib/markets/chart.ts; this is the shell.
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import type { MarketsPayload, MarketRow, MarketSection } from "@/lib/markets";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { recordSeries, seriesSamples } from "@/lib/series";
 import { Chart, type ChartPoint } from "@/components/Chart";
-import { CandleChart, type OverlayLine, type BandOverlay } from "@/components/CandleChart";
+import { CandleChart, type OverlayLine, type BandOverlay, type PriceGuide } from "@/components/CandleChart";
+import { loadAlerts, addAlert, removeAlert, crossed, type PriceAlert } from "@/lib/markets/alerts";
 import { shellLayoutStore } from "@/lib/console/store";
 import { candlesToPoints, hiLo, periodChange, RANGES, RANGE_LABEL, type Candle, type Range } from "@/lib/markets/chart";
 import { sma, bollinger, rsi, volumeProfile, rescaleShape, anomalyFlags } from "@/lib/markets/indicators";
@@ -76,6 +77,18 @@ function fmtNum(n: number): string {
 /** Signed magnitude used for movers-first ordering; nulls sort last. */
 function absMove(r: MarketRow): number {
   return r.changePct == null ? -1 : Math.abs(r.changePct);
+}
+
+/** Fire a browser Notification for a crossed alert (dormant-safe: no-op unless the
+ *  user granted permission and the API exists). */
+function notifyAlert(a: PriceAlert, price: number): void {
+  if (typeof Notification === "undefined" || Notification.permission !== "granted") return;
+  try {
+    new Notification(`${a.symbol} ${a.dir === "above" ? "≥" : "≤"} ${fmtNum(a.price)}`, {
+      body: `${a.name} is now ${fmtNum(price)}`,
+      tag: a.id,
+    });
+  } catch { /* dormant-safe */ }
 }
 
 /** Heat-strip / change colour scaled by move magnitude (green up, red down). */
@@ -163,6 +176,38 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
     return () => { alive = false; };
   }, [athSyms.join(",")]); // eslint-disable-line react-hooks/exhaustive-deps
   const athOf = (r: MarketRow) => athPct(r.num, r.chartSymbol ? athMap[r.chartSymbol.toUpperCase()] : undefined);
+
+  // Local price alerts: arm the bell, click a price on the chart to set a level;
+  // a browser Notification fires when the live quote crosses it (edge-triggered).
+  const [alerts, setAlerts] = useState<PriceAlert[]>([]);
+  const [armed, setArmed] = useState(false);
+  useEffect(() => { setAlerts(loadAlerts()); }, []);
+  const prevPrices = useRef<Record<string, number>>({});
+  useEffect(() => {
+    if (!data.generatedAt) return;
+    for (const a of alerts) {
+      const row = allRows.find((r) => r.id === a.rowId);
+      if (!row || typeof row.num !== "number") continue;
+      if (crossed(a, prevPrices.current[a.rowId], row.num)) notifyAlert(a, row.num);
+    }
+    for (const r of allRows) if (typeof r.num === "number") prevPrices.current[r.id] = r.num;
+  }, [data.generatedAt, alerts, allRows]);
+  const armToggle = () => setArmed((v) => {
+    const next = !v;
+    if (next && typeof Notification !== "undefined" && Notification.permission === "default") Notification.requestPermission().catch(() => {});
+    return next;
+  });
+  const placeAlert = (price: number) => {
+    if (!selRow) return;
+    const cur = selRow.num ?? price;
+    setAlerts(addAlert({ rowId: selRow.id, symbol: selRow.symbol ?? selRow.id, name: selRow.name, price, dir: price >= cur ? "above" : "below", createdAt: Date.now() }));
+    setArmed(false);
+  };
+  const selAlerts = useMemo(() => alerts.filter((a) => a.rowId === selId), [alerts, selId]);
+  const selGuides = useMemo<PriceGuide[]>(
+    () => selAlerts.map((a) => ({ price: a.price, color: a.dir === "above" ? "#16a34a" : "#dc2626", label: `${a.dir === "above" ? "▲" : "▼"} ${fmtNum(a.price)}` })),
+    [selAlerts],
+  );
 
   // Primary historical chart: keyless Yahoo v8 OHLC for the selected instrument +
   // range. Dormant-safe — the route never 5xxes, and a <2-candle result (dormant /
@@ -389,9 +434,15 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
                 </div>
 
                 <div className="tn-mk-chart-ctrls">
-                  <div className="tn-mk-seg" role="tablist" aria-label="Chart type">
-                    <button role="tab" aria-selected={chartType === "candles"} className={chartType === "candles" ? "active" : ""} onClick={() => setChartType("candles")}>Candles</button>
-                    <button role="tab" aria-selected={chartType === "line"} className={chartType === "line" ? "active" : ""} onClick={() => setChartType("line")}>Line</button>
+                  <div className="tn-mk-ctrls-l">
+                    <div className="tn-mk-seg" role="tablist" aria-label="Chart type">
+                      <button role="tab" aria-selected={chartType === "candles"} className={chartType === "candles" ? "active" : ""} onClick={() => setChartType("candles")}>Candles</button>
+                      <button role="tab" aria-selected={chartType === "line"} className={chartType === "line" ? "active" : ""} onClick={() => setChartType("line")}>Line</button>
+                    </div>
+                    {hasHistory && chartType === "candles" && (
+                      <button className={`tn-mk-bell ${armed ? "on" : ""}`} aria-pressed={armed} onClick={armToggle}
+                        title={armed ? "Click a price on the chart to set an alert" : "Arm a price alert"}>🔔</button>
+                    )}
                   </div>
                   {hasHistory && chartType === "candles" && (
                     <div className="tn-mk-inds" role="group" aria-label="Technical overlays">
@@ -401,6 +452,17 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
                     </div>
                   )}
                 </div>
+                {armed && <div className="tn-mk-arm-hint">Click a price level on the chart to set an alert.</div>}
+                {selAlerts.length > 0 && (
+                  <div className="tn-mk-alerts">
+                    {selAlerts.map((a) => (
+                      <span key={a.id} className={`tn-mk-alert ${a.dir}`}>
+                        🔔 {a.dir === "above" ? "≥" : "≤"} {fmtNum(a.price)}
+                        <button onClick={() => setAlerts(removeAlert(a.id))} aria-label="Remove alert">×</button>
+                      </span>
+                    ))}
+                  </div>
+                )}
 
                 {hasHistory && chartType === "candles" ? (
                   <div className="tn-mk-canvas">
@@ -414,7 +476,7 @@ export default function MarketsDetail({ instanceId, config }: WidgetDetailProps)
                         <span className="tn-mk-ohlc-t">{new Date(hover.t).toLocaleString()}</span>
                       </div>
                     )}
-                    <CandleChart candles={candles} height={240} up={chartUp} overlays={overlays} band={band} volume={volProfile} anomalies={anomalies} onHover={(c) => setHover(c)} />
+                    <CandleChart candles={candles} height={240} up={chartUp} overlays={overlays} band={band} volume={volProfile} anomalies={anomalies} guides={selGuides} armed={armed} onPriceClick={placeAlert} onHover={(c) => setHover(c)} />
                     {ind.rsi && rsiPoints.length >= 2 && (
                       <div className="tn-mk-rsi">
                         <span className="tn-mk-rsi-label">RSI 14</span>

--- a/lib/markets.ts
+++ b/lib/markets.ts
@@ -50,6 +50,10 @@ export interface MarketRow {
   /** Optional secondary line (market cap, unit, as-of date). */
   sub?: string;
   image?: string;
+  /** Yahoo v8 ticker for the history chart when it differs from the display symbol
+   *  (e.g. crypto BTC→BTC-USD, commodity Brent→BZ=F). Undefined ⇒ no real history
+   *  chart for this row (the focus view falls back to its live session series). */
+  chartSymbol?: string;
 }
 
 export interface MarketSection {
@@ -79,6 +83,8 @@ export function cryptoRows(assets: MarketAsset[]): MarketRow[] {
     changePct: a.changePct24h,
     image: a.image,
     sub: a.marketCap != null ? `mkt cap ${formatCompactUsd(a.marketCap)}` : undefined,
+    // Yahoo charts crypto under the "-USD" pair (BTC→BTC-USD), so history works.
+    chartSymbol: `${a.symbol}-USD`,
   }));
 }
 

--- a/lib/markets.ts
+++ b/lib/markets.ts
@@ -182,6 +182,31 @@ export function parseYahooChart(json: YahooChart | null | undefined, spec: Quote
   return { id: `q:${spec.symbol}`, name: spec.name, symbol: spec.symbol, value: formatPrice(price), num: price, changePct };
 }
 
+/** Pure: a Yahoo index quote (e.g. ^TNX yield, ^VIX) → a macro row with a unit
+ *  suffix instead of a "$" price. Keyless macro fallback when FRED isn't keyed —
+ *  ^TNX/^FVX/^TYX quote the yield directly in %; ^VIX is a plain level. */
+export function macroRowFromYahoo(
+  json: YahooChart | null | undefined,
+  spec: { y: string; symbol: string; name: string; unit: string },
+): MarketRow | null {
+  const meta = json?.chart?.result?.[0]?.meta;
+  if (!meta) return null;
+  const price = meta.regularMarketPrice == null ? Number.NaN : Number(meta.regularMarketPrice);
+  if (!Number.isFinite(price)) return null;
+  const prevRaw = meta.chartPreviousClose ?? meta.previousClose;
+  const prev = prevRaw == null ? Number.NaN : Number(prevRaw);
+  const changePct = Number.isFinite(prev) && prev !== 0 ? Number((((price - prev) / prev) * 100).toFixed(2)) : null;
+  return {
+    id: `macro:${spec.symbol}`,
+    name: spec.name,
+    symbol: spec.symbol,
+    value: `${price.toLocaleString("en-US", { maximumFractionDigits: 2 })}${spec.unit}`,
+    num: price,
+    changePct,
+    chartSymbol: spec.y,
+  };
+}
+
 /** Compact USD, e.g. "$1.2T", "$845B", "$12.3M". */
 export function formatCompactUsd(n: number): string {
   const abs = Math.abs(n);

--- a/lib/markets/alerts.ts
+++ b/lib/markets/alerts.ts
@@ -1,0 +1,51 @@
+"use client";
+// Local price alerts for the Markets focus chart. Persisted to localStorage (no
+// account, no server) — the user arms the bell, clicks a price on the chart, and
+// gets a browser Notification when the live quote crosses it. The crossing test is
+// a pure, unit-tested function; everything else is thin persistence + the Web
+// Notification API (permission-gated, dormant-safe when denied/unsupported).
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export type AlertDir = "above" | "below";
+export interface PriceAlert {
+  id: string;
+  rowId: string;    // MarketRow.id this alert watches
+  symbol: string;
+  name: string;
+  price: number;
+  dir: AlertDir;
+  createdAt: number;
+}
+
+const KEY = "tn.mkalerts.v1";
+const VERSION = 1;
+const CAP = 60;
+
+export function loadAlerts(): PriceAlert[] {
+  return loadPersisted<PriceAlert[]>(KEY, VERSION) ?? [];
+}
+function save(list: PriceAlert[]): void {
+  savePersisted(KEY, VERSION, list.slice(-CAP));
+}
+
+/** Add an alert (deduped by row+direction+price); returns the new list. */
+export function addAlert(a: { rowId: string; symbol: string; name: string; price: number; dir: AlertDir; createdAt: number }): PriceAlert[] {
+  const list = loadAlerts();
+  const id = `${a.rowId}:${a.dir}:${Math.round(a.price * 1e6)}`;
+  if (!list.some((x) => x.id === id)) list.push({ ...a, id });
+  save(list);
+  return loadAlerts();
+}
+export function removeAlert(id: string): PriceAlert[] {
+  const list = loadAlerts().filter((a) => a.id !== id);
+  save(list);
+  return list;
+}
+
+/** Pure: did `cur` cross the alert threshold relative to the previous quote?
+ *  Direction-aware and edge-triggered — only the transition fires, not every
+ *  tick that stays beyond the level. Returns false without a prior sample. */
+export function crossed(alert: { price: number; dir: AlertDir }, prev: number | undefined, cur: number): boolean {
+  if (prev == null || !Number.isFinite(prev) || !Number.isFinite(cur)) return false;
+  return alert.dir === "above" ? prev < alert.price && cur >= alert.price : prev > alert.price && cur <= alert.price;
+}

--- a/lib/markets/chart.ts
+++ b/lib/markets/chart.ts
@@ -3,10 +3,44 @@
 // figures the UI shows (period change, hi/lo), and projects candles to Chart points.
 // Pure + isomorphic so it unit-tests against a captured fixture.
 
-export type Range = "1mo" | "6mo" | "1y";
-export const RANGES: Range[] = ["1mo", "6mo", "1y"];
+// Timeframe model. The UI exposes short intraday / mid / long windows; each maps
+// to a Yahoo v8 (range, interval) pair. Intraday windows over-fetch a day and are
+// sliced to the intended span (Yahoo has no native "last hour" range), so the data
+// stays REAL — we window it, never synthesise it.
+export type Range = "1h" | "1d" | "1w" | "1mo" | "6mo" | "1y";
+export const RANGES: Range[] = ["1h", "1d", "1w", "1mo", "6mo", "1y"];
+export const RANGE_LABEL: Record<Range, string> = {
+  "1h": "1H", "1d": "1D", "1w": "1W", "1mo": "1M", "6mo": "6M", "1y": "1Y",
+};
+
+/** Yahoo (range, interval) + optional trailing-window slice for each timeframe. */
+export interface YahooParams { range: string; interval: string; sliceMs?: number }
+const HOUR = 3_600_000, DAY = 86_400_000, WEEK = 7 * DAY;
+const TF: Record<Range, YahooParams> = {
+  "1h": { range: "1d", interval: "2m", sliceMs: HOUR },
+  "1d": { range: "1d", interval: "5m", sliceMs: DAY },
+  "1w": { range: "5d", interval: "30m", sliceMs: WEEK },
+  "1mo": { range: "1mo", interval: "1d" },
+  "6mo": { range: "6mo", interval: "1d" },
+  "1y": { range: "1y", interval: "1wk" },
+};
+/** Pure: our timeframe key → the Yahoo params the chart route requests. */
+export function yahooParamsFor(range: Range): YahooParams {
+  return TF[range] ?? TF["6mo"];
+}
 
 export interface Candle { t: number; o: number; h: number; l: number; c: number; v: number }
+
+/** Pure: keep only candles within `ms` of the last candle (trailing-window slice).
+ *  Used to turn an over-fetched intraday day into a "last hour / last day" view. */
+export function sliceRecent(candles: Candle[], ms?: number): Candle[] {
+  if (!ms || candles.length === 0) return candles;
+  const cutoff = candles[candles.length - 1].t - ms;
+  const windowed = candles.filter((k) => k.t >= cutoff);
+  // Guard against a too-aggressive slice leaving <2 bars (sparse intraday): fall
+  // back to the whole fetched series so the chart still renders something real.
+  return windowed.length >= 2 ? windowed : candles;
+}
 
 interface YahooQuote { open?: (number | null)[]; high?: (number | null)[]; low?: (number | null)[]; close?: (number | null)[]; volume?: (number | null)[] }
 interface YahooResult { timestamp?: number[]; indicators?: { quote?: YahooQuote[] } }

--- a/lib/markets/indicators.ts
+++ b/lib/markets/indicators.ts
@@ -1,0 +1,119 @@
+// Pure technical-indicator + volume maths for the Markets focus chart. Everything
+// here is deterministic, isomorphic and node-testable — the chart component only
+// projects these arrays to SVG. No fabrication: an indicator is `null` wherever
+// there isn't enough history to compute it honestly.
+
+import type { Candle } from "@/lib/markets/chart";
+
+/** Simple moving average, aligned to `values`; null until `period` samples exist. */
+export function sma(values: number[], period: number): (number | null)[] {
+  const out: (number | null)[] = new Array(values.length).fill(null);
+  if (period <= 0) return out;
+  let sum = 0;
+  for (let i = 0; i < values.length; i++) {
+    sum += values[i];
+    if (i >= period) sum -= values[i - period];
+    if (i >= period - 1) out[i] = sum / period;
+  }
+  return out;
+}
+
+export interface Band { mid: number | null; upper: number | null; lower: number | null }
+/** Bollinger bands: SMA(period) ± mult·σ over a trailing window (population σ). */
+export function bollinger(values: number[], period = 20, mult = 2): Band[] {
+  const out: Band[] = values.map(() => ({ mid: null, upper: null, lower: null }));
+  if (period <= 0) return out;
+  for (let i = period - 1; i < values.length; i++) {
+    let mean = 0;
+    for (let j = i - period + 1; j <= i; j++) mean += values[j];
+    mean /= period;
+    let variance = 0;
+    for (let j = i - period + 1; j <= i; j++) variance += (values[j] - mean) ** 2;
+    const sd = Math.sqrt(variance / period);
+    out[i] = { mid: mean, upper: mean + mult * sd, lower: mean - mult * sd };
+  }
+  return out;
+}
+
+/** Wilder's RSI (0..100), aligned to `values`; null for the first `period` samples. */
+export function rsi(values: number[], period = 14): (number | null)[] {
+  const out: (number | null)[] = new Array(values.length).fill(null);
+  if (values.length < period + 1 || period <= 0) return out;
+  let gain = 0, loss = 0;
+  for (let i = 1; i <= period; i++) {
+    const d = values[i] - values[i - 1];
+    if (d >= 0) gain += d; else loss -= d;
+  }
+  let avgGain = gain / period, avgLoss = loss / period;
+  const rsiAt = (g: number, l: number) => (l === 0 ? 100 : 100 - 100 / (1 + g / l));
+  out[period] = rsiAt(avgGain, avgLoss);
+  for (let i = period + 1; i < values.length; i++) {
+    const d = values[i] - values[i - 1];
+    const g = d > 0 ? d : 0, l = d < 0 ? -d : 0;
+    avgGain = (avgGain * (period - 1) + g) / period;
+    avgLoss = (avgLoss * (period - 1) + l) / period;
+    out[i] = rsiAt(avgGain, avgLoss);
+  }
+  return out;
+}
+
+export interface VolBin { lo: number; hi: number; volume: number }
+/** Volume-by-price profile: `bins` equal price buckets across the range, each
+ *  summing the volume of candles whose typical price ((h+l+c)/3) lands in it.
+ *  The max-volume bin is the point-of-control (high-density support/resistance). */
+export function volumeProfile(candles: Candle[], bins = 24): VolBin[] {
+  if (candles.length === 0 || bins <= 0) return [];
+  let lo = Infinity, hi = -Infinity;
+  for (const k of candles) { if (k.l < lo) lo = k.l; if (k.h > hi) hi = k.h; }
+  if (!(hi > lo)) return [];
+  const step = (hi - lo) / bins;
+  const out: VolBin[] = Array.from({ length: bins }, (_, i) => ({ lo: lo + i * step, hi: lo + (i + 1) * step, volume: 0 }));
+  for (const k of candles) {
+    const price = (k.h + k.l + k.c) / 3;
+    let idx = Math.floor((price - lo) / step);
+    if (idx < 0) idx = 0;
+    if (idx >= bins) idx = bins - 1;
+    out[idx].volume += Math.max(0, k.v);
+  }
+  return out;
+}
+
+/** Index of the highest-volume bin (point of control); -1 for an empty profile. */
+export function pointOfControl(profile: VolBin[]): number {
+  let best = -1, max = -Infinity;
+  for (let i = 0; i < profile.length; i++) if (profile[i].volume > max) { max = profile[i].volume; best = i; }
+  return best;
+}
+
+/** Min-max rescale a series into [outLo, outHi] — used to overlay a benchmark's
+ *  SHAPE on the instrument's price axis for correlation (not a price claim). */
+export function rescaleShape(values: number[], outLo: number, outHi: number): number[] {
+  let lo = Infinity, hi = -Infinity;
+  for (const v of values) { if (v < lo) lo = v; if (v > hi) hi = v; }
+  if (!Number.isFinite(lo) || hi === lo) return values.map(() => (outLo + outHi) / 2);
+  const m = (outHi - outLo) / (hi - lo);
+  return values.map((v) => outLo + (v - lo) * m);
+}
+
+export interface Anomaly { t: number; idx: number; pct: number; up: boolean }
+/** Data-driven event anchors: bars whose single-step return is ≥ k·σ from the mean
+ *  return — the abrupt moves worth flagging on the time axis. No external dataset,
+ *  so nothing is invented; each anchor carries the real % move and its timestamp. */
+export function anomalyFlags(candles: Candle[], k = 2.5): Anomaly[] {
+  if (candles.length < 8) return [];
+  const rets: number[] = [];
+  for (let i = 1; i < candles.length; i++) {
+    const prev = candles[i - 1].c;
+    rets.push(prev !== 0 ? (candles[i].c - prev) / prev : 0);
+  }
+  const mean = rets.reduce((a, b) => a + b, 0) / rets.length;
+  const sd = Math.sqrt(rets.reduce((a, b) => a + (b - mean) ** 2, 0) / rets.length);
+  if (sd === 0) return [];
+  const out: Anomaly[] = [];
+  for (let i = 0; i < rets.length; i++) {
+    if (Math.abs(rets[i] - mean) >= k * sd) {
+      out.push({ t: candles[i + 1].t, idx: i + 1, pct: rets[i] * 100, up: rets[i] >= 0 });
+    }
+  }
+  return out;
+}

--- a/tests/unit/markets-alerts.test.ts
+++ b/tests/unit/markets-alerts.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { crossed } from "@/lib/markets/alerts";
+
+describe("crossed (edge-triggered price alert)", () => {
+  it("fires an 'above' alert only on the upward crossing", () => {
+    const a = { price: 100, dir: "above" as const };
+    expect(crossed(a, 98, 101)).toBe(true);   // crossed up through 100
+    expect(crossed(a, 101, 103)).toBe(false);  // already above → no re-fire
+    expect(crossed(a, 103, 99)).toBe(false);   // moving down → not an 'above' hit
+    expect(crossed(a, 100, 101)).toBe(false);  // was already at the level
+  });
+  it("fires a 'below' alert only on the downward crossing", () => {
+    const a = { price: 50, dir: "below" as const };
+    expect(crossed(a, 52, 49)).toBe(true);
+    expect(crossed(a, 49, 48)).toBe(false);
+    expect(crossed(a, 48, 51)).toBe(false);
+  });
+  it("is safe without a prior sample or with non-finite input", () => {
+    expect(crossed({ price: 10, dir: "above" }, undefined, 11)).toBe(false);
+    expect(crossed({ price: 10, dir: "above" }, NaN, 11)).toBe(false);
+    expect(crossed({ price: 10, dir: "above" }, 9, NaN)).toBe(false);
+  });
+});

--- a/tests/unit/markets-indicators.test.ts
+++ b/tests/unit/markets-indicators.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { yahooParamsFor, sliceRecent, type Candle } from "@/lib/markets/chart";
+import { sma, bollinger, rsi, volumeProfile, pointOfControl, rescaleShape, anomalyFlags } from "@/lib/markets/indicators";
+
+/** Build candles at 1-minute spacing from a list of closes (o=h=l=c for simplicity). */
+function candlesFrom(closes: number[], stepMs = 60_000, vols?: number[]): Candle[] {
+  return closes.map((c, i) => ({ t: i * stepMs, o: c, h: c, l: c, c, v: vols?.[i] ?? 1 }));
+}
+
+describe("yahooParamsFor / timeframes", () => {
+  it("maps intraday windows to a Yahoo range+interval with a trailing slice", () => {
+    expect(yahooParamsFor("1h")).toEqual({ range: "1d", interval: "2m", sliceMs: 3_600_000 });
+    expect(yahooParamsFor("1d")).toEqual({ range: "1d", interval: "5m", sliceMs: 86_400_000 });
+    expect(yahooParamsFor("1w").interval).toBe("30m");
+  });
+  it("maps long windows with no slice", () => {
+    expect(yahooParamsFor("1y")).toEqual({ range: "1y", interval: "1wk" });
+    expect(yahooParamsFor("6mo").sliceMs).toBeUndefined();
+  });
+});
+
+describe("sliceRecent", () => {
+  it("keeps only candles within `ms` of the last one", () => {
+    const c = candlesFrom([1, 2, 3, 4, 5], 60_000); // 0..4 min
+    const last2 = sliceRecent(c, 60_000); // last minute → t>=240000 → indices 4 and (>=240000)… only idx4? cutoff=240000
+    expect(last2.map((k) => k.c)).toEqual([4, 5]); // t=180000(idx3) and 240000(idx4) >= 240000-60000=180000
+  });
+  it("falls back to the whole series when the window leaves <2 bars", () => {
+    const c = candlesFrom([1, 2, 3], 60_000);
+    expect(sliceRecent(c, 1).length).toBe(3); // 1ms window → <2 → whole series
+  });
+  it("no-ops without a slice window", () => {
+    const c = candlesFrom([1, 2, 3]);
+    expect(sliceRecent(c, undefined)).toBe(c);
+  });
+});
+
+describe("sma", () => {
+  it("nulls until the window fills, then averages", () => {
+    expect(sma([1, 2, 3, 4, 5], 3)).toEqual([null, null, 2, 3, 4]);
+  });
+});
+
+describe("bollinger", () => {
+  it("collapses to the price on a flat series (σ=0)", () => {
+    const b = bollinger([10, 10, 10, 10], 3);
+    expect(b[0]).toEqual({ mid: null, upper: null, lower: null });
+    expect(b[2]).toEqual({ mid: 10, upper: 10, lower: 10 });
+  });
+  it("brackets the mean by mult·σ", () => {
+    const b = bollinger([2, 4, 6], 3, 2); // mean 4, popσ = sqrt(8/3)
+    const sd = Math.sqrt(8 / 3);
+    expect(b[2].mid).toBeCloseTo(4);
+    expect(b[2].upper).toBeCloseTo(4 + 2 * sd);
+    expect(b[2].lower).toBeCloseTo(4 - 2 * sd);
+  });
+});
+
+describe("rsi", () => {
+  it("is 100 for a monotonically rising series (no losses)", () => {
+    const r = rsi(Array.from({ length: 20 }, (_, i) => i + 1), 14);
+    expect(r.slice(0, 14).every((v) => v === null)).toBe(true);
+    expect(r[14]).toBe(100);
+    expect(r[19]).toBe(100);
+  });
+  it("is dormant-safe below the minimum sample count", () => {
+    expect(rsi([1, 2, 3], 14).every((v) => v === null)).toBe(true);
+  });
+});
+
+describe("volumeProfile / pointOfControl", () => {
+  it("buckets volume by price and finds the point of control", () => {
+    // Prices 10 and 20; the 20-level carries the most volume.
+    const c: Candle[] = [
+      { t: 0, o: 10, h: 10, l: 10, c: 10, v: 5 },
+      { t: 1, o: 20, h: 20, l: 20, c: 20, v: 50 },
+      { t: 2, o: 20, h: 20, l: 20, c: 20, v: 50 },
+    ];
+    const prof = volumeProfile(c, 10);
+    expect(prof.length).toBe(10);
+    const total = prof.reduce((s, b) => s + b.volume, 0);
+    expect(total).toBe(105);
+    const poc = pointOfControl(prof);
+    expect(prof[poc].hi).toBeGreaterThan(19); // the top bin holds the 100 units at price 20
+  });
+  it("is empty for no candles", () => {
+    expect(volumeProfile([], 10)).toEqual([]);
+    expect(pointOfControl([])).toBe(-1);
+  });
+});
+
+describe("rescaleShape", () => {
+  it("min-max maps a series into the target range", () => {
+    expect(rescaleShape([0, 5, 10], 0, 100)).toEqual([0, 50, 100]);
+  });
+  it("centres a flat series", () => {
+    expect(rescaleShape([7, 7, 7], 0, 100)).toEqual([50, 50, 50]);
+  });
+});
+
+describe("anomalyFlags", () => {
+  it("flags an abrupt outlier move with its real % and direction", () => {
+    // 9 calm ~+1% steps, then one ~+20% jump.
+    const closes = [100, 101, 102, 103, 104, 105, 106, 107, 108, 130];
+    const flags = anomalyFlags(candlesFrom(closes), 2);
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const jump = flags[flags.length - 1];
+    expect(jump.up).toBe(true);
+    expect(jump.pct).toBeGreaterThan(15);
+    expect(jump.idx).toBe(9);
+  });
+  it("returns nothing for a short or flat series", () => {
+    expect(anomalyFlags(candlesFrom([1, 2, 3]))).toEqual([]);
+    expect(anomalyFlags(candlesFrom([5, 5, 5, 5, 5, 5, 5, 5, 5, 5]))).toEqual([]);
+  });
+});

--- a/tests/unit/markets-sections.test.ts
+++ b/tests/unit/markets-sections.test.ts
@@ -3,6 +3,7 @@ import {
   parseFx,
   parseEquities,
   parseMacro,
+  macroRowFromYahoo,
   cryptoRows,
   formatCompactUsd,
   type MarketAsset,
@@ -43,6 +44,16 @@ test("parseMacro formats latest observations with units", () => {
   expect(out).toHaveLength(2);
   expect(out.find((r) => r.id === "macro:DGS10")!.value).toBe("4.23%");
   expect(out.find((r) => r.id === "macro:VIXCLS")!.value).toBe("13.8");
+});
+
+test("macroRowFromYahoo formats a yield index with its unit + day change (keyless)", () => {
+  const json = { chart: { result: [{ meta: { regularMarketPrice: 4.561, chartPreviousClose: 4.569 } }] } };
+  const row = macroRowFromYahoo(json, { y: "^TNX", symbol: "US 10Y", name: "US 10-Yr Treasury Yield", unit: "%" });
+  expect(row!.value).toBe("4.56%");
+  expect(row!.num).toBe(4.561);
+  expect(row!.changePct).toBe(-0.18); // (4.561-4.569)/4.569*100
+  expect(row!.chartSymbol).toBe("^TNX"); // chartable history
+  expect(macroRowFromYahoo(null, { y: "^TNX", symbol: "x", name: "x", unit: "%" })).toBeNull();
 });
 
 test("cryptoRows carries market cap as a compact sub-line", () => {


### PR DESCRIPTION
Full rebuild of the Markets focus view across all four areas of the brief.

**1 · Chart** — dependency-free SVG candlesticks (kept the zero-dep identity, no charting lib) with an O/H/L/C/V hover read-out + crosshair; a Candles/Line toggle where the line view gets a performance-tinted gradient fill (green up / red down); expanded timeframes **1H/1D/1W/1M/6M/1Y** (intraday over-fetched then sliced to span — real data, windowed).

**2 · Layers** — toggles for MA 50/200, Bollinger bands, volume-by-price profile, an RSI-14 sub-panel, a benchmark shape overlay (crypto->BTC/ETH, else SPY/QQQ), and data-driven "Events" anomaly anchors. All maths are pure + unit-tested in `lib/markets/indicators.ts`.

**3 · Table/UX** — sortable **ATH %** column via a new batched keyless `/api/markets/ath`; a 52-week range slider + "From ATH" metric; and the dormant "set FRED_API_KEY" macro panel replaced with **live keyless Treasury yields (^TNX/^FVX/^TYX) + VIX** (FRED still used when keyed). Real OHLC now also drives crypto/commodity charts via a new `chartSymbol` (BTC->BTC-USD, Brent->BZ=F).

**4 · Utilities** — click-to-set price alerts drawn as chart guides, firing edge-triggered browser Notifications (permission-gated, dormant-safe).

Verified: `tsc --noEmit` clean, 657 tests pass, and confirmed in-browser (candles, overlays, OHLC hover, gradient line, ATH column populated, live yields via API). Keyless-first and dormant-safe throughout; no fabricated data.