### PR TITLE
feat(events): operations-grade Disasters & Events (proximity threats, filters, clusters, alerting)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1377,6 +1377,47 @@ a { color: var(--tn-accent); }
 .tn-evd-rowbtn { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 6px; padding: 0; margin: 0; background: none; border: 0; font: inherit; color: inherit; text-align: left; cursor: pointer; border-radius: 4px; }
 .tn-evd-rowbtn:hover b { text-decoration: underline; }
 
+/* Signal-to-noise: hidden-by-filters affordance (compact). */
+.tn-ev-hidden { margin-left: auto; font: inherit; font-size: 10.5px; padding: 1px 8px; border-radius: 999px; border: 1px solid var(--tn-border); background: transparent; color: var(--tn-text-faint); cursor: pointer; }
+.tn-ev-hidden:hover { color: var(--tn-text); border-color: var(--tn-border-strong); }
+
+/* Direct Operational Threats — escalated events (compact + detail). */
+.tn-ev-threats-h { color: #b91c1c !important; }
+.tn-ev-threats-h > span:first-child { color: #b91c1c; }
+.tn-w-list li.is-threat, .tn-evd-list li.is-threat { box-shadow: inset 3px 0 0 #b91c1c; background: rgba(185, 29, 29, 0.06); }
+.tn-ev-threat-chip { flex: none; font-size: 10px; font-weight: 700; padding: 1px 5px; border-radius: 3px; background: rgba(185, 29, 29, 0.14); color: #b91c1c; white-space: nowrap; }
+
+/* Detail ops controls: filters + asset manager side by side. */
+.tn-evd-controls { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin: 12px 0; }
+@media (max-width: 760px) { .tn-evd-controls { grid-template-columns: 1fr; } }
+.tn-evd-ctl { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 8px; padding: 10px 12px; }
+.tn-evd-ctl-h { display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; color: var(--tn-text-faint); margin-bottom: 8px; }
+.tn-evd-clear { margin-left: auto; font: inherit; font-size: 10.5px; text-transform: none; letter-spacing: 0; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--tn-border); background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-evd-clear.is-on { background: var(--tn-accent-soft); border-color: var(--tn-accent); color: var(--tn-accent); }
+.tn-evd-ctl-body { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; }
+.tn-evd-field { display: inline-flex; flex-direction: column; gap: 2px; font-size: 10.5px; color: var(--tn-text-faint); }
+.tn-evd-field select, .tn-evd-field input { font: inherit; font-size: 12px; color: var(--tn-text); background: var(--tn-surface-solid); border: 1px solid var(--tn-border); border-radius: 5px; padding: 3px 6px; min-width: 64px; }
+.tn-evd-chips { display: flex; flex-wrap: wrap; gap: 4px; width: 100%; }
+.tn-evd-chip { font: inherit; font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px dashed var(--tn-border-strong); background: transparent; color: var(--tn-text-faint); cursor: pointer; }
+.tn-evd-chip.is-on { border-style: solid; border-color: var(--tn-accent); background: var(--tn-accent-soft); color: var(--tn-accent); }
+.tn-evd-assetform { display: flex; flex-wrap: wrap; gap: 6px; width: 100%; }
+.tn-evd-assetform input { font: inherit; font-size: 12px; color: var(--tn-text); background: var(--tn-surface-solid); border: 1px solid var(--tn-border); border-radius: 5px; padding: 3px 7px; }
+.tn-evd-assetform input:first-child { flex: 1 1 120px; }
+.tn-evd-assetform input:not(:first-child) { width: 74px; }
+.tn-evd-assetform button { font: inherit; font-size: 12px; padding: 3px 12px; border-radius: 5px; border: 1px solid var(--tn-accent); background: var(--tn-accent-soft); color: var(--tn-accent); cursor: pointer; }
+.tn-evd-err { width: 100%; margin: 4px 0 0; font-size: 11px; color: #b91c1c; }
+.tn-evd-assetlist { list-style: none; margin: 8px 0 0; padding: 0; width: 100%; display: grid; gap: 4px; }
+.tn-evd-assetlist li { display: flex; align-items: center; gap: 6px; }
+.tn-evd-asset-go { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 8px; background: none; border: 0; padding: 3px 4px; font: inherit; color: inherit; text-align: left; cursor: pointer; border-radius: 4px; }
+.tn-evd-asset-go:hover { background: var(--tn-surface-solid); }
+.tn-evd-asset-dot { flex: none; width: 9px; height: 9px; border-radius: 2px; transform: rotate(45deg); }
+.tn-evd-asset-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+.tn-evd-asset-coord { flex: none; font-family: var(--tn-mono); font-size: 11px; color: var(--tn-text-faint); }
+.tn-evd-asset-x { flex: none; font: inherit; font-size: 12px; background: none; border: 0; color: var(--tn-text-faint); cursor: pointer; padding: 2px 4px; }
+.tn-evd-asset-x:hover { color: #b91c1c; }
+.tn-evd-threatboard { border: 1px solid rgba(185, 29, 29, 0.35); border-radius: 8px; padding: 8px 10px; margin: 12px 0; background: rgba(185, 29, 29, 0.04); }
+.tn-evd-threatboard-h { color: #b91c1c !important; margin-bottom: 8px; }
+
 /* ── Headlines focus view (W2) ─────────────────────────────────────── */
 .tn-hd { max-width: 1000px; margin: 0 auto; }
 .tn-hd-bar { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin-bottom: 12px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1418,6 +1418,20 @@ a { color: var(--tn-accent); }
 .tn-evd-threatboard { border: 1px solid rgba(185, 29, 29, 0.35); border-radius: 8px; padding: 8px 10px; margin: 12px 0; background: rgba(185, 29, 29, 0.04); }
 .tn-evd-threatboard-h { color: #b91c1c !important; margin-bottom: 8px; }
 
+/* Proactive alerting (feature 5). */
+.tn-evd-alerting { margin: 12px 0; }
+.tn-evd-armtoggle { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; font-size: 11px; text-transform: none; letter-spacing: 0; color: var(--tn-text-muted); cursor: pointer; }
+.tn-evd-webhook { flex: 1 1 260px; font: inherit; font-size: 12px; color: var(--tn-text); background: var(--tn-surface-solid); border: 1px solid var(--tn-border); border-radius: 5px; padding: 3px 8px; }
+.tn-evd-note { width: 100%; margin: 8px 0 0; font-size: 11px; line-height: 1.45; color: var(--tn-text-faint); }
+
+/* Logistics exposure (feature 6). */
+.tn-evd-exposure { border: 1px solid var(--tn-border); border-radius: 8px; padding: 8px 12px; background: var(--tn-surface-2); }
+.tn-evd-exposure-list { list-style: none; margin: 8px 0 0; padding: 0; display: grid; gap: 8px; }
+.tn-evd-exposure-list > li { display: block; }
+.tn-evd-hubs { display: flex; flex-wrap: wrap; gap: 4px 10px; margin: 3px 0 0 22px; }
+.tn-evd-hub { font-size: 11px; color: var(--tn-text-muted); }
+.tn-evd-hub i { font-style: normal; font-size: 10px; padding: 0 5px; border-radius: 3px; background: var(--tn-border); color: var(--tn-text-faint); }
+
 /* ── Headlines focus view (W2) ─────────────────────────────────────── */
 .tn-hd { max-width: 1000px; margin: 0 auto; }
 .tn-hd-bar { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin-bottom: 12px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1339,6 +1339,44 @@ a { color: var(--tn-accent); }
 .tn-evd-export button { font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border, #1e293b); border-radius: 6px; background: transparent; color: var(--tn-accent, #38bdf8); cursor: pointer; }
 .tn-evd-export button:disabled { opacity: .4; cursor: default; }
 
+/* ── Disasters & Events: ops upgrade (map-link + clusters) ─────────── */
+/* Grouping tabs (shared compact + detail). */
+.tn-ev-tabs { display: inline-flex; gap: 4px; }
+.tn-ev-tab { font: inherit; font-size: 11px; padding: 2px 9px; border: 1px solid var(--tn-border); border-radius: 999px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-ev-tab:hover { border-color: var(--tn-border-strong); color: var(--tn-text); }
+.tn-ev-tab.is-active { background: var(--tn-accent-soft); border-color: var(--tn-accent); color: var(--tn-accent); }
+
+/* Compact widget shell. */
+.tn-ev { display: flex; flex-direction: column; gap: 6px; }
+.tn-ev-tabs { padding: 2px 2px 0; }
+.tn-ev-groups { display: flex; flex-direction: column; }
+.tn-ev-group { border-bottom: 1px solid var(--tn-border); }
+.tn-ev-group-h { display: flex; align-items: center; gap: 6px; width: 100%; padding: 5px 6px; background: transparent; border: 0; font: inherit; font-size: 11px; font-weight: 700; letter-spacing: .02em; text-transform: uppercase; color: var(--tn-text-muted); cursor: pointer; }
+.tn-ev-group-h:hover { background: var(--tn-surface-2); color: var(--tn-text); }
+.tn-ev-group-label { flex: 1; text-align: left; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-ev-group-count { flex: none; font-family: var(--tn-mono); font-weight: 600; color: var(--tn-text-faint); }
+.tn-ev-chev { flex: none; transition: transform .12s ease; color: var(--tn-text-faint); font-size: 10px; }
+.tn-ev-chev.is-open { transform: rotate(90deg); }
+
+/* Clickable feed rows (compact). */
+.tn-ev-row { display: flex; align-items: center; gap: 6px; width: 100%; min-width: 0; padding: 0; margin: 0; background: none; border: 0; font: inherit; color: inherit; text-align: left; cursor: pointer; border-radius: 4px; }
+.tn-ev .tn-w-list li { transition: background .12s ease; }
+.tn-ev .tn-w-list li:hover { background: var(--tn-surface-2); }
+.tn-ev-row.is-flash, .tn-evd-rowbtn.is-flash { animation: tn-ev-flash 1.2s ease-out; }
+@keyframes tn-ev-flash {
+  0% { background: var(--tn-accent-soft); box-shadow: inset 2px 0 0 var(--tn-accent); }
+  100% { background: transparent; box-shadow: inset 2px 0 0 transparent; }
+}
+
+/* Detail: grouping toolbar + collapsible group headers + clickable rows. */
+.tn-evd-toolbar { display: flex; align-items: center; gap: 10px; margin: 4px 0 10px; }
+.tn-evd-group-toggle { display: flex; align-items: center; gap: 8px; width: 100%; padding: 4px 2px; background: transparent; border: 0; font: inherit; cursor: pointer; margin-bottom: 6px; }
+.tn-evd-group-toggle .tn-evd-group-h { margin: 0; }
+.tn-evd-group-toggle .tn-ev-group-count { font-family: var(--tn-mono); font-size: 12px; color: var(--tn-text-faint); }
+.tn-evd-list li { display: flex; align-items: center; flex-wrap: wrap; gap: 4px 6px; }
+.tn-evd-rowbtn { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 6px; padding: 0; margin: 0; background: none; border: 0; font: inherit; color: inherit; text-align: left; cursor: pointer; border-radius: 4px; }
+.tn-evd-rowbtn:hover b { text-decoration: underline; }
+
 /* ── Headlines focus view (W2) ─────────────────────────────────────── */
 .tn-hd { max-width: 1000px; margin: 0 auto; }
 .tn-hd-bar { display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; margin-bottom: 12px; }

--- a/components/InsetMap.tsx
+++ b/components/InsetMap.tsx
@@ -22,11 +22,14 @@ export default function InsetMap({
   points,
   height = 320,
   onSelect,
+  onMapClick,
   track,
 }: {
   points: InsetPoint[];
   height?: number;
   onSelect?: (id: string) => void;
+  /** Optional: fired on a click NOT on a point (used for click-to-add-asset). */
+  onMapClick?: (lat: number, lon: number) => void;
   /** Optional ground-track polyline: [lon,lat] segments (already antimeridian-split). */
   track?: [number, number][][];
 }) {
@@ -34,6 +37,8 @@ export default function InsetMap({
   const mapRef = useRef<maplibregl.Map | null>(null);
   const selectRef = useRef(onSelect);
   selectRef.current = onSelect;
+  const mapClickRef = useRef(onMapClick);
+  mapClickRef.current = onMapClick;
   // Latest props for the async 'load' handler — it is registered once, so without these
   // it would paint the INITIAL selection if props changed during the style fetch.
   const pointsRef = useRef(points); pointsRef.current = points;
@@ -71,6 +76,12 @@ export default function InsetMap({
       map.on("click", LAYER, (e) => {
         const id = e.features?.[0]?.properties?.id;
         if (typeof id === "string" && id) selectRef.current?.(id);
+      });
+      // Generic map click (add-asset mode) — only when the click missed a point.
+      map.on("click", (e) => {
+        if (!mapClickRef.current) return;
+        const hits = map.queryRenderedFeatures(e.point, { layers: [LAYER] });
+        if (hits.length === 0) mapClickRef.current(e.lngLat.lat, e.lngLat.lng);
       });
       map.on("mouseenter", LAYER, () => { map.getCanvas().style.cursor = "pointer"; });
       map.on("mouseleave", LAYER, () => { map.getCanvas().style.cursor = ""; });

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -21,6 +21,7 @@ import { FeedOverlay } from "@/components/FeedOverlay";
 import { CinematicDive } from "@/components/CinematicDive";
 import { scopeStore } from "@/lib/shell/scope";
 import { viewModeStore } from "@/lib/shell/viewMode";
+import { assetsStore } from "@/lib/events/assets";
 import ConsoleWorkspace from "@/components/console/ConsoleWorkspace";
 import { shellLayoutStore } from "@/lib/console/store";
 import { applyPreset, DEFAULT_PRESET_ID } from "@/lib/console/presets";
@@ -44,6 +45,7 @@ export default function ConsoleShell() {
     langStore.hydrate();
     scopeStore.hydrate();
     viewModeStore.hydrate();
+    assetsStore.hydrate();
     shellLayoutStore.hydrate();
     const c = new URLSearchParams(window.location.search).get("c");
     if (c) { const l = decodeLayout(c); if (l) shellLayoutStore.replace(l); }

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -22,6 +22,7 @@ import { CinematicDive } from "@/components/CinematicDive";
 import { scopeStore } from "@/lib/shell/scope";
 import { viewModeStore } from "@/lib/shell/viewMode";
 import { assetsStore } from "@/lib/events/assets";
+import { alertingStore } from "@/lib/events/alerting";
 import ConsoleWorkspace from "@/components/console/ConsoleWorkspace";
 import { shellLayoutStore } from "@/lib/console/store";
 import { applyPreset, DEFAULT_PRESET_ID } from "@/lib/console/presets";
@@ -46,6 +47,7 @@ export default function ConsoleShell() {
     scopeStore.hydrate();
     viewModeStore.hydrate();
     assetsStore.hydrate();
+    alertingStore.hydrate();
     shellLayoutStore.hydrate();
     const c = new URLSearchParams(window.location.search).get("c");
     if (c) { const l = decodeLayout(c); if (l) shellLayoutStore.replace(l); }

--- a/lib/console/widgets/events.detail.tsx
+++ b/lib/console/widgets/events.detail.tsx
@@ -1,12 +1,13 @@
 // lib/console/widgets/events.detail.tsx
 "use client";
-// Events focus view. Reuses the SAME feed pipeline as the docked widget
-// (useEventFeeds → projectEventFeed) but renders deep: a tier/type triage header,
-// a feed grouped by region OR hazard type with honest per-domain metric lines
-// joined back to the raw SignalFeature props, a recency chart, an event map, and
-// export. Rows are clickable — they fly the globe and open the same dossier a map
-// click would (lib/events/openEvent). Grouping + collapse state persist per widget
-// instance in `config` (shared with the compact widget via lib/events/opsConfig).
+// Events focus view — the operations console for the Disasters & Events feed.
+// Reuses the SAME feed pipeline as the docked widget (useEventFeeds →
+// projectEventFeed) but renders deep: a tier triage header, a recency chart, an
+// event/asset map, persisted signal-to-noise FILTERS, an operator ASSET manager
+// (add by form or by clicking the map), a pinned Direct Operational Threats board,
+// and a region/type clustered feed with per-domain metric lines. Rows fly the
+// globe + open the dossier. All heavy logic is pure + unit-tested in
+// lib/events/{regions,filters,assets,opsConfig}.ts; this is the shell.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import { EVENT_SOURCES } from "@/lib/events/sources";
@@ -16,7 +17,8 @@ import { useScope } from "@/lib/shell/scope";
 import { useTimeWindow, windowMsFor } from "@/lib/shell/timeWindow";
 import { useNow } from "@/lib/shell/useNow";
 import { shellLayoutStore } from "@/lib/console/store";
-import { SEVERITY_COLOR, type SeverityTier, type NormalizedEvent } from "@/lib/events/model";
+import { mapViewStore } from "@/lib/mapView";
+import { SEVERITY_COLOR, type SeverityTier, type EventType, type NormalizedEvent } from "@/lib/events/model";
 import type { SignalFeature } from "@/lib/signals/types";
 import { countBy } from "@/lib/widgets/buckets";
 import { eventMetricLine } from "@/lib/widgets/eventMetrics";
@@ -25,38 +27,59 @@ import { Chart, type ChartPoint } from "@/components/Chart";
 import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
 import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
-import { groupByRegion, groupByType, type EventGroup } from "@/lib/events/regions";
+import { groupByRegion, groupByType, regionOf, REGION_LABEL, TYPE_LABEL, type RegionId, type EventGroup } from "@/lib/events/regions";
 import { readGroupBy, readCollapsed, isCollapsed, toggleCollapsed, type GroupBy } from "@/lib/events/opsConfig";
+import { readFilters, applyEventFilters, toggleAllowSet, isAllowed } from "@/lib/events/filters";
+import { useAssets, assessThreats, makeAsset, assetsStore, type Threat } from "@/lib/events/assets";
 import { openEvent } from "@/lib/events/openEvent";
 
 const TIERS: SeverityTier[] = ["S4", "S3", "S2", "S1", "S0"];
+const TIER_CHOICES: SeverityTier[] = ["S0", "S1", "S2", "S3", "S4"];
 const GROUP_TABS: { id: GroupBy; label: string }[] = [
   { id: "region", label: "By region" },
   { id: "type", label: "By hazard" },
   { id: "none", label: "Flat" },
 ];
+const ASSET_COLOR = "#2563eb";
 
 export default function EventsDetail({ instanceId, config }: WidgetDetailProps) {
   const scope = useScope();
   const win = useTimeWindow();
   const now = useNow(60_000);
   const { bySource, status, updatedAt } = useEventFeeds();
+  const assets = useAssets();
 
   const inputs: FeedInput[] = useMemo(
     () => EVENT_SOURCES.map((source) => ({ source, features: bySource[source.id] ?? [] })),
     [bySource],
   );
-  const minTier = ((config.minTier as string) ?? "S1") as SeverityTier;
   const groupBy = readGroupBy(config);
   const collapsed = readCollapsed(config);
+  const filters = useMemo(() => readFilters(config), [config]);
 
   const projected = useMemo(
-    () => projectEventFeed(inputs, scope, windowMsFor(win), now, { types: null, minTier, sort: "severity" }),
-    [inputs, scope, win, now, minTier],
+    () => projectEventFeed(inputs, scope, windowMsFor(win), now, { types: null, minTier: "S0", sort: "severity" }),
+    [inputs, scope, win, now],
   );
+  const { rows: filtered, hidden } = useMemo(() => applyEventFilters(projected.rows, filters), [projected.rows, filters]);
 
-  // Join back to raw props for per-domain metrics (lost in NormalizedEvent) AND the
-  // dossier a row-click opens.
+  const threats = useMemo(() => assessThreats(filtered, assets), [filtered, assets]);
+  const threatRows = useMemo(() => filtered.filter((e) => threats.has(e.id)), [filtered, threats]);
+  const restRows = useMemo(() => filtered.filter((e) => !threats.has(e.id)), [filtered, threats]);
+
+  // Universes for the chip filters = types/regions PRESENT before filtering, so a
+  // chip never vanishes the moment you deselect it.
+  const typeUniverse = useMemo(() => {
+    const seen = new Set<EventType>();
+    for (const e of projected.rows) seen.add(e.type);
+    return [...seen];
+  }, [projected.rows]);
+  const regionUniverse = useMemo(() => {
+    const seen = new Set<RegionId>();
+    for (const e of projected.rows) seen.add(regionOf(e.geo.lat, e.geo.lon));
+    return [...seen];
+  }, [projected.rows]);
+
   const featureIndex = useMemo(() => {
     const m = new Map<string, { feature: SignalFeature; sourceLabel: string }>();
     for (const s of EVENT_SOURCES) for (const f of bySource[s.id] ?? []) m.set(f.id, { feature: f, sourceLabel: s.label });
@@ -73,59 +96,116 @@ export default function EventsDetail({ instanceId, config }: WidgetDetailProps) 
     if (flashTimer.current) clearTimeout(flashTimer.current);
     flashTimer.current = setTimeout(() => setFlashId(null), 1200);
   }, [featureIndex]);
+
+  // --- Asset manager state (add form + click-to-add) -------------------------
+  const [addMode, setAddMode] = useState(false);
+  const [name, setName] = useState("");
+  const [lat, setLat] = useState("");
+  const [lon, setLon] = useState("");
+  const [addErr, setAddErr] = useState<string | null>(null);
+  const submitAsset = () => {
+    const a = makeAsset(name || "Asset", Number(lat), Number(lon));
+    if (!a) { setAddErr("Enter a name and valid lat (−90..90) / lon (−180..180)."); return; }
+    assetsStore.add(a);
+    setName(""); setLat(""); setLon(""); setAddErr(null);
+  };
+  const onMapClick = useCallback((clat: number, clon: number) => {
+    const a = makeAsset(name.trim() || `POI ${clat.toFixed(2)}, ${clon.toFixed(2)}`, clat, clon);
+    if (a) assetsStore.add(a);
+  }, [name]);
+
   const onSelectId = useCallback((id: string) => {
+    if (id.startsWith("asset:")) {
+      const a = assets.find((x) => `asset:${x.id}` === id);
+      if (a) mapViewStore.flyToPoint({ lat: a.lat, lon: a.lon, zoom: 6 });
+      return;
+    }
     const e = projected.rows.find((r) => r.id === id);
     if (e) onOpen(e);
-  }, [projected.rows, onOpen]);
+  }, [projected.rows, onOpen, assets]);
 
+  // --- Config writers --------------------------------------------------------
   const setGroupBy = (g: GroupBy) => shellLayoutStore.configure(instanceId, { evGroupBy: g });
   const onToggleGroup = (key: string) =>
     shellLayoutStore.configure(instanceId, { evCollapsed: toggleCollapsed(collapsed, groupBy, key) });
+  const setMinTier = (t: SeverityTier) => shellLayoutStore.configure(instanceId, { evMinTier: t });
+  const setMinMag = (m: number) => shellLayoutStore.configure(instanceId, { evMinQuakeMag: m });
+  const toggleType = (t: EventType) =>
+    shellLayoutStore.configure(instanceId, { evTypes: toggleAllowSet(filters.types, t, typeUniverse) });
+  const toggleRegion = (r: RegionId) =>
+    shellLayoutStore.configure(instanceId, { evRegions: toggleAllowSet(filters.regions, r, regionUniverse) });
+  const clearFilters = () =>
+    shellLayoutStore.configure(instanceId, { evMinTier: "S0", evMinQuakeMag: 0, evTypes: null, evRegions: null });
 
-  const tierCounts = useMemo(() => countBy(projected.rows, (e) => e.severity.tier), [projected.rows]);
+  const tierCounts = useMemo(() => countBy(filtered, (e) => e.severity.tier), [filtered]);
   const groups: EventGroup[] = useMemo(() => {
-    if (groupBy === "region") return groupByRegion(projected.rows);
-    if (groupBy === "type") return groupByType(projected.rows);
-    return [{ key: "all", label: "All events", events: projected.rows }];
-  }, [groupBy, projected.rows]);
+    if (groupBy === "region") return groupByRegion(restRows);
+    if (groupBy === "type") return groupByType(restRows);
+    return [{ key: "all", label: "All events", events: restRows }];
+  }, [groupBy, restRows]);
 
   const recency: ChartPoint[] = useMemo(() => {
-    const ts = projected.rows
+    const ts = filtered
       .map((e) => (e.occurredAt ? Date.parse(e.occurredAt) : NaN))
       .filter((n) => Number.isFinite(n));
     return timeBins(ts, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
-  }, [projected.rows, now]);
+  }, [filtered, now]);
 
-  const mapPoints: InsetPoint[] = useMemo(
-    () => projected.rows.map((e) => ({
-      lat: e.geo.lat, lon: e.geo.lon, id: e.id, color: e.color,
+  const mapPoints: InsetPoint[] = useMemo(() => {
+    const evPts: InsetPoint[] = filtered.map((e) => ({
+      lat: e.geo.lat, lon: e.geo.lon, id: e.id, color: threats.has(e.id) ? "#dc2626" : e.color,
       props: { title: e.title, tier: e.severity.tier },
-    })),
-    [projected.rows],
-  );
+    }));
+    const assetPts: InsetPoint[] = assets.map((a) => ({
+      lat: a.lat, lon: a.lon, id: `asset:${a.id}`, color: ASSET_COLOR, props: { title: a.name },
+    }));
+    return [...evPts, ...assetPts];
+  }, [filtered, threats, assets]);
 
   const perSource = useMemo(() => {
-    const counts = countBy(projected.rows, (e) => e.source.id);
+    const counts = countBy(filtered, (e) => e.source.id);
     return EVENT_SOURCES.map((s) => ({ id: s.id, label: s.label, attribution: s.attribution, count: counts[s.id] ?? 0 }));
-  }, [projected.rows]);
+  }, [filtered]);
 
   const exportRows = useMemo(
-    () => projected.rows.map((e) => ({
+    () => filtered.map((e) => ({
       tier: e.severity.tier, type: e.type, title: e.title, place: e.place.name,
       metric: eventMetricLine(e.type, featureIndex.get(e.id)?.feature.props),
+      threat: threats.has(e.id) ? `${Math.round(threats.get(e.id)!.distanceKm)}km from ${threats.get(e.id)!.assetName}` : "",
       lat: e.geo.lat, lon: e.geo.lon, occurredAt: e.occurredAt ?? "",
     })),
-    [projected.rows, featureIndex],
+    [filtered, featureIndex, threats],
   );
   const exportGeo = useMemo(
-    () => projected.rows.map((e) => ({ lat: e.geo.lat, lon: e.geo.lon, properties: { tier: e.severity.tier, type: e.type, title: e.title } })),
-    [projected.rows],
+    () => filtered.map((e) => ({ lat: e.geo.lat, lon: e.geo.lon, properties: { tier: e.severity.tier, type: e.type, title: e.title } })),
+    [filtered],
   );
+
+  const renderRow = (e: NormalizedEvent) => {
+    const metric = eventMetricLine(e.type, featureIndex.get(e.id)?.feature.props);
+    const threat = threats.get(e.id);
+    return (
+      <li key={e.id} className={threat ? "is-threat" : undefined}>
+        <button
+          type="button"
+          className={`tn-evd-rowbtn${flashId === e.id ? " is-flash" : ""}`}
+          onClick={() => onOpen(e)}
+          title="Click to fly the map here and open the dossier"
+        >
+          <span className="tn-w-sev" style={{ background: SEVERITY_COLOR[e.severity.tier] }}>{e.severity.tier}</span>{" "}
+          <b>{e.title}</b> <span className="tn-w-place">{e.place.name}</span>
+          {threat && <span className="tn-ev-threat-chip">⚠ {Math.round(threat.distanceKm)}km · {threat.assetName}</span>}
+          {metric && <span className="tn-evd-metric"> · {metric}</span>}
+        </button>
+        {e.link && <a className="tn-evd-src" href={e.link} target="_blank" rel="noreferrer"> source ↗</a>}
+      </li>
+    );
+  };
 
   return (
     <div className="tn-evd">
       <div className="tn-evd-head">
-        <div className="tn-evd-stat"><b>{projected.shown}</b> of {projected.total} events</div>
+        <div className="tn-evd-stat"><b>{filtered.length}</b> of {projected.total} events{hidden > 0 ? ` · ${hidden} hidden by filters` : ""}</div>
         <div className="tn-evd-scope">{scope.label}{updatedAt ? ` · updated ${Math.round((now - updatedAt) / 60000)}m ago` : ""}</div>
         <div className="tn-evd-tiers">
           {TIERS.map((t) => (
@@ -144,19 +224,106 @@ export default function EventsDetail({ instanceId, config }: WidgetDetailProps) 
             : <p className="tn-w-empty">No timestamped events in the window.</p>}
         </div>
         <div className="tn-evd-panel">
-          <h3 className="tn-evd-group-h">Locations · click a dot to fly</h3>
+          <h3 className="tn-evd-group-h">Locations{addMode ? " · click the map to drop an asset" : " · click a dot to fly"}</h3>
           {mapPoints.length > 0
-            ? <InsetMap points={mapPoints} height={220} onSelect={onSelectId} />
+            ? <InsetMap points={mapPoints} height={220} onSelect={onSelectId} onMapClick={addMode ? onMapClick : undefined} />
             : <p className="tn-w-empty">No mappable events right now.</p>}
         </div>
       </div>
 
-      {status === "loading" && projected.shown === 0 && <p className="tn-w-empty">Loading events…</p>}
-      {projected.shown === 0 && status !== "loading" && (
-        <p className="tn-w-empty">No events above {minTier} in {scope.label}.</p>
+      {/* Signal-to-noise filters + operator assets */}
+      <div className="tn-evd-controls">
+        <section className="tn-evd-ctl">
+          <div className="tn-evd-ctl-h">
+            <span>Signal-to-noise filters</span>
+            {hidden > 0 && <button className="tn-evd-clear" onClick={clearFilters}>clear · {hidden} hidden</button>}
+          </div>
+          <div className="tn-evd-ctl-body">
+            <label className="tn-evd-field">
+              <span>Min severity</span>
+              <select value={filters.minTier} onChange={(e) => setMinTier(e.target.value as SeverityTier)}>
+                {TIER_CHOICES.map((t) => <option key={t} value={t}>{t}</option>)}
+              </select>
+            </label>
+            <label className="tn-evd-field">
+              <span>Min quake M</span>
+              <input
+                type="number" min={0} max={9} step={0.5} value={filters.minQuakeMag || ""}
+                placeholder="0"
+                onChange={(e) => setMinMag(Math.max(0, Number(e.target.value) || 0))}
+              />
+            </label>
+            {typeUniverse.length > 1 && (
+              <div className="tn-evd-chips" aria-label="Hazard types">
+                {typeUniverse.map((t) => (
+                  <button key={t} className={`tn-evd-chip${isAllowed(filters.types, t) ? " is-on" : ""}`} onClick={() => toggleType(t)}>
+                    {TYPE_LABEL[t]}
+                  </button>
+                ))}
+              </div>
+            )}
+            {regionUniverse.length > 1 && (
+              <div className="tn-evd-chips" aria-label="Regions">
+                {regionUniverse.map((r) => (
+                  <button key={r} className={`tn-evd-chip${isAllowed(filters.regions, r) ? " is-on" : ""}`} onClick={() => toggleRegion(r)}>
+                    {REGION_LABEL[r]}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="tn-evd-ctl">
+          <div className="tn-evd-ctl-h">
+            <span>My assets ({assets.length})</span>
+            <button className={`tn-evd-clear${addMode ? " is-on" : ""}`} onClick={() => setAddMode((v) => !v)}>
+              {addMode ? "click-to-add: ON" : "＋ click map"}
+            </button>
+          </div>
+          <div className="tn-evd-ctl-body">
+            <div className="tn-evd-assetform">
+              <input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+              <input placeholder="Lat" inputMode="decimal" value={lat} onChange={(e) => setLat(e.target.value)} />
+              <input placeholder="Lon" inputMode="decimal" value={lon} onChange={(e) => setLon(e.target.value)} />
+              <button onClick={submitAsset}>Add</button>
+            </div>
+            {addErr && <p className="tn-evd-err">{addErr}</p>}
+            {assets.length === 0 ? (
+              <p className="tn-w-empty">No assets yet. Add sites to flag events that threaten them.</p>
+            ) : (
+              <ul className="tn-evd-assetlist">
+                {assets.map((a) => (
+                  <li key={a.id}>
+                    <button className="tn-evd-asset-go" onClick={() => mapViewStore.flyToPoint({ lat: a.lat, lon: a.lon, zoom: 6 })} title="Fly to asset">
+                      <span className="tn-evd-asset-dot" style={{ background: ASSET_COLOR }} />
+                      <span className="tn-evd-asset-name">{a.name}</span>
+                      <span className="tn-evd-asset-coord">{a.lat.toFixed(2)}, {a.lon.toFixed(2)}</span>
+                    </button>
+                    <button className="tn-evd-asset-x" onClick={() => assetsStore.remove(a.id)} aria-label={`Remove ${a.name}`}>✕</button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      </div>
+
+      {status === "loading" && filtered.length === 0 && hidden === 0 && <p className="tn-w-empty">Loading events…</p>}
+      {filtered.length === 0 && status !== "loading" && (
+        <p className="tn-w-empty">
+          {hidden > 0 ? `All ${hidden} events hidden by filters in ${scope.label}.` : `No events in ${scope.label}.`}
+        </p>
       )}
 
-      {projected.shown > 0 && (
+      {threatRows.length > 0 && (
+        <section className="tn-evd-group tn-evd-threatboard">
+          <h3 className="tn-evd-group-h tn-evd-threatboard-h">⚠ Direct Operational Threats · {threatRows.length}</h3>
+          <ul className="tn-evd-list">{threatRows.map(renderRow)}</ul>
+        </section>
+      )}
+
+      {restRows.length > 0 && (
         <div className="tn-evd-toolbar">
           <div className="tn-ev-tabs" role="tablist" aria-label="Group events by">
             {GROUP_TABS.map((t) => (
@@ -190,28 +357,7 @@ export default function EventsDetail({ instanceId, config }: WidgetDetailProps) 
                 <span className="tn-ev-group-count">{g.events.length}</span>
               </button>
             )}
-            {open && (
-              <ul className="tn-evd-list">
-                {g.events.map((e) => {
-                  const metric = eventMetricLine(e.type, featureIndex.get(e.id)?.feature.props);
-                  return (
-                    <li key={e.id}>
-                      <button
-                        type="button"
-                        className={`tn-evd-rowbtn${flashId === e.id ? " is-flash" : ""}`}
-                        onClick={() => onOpen(e)}
-                        title="Click to fly the map here and open the dossier"
-                      >
-                        <span className="tn-w-sev" style={{ background: SEVERITY_COLOR[e.severity.tier] }}>{e.severity.tier}</span>{" "}
-                        <b>{e.title}</b> <span className="tn-w-place">{e.place.name}</span>
-                        {metric && <span className="tn-evd-metric"> · {metric}</span>}
-                      </button>
-                      {e.link && <a className="tn-evd-src" href={e.link} target="_blank" rel="noreferrer"> source ↗</a>}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
+            {open && <ul className="tn-evd-list">{g.events.map(renderRow)}</ul>}
           </section>
         );
       })}

--- a/lib/console/widgets/events.detail.tsx
+++ b/lib/console/widgets/events.detail.tsx
@@ -30,7 +30,9 @@ import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
 import { groupByRegion, groupByType, regionOf, REGION_LABEL, TYPE_LABEL, type RegionId, type EventGroup } from "@/lib/events/regions";
 import { readGroupBy, readCollapsed, isCollapsed, toggleCollapsed, type GroupBy } from "@/lib/events/opsConfig";
 import { readFilters, applyEventFilters, toggleAllowSet, isAllowed } from "@/lib/events/filters";
-import { useAssets, assessThreats, makeAsset, assetsStore, type Threat } from "@/lib/events/assets";
+import { useAssets, assessThreats, makeAsset, assetsStore, impactRadiusKm } from "@/lib/events/assets";
+import { useAlerting, alertingStore, requestNotifyPermission } from "@/lib/events/alerting";
+import { nearbyHubs, HUB_TYPE_LABEL } from "@/lib/events/hubs";
 import { openEvent } from "@/lib/events/openEvent";
 
 const TIERS: SeverityTier[] = ["S4", "S3", "S2", "S1", "S0"];
@@ -114,6 +116,19 @@ export default function EventsDetail({ instanceId, config }: WidgetDetailProps) 
     if (a) assetsStore.add(a);
   }, [name]);
 
+  // --- Proactive alerting config (feature 5) ---------------------------------
+  const alerting = useAlerting();
+  const [perm, setPerm] = useState<NotificationPermission | "unsupported">("default");
+  useEffect(() => {
+    if (typeof window === "undefined" || !("Notification" in window)) { setPerm("unsupported"); return; }
+    setPerm(Notification.permission);
+  }, []);
+  const enableNotify = async () => {
+    const ok = await requestNotifyPermission();
+    setPerm(typeof window !== "undefined" && "Notification" in window ? Notification.permission : "unsupported");
+    alertingStore.setNotify(ok);
+  };
+
   const onSelectId = useCallback((id: string) => {
     if (id.startsWith("asset:")) {
       const a = assets.find((x) => `asset:${x.id}` === id);
@@ -143,6 +158,15 @@ export default function EventsDetail({ instanceId, config }: WidgetDetailProps) 
     if (groupBy === "type") return groupByType(restRows);
     return [{ key: "all", label: "All events", events: restRows }];
   }, [groupBy, restRows]);
+
+  // Logistics exposure (feature 6): severe events with curated hubs in reach.
+  const exposure = useMemo(() => {
+    const severe = filtered.filter((e) => e.severity.tier === "S3" || e.severity.tier === "S4");
+    return severe
+      .map((e) => { const radiusKm = impactRadiusKm(e); return { event: e, radiusKm, hubs: nearbyHubs(e, radiusKm).slice(0, 5) }; })
+      .filter((x) => x.hubs.length > 0)
+      .slice(0, 8);
+  }, [filtered]);
 
   const recency: ChartPoint[] = useMemo(() => {
     const ts = filtered
@@ -309,6 +333,51 @@ export default function EventsDetail({ instanceId, config }: WidgetDetailProps) 
         </section>
       </div>
 
+      {/* Proactive alerting (feature 5) */}
+      <section className="tn-evd-ctl tn-evd-alerting">
+        <div className="tn-evd-ctl-h">
+          <span>Proactive alerting</span>
+          <label className="tn-evd-armtoggle">
+            <input type="checkbox" checked={alerting.rule.enabled} onChange={(e) => alertingStore.setRule({ enabled: e.target.checked })} />
+            {alerting.rule.enabled ? "armed" : "off"}
+          </label>
+        </div>
+        <div className="tn-evd-ctl-body">
+          <label className="tn-evd-field">
+            <span>Min tier</span>
+            <select value={alerting.rule.minTier} onChange={(e) => alertingStore.setRule({ minTier: e.target.value as SeverityTier })}>
+              {TIER_CHOICES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </label>
+          <label className="tn-evd-field">
+            <span>Within (km)</span>
+            <input
+              type="number" min={1} step={10} value={alerting.rule.radiusKm}
+              onChange={(e) => alertingStore.setRule({ radiusKm: Math.max(1, Number(e.target.value) || 1) })}
+            />
+          </label>
+          <button
+            className={`tn-evd-chip${alerting.notify && perm === "granted" ? " is-on" : ""}`}
+            onClick={enableNotify}
+            disabled={perm === "unsupported"}
+          >
+            {perm === "unsupported" ? "notifications n/a" : alerting.notify && perm === "granted" ? "🔔 notifications on" : "enable notifications"}
+          </button>
+          <input
+            className="tn-evd-webhook"
+            placeholder="Webhook / Slack / PagerDuty incoming-webhook URL"
+            value={alerting.webhookUrl}
+            onChange={(e) => alertingStore.setWebhook(e.target.value)}
+          />
+        </div>
+        <p className="tn-evd-note">
+          {assets.length === 0
+            ? "Add an asset above to arm proximity alerts."
+            : `Fires from this browser while the console is open — new hazards ≥ ${alerting.rule.minTier} within ${alerting.rule.radiusKm} km of an asset.`}
+          {perm === "denied" && " Browser notifications are blocked in your settings."}
+        </p>
+      </section>
+
       {status === "loading" && filtered.length === 0 && hidden === 0 && <p className="tn-w-empty">Loading events…</p>}
       {filtered.length === 0 && status !== "loading" && (
         <p className="tn-w-empty">
@@ -320,6 +389,33 @@ export default function EventsDetail({ instanceId, config }: WidgetDetailProps) 
         <section className="tn-evd-group tn-evd-threatboard">
           <h3 className="tn-evd-group-h tn-evd-threatboard-h">⚠ Direct Operational Threats · {threatRows.length}</h3>
           <ul className="tn-evd-list">{threatRows.map(renderRow)}</ul>
+        </section>
+      )}
+
+      {/* Logistics exposure (feature 6) — severe events near curated hubs */}
+      {exposure.length > 0 && (
+        <section className="tn-evd-group tn-evd-exposure">
+          <h3 className="tn-evd-group-h">Logistics exposure · severe events near curated hubs</h3>
+          <p className="tn-evd-note">
+            Great-circle proximity only — hubs within each event&apos;s modelled impact radius (potential disruption, not a confirmed
+            closure). Curated reference set of ~50 major ports, airports &amp; manufacturing clusters.
+          </p>
+          <ul className="tn-evd-exposure-list">
+            {exposure.map(({ event, radiusKm, hubs }) => (
+              <li key={event.id}>
+                <button className="tn-evd-rowbtn" onClick={() => onOpen(event)} title="Click to fly the map here">
+                  <span className="tn-w-sev" style={{ background: SEVERITY_COLOR[event.severity.tier] }}>{event.severity.tier}</span>{" "}
+                  <b>{event.title}</b>
+                  <span className="tn-evd-metric"> · {hubs.length} hub{hubs.length > 1 ? "s" : ""} within {Math.round(radiusKm)} km</span>
+                </button>
+                <div className="tn-evd-hubs">
+                  {hubs.map(({ hub, distanceKm }) => (
+                    <span key={hub.name} className="tn-evd-hub">{hub.name} <i>{HUB_TYPE_LABEL[hub.type]}</i> · {Math.round(distanceKm)} km</span>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
         </section>
       )}
 

--- a/lib/console/widgets/events.detail.tsx
+++ b/lib/console/widgets/events.detail.tsx
@@ -2,9 +2,12 @@
 "use client";
 // Events focus view. Reuses the SAME feed pipeline as the docked widget
 // (useEventFeeds → projectEventFeed) but renders deep: a tier/type triage header,
-// a feed grouped by event type with honest per-domain metric lines joined back to
-// the raw SignalFeature props, and (Task 10/11) a recency chart, event map and export.
-import { useMemo } from "react";
+// a feed grouped by region OR hazard type with honest per-domain metric lines
+// joined back to the raw SignalFeature props, a recency chart, an event map, and
+// export. Rows are clickable — they fly the globe and open the same dossier a map
+// click would (lib/events/openEvent). Grouping + collapse state persist per widget
+// instance in `config` (shared with the compact widget via lib/events/opsConfig).
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import { EVENT_SOURCES } from "@/lib/events/sources";
 import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
@@ -12,7 +15,8 @@ import { projectEventFeed, type FeedInput } from "@/lib/widgets/eventFeed";
 import { useScope } from "@/lib/shell/scope";
 import { useTimeWindow, windowMsFor } from "@/lib/shell/timeWindow";
 import { useNow } from "@/lib/shell/useNow";
-import { SEVERITY_COLOR, type SeverityTier, type EventType } from "@/lib/events/model";
+import { shellLayoutStore } from "@/lib/console/store";
+import { SEVERITY_COLOR, type SeverityTier, type NormalizedEvent } from "@/lib/events/model";
 import type { SignalFeature } from "@/lib/signals/types";
 import { countBy } from "@/lib/widgets/buckets";
 import { eventMetricLine } from "@/lib/widgets/eventMetrics";
@@ -21,11 +25,18 @@ import { Chart, type ChartPoint } from "@/components/Chart";
 import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
 import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
+import { groupByRegion, groupByType, type EventGroup } from "@/lib/events/regions";
+import { readGroupBy, readCollapsed, isCollapsed, toggleCollapsed, type GroupBy } from "@/lib/events/opsConfig";
+import { openEvent } from "@/lib/events/openEvent";
 
 const TIERS: SeverityTier[] = ["S4", "S3", "S2", "S1", "S0"];
-const TYPE_LABEL: Partial<Record<EventType, string>> = { quake: "Quakes", disaster: "Disasters", cyclone: "Cyclones" };
+const GROUP_TABS: { id: GroupBy; label: string }[] = [
+  { id: "region", label: "By region" },
+  { id: "type", label: "By hazard" },
+  { id: "none", label: "Flat" },
+];
 
-export default function EventsDetail({ config }: WidgetDetailProps) {
+export default function EventsDetail({ instanceId, config }: WidgetDetailProps) {
   const scope = useScope();
   const win = useTimeWindow();
   const now = useNow(60_000);
@@ -36,25 +47,47 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
     [bySource],
   );
   const minTier = ((config.minTier as string) ?? "S1") as SeverityTier;
+  const groupBy = readGroupBy(config);
+  const collapsed = readCollapsed(config);
 
   const projected = useMemo(
     () => projectEventFeed(inputs, scope, windowMsFor(win), now, { types: null, minTier, sort: "severity" }),
     [inputs, scope, win, now, minTier],
   );
 
-  // Join back to raw props for per-domain metrics (lost in NormalizedEvent).
-  const featureById = useMemo(() => {
-    const m = new Map<string, SignalFeature>();
-    for (const s of EVENT_SOURCES) for (const f of bySource[s.id] ?? []) m.set(f.id, f);
+  // Join back to raw props for per-domain metrics (lost in NormalizedEvent) AND the
+  // dossier a row-click opens.
+  const featureIndex = useMemo(() => {
+    const m = new Map<string, { feature: SignalFeature; sourceLabel: string }>();
+    for (const s of EVENT_SOURCES) for (const f of bySource[s.id] ?? []) m.set(f.id, { feature: f, sourceLabel: s.label });
     return m;
   }, [bySource]);
 
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (flashTimer.current) clearTimeout(flashTimer.current); }, []);
+  const onOpen = useCallback((e: NormalizedEvent) => {
+    const hit = featureIndex.get(e.id);
+    openEvent(e, hit?.feature, hit?.sourceLabel);
+    setFlashId(e.id);
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setFlashId(null), 1200);
+  }, [featureIndex]);
+  const onSelectId = useCallback((id: string) => {
+    const e = projected.rows.find((r) => r.id === id);
+    if (e) onOpen(e);
+  }, [projected.rows, onOpen]);
+
+  const setGroupBy = (g: GroupBy) => shellLayoutStore.configure(instanceId, { evGroupBy: g });
+  const onToggleGroup = (key: string) =>
+    shellLayoutStore.configure(instanceId, { evCollapsed: toggleCollapsed(collapsed, groupBy, key) });
+
   const tierCounts = useMemo(() => countBy(projected.rows, (e) => e.severity.tier), [projected.rows]);
-  const groups = useMemo(() => {
-    const by = new Map<EventType, typeof projected.rows>();
-    for (const e of projected.rows) { const g = by.get(e.type) ?? []; g.push(e); by.set(e.type, g); }
-    return [...by.entries()];
-  }, [projected.rows]);
+  const groups: EventGroup[] = useMemo(() => {
+    if (groupBy === "region") return groupByRegion(projected.rows);
+    if (groupBy === "type") return groupByType(projected.rows);
+    return [{ key: "all", label: "All events", events: projected.rows }];
+  }, [groupBy, projected.rows]);
 
   const recency: ChartPoint[] = useMemo(() => {
     const ts = projected.rows
@@ -79,10 +112,10 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
   const exportRows = useMemo(
     () => projected.rows.map((e) => ({
       tier: e.severity.tier, type: e.type, title: e.title, place: e.place.name,
-      metric: eventMetricLine(e.type, featureById.get(e.id)?.props),
+      metric: eventMetricLine(e.type, featureIndex.get(e.id)?.feature.props),
       lat: e.geo.lat, lon: e.geo.lon, occurredAt: e.occurredAt ?? "",
     })),
-    [projected.rows, featureById],
+    [projected.rows, featureIndex],
   );
   const exportGeo = useMemo(
     () => projected.rows.map((e) => ({ lat: e.geo.lat, lon: e.geo.lon, properties: { tier: e.severity.tier, type: e.type, title: e.title } })),
@@ -111,9 +144,9 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
             : <p className="tn-w-empty">No timestamped events in the window.</p>}
         </div>
         <div className="tn-evd-panel">
-          <h3 className="tn-evd-group-h">Locations</h3>
+          <h3 className="tn-evd-group-h">Locations · click a dot to fly</h3>
           {mapPoints.length > 0
-            ? <InsetMap points={mapPoints} height={220} />
+            ? <InsetMap points={mapPoints} height={220} onSelect={onSelectId} />
             : <p className="tn-w-empty">No mappable events right now.</p>}
         </div>
       </div>
@@ -123,24 +156,65 @@ export default function EventsDetail({ config }: WidgetDetailProps) {
         <p className="tn-w-empty">No events above {minTier} in {scope.label}.</p>
       )}
 
-      {groups.map(([type, rows]) => (
-        <section key={type} className="tn-evd-group">
-          <h3 className="tn-evd-group-h">{TYPE_LABEL[type] ?? type} · {rows.length}</h3>
-          <ul className="tn-evd-list">
-            {rows.map((e) => {
-              const metric = eventMetricLine(e.type, featureById.get(e.id)?.props);
-              return (
-                <li key={e.id}>
-                  <span className="tn-w-sev" style={{ background: SEVERITY_COLOR[e.severity.tier] }}>{e.severity.tier}</span>{" "}
-                  <b>{e.title}</b> <span className="tn-w-place">{e.place.name}</span>
-                  {metric && <span className="tn-evd-metric"> · {metric}</span>}
-                  {e.link && <a className="tn-evd-src" href={e.link} target="_blank" rel="noreferrer"> source ↗</a>}
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-      ))}
+      {projected.shown > 0 && (
+        <div className="tn-evd-toolbar">
+          <div className="tn-ev-tabs" role="tablist" aria-label="Group events by">
+            {GROUP_TABS.map((t) => (
+              <button
+                key={t.id}
+                role="tab"
+                aria-selected={groupBy === t.id}
+                className={`tn-ev-tab${groupBy === t.id ? " is-active" : ""}`}
+                onClick={() => setGroupBy(t.id)}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {groups.map((g) => {
+        const open = groupBy === "none" || !isCollapsed(collapsed, groupBy, g.key);
+        return (
+          <section key={g.key} className="tn-evd-group">
+            {groupBy !== "none" && (
+              <button
+                type="button"
+                className="tn-evd-group-toggle"
+                aria-expanded={open}
+                onClick={() => onToggleGroup(g.key)}
+              >
+                <span className={`tn-ev-chev${open ? " is-open" : ""}`} aria-hidden>▸</span>
+                <span className="tn-evd-group-h">{g.label}</span>
+                <span className="tn-ev-group-count">{g.events.length}</span>
+              </button>
+            )}
+            {open && (
+              <ul className="tn-evd-list">
+                {g.events.map((e) => {
+                  const metric = eventMetricLine(e.type, featureIndex.get(e.id)?.feature.props);
+                  return (
+                    <li key={e.id}>
+                      <button
+                        type="button"
+                        className={`tn-evd-rowbtn${flashId === e.id ? " is-flash" : ""}`}
+                        onClick={() => onOpen(e)}
+                        title="Click to fly the map here and open the dossier"
+                      >
+                        <span className="tn-w-sev" style={{ background: SEVERITY_COLOR[e.severity.tier] }}>{e.severity.tier}</span>{" "}
+                        <b>{e.title}</b> <span className="tn-w-place">{e.place.name}</span>
+                        {metric && <span className="tn-evd-metric"> · {metric}</span>}
+                      </button>
+                      {e.link && <a className="tn-evd-src" href={e.link} target="_blank" rel="noreferrer"> source ↗</a>}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+        );
+      })}
 
       <footer className="tn-evd-foot">
         <div className="tn-evd-sources">

--- a/lib/console/widgets/events.tsx
+++ b/lib/console/widgets/events.tsx
@@ -12,10 +12,12 @@
 //     r.magnitude?.value → EventLite.magnitude  (NESTED, optional number)
 //   Display uses r.place.name for the human location label.
 //
-// M20 ops upgrade: rows are now clickable (fly the globe + open the dossier, via
-// lib/events/openEvent) and the long feed collapses into region/type clusters with
-// counts (persisted per widget instance in `config`). Pure grouping lives in
-// lib/events/regions.ts; pure view-pref reads in lib/events/opsConfig.ts.
+// M20 ops upgrade: rows are clickable (fly the globe + open the dossier, via
+// lib/events/openEvent); the long feed collapses into region/type clusters with
+// counts; persisted signal-to-noise filters trim it (with an honest hidden count);
+// and events whose modelled impact radius reaches an operator asset are escalated
+// to Direct Operational Threats, pinned to the top. Pure logic: lib/events/{regions,
+// filters,assets}.ts; pure view-pref reads: lib/events/opsConfig.ts.
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EVENT_SOURCES } from "@/lib/events/sources";
@@ -29,11 +31,12 @@ import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { shellLayoutStore } from "@/lib/console/store";
 import { runAlertRule } from "@/lib/console/alerts";
 import { eventAlerts, type EventLite } from "@/lib/console/widgets/events.rules";
-import type { SeverityTier } from "@/lib/events/model";
 import type { NormalizedEvent } from "@/lib/events/model";
 import type { SignalFeature } from "@/lib/signals/types";
 import { groupByRegion, groupByType, type EventGroup } from "@/lib/events/regions";
 import { readGroupBy, readCollapsed, isCollapsed, toggleCollapsed, type GroupBy } from "@/lib/events/opsConfig";
+import { readFilters, applyEventFilters } from "@/lib/events/filters";
+import { useAssets, assessThreats, type Threat } from "@/lib/events/assets";
 import { openEvent } from "@/lib/events/openEvent";
 import EventsDetail from "@/lib/console/widgets/events.detail";
 
@@ -46,25 +49,32 @@ const GROUP_TABS: { id: GroupBy; label: string }[] = [
 function EventRow({
   e,
   feature,
+  threat,
   flashed,
   onOpen,
 }: {
   e: NormalizedEvent;
   feature?: SignalFeature;
+  threat?: Threat;
   flashed: boolean;
   onOpen: (e: NormalizedEvent, f?: SignalFeature) => void;
 }) {
   return (
-    <li>
+    <li className={threat ? "is-threat" : undefined}>
       <button
         type="button"
         className={`tn-ev-row${flashed ? " is-flash" : ""}`}
         onClick={() => onOpen(e, feature)}
-        title={`${e.title} — ${e.place.name}\nClick to fly the map here`}
+        title={
+          threat
+            ? `${e.title} — ${e.place.name}\nDirect operational threat: ${Math.round(threat.distanceKm)} km from ${threat.assetName}`
+            : `${e.title} — ${e.place.name}\nClick to fly the map here`
+        }
       >
         <span className={`tn-w-sev tn-sev-${e.severity.tier}`}>{e.severity.tier}</span>
         <b className="tn-w-kind">{e.type}</b>
         <span className="tn-w-place">{e.place.name}</span>
+        {threat && <span className="tn-ev-threat-chip">⚠ {Math.round(threat.distanceKm)}km</span>}
         {e.magnitude && (
           <span className="tn-w-mag">
             {e.magnitude.value}
@@ -81,37 +91,41 @@ function EventsBody({ instanceId, config }: WidgetBodyProps) {
   const win = useTimeWindow();
   const now = useNow(60_000);
   const { bySource, status } = useEventFeeds();
+  const assets = useAssets();
 
-  // Exact pattern copied from components/shell/EventFeed.tsx.
   const inputs: FeedInput[] = useMemo(
     () => EVENT_SOURCES.map((source) => ({ source, features: bySource[source.id] ?? [] })),
     [bySource],
   );
 
-  const minTier = ((config.minTier as string) ?? "S1") as SeverityTier;
   const sort = ((config.sort as string) ?? "severity") as FeedSort;
   const groupBy = readGroupBy(config);
   const collapsed = readCollapsed(config);
+  const filters = useMemo(() => readFilters(config), [config]);
 
+  // Project ALL in-scope/in-window rows (minTier S0) so the filter module owns the
+  // tier/type/mag/region trim and the hidden count stays honest.
   const projected = useMemo(
     () =>
       projectEventFeed(inputs, scope, windowMsFor(win), now, {
         types: null,
-        minTier,
+        minTier: "S0",
         sort: sort === "nearest" && !scope.center ? "severity" : sort,
       }),
-    [inputs, scope, win, now, minTier, sort],
+    [inputs, scope, win, now, sort],
   );
+  const { rows: filtered, hidden } = useMemo(() => applyEventFilters(projected.rows, filters), [projected.rows, filters]);
 
-  // Join back to the raw SignalFeature so a row-click opens the same dossier a map
-  // click would (source label carried for the dossier credit).
+  const threats = useMemo(() => assessThreats(filtered, assets), [filtered, assets]);
+  const threatRows = useMemo(() => filtered.filter((e) => threats.has(e.id)), [filtered, threats]);
+  const restRows = useMemo(() => filtered.filter((e) => !threats.has(e.id)), [filtered, threats]);
+
   const featureIndex = useMemo(() => {
     const m = new Map<string, { feature: SignalFeature; sourceLabel: string }>();
     for (const s of EVENT_SOURCES) for (const f of bySource[s.id] ?? []) m.set(f.id, { feature: f, sourceLabel: s.label });
     return m;
   }, [bySource]);
 
-  // Row flash on click (a short highlight so the eye stays anchored while the map flies).
   const [flashId, setFlashId] = useState<string | null>(null);
   const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (flashTimer.current) clearTimeout(flashTimer.current); }, []);
@@ -126,28 +140,30 @@ function EventsBody({ instanceId, config }: WidgetBodyProps) {
   const setGroupBy = (g: GroupBy) => shellLayoutStore.configure(instanceId, { evGroupBy: g });
   const onToggleGroup = (key: string) =>
     shellLayoutStore.configure(instanceId, { evCollapsed: toggleCollapsed(collapsed, groupBy, key) });
+  const clearFilters = () =>
+    shellLayoutStore.configure(instanceId, { evMinTier: "S0", evMinQuakeMag: 0, evTypes: null, evRegions: null });
 
   const groups: EventGroup[] = useMemo(() => {
-    if (groupBy === "region") return groupByRegion(projected.rows);
-    if (groupBy === "type") return groupByType(projected.rows);
-    return [{ key: "all", label: "All events", events: projected.rows }];
-  }, [groupBy, projected.rows]);
+    if (groupBy === "region") return groupByRegion(restRows);
+    if (groupBy === "type") return groupByType(restRows);
+    return [{ key: "all", label: "All events", events: restRows }];
+  }, [groupBy, restRows]);
 
   const lite: EventLite[] = useMemo(
     () =>
-      projected.rows.map((r) => ({
+      filtered.map((r) => ({
         id: r.id,
         type: r.type,
         tier: r.severity.tier,
         title: r.title,
         magnitude: r.magnitude?.value,
       })),
-    [projected.rows],
+    [filtered],
   );
 
   const exportRows = useMemo(
     () =>
-      projected.rows.map((r) => ({
+      filtered.map((r) => ({
         tier: r.severity.tier,
         type: r.type,
         title: r.title,
@@ -156,41 +172,39 @@ function EventsBody({ instanceId, config }: WidgetBodyProps) {
         unit: r.magnitude?.unit ?? "",
         lat: r.geo.lat,
         lon: r.geo.lon,
+        threat: threats.has(r.id) ? `${Math.round(threats.get(r.id)!.distanceKm)}km from ${threats.get(r.id)!.assetName}` : "",
       })),
-    [projected.rows],
+    [filtered, threats],
   );
   const exportGeo = useMemo(
     () =>
-      projected.rows.map((r) => ({
+      filtered.map((r) => ({
         lat: r.geo.lat,
         lon: r.geo.lon,
         properties: { tier: r.severity.tier, type: r.type, title: r.title, place: r.place.name, magnitude: r.magnitude?.value },
       })),
-    [projected.rows],
+    [filtered],
   );
 
   const report = useWidgetReport();
   useEffect(() => {
     report({
       alerts: runAlertRule(eventAlerts, lite, config),
-      count: projected.shown,
+      count: filtered.length,
       freshLabel: "5m",
       export: { rows: exportRows, geo: exportGeo, name: "events" },
     });
-  }, [lite, projected.shown, report, config, exportRows, exportGeo]);
+  }, [lite, filtered.length, report, config, exportRows, exportGeo]);
 
-  if (status === "loading" && projected.shown === 0) {
+  if (status === "loading" && filtered.length === 0 && hidden === 0) {
     return <p className="tn-w-empty">Loading events…</p>;
-  }
-  if (projected.shown === 0) {
-    return (
-      <p className="tn-w-empty">
-        No events above {minTier} in {scope.label}.
-      </p>
-    );
   }
 
   const flat = groupBy === "none";
+  const renderRow = (e: NormalizedEvent) => {
+    const hit = featureIndex.get(e.id);
+    return <EventRow key={e.id} e={e} feature={hit?.feature} threat={threats.get(e.id)} flashed={flashId === e.id} onOpen={onOpen} />;
+  };
 
   return (
     <div className="tn-ev">
@@ -206,43 +220,55 @@ function EventsBody({ instanceId, config }: WidgetBodyProps) {
             {t.label}
           </button>
         ))}
+        {hidden > 0 && (
+          <button className="tn-ev-hidden" onClick={clearFilters} title="Filtered out by your signal-to-noise settings. Click to clear filters.">
+            {hidden} hidden ✕
+          </button>
+        )}
       </div>
 
-      {flat ? (
-        <ul className="tn-w-list">
-          {groups[0].events.slice(0, 200).map((e) => {
-            const hit = featureIndex.get(e.id);
-            return <EventRow key={e.id} e={e} feature={hit?.feature} flashed={flashId === e.id} onOpen={onOpen} />;
-          })}
-        </ul>
-      ) : (
-        <div className="tn-ev-groups">
-          {groups.map((g) => {
-            const open = !isCollapsed(collapsed, groupBy, g.key);
-            return (
-              <section key={g.key} className="tn-ev-group">
-                <button
-                  type="button"
-                  className="tn-ev-group-h"
-                  aria-expanded={open}
-                  onClick={() => onToggleGroup(g.key)}
-                >
-                  <span className={`tn-ev-chev${open ? " is-open" : ""}`} aria-hidden>▸</span>
-                  <span className="tn-ev-group-label">{g.label}</span>
-                  <span className="tn-ev-group-count">{g.events.length}</span>
-                </button>
-                {open && (
-                  <ul className="tn-w-list">
-                    {g.events.slice(0, 200).map((e) => {
-                      const hit = featureIndex.get(e.id);
-                      return <EventRow key={e.id} e={e} feature={hit?.feature} flashed={flashId === e.id} onOpen={onOpen} />;
-                    })}
-                  </ul>
-                )}
-              </section>
-            );
-          })}
-        </div>
+      {filtered.length === 0 && (
+        <p className="tn-w-empty">
+          {hidden > 0 ? `All ${hidden} events hidden by filters in ${scope.label}.` : `No events in ${scope.label}.`}
+        </p>
+      )}
+
+      {threatRows.length > 0 && (
+        <section className="tn-ev-group tn-ev-threats">
+          <div className="tn-ev-group-h tn-ev-threats-h">
+            <span aria-hidden>⚠</span>
+            <span className="tn-ev-group-label">Direct Operational Threats</span>
+            <span className="tn-ev-group-count">{threatRows.length}</span>
+          </div>
+          <ul className="tn-w-list">{threatRows.slice(0, 100).map(renderRow)}</ul>
+        </section>
+      )}
+
+      {restRows.length > 0 && (
+        flat ? (
+          <ul className="tn-w-list">{groups[0].events.slice(0, 200).map(renderRow)}</ul>
+        ) : (
+          <div className="tn-ev-groups">
+            {groups.map((g) => {
+              const open = !isCollapsed(collapsed, groupBy, g.key);
+              return (
+                <section key={g.key} className="tn-ev-group">
+                  <button
+                    type="button"
+                    className="tn-ev-group-h"
+                    aria-expanded={open}
+                    onClick={() => onToggleGroup(g.key)}
+                  >
+                    <span className={`tn-ev-chev${open ? " is-open" : ""}`} aria-hidden>▸</span>
+                    <span className="tn-ev-group-label">{g.label}</span>
+                    <span className="tn-ev-group-count">{g.events.length}</span>
+                  </button>
+                  {open && <ul className="tn-w-list">{g.events.slice(0, 200).map(renderRow)}</ul>}
+                </section>
+              );
+            })}
+          </div>
+        )
       )}
     </div>
   );

--- a/lib/console/widgets/events.tsx
+++ b/lib/console/widgets/events.tsx
@@ -37,6 +37,7 @@ import { groupByRegion, groupByType, type EventGroup } from "@/lib/events/region
 import { readGroupBy, readCollapsed, isCollapsed, toggleCollapsed, type GroupBy } from "@/lib/events/opsConfig";
 import { readFilters, applyEventFilters } from "@/lib/events/filters";
 import { useAssets, assessThreats, type Threat } from "@/lib/events/assets";
+import { useAlerting, alertingStore, matchAlerts, fireBrowserNotification, postWebhook } from "@/lib/events/alerting";
 import { openEvent } from "@/lib/events/openEvent";
 import EventsDetail from "@/lib/console/widgets/events.detail";
 
@@ -119,6 +120,28 @@ function EventsBody({ instanceId, config }: WidgetBodyProps) {
   const threats = useMemo(() => assessThreats(filtered, assets), [filtered, assets]);
   const threatRows = useMemo(() => filtered.filter((e) => threats.has(e.id)), [filtered, threats]);
   const restRows = useMemo(() => filtered.filter((e) => !threats.has(e.id)), [filtered, threats]);
+
+  // Proactive alerting (feature 5): the docked widget is the always-mounted driver.
+  // On the first armed pass we take a SILENT baseline (existing events don't
+  // stampede), then only genuinely-new matching events raise a browser Notification
+  // and/or POST to the operator's webhook. All dormant-safe. Runs over the full
+  // in-scope set (not the display filters) so alerting is independent of the view.
+  const alerting = useAlerting();
+  useEffect(() => {
+    if (!alerting.rule.enabled) return;
+    const fired = new Set(alerting.fired);
+    const hits = matchAlerts(projected.rows, assets, alerting.rule, fired);
+    if (!alerting.seeded) {
+      alertingStore.markFired(hits.map((h) => h.eventId)); // silent baseline (may be empty)
+      return;
+    }
+    if (hits.length === 0) return;
+    for (const h of hits) {
+      if (alerting.notify) fireBrowserNotification(h);
+      if (alerting.webhookUrl) void postWebhook(alerting.webhookUrl, h);
+    }
+    alertingStore.markFired(hits.map((h) => h.eventId));
+  }, [projected.rows, assets, alerting]);
 
   const featureIndex = useMemo(() => {
     const m = new Map<string, { feature: SignalFeature; sourceLabel: string }>();

--- a/lib/console/widgets/events.tsx
+++ b/lib/console/widgets/events.tsx
@@ -11,8 +11,13 @@
 //     r.title           → EventLite.title
 //     r.magnitude?.value → EventLite.magnitude  (NESTED, optional number)
 //   Display uses r.place.name for the human location label.
+//
+// M20 ops upgrade: rows are now clickable (fly the globe + open the dossier, via
+// lib/events/openEvent) and the long feed collapses into region/type clusters with
+// counts (persisted per widget instance in `config`). Pure grouping lives in
+// lib/events/regions.ts; pure view-pref reads in lib/events/opsConfig.ts.
 "use client";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EVENT_SOURCES } from "@/lib/events/sources";
 import { useEventFeeds } from "@/lib/widgets/useEventFeeds";
 import { projectEventFeed, type FeedInput, type FeedSort } from "@/lib/widgets/eventFeed";
@@ -21,12 +26,57 @@ import { useTimeWindow, windowMsFor } from "@/lib/shell/timeWindow";
 import { useNow } from "@/lib/shell/useNow";
 import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { shellLayoutStore } from "@/lib/console/store";
 import { runAlertRule } from "@/lib/console/alerts";
 import { eventAlerts, type EventLite } from "@/lib/console/widgets/events.rules";
 import type { SeverityTier } from "@/lib/events/model";
+import type { NormalizedEvent } from "@/lib/events/model";
+import type { SignalFeature } from "@/lib/signals/types";
+import { groupByRegion, groupByType, type EventGroup } from "@/lib/events/regions";
+import { readGroupBy, readCollapsed, isCollapsed, toggleCollapsed, type GroupBy } from "@/lib/events/opsConfig";
+import { openEvent } from "@/lib/events/openEvent";
 import EventsDetail from "@/lib/console/widgets/events.detail";
 
-function EventsBody({ config }: WidgetBodyProps) {
+const GROUP_TABS: { id: GroupBy; label: string }[] = [
+  { id: "region", label: "Region" },
+  { id: "type", label: "Type" },
+  { id: "none", label: "Flat" },
+];
+
+function EventRow({
+  e,
+  feature,
+  flashed,
+  onOpen,
+}: {
+  e: NormalizedEvent;
+  feature?: SignalFeature;
+  flashed: boolean;
+  onOpen: (e: NormalizedEvent, f?: SignalFeature) => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        className={`tn-ev-row${flashed ? " is-flash" : ""}`}
+        onClick={() => onOpen(e, feature)}
+        title={`${e.title} — ${e.place.name}\nClick to fly the map here`}
+      >
+        <span className={`tn-w-sev tn-sev-${e.severity.tier}`}>{e.severity.tier}</span>
+        <b className="tn-w-kind">{e.type}</b>
+        <span className="tn-w-place">{e.place.name}</span>
+        {e.magnitude && (
+          <span className="tn-w-mag">
+            {e.magnitude.value}
+            {e.magnitude.unit}
+          </span>
+        )}
+      </button>
+    </li>
+  );
+}
+
+function EventsBody({ instanceId, config }: WidgetBodyProps) {
   const scope = useScope();
   const win = useTimeWindow();
   const now = useNow(60_000);
@@ -40,6 +90,8 @@ function EventsBody({ config }: WidgetBodyProps) {
 
   const minTier = ((config.minTier as string) ?? "S1") as SeverityTier;
   const sort = ((config.sort as string) ?? "severity") as FeedSort;
+  const groupBy = readGroupBy(config);
+  const collapsed = readCollapsed(config);
 
   const projected = useMemo(
     () =>
@@ -51,8 +103,36 @@ function EventsBody({ config }: WidgetBodyProps) {
     [inputs, scope, win, now, minTier, sort],
   );
 
-  // Map NormalizedEvent rows → EventLite for the alert rules.
-  // Key field renames: r.severity.tier → tier; r.magnitude?.value → magnitude.
+  // Join back to the raw SignalFeature so a row-click opens the same dossier a map
+  // click would (source label carried for the dossier credit).
+  const featureIndex = useMemo(() => {
+    const m = new Map<string, { feature: SignalFeature; sourceLabel: string }>();
+    for (const s of EVENT_SOURCES) for (const f of bySource[s.id] ?? []) m.set(f.id, { feature: f, sourceLabel: s.label });
+    return m;
+  }, [bySource]);
+
+  // Row flash on click (a short highlight so the eye stays anchored while the map flies).
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (flashTimer.current) clearTimeout(flashTimer.current); }, []);
+  const onOpen = useCallback((e: NormalizedEvent, f?: SignalFeature) => {
+    const hit = featureIndex.get(e.id);
+    openEvent(e, f ?? hit?.feature, hit?.sourceLabel);
+    setFlashId(e.id);
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setFlashId(null), 1200);
+  }, [featureIndex]);
+
+  const setGroupBy = (g: GroupBy) => shellLayoutStore.configure(instanceId, { evGroupBy: g });
+  const onToggleGroup = (key: string) =>
+    shellLayoutStore.configure(instanceId, { evCollapsed: toggleCollapsed(collapsed, groupBy, key) });
+
+  const groups: EventGroup[] = useMemo(() => {
+    if (groupBy === "region") return groupByRegion(projected.rows);
+    if (groupBy === "type") return groupByType(projected.rows);
+    return [{ key: "all", label: "All events", events: projected.rows }];
+  }, [groupBy, projected.rows]);
+
   const lite: EventLite[] = useMemo(
     () =>
       projected.rows.map((r) => ({
@@ -110,23 +190,61 @@ function EventsBody({ config }: WidgetBodyProps) {
     );
   }
 
+  const flat = groupBy === "none";
+
   return (
-    <ul className="tn-w-list">
-      {projected.rows.slice(0, 100).map((r) => (
-        <li key={r.id}>
-          <span className={`tn-w-sev tn-sev-${r.severity.tier}`}>{r.severity.tier}</span>{" "}
-          <b className="tn-w-kind">{r.type}</b>{" "}
-          <span className="tn-w-place">{r.place.name}</span>
-          {r.magnitude && (
-            <span className="tn-w-mag">
-              {" "}
-              {r.magnitude.value}
-              {r.magnitude.unit}
-            </span>
-          )}
-        </li>
-      ))}
-    </ul>
+    <div className="tn-ev">
+      <div className="tn-ev-tabs" role="tablist" aria-label="Group events by">
+        {GROUP_TABS.map((t) => (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={groupBy === t.id}
+            className={`tn-ev-tab${groupBy === t.id ? " is-active" : ""}`}
+            onClick={() => setGroupBy(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {flat ? (
+        <ul className="tn-w-list">
+          {groups[0].events.slice(0, 200).map((e) => {
+            const hit = featureIndex.get(e.id);
+            return <EventRow key={e.id} e={e} feature={hit?.feature} flashed={flashId === e.id} onOpen={onOpen} />;
+          })}
+        </ul>
+      ) : (
+        <div className="tn-ev-groups">
+          {groups.map((g) => {
+            const open = !isCollapsed(collapsed, groupBy, g.key);
+            return (
+              <section key={g.key} className="tn-ev-group">
+                <button
+                  type="button"
+                  className="tn-ev-group-h"
+                  aria-expanded={open}
+                  onClick={() => onToggleGroup(g.key)}
+                >
+                  <span className={`tn-ev-chev${open ? " is-open" : ""}`} aria-hidden>▸</span>
+                  <span className="tn-ev-group-label">{g.label}</span>
+                  <span className="tn-ev-group-count">{g.events.length}</span>
+                </button>
+                {open && (
+                  <ul className="tn-w-list">
+                    {g.events.slice(0, 200).map((e) => {
+                      const hit = featureIndex.get(e.id);
+                      return <EventRow key={e.id} e={e} feature={hit?.feature} flashed={flashId === e.id} onOpen={onOpen} />;
+                    })}
+                  </ul>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -136,7 +254,7 @@ export const EVENTS_WIDGET = {
   icon: "🌎",
   category: "Events",
   defaultHeight: 320,
-  defaultConfig: { minTier: "S1", sort: "severity" },
+  defaultConfig: { minTier: "S1", sort: "severity", evGroupBy: "region" },
   component: EventsBody,
   detail: EventsDetail,
   capabilities: { filter: true, sort: true },

--- a/lib/events/alerting.ts
+++ b/lib/events/alerting.ts
@@ -1,0 +1,192 @@
+"use client";
+// Proactive, client-side alerting for the Disasters & Events feed. The operator
+// arms a rule — "any hazard of type … at/above tier … within R km of one of my
+// assets" — and when a NEW matching event appears we (optionally) raise a browser
+// Notification and/or POST to a generic incoming-webhook URL (Slack / PagerDuty /
+// Teams style). Everything is:
+//   • keyless & client-only — no server secrets, no stored credentials beyond the
+//     URL the operator pastes (kept in their own localStorage);
+//   • DORMANT-SAFE — denied Notification permission, an empty URL, or a failed POST
+//     all degrade to a silent no-op, never an error;
+//   • de-duplicated — a persisted `fired` set + a one-time silent `seeded` baseline
+//     means existing events don't stampede the operator on first arm / reload.
+// The matcher + coercion are PURE and unit-tested; the store + browser bridges are
+// the thin impure shell (lib/shell/watchlist idiom).
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { haversineKm } from "@/lib/geo/haversine";
+import { severityRank, type NormalizedEvent, type EventType, type SeverityTier } from "@/lib/events/model";
+import type { Asset } from "@/lib/events/assets";
+
+export interface AlertRuleConfig {
+  enabled: boolean;
+  /** Only events at/above this tier match. */
+  minTier: SeverityTier;
+  /** null = any hazard type; otherwise the set to match. */
+  types: EventType[] | null;
+  /** Match when an event is within this many km of ANY asset. */
+  radiusKm: number;
+}
+
+export const DEFAULT_ALERT_RULE: AlertRuleConfig = { enabled: false, minTier: "S3", types: null, radiusKm: 250 };
+
+export interface AlertHit {
+  eventId: string;
+  title: string;
+  tier: SeverityTier;
+  type: EventType;
+  assetId: string;
+  assetName: string;
+  distanceKm: number;
+}
+
+const TIER_SET = new Set<SeverityTier>(["S0", "S1", "S2", "S3", "S4"]);
+
+/**
+ * PURE: events matching the rule (type + tier) that sit within rule.radiusKm of at
+ * least one asset and are NOT already in `fired`. Nearest asset wins per event.
+ */
+export function matchAlerts(
+  events: NormalizedEvent[],
+  assets: Asset[],
+  rule: AlertRuleConfig,
+  fired: Set<string>,
+): AlertHit[] {
+  if (!rule.enabled || assets.length === 0) return [];
+  const floor = severityRank(rule.minTier);
+  const out: AlertHit[] = [];
+  for (const e of events) {
+    if (fired.has(e.id)) continue;
+    if (severityRank(e.severity.tier) < floor) continue;
+    if (rule.types && !rule.types.includes(e.type)) continue;
+    let best: { assetId: string; assetName: string; distanceKm: number } | null = null;
+    for (const a of assets) {
+      const d = haversineKm(e.geo.lat, e.geo.lon, a.lat, a.lon);
+      if (d <= rule.radiusKm && (!best || d < best.distanceKm)) {
+        best = { assetId: a.id, assetName: a.name, distanceKm: d };
+      }
+    }
+    if (best) out.push({ eventId: e.id, title: e.title, tier: e.severity.tier, type: e.type, ...best });
+  }
+  return out;
+}
+
+/** PURE: coerce a persisted rule into a valid one (garbage → defaults). */
+export function coerceAlertRule(saved: unknown): AlertRuleConfig {
+  const s = (saved ?? {}) as Partial<AlertRuleConfig>;
+  const minTier = TIER_SET.has(s.minTier as SeverityTier) ? (s.minTier as SeverityTier) : DEFAULT_ALERT_RULE.minTier;
+  const radiusKm = Number.isFinite(s.radiusKm) && (s.radiusKm as number) > 0 ? (s.radiusKm as number) : DEFAULT_ALERT_RULE.radiusKm;
+  const types = Array.isArray(s.types) ? (s.types.filter((t) => typeof t === "string") as EventType[]) : null;
+  return { enabled: s.enabled === true, minTier, types, radiusKm };
+}
+
+// --- Persisted state ---------------------------------------------------------
+
+interface AlertingState {
+  rule: AlertRuleConfig;
+  /** Raise browser Notifications for hits. */
+  notify: boolean;
+  /** Optional generic incoming-webhook URL to POST hits to. */
+  webhookUrl: string;
+  /** Already-notified event ids (capped) — dedupe across renders + reloads. */
+  fired: string[];
+  /** One-time silent baseline taken so existing events don't stampede on first arm. */
+  seeded: boolean;
+}
+
+const FIRED_CAP = 300;
+const PERSIST_KEY = "tn.events.alerting.v1";
+const PERSIST_VERSION = 1;
+
+function defaultState(): AlertingState {
+  return { rule: { ...DEFAULT_ALERT_RULE }, notify: false, webhookUrl: "", fired: [], seeded: false };
+}
+
+function coerceState(saved: unknown): AlertingState {
+  const s = (saved ?? {}) as Partial<AlertingState>;
+  return {
+    rule: coerceAlertRule(s.rule),
+    notify: s.notify === true,
+    webhookUrl: typeof s.webhookUrl === "string" ? s.webhookUrl : "",
+    fired: Array.isArray(s.fired) ? s.fired.filter((x) => typeof x === "string").slice(0, FIRED_CAP) : [],
+    seeded: s.seeded === true,
+  };
+}
+
+let state: AlertingState = defaultState();
+const listeners = new Set<() => void>();
+function emit() { for (const l of listeners) l(); savePersisted(PERSIST_KEY, PERSIST_VERSION, state); }
+
+export const alertingStore = {
+  get(): AlertingState { return state; },
+  setRule(patch: Partial<AlertRuleConfig>) { state = { ...state, rule: { ...state.rule, ...patch } }; emit(); },
+  setNotify(on: boolean) { state = { ...state, notify: on }; emit(); },
+  setWebhook(url: string) { state = { ...state, webhookUrl: url }; emit(); },
+  /** Record ids as fired (capped, newest-first) and mark the baseline taken. */
+  markFired(ids: string[]) {
+    if (ids.length === 0 && state.seeded) return;
+    const merged = [...ids, ...state.fired.filter((x) => !ids.includes(x))].slice(0, FIRED_CAP);
+    state = { ...state, fired: merged, seeded: true };
+    emit();
+  },
+  /** Forget the fired history (re-baseline on the next tick). */
+  resetFired() { state = { ...state, fired: [], seeded: false }; emit(); },
+  hydrate() { state = coerceState(loadPersisted<AlertingState>(PERSIST_KEY, PERSIST_VERSION)); emit(); },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => { listeners.delete(listener); };
+  },
+};
+
+export function useAlerting(): AlertingState {
+  return useSyncExternalStore(alertingStore.subscribe, alertingStore.get, alertingStore.get);
+}
+
+// --- Browser bridges (dormant-safe) -----------------------------------------
+
+/** Ask for Notification permission. Resolves false when unsupported / denied. */
+export async function requestNotifyPermission(): Promise<boolean> {
+  if (typeof window === "undefined" || !("Notification" in window)) return false;
+  try {
+    if (Notification.permission === "granted") return true;
+    const res = await Notification.requestPermission();
+    return res === "granted";
+  } catch {
+    return false;
+  }
+}
+
+/** Raise a browser Notification for a hit. No-op unless permission is granted. */
+export function fireBrowserNotification(hit: AlertHit): void {
+  if (typeof window === "undefined" || !("Notification" in window)) return;
+  try {
+    if (Notification.permission !== "granted") return;
+    new Notification(`⚠ ${hit.tier} ${hit.type} · ${hit.title}`, {
+      body: `${Math.round(hit.distanceKm)} km from ${hit.assetName}`,
+      tag: `tn-ev-${hit.eventId}`,
+    });
+  } catch {
+    /* some browsers throw on construct without a service worker — non-fatal */
+  }
+}
+
+/** POST a hit to a generic incoming-webhook URL. Silent on any failure / empty URL. */
+export async function postWebhook(url: string, hit: AlertHit): Promise<void> {
+  const target = (url ?? "").trim();
+  if (!target) return;
+  try {
+    await fetch(target, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // `text` doubles as a Slack-compatible field; the structured fields ride alongside.
+      body: JSON.stringify({
+        text: `⚠ ${hit.tier} ${hit.type}: ${hit.title} — ${Math.round(hit.distanceKm)} km from ${hit.assetName}`,
+        event: hit,
+        source: "World Monitor — Disasters & Events",
+      }),
+    });
+  } catch {
+    /* CORS / offline / bad URL — dormant-safe, never throws into the render */
+  }
+}

--- a/lib/events/assets.ts
+++ b/lib/events/assets.ts
@@ -1,0 +1,166 @@
+"use client";
+// Operator ASSETS (points of interest) + proximity matching for the Disasters &
+// Events feed. An operator drops their own sites (name + lat/lon, optionally a
+// footprint radius) — persisted locally — and any event whose modelled impact
+// radius reaches one is escalated from a "Global Event" to a **Direct Operational
+// Threat**. Follows the lib/shell/watchlist idiom: PURE list ops + PURE proximity
+// maths (unit-tested via direct import) wrapped by a thin persisted external store.
+//
+// Honesty: `impactRadiusKm` is a COARSE, documented hazard-footprint heuristic for
+// proximity flagging — NOT an authoritative inundation/shaking model. It never
+// fabricates per-event figures; it maps (type, tier, magnitude) to a radius band.
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { haversineKm } from "@/lib/geo/haversine";
+import type { NormalizedEvent, EventType, SeverityTier } from "@/lib/events/model";
+
+export interface Asset {
+  /** Stable id (dedupe / remove / config key). */
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  /** Extra footprint buffer (km) added to the event's impact radius. Default 0. */
+  radiusKm: number;
+  createdAt: number;
+}
+
+export const ASSET_CAP = 50;
+
+/** Tier → default impact radius (km) when a type has no better basis. */
+const TIER_RADIUS: Record<SeverityTier, number> = { S0: 25, S1: 60, S2: 120, S3: 220, S4: 350 };
+
+/** Quake felt/impact radius band by magnitude — coarse, documented. */
+function quakeRadiusKm(mag: number | undefined): number {
+  if (mag == null || !Number.isFinite(mag)) return 60;
+  if (mag < 4) return 30;
+  if (mag < 5) return 80;
+  if (mag < 6) return 200;
+  if (mag < 7) return 400;
+  return 700;
+}
+
+const TYPE_TIER_RADIUS: Partial<Record<EventType, Record<SeverityTier, number>>> = {
+  cyclone: { S0: 120, S1: 180, S2: 280, S3: 400, S4: 550 },
+  flood: { S0: 30, S1: 60, S2: 120, S3: 200, S4: 300 },
+  storm: { S0: 40, S1: 80, S2: 150, S3: 250, S4: 350 },
+  volcano: { S0: 20, S1: 40, S2: 80, S3: 150, S4: 250 },
+  disaster: { S0: 50, S1: 90, S2: 160, S3: 260, S4: 400 },
+};
+
+/** PURE: a coarse impact radius (km) for an event, from its type/tier/magnitude. */
+export function impactRadiusKm(e: NormalizedEvent): number {
+  if (e.type === "quake") return quakeRadiusKm(e.magnitude?.value);
+  const byTier = TYPE_TIER_RADIUS[e.type];
+  return (byTier ?? TIER_RADIUS)[e.severity.tier];
+}
+
+export interface Threat {
+  assetId: string;
+  assetName: string;
+  /** Distance from the event anchor to the nearest intersecting asset. */
+  distanceKm: number;
+  /** The modelled impact radius used for the intersection test. */
+  impactRadiusKm: number;
+}
+
+/**
+ * PURE: for each event, the nearest asset its impact radius reaches (event impact
+ * radius + that asset's footprint buffer). Events with no intersecting asset are
+ * absent from the map. Deterministic: ties break toward the smaller distance, then
+ * the lexicographically-smaller asset id.
+ */
+export function assessThreats(events: NormalizedEvent[], assets: Asset[]): Map<string, Threat> {
+  const out = new Map<string, Threat>();
+  if (assets.length === 0) return out;
+  for (const e of events) {
+    const reach = impactRadiusKm(e);
+    let best: Threat | null = null;
+    for (const a of assets) {
+      const d = haversineKm(e.geo.lat, e.geo.lon, a.lat, a.lon);
+      if (d > reach + (a.radiusKm || 0)) continue;
+      if (
+        !best ||
+        d < best.distanceKm ||
+        (d === best.distanceKm && a.id < best.assetId)
+      ) {
+        best = { assetId: a.id, assetName: a.name, distanceKm: d, impactRadiusKm: reach };
+      }
+    }
+    if (best) out.set(e.id, best);
+  }
+  return out;
+}
+
+// --- PURE list ops (unit-tested) --------------------------------------------
+
+/** Build a validated Asset, or null if the coords are out of range / name blank. */
+export function makeAsset(name: string, lat: number, lon: number, radiusKm = 0, now = Date.now()): Asset | null {
+  const nm = (name ?? "").trim();
+  if (!nm) return null;
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) return null;
+  if (!Number.isFinite(lon) || lon < -180 || lon > 180) return null;
+  const r = Number.isFinite(radiusKm) && radiusKm > 0 ? radiusKm : 0;
+  return { id: `poi:${now}:${Math.round(lat * 1e4)}:${Math.round(lon * 1e4)}`, name: nm, lat, lon, radiusKm: r, createdAt: now };
+}
+
+/** Add an asset (replace same id), newest-first, capped. */
+export function addAsset(list: Asset[], a: Asset, cap = ASSET_CAP): Asset[] {
+  return [a, ...list.filter((x) => x.id !== a.id)].slice(0, cap);
+}
+
+export function removeAsset(list: Asset[], id: string): Asset[] {
+  return list.filter((a) => a.id !== id);
+}
+
+/** Coerce a persisted blob into a clean Asset[] (drops malformed entries). */
+export function coerceAssets(saved: unknown): Asset[] {
+  if (!Array.isArray(saved)) return [];
+  const out: Asset[] = [];
+  for (const raw of saved) {
+    const a = raw as Partial<Asset>;
+    if (typeof a?.id !== "string" || typeof a?.name !== "string") continue;
+    if (!Number.isFinite(a.lat) || !Number.isFinite(a.lon)) continue;
+    if ((a.lat as number) < -90 || (a.lat as number) > 90) continue;
+    if ((a.lon as number) < -180 || (a.lon as number) > 180) continue;
+    out.push({
+      id: a.id,
+      name: a.name,
+      lat: a.lat as number,
+      lon: a.lon as number,
+      radiusKm: Number.isFinite(a.radiusKm) && (a.radiusKm as number) > 0 ? (a.radiusKm as number) : 0,
+      createdAt: Number.isFinite(a.createdAt) ? (a.createdAt as number) : 0,
+    });
+  }
+  return out.slice(0, ASSET_CAP);
+}
+
+// --- Persisted external store ------------------------------------------------
+
+const PERSIST_KEY = "tn.events.assets.v1";
+const PERSIST_VERSION = 1;
+
+let state: Asset[] = [];
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+}
+
+export const assetsStore = {
+  add(a: Asset) { state = addAsset(state, a); emit(); },
+  remove(id: string) { state = removeAsset(state, id); emit(); },
+  clear() { if (state.length === 0) return; state = []; emit(); },
+  get(): Asset[] { return state; },
+  hydrate() { state = coerceAssets(loadPersisted<Asset[]>(PERSIST_KEY, PERSIST_VERSION)); emit(); },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => { listeners.delete(listener); };
+  },
+};
+
+export function useAssets(): Asset[] {
+  return useSyncExternalStore(assetsStore.subscribe, assetsStore.get, assetsStore.get);
+}

--- a/lib/events/filters.ts
+++ b/lib/events/filters.ts
@@ -1,0 +1,105 @@
+// lib/events/filters.ts
+// PURE signal-to-noise filtering for the Disasters & Events feed. The operator's
+// tuning (min severity, min quake magnitude, hazard-type allow-set, region
+// allow-set) is persisted in the widget `config` bag; this module both coerces it
+// out of that bag and applies it, returning the kept rows AND an honest hidden
+// count so the UI can surface "N hidden by filters" (never silently drop data).
+
+import { type NormalizedEvent, type SeverityTier, type EventType, severityRank } from "@/lib/events/model";
+import { regionOf, type RegionId, REGIONS, TYPE_ORDER } from "@/lib/events/regions";
+
+export interface EventFilters {
+  /** Hide events below this display tier. */
+  minTier: SeverityTier;
+  /** Hide quakes whose native magnitude is below this (0 = off). Non-quakes ignore it. */
+  minQuakeMag: number;
+  /** null = all hazard types kept; otherwise only these are kept. */
+  types: EventType[] | null;
+  /** null = all regions kept; otherwise only these are kept. */
+  regions: RegionId[] | null;
+}
+
+export const DEFAULT_FILTERS: EventFilters = {
+  minTier: "S1",
+  minQuakeMag: 0,
+  types: null,
+  regions: null,
+};
+
+const TIER_SET = new Set<SeverityTier>(["S0", "S1", "S2", "S3", "S4"]);
+const TYPE_SET = new Set<EventType>(TYPE_ORDER);
+const REGION_SET = new Set<RegionId>(REGIONS.map((r) => r.id));
+
+/** Coerce a persisted config bag into a valid EventFilters (garbage → defaults). */
+export function readFilters(config: Record<string, unknown>): EventFilters {
+  const tierRaw = (config.evMinTier ?? config.minTier) as SeverityTier;
+  const minTier = TIER_SET.has(tierRaw) ? tierRaw : DEFAULT_FILTERS.minTier;
+
+  const magRaw = Number(config.evMinQuakeMag);
+  const minQuakeMag = Number.isFinite(magRaw) && magRaw > 0 ? magRaw : 0;
+
+  const types = coerceSet(config.evTypes, TYPE_SET);
+  const regions = coerceSet(config.evRegions, REGION_SET);
+
+  return { minTier, minQuakeMag, types, regions };
+}
+
+function coerceSet<T>(raw: unknown, valid: Set<T>): T[] | null {
+  if (!Array.isArray(raw)) return null; // absent / junk = "all"
+  const kept = raw.filter((v): v is T => valid.has(v as T));
+  // An empty allow-set is a real state ("hide everything of this axis") — keep it.
+  return kept;
+}
+
+/** Does a single event pass the filters? PURE, exported for direct testing. */
+export function passesFilters(e: NormalizedEvent, f: EventFilters): boolean {
+  if (severityRank(e.severity.tier) < severityRank(f.minTier)) return false;
+  if (e.type === "quake" && f.minQuakeMag > 0) {
+    const mag = e.magnitude?.value;
+    if (mag != null && mag < f.minQuakeMag) return false;
+  }
+  if (f.types && !f.types.includes(e.type)) return false;
+  if (f.regions && !f.regions.includes(regionOf(e.geo.lat, e.geo.lon))) return false;
+  return true;
+}
+
+export interface FilteredFeed {
+  rows: NormalizedEvent[];
+  /** Count removed by the filters (relative to the input) — for the honest affordance. */
+  hidden: number;
+}
+
+/** Apply the filters, preserving input order; report how many were hidden. */
+export function applyEventFilters(rows: NormalizedEvent[], f: EventFilters): FilteredFeed {
+  const kept = rows.filter((e) => passesFilters(e, f));
+  return { rows: kept, hidden: rows.length - kept.length };
+}
+
+/**
+ * PURE chip toggle for an allow-set axis (hazard types / regions). `null` means
+ * "all"; clicking an item toggles its membership. Selecting the whole universe
+ * collapses back to `null` (the compact "all allowed" state).
+ */
+export function toggleAllowSet<T>(current: T[] | null, item: T, universe: T[]): T[] | null {
+  const base = current ?? universe;
+  const next = base.includes(item) ? base.filter((x) => x !== item) : [...base, item];
+  const uni = new Set(universe);
+  const nextSet = new Set(next);
+  if (nextSet.size === uni.size && [...uni].every((x) => nextSet.has(x))) return null;
+  return next;
+}
+
+/** Is `item` currently allowed by an allow-set (null = all allowed)? */
+export function isAllowed<T>(current: T[] | null, item: T): boolean {
+  return current === null || current.includes(item);
+}
+
+/** Is the filter set doing anything at all? (For the compact "showing all" case.) */
+export function filtersActive(f: EventFilters): boolean {
+  return (
+    f.minTier !== "S0" ||
+    f.minQuakeMag > 0 ||
+    f.types !== null ||
+    f.regions !== null
+  );
+}

--- a/lib/events/hubs.ts
+++ b/lib/events/hubs.ts
@@ -1,0 +1,111 @@
+// lib/events/hubs.ts
+// A small CURATED REFERENCE SET of major global logistics hubs (container ports,
+// international airports, and manufacturing clusters) with real, published
+// coordinates. It exists so a severe event can surface the downstream hubs that
+// sit nearby and could face disruption — WITHOUT fabricating any per-event figure.
+//
+// HONESTY / SCOPE:
+//   • This is a hand-curated sample of ~50 of the world's largest hubs, NOT an
+//     exhaustive or authoritative facilities database. Coordinates are approximate
+//     hub centroids.
+//   • `nearbyHubs` only computes great-circle distance (haversine). It NEVER claims
+//     a closure, an ETA, or a dollar impact — the caller phrases results as
+//     "hubs within N km (potential disruption)".
+
+import { haversineKm } from "@/lib/geo/haversine";
+import type { NormalizedEvent } from "@/lib/events/model";
+
+export type HubType = "port" | "airport" | "manufacturing";
+
+export interface Hub {
+  name: string;
+  type: HubType;
+  country: string;
+  lat: number;
+  lon: number;
+}
+
+export const HUB_TYPE_LABEL: Record<HubType, string> = {
+  port: "Port",
+  airport: "Airport",
+  manufacturing: "Mfg. hub",
+};
+
+/** Curated reference set — ~50 major global logistics hubs. */
+export const HUBS: Hub[] = [
+  // ── Container ports (throughput leaders) ─────────────────────────────
+  { name: "Port of Shanghai", type: "port", country: "China", lat: 30.63, lon: 122.07 },
+  { name: "Port of Singapore", type: "port", country: "Singapore", lat: 1.26, lon: 103.83 },
+  { name: "Port of Ningbo-Zhoushan", type: "port", country: "China", lat: 29.87, lon: 121.83 },
+  { name: "Port of Shenzhen", type: "port", country: "China", lat: 22.55, lon: 113.88 },
+  { name: "Port of Guangzhou", type: "port", country: "China", lat: 23.09, lon: 113.49 },
+  { name: "Port of Busan", type: "port", country: "South Korea", lat: 35.10, lon: 129.04 },
+  { name: "Port of Qingdao", type: "port", country: "China", lat: 36.09, lon: 120.31 },
+  { name: "Port of Hong Kong", type: "port", country: "Hong Kong", lat: 22.30, lon: 114.13 },
+  { name: "Port of Rotterdam", type: "port", country: "Netherlands", lat: 51.95, lon: 4.14 },
+  { name: "Port of Antwerp-Bruges", type: "port", country: "Belgium", lat: 51.28, lon: 4.34 },
+  { name: "Port of Hamburg", type: "port", country: "Germany", lat: 53.54, lon: 9.93 },
+  { name: "Port of Los Angeles / Long Beach", type: "port", country: "USA", lat: 33.74, lon: -118.26 },
+  { name: "Port of New York & New Jersey", type: "port", country: "USA", lat: 40.66, lon: -74.09 },
+  { name: "Port of Jebel Ali (Dubai)", type: "port", country: "UAE", lat: 25.01, lon: 55.06 },
+  { name: "Port of Tanjung Pelepas", type: "port", country: "Malaysia", lat: 1.36, lon: 103.55 },
+  { name: "Port of Kaohsiung", type: "port", country: "Taiwan", lat: 22.61, lon: 120.28 },
+  { name: "Port of Colombo", type: "port", country: "Sri Lanka", lat: 6.95, lon: 79.84 },
+  { name: "Port of Piraeus", type: "port", country: "Greece", lat: 37.94, lon: 23.63 },
+  { name: "Port of Santos", type: "port", country: "Brazil", lat: -23.98, lon: -46.30 },
+  { name: "Port of Valencia", type: "port", country: "Spain", lat: 39.44, lon: -0.31 },
+  { name: "Port of Tokyo / Yokohama", type: "port", country: "Japan", lat: 35.45, lon: 139.68 },
+  { name: "Suez Canal (Port Said)", type: "port", country: "Egypt", lat: 31.25, lon: 32.30 },
+  { name: "Panama Canal (Balboa)", type: "port", country: "Panama", lat: 8.95, lon: -79.56 },
+
+  // ── International airports (passenger + cargo gateways) ───────────────
+  { name: "Hartsfield-Jackson Atlanta (ATL)", type: "airport", country: "USA", lat: 33.64, lon: -84.43 },
+  { name: "Dubai Intl (DXB)", type: "airport", country: "UAE", lat: 25.25, lon: 55.36 },
+  { name: "Beijing Capital (PEK)", type: "airport", country: "China", lat: 40.08, lon: 116.60 },
+  { name: "London Heathrow (LHR)", type: "airport", country: "UK", lat: 51.47, lon: -0.45 },
+  { name: "Tokyo Haneda (HND)", type: "airport", country: "Japan", lat: 35.55, lon: 139.78 },
+  { name: "Los Angeles Intl (LAX)", type: "airport", country: "USA", lat: 33.94, lon: -118.41 },
+  { name: "Chicago O'Hare (ORD)", type: "airport", country: "USA", lat: 41.98, lon: -87.90 },
+  { name: "Paris Charles de Gaulle (CDG)", type: "airport", country: "France", lat: 49.01, lon: 2.55 },
+  { name: "Frankfurt (FRA)", type: "airport", country: "Germany", lat: 50.04, lon: 8.56 },
+  { name: "Amsterdam Schiphol (AMS)", type: "airport", country: "Netherlands", lat: 52.31, lon: 4.76 },
+  { name: "Singapore Changi (SIN)", type: "airport", country: "Singapore", lat: 1.36, lon: 103.99 },
+  { name: "Hong Kong Intl (HKG)", type: "airport", country: "Hong Kong", lat: 22.31, lon: 113.91 },
+  { name: "Seoul Incheon (ICN)", type: "airport", country: "South Korea", lat: 37.46, lon: 126.44 },
+  { name: "Memphis Intl (MEM cargo)", type: "airport", country: "USA", lat: 35.04, lon: -89.98 },
+  { name: "Indira Gandhi Delhi (DEL)", type: "airport", country: "India", lat: 28.56, lon: 77.10 },
+  { name: "İstanbul (IST)", type: "airport", country: "Türkiye", lat: 41.26, lon: 28.74 },
+
+  // ── Manufacturing clusters ───────────────────────────────────────────
+  { name: "Shenzhen electronics cluster", type: "manufacturing", country: "China", lat: 22.54, lon: 114.06 },
+  { name: "Suzhou industrial park", type: "manufacturing", country: "China", lat: 31.31, lon: 120.67 },
+  { name: "Taipei/Hsinchu semiconductor belt", type: "manufacturing", country: "Taiwan", lat: 24.78, lon: 120.99 },
+  { name: "Penang (Bayan Lepas) tech hub", type: "manufacturing", country: "Malaysia", lat: 5.29, lon: 100.28 },
+  { name: "Ho Chi Minh City mfg. zone", type: "manufacturing", country: "Vietnam", lat: 10.82, lon: 106.63 },
+  { name: "Chennai auto cluster", type: "manufacturing", country: "India", lat: 12.99, lon: 80.16 },
+  { name: "Toyota City", type: "manufacturing", country: "Japan", lat: 35.08, lon: 137.16 },
+  { name: "Stuttgart auto cluster", type: "manufacturing", country: "Germany", lat: 48.78, lon: 9.18 },
+  { name: "Monterrey mfg. hub", type: "manufacturing", country: "Mexico", lat: 25.67, lon: -100.31 },
+  { name: "Guadalajara electronics hub", type: "manufacturing", country: "Mexico", lat: 20.67, lon: -103.35 },
+  { name: "Bengaluru tech hub", type: "manufacturing", country: "India", lat: 12.97, lon: 77.59 },
+  { name: "Guanajuato/Bajío auto belt", type: "manufacturing", country: "Mexico", lat: 21.02, lon: -101.26 },
+];
+
+export interface NearbyHub {
+  hub: Hub;
+  distanceKm: number;
+}
+
+/**
+ * PURE: hubs within `radiusKm` of an event's anchor, nearest first. Caller decides
+ * the radius (typically the event's modelled impact radius). No disruption claim is
+ * made here beyond proximity.
+ */
+export function nearbyHubs(event: NormalizedEvent, radiusKm: number, hubs: Hub[] = HUBS): NearbyHub[] {
+  const out: NearbyHub[] = [];
+  for (const hub of hubs) {
+    const distanceKm = haversineKm(event.geo.lat, event.geo.lon, hub.lat, hub.lon);
+    if (distanceKm <= radiusKm) out.push({ hub, distanceKm });
+  }
+  return out.sort((a, b) => a.distanceKm - b.distanceKm);
+}

--- a/lib/events/openEvent.ts
+++ b/lib/events/openEvent.ts
@@ -1,0 +1,42 @@
+"use client";
+// Row-click action for the Disasters & Events feed: pan+zoom the globe to the
+// event's coordinates and (when we can join back to the raw SignalFeature) open
+// the SAME signal dossier a map click would — so a feed row behaves exactly like
+// clicking that hazard on the map. Reuses mapViewStore.flyToPoint + overlay +
+// buildSignalObject; no map logic is duplicated. Kept side-effect-only here; the
+// pure zoom pick is exported for unit testing.
+
+import { overlay } from "@/lib/overlay";
+import { mapViewStore } from "@/lib/mapView";
+import { buildSignalObject } from "@/lib/widgets/signalObject";
+import type { SignalFeature } from "@/lib/signals/types";
+import type { NormalizedEvent, GeoPrecision } from "@/lib/events/model";
+
+/** Sensible fly-to zoom by the point's geo precision (exact quake vs country centroid). */
+export function zoomForPrecision(precision: GeoPrecision): number {
+  switch (precision) {
+    case "EXACT": return 6;
+    case "CITY": return 5.5;
+    case "ADMIN": return 4.5;
+    case "COUNTRY_CENTROID": return 3.5;
+    default: return 4.5;
+  }
+}
+
+/**
+ * Fly to an event and, when the raw feature is available, open its dossier.
+ * `feature` is optional so the compact widget can link even before the raw
+ * SignalFeature map is built (it still flies).
+ */
+export function openEvent(
+  event: NormalizedEvent,
+  feature?: SignalFeature,
+  sourceLabel?: string,
+): void {
+  if (feature) overlay.open(buildSignalObject(feature, sourceLabel ?? event.source.label));
+  mapViewStore.flyToPoint({
+    lat: event.geo.lat,
+    lon: event.geo.lon,
+    zoom: zoomForPrecision(event.geo.precision),
+  });
+}

--- a/lib/events/opsConfig.ts
+++ b/lib/events/opsConfig.ts
@@ -1,0 +1,49 @@
+// lib/events/opsConfig.ts
+// PURE readers/coercers over the Disasters & Events widget's persisted `config`
+// bag (a Record<string,unknown> the shell already persists per widget instance —
+// same store markets.detail writes `selectedId` into). Keeping these pure and
+// node-testable means the compact widget and the focus view read view-prefs the
+// SAME way, and a stale/garbage saved value degrades to a safe default instead of
+// throwing. Group 1 owns the clustering prefs (grouping mode + collapse state);
+// Group 2 extends this file with the signal-to-noise filter shape.
+
+export type GroupBy = "region" | "type" | "none";
+export const GROUP_BY_VALUES: GroupBy[] = ["region", "type", "none"];
+export const DEFAULT_GROUP_BY: GroupBy = "region";
+
+/** Grouping mode from config, defaulting to region; junk → default. */
+export function readGroupBy(config: Record<string, unknown>): GroupBy {
+  const v = config.evGroupBy;
+  return GROUP_BY_VALUES.includes(v as GroupBy) ? (v as GroupBy) : DEFAULT_GROUP_BY;
+}
+
+/** Persisted collapse map (groupKey → collapsed) from config; junk → {}. */
+export function readCollapsed(config: Record<string, unknown>): Record<string, boolean> {
+  const v = config.evCollapsed;
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  const out: Record<string, boolean> = {};
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof val === "boolean") out[k] = val;
+  }
+  return out;
+}
+
+/** Namespaced collapse key so a region id and a type id never collide. */
+export function collapseKey(mode: GroupBy, key: string): string {
+  return `${mode}:${key}`;
+}
+
+/** Is this group collapsed? (Absent = expanded.) */
+export function isCollapsed(collapsed: Record<string, boolean>, mode: GroupBy, key: string): boolean {
+  return collapsed[collapseKey(mode, key)] === true;
+}
+
+/** Pure toggle: return the next collapse map with (mode,key) flipped. */
+export function toggleCollapsed(
+  collapsed: Record<string, boolean>,
+  mode: GroupBy,
+  key: string,
+): Record<string, boolean> {
+  const ck = collapseKey(mode, key);
+  return { ...collapsed, [ck]: !(collapsed[ck] === true) };
+}

--- a/lib/events/regions.ts
+++ b/lib/events/regions.ts
@@ -1,0 +1,110 @@
+// lib/events/regions.ts
+// PURE geographic bucketing for the Disasters & Events feed. Assigns each event a
+// coarse operational REGION (so an operator scans by area of responsibility) and
+// groups a NormalizedEvent[] by region or by hazard type, in a stable display
+// order with counts.
+//
+// Honesty note: `regionOf` is a deliberately COARSE lon/lat box classifier for
+// grouping the feed — NOT an authoritative political geography. Boxes overlap, so
+// the first match in a fixed priority order wins; the order is chosen to place
+// well-known cities in the intuitive bucket (see tests/unit/events-regions.test.ts).
+
+import type { NormalizedEvent, EventType } from "@/lib/events/model";
+
+export type RegionId =
+  | "na" | "latam" | "eu" | "mena" | "africa" | "asia" | "oceania" | "polar" | "other";
+
+export interface RegionMeta {
+  id: RegionId;
+  label: string;
+}
+
+/** Stable display order for region groups. */
+export const REGIONS: RegionMeta[] = [
+  { id: "na", label: "North America" },
+  { id: "latam", label: "Latin America" },
+  { id: "eu", label: "Europe" },
+  { id: "mena", label: "Middle East & N. Africa" },
+  { id: "africa", label: "Africa" },
+  { id: "asia", label: "Asia / APAC" },
+  { id: "oceania", label: "Oceania" },
+  { id: "polar", label: "Polar" },
+  { id: "other", label: "Other / Oceanic" },
+];
+
+export const REGION_LABEL: Record<RegionId, string> = REGIONS.reduce(
+  (acc, r) => { acc[r.id] = r.label; return acc; },
+  {} as Record<RegionId, string>,
+);
+
+const inBox = (lat: number, lon: number, s: number, n: number, w: number, e: number) =>
+  lat >= s && lat <= n && lon >= w && lon <= e;
+
+/**
+ * Coarse region for a point. First matching box wins — order matters because the
+ * boxes overlap. Malformed coords fall through to "other" (never thrown away).
+ */
+export function regionOf(lat: number, lon: number): RegionId {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return "other";
+  if (lat < -60) return "polar";
+  // Oceania: Australia / NZ / SW + SE Pacific.
+  if (inBox(lat, lon, -50, 0, 110, 180) || inBox(lat, lon, -50, 0, -180, -130)) return "oceania";
+  if (inBox(lat, lon, 12, 42, -17, 63)) return "mena";
+  if (inBox(lat, lon, 36, 82, -25, 60)) return "eu";
+  if (inBox(lat, lon, -40, 12, -20, 52)) return "africa";
+  if (inBox(lat, lon, -10, 82, 60, 180)) return "asia";
+  if (inBox(lat, lon, 12, 85, -170, -50)) return "na";
+  if (inBox(lat, lon, -60, 15, -125, -30)) return "latam";
+  return "other";
+}
+
+/** Stable display order + labels for hazard-type groups. */
+export const TYPE_ORDER: EventType[] = [
+  "quake", "cyclone", "flood", "storm", "fire", "volcano", "disaster", "conflict", "other",
+];
+
+export const TYPE_LABEL: Record<EventType, string> = {
+  quake: "Earthquakes",
+  cyclone: "Cyclones",
+  flood: "Floods",
+  storm: "Storms",
+  fire: "Wildfires",
+  volcano: "Volcanoes",
+  disaster: "Disasters",
+  conflict: "Conflict",
+  other: "Other",
+};
+
+export interface EventGroup {
+  /** Stable key: the RegionId or EventType. */
+  key: string;
+  label: string;
+  events: NormalizedEvent[];
+}
+
+/** Group events by coarse region, in REGIONS order, dropping empty buckets. */
+export function groupByRegion(events: NormalizedEvent[]): EventGroup[] {
+  const by = new Map<RegionId, NormalizedEvent[]>();
+  for (const e of events) {
+    const r = regionOf(e.geo.lat, e.geo.lon);
+    const g = by.get(r) ?? [];
+    g.push(e);
+    by.set(r, g);
+  }
+  return REGIONS
+    .filter((r) => by.has(r.id))
+    .map((r) => ({ key: r.id, label: r.label, events: by.get(r.id)! }));
+}
+
+/** Group events by hazard type, in TYPE_ORDER, dropping empty buckets. */
+export function groupByType(events: NormalizedEvent[]): EventGroup[] {
+  const by = new Map<EventType, NormalizedEvent[]>();
+  for (const e of events) {
+    const g = by.get(e.type) ?? [];
+    g.push(e);
+    by.set(e.type, g);
+  }
+  return TYPE_ORDER
+    .filter((t) => by.has(t))
+    .map((t) => ({ key: t, label: TYPE_LABEL[t], events: by.get(t)! }));
+}

--- a/tests/unit/events-alerting.test.ts
+++ b/tests/unit/events-alerting.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import { matchAlerts, coerceAlertRule, DEFAULT_ALERT_RULE, type AlertRuleConfig } from "@/lib/events/alerting";
+import { makeAsset, type Asset } from "@/lib/events/assets";
+import type { NormalizedEvent, EventType, SeverityTier } from "@/lib/events/model";
+
+function ev(id: string, lat: number, lon: number, opts: { type?: EventType; tier?: SeverityTier } = {}): NormalizedEvent {
+  return {
+    id, type: opts.type ?? "quake", title: id, place: { name: id },
+    geo: { lat, lon, precision: "EXACT" }, occurredAt: null,
+    severity: { tier: opts.tier ?? "S3", raw: 6 },
+    source: { id: "x", label: "X", attribution: "X" }, color: "#000",
+  };
+}
+
+const rule = (over: Partial<AlertRuleConfig> = {}): AlertRuleConfig => ({ enabled: true, minTier: "S3", types: null, radiusKm: 300, ...over });
+const asset: Asset = makeAsset("Tokyo Site", 35.70, 139.70, 0, 1)!;
+
+test("matchAlerts is inert when disabled or when there are no assets", () => {
+  expect(matchAlerts([ev("a", 35.68, 139.69)], [asset], rule({ enabled: false }), new Set())).toEqual([]);
+  expect(matchAlerts([ev("a", 35.68, 139.69)], [], rule(), new Set())).toEqual([]);
+});
+
+test("matchAlerts fires for a new in-range event and picks the nearest asset", () => {
+  const assets = [asset, makeAsset("Far", 36.5, 139.7, 0, 2)!];
+  const hits = matchAlerts([ev("q", 35.68, 139.69)], assets, rule(), new Set());
+  expect(hits.length).toBe(1);
+  expect(hits[0].assetName).toBe("Tokyo Site");
+  expect(hits[0].eventId).toBe("q");
+});
+
+test("matchAlerts respects tier, type, radius and the fired set", () => {
+  // Below tier
+  expect(matchAlerts([ev("a", 35.68, 139.69, { tier: "S2" })], [asset], rule({ minTier: "S3" }), new Set())).toEqual([]);
+  // Wrong type
+  expect(matchAlerts([ev("a", 35.68, 139.69, { type: "quake" })], [asset], rule({ types: ["cyclone"] }), new Set())).toEqual([]);
+  // Out of radius (London is far from a Tokyo asset)
+  expect(matchAlerts([ev("a", 51.5, -0.12)], [asset], rule({ radiusKm: 200 }), new Set())).toEqual([]);
+  // Already fired → skipped
+  expect(matchAlerts([ev("a", 35.68, 139.69)], [asset], rule(), new Set(["a"]))).toEqual([]);
+});
+
+test("coerceAlertRule fills defaults for junk", () => {
+  expect(coerceAlertRule(null)).toEqual(DEFAULT_ALERT_RULE);
+  expect(coerceAlertRule({ enabled: true, minTier: "S1", radiusKm: 50, types: ["quake"] })).toEqual({
+    enabled: true, minTier: "S1", radiusKm: 50, types: ["quake"],
+  });
+  expect(coerceAlertRule({ minTier: "bogus", radiusKm: -3 })).toEqual({
+    enabled: false, minTier: DEFAULT_ALERT_RULE.minTier, radiusKm: DEFAULT_ALERT_RULE.radiusKm, types: null,
+  });
+});

--- a/tests/unit/events-assets.test.ts
+++ b/tests/unit/events-assets.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "vitest";
+import {
+  makeAsset,
+  addAsset,
+  removeAsset,
+  coerceAssets,
+  impactRadiusKm,
+  assessThreats,
+  ASSET_CAP,
+  type Asset,
+} from "@/lib/events/assets";
+import type { NormalizedEvent, EventType, SeverityTier } from "@/lib/events/model";
+
+function ev(id: string, lat: number, lon: number, opts: { type?: EventType; tier?: SeverityTier; mag?: number } = {}): NormalizedEvent {
+  const e: NormalizedEvent = {
+    id, type: opts.type ?? "quake", title: id, place: { name: id },
+    geo: { lat, lon, precision: "EXACT" }, occurredAt: null,
+    severity: { tier: opts.tier ?? "S3", raw: 6 },
+    source: { id: "x", label: "X", attribution: "X" }, color: "#000",
+  };
+  if (opts.mag != null) e.magnitude = { value: opts.mag, unit: "M" };
+  return e;
+}
+
+test("makeAsset validates name + coord ranges", () => {
+  expect(makeAsset("", 10, 10)).toBe(null);
+  expect(makeAsset("Port", 200, 10)).toBe(null);
+  expect(makeAsset("Port", 10, 999)).toBe(null);
+  const a = makeAsset("  Rotterdam  ", 51.95, 4.14, 30, 1000);
+  expect(a).not.toBe(null);
+  expect(a!.name).toBe("Rotterdam");
+  expect(a!.radiusKm).toBe(30);
+});
+
+test("addAsset dedupes + caps; removeAsset drops one", () => {
+  const a = makeAsset("A", 1, 1, 0, 1)!;
+  const b = makeAsset("B", 2, 2, 0, 2)!;
+  expect(addAsset(addAsset([], a), b).map((x) => x.name)).toEqual(["B", "A"]);
+  // dedupe by id
+  expect(addAsset([a], { ...a, name: "A2" }).length).toBe(1);
+  expect(removeAsset([a, b], a.id).map((x) => x.name)).toEqual(["B"]);
+  let list: Asset[] = [];
+  for (let i = 0; i < ASSET_CAP + 5; i++) list = addAsset(list, makeAsset(`P${i}`, 0, i / 100, 0, i)!);
+  expect(list.length).toBe(ASSET_CAP);
+});
+
+test("coerceAssets drops malformed persisted entries", () => {
+  const clean = coerceAssets([
+    { id: "1", name: "ok", lat: 10, lon: 10, radiusKm: 5, createdAt: 1 },
+    { id: "2", name: "bad-lat", lat: 999, lon: 0 },
+    { name: "no-id", lat: 0, lon: 0 },
+    "garbage",
+  ]);
+  expect(clean.map((a) => a.id)).toEqual(["1"]);
+  expect(coerceAssets(null)).toEqual([]);
+});
+
+test("impactRadiusKm bands by magnitude (quake) and tier (others)", () => {
+  expect(impactRadiusKm(ev("q1", 0, 0, { type: "quake", mag: 3.5 }))).toBe(30);
+  expect(impactRadiusKm(ev("q2", 0, 0, { type: "quake", mag: 6.2 }))).toBe(400);
+  expect(impactRadiusKm(ev("q3", 0, 0, { type: "quake" }))).toBe(60); // no magnitude → default band
+  // cyclone S4 uses the cyclone tier table (larger footprint than a generic disaster).
+  expect(impactRadiusKm(ev("c", 0, 0, { type: "cyclone", tier: "S4" }))).toBe(550);
+});
+
+test("assessThreats flags events reaching an asset and picks the nearest", () => {
+  const assets: Asset[] = [
+    makeAsset("Near", 35.70, 139.70, 0, 1)!,   // ~2 km from the Tokyo quake
+    makeAsset("Mid", 36.10, 139.70, 0, 2)!,     // ~47 km
+  ];
+  // M6 quake at Tokyo → 400 km reach → both assets intersect; nearest = "Near".
+  const t = assessThreats([ev("quake", 35.68, 139.69, { type: "quake", mag: 6 })], assets);
+  expect(t.has("quake")).toBe(true);
+  expect(t.get("quake")!.assetName).toBe("Near");
+  expect(t.get("quake")!.impactRadiusKm).toBe(400);
+
+  // No assets → no threats.
+  expect(assessThreats([ev("quake", 35.68, 139.69, { mag: 6 })], []).size).toBe(0);
+
+  // A distant asset (London) is out of a M4 quake's 80 km reach.
+  const far = assessThreats(
+    [ev("small", 35.68, 139.69, { type: "quake", mag: 4 })],
+    [makeAsset("London", 51.5, -0.12, 0, 3)!],
+  );
+  expect(far.size).toBe(0);
+});
+
+test("assessThreats honours the per-asset footprint buffer", () => {
+  const evt = ev("small", 35.68, 139.69, { type: "quake", mag: 4 }); // 80 km reach
+  const at100 = makeAsset("Site", 36.58, 139.69, 0, 1)!;             // ~100 km north
+  expect(assessThreats([evt], [at100]).size).toBe(0);               // 80 < 100 → clear
+  const buffered = makeAsset("Site", 36.58, 139.69, 50, 1)!;         // +50 km footprint
+  expect(assessThreats([evt], [buffered]).size).toBe(1);            // 130 ≥ 100 → threat
+});

--- a/tests/unit/events-filters.test.ts
+++ b/tests/unit/events-filters.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "vitest";
+import {
+  passesFilters,
+  applyEventFilters,
+  readFilters,
+  toggleAllowSet,
+  isAllowed,
+  filtersActive,
+  DEFAULT_FILTERS,
+  type EventFilters,
+} from "@/lib/events/filters";
+import type { NormalizedEvent, EventType, SeverityTier } from "@/lib/events/model";
+
+function ev(
+  id: string,
+  opts: { type?: EventType; tier?: SeverityTier; mag?: number; lat?: number; lon?: number } = {},
+): NormalizedEvent {
+  const e: NormalizedEvent = {
+    id, type: opts.type ?? "quake", title: id, place: { name: id },
+    geo: { lat: opts.lat ?? 35.68, lon: opts.lon ?? 139.69, precision: "EXACT" }, // Tokyo → asia
+    occurredAt: null, severity: { tier: opts.tier ?? "S2", raw: 5 },
+    source: { id: "x", label: "X", attribution: "X" }, color: "#000",
+  };
+  if (opts.mag != null) e.magnitude = { value: opts.mag, unit: "M" };
+  return e;
+}
+
+const F = (over: Partial<EventFilters> = {}): EventFilters => ({ ...DEFAULT_FILTERS, minTier: "S0", ...over });
+
+test("min severity hides lower tiers", () => {
+  expect(passesFilters(ev("a", { tier: "S1" }), F({ minTier: "S2" }))).toBe(false);
+  expect(passesFilters(ev("a", { tier: "S3" }), F({ minTier: "S2" }))).toBe(true);
+});
+
+test("min quake magnitude only affects quakes with a known magnitude", () => {
+  expect(passesFilters(ev("q", { type: "quake", mag: 4.2 }), F({ minQuakeMag: 5 }))).toBe(false);
+  expect(passesFilters(ev("q", { type: "quake", mag: 6.1 }), F({ minQuakeMag: 5 }))).toBe(true);
+  // A cyclone is untouched by the quake-magnitude floor.
+  expect(passesFilters(ev("c", { type: "cyclone" }), F({ minQuakeMag: 5 }))).toBe(true);
+  // A quake with no magnitude value is not hidden (we never guess).
+  expect(passesFilters(ev("q2", { type: "quake" }), F({ minQuakeMag: 5 }))).toBe(true);
+});
+
+test("type + region allow-sets", () => {
+  expect(passesFilters(ev("q", { type: "quake" }), F({ types: ["cyclone"] }))).toBe(false);
+  expect(passesFilters(ev("q", { type: "quake" }), F({ types: ["quake"] }))).toBe(true);
+  // Tokyo is 'asia'; a region set without asia hides it.
+  expect(passesFilters(ev("q"), F({ regions: ["eu"] }))).toBe(false);
+  expect(passesFilters(ev("q"), F({ regions: ["asia"] }))).toBe(true);
+});
+
+test("applyEventFilters reports an honest hidden count", () => {
+  const rows = [
+    ev("a", { tier: "S1" }),
+    ev("b", { tier: "S3" }),
+    ev("c", { tier: "S4" }),
+  ];
+  const { rows: kept, hidden } = applyEventFilters(rows, F({ minTier: "S3" }));
+  expect(kept.map((e) => e.id)).toEqual(["b", "c"]);
+  expect(hidden).toBe(1);
+});
+
+test("readFilters coerces junk to safe defaults and honours minTier fallback", () => {
+  expect(readFilters({})).toEqual(DEFAULT_FILTERS);
+  expect(readFilters({ minTier: "S3" }).minTier).toBe("S3"); // legacy key fallback
+  expect(readFilters({ evMinTier: "S2", minTier: "S3" }).minTier).toBe("S2"); // new key wins
+  expect(readFilters({ evMinQuakeMag: -4 }).minQuakeMag).toBe(0);
+  expect(readFilters({ evMinQuakeMag: 5.5 }).minQuakeMag).toBe(5.5);
+  expect(readFilters({ evTypes: "quake" }).types).toBe(null); // non-array → all
+  expect(readFilters({ evTypes: ["quake", "junk"] }).types).toEqual(["quake"]);
+  expect(readFilters({ evRegions: ["asia", "nope"] }).regions).toEqual(["asia"]);
+});
+
+test("toggleAllowSet toggles membership and collapses to null at full coverage", () => {
+  const universe: EventType[] = ["quake", "cyclone", "disaster"];
+  // From "all" (null), deselect one → explicit remaining set.
+  expect(toggleAllowSet<EventType>(null, "quake", universe)).toEqual(["cyclone", "disaster"]);
+  // Re-selecting to full coverage collapses back to null.
+  expect(toggleAllowSet<EventType>(["cyclone", "disaster"], "quake", universe)).toBe(null);
+  // Deselect the last remaining → empty set (a real "hide all" state, not null).
+  expect(toggleAllowSet<EventType>(["quake"], "quake", universe)).toEqual([]);
+});
+
+test("isAllowed + filtersActive", () => {
+  expect(isAllowed(null, "quake")).toBe(true);
+  expect(isAllowed(["cyclone"], "quake")).toBe(false);
+  expect(filtersActive(DEFAULT_FILTERS)).toBe(true); // default minTier S1 is a filter
+  expect(filtersActive(F())).toBe(false); // S0 + no others = inert
+});

--- a/tests/unit/events-hubs.test.ts
+++ b/tests/unit/events-hubs.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+import { nearbyHubs, HUBS, HUB_TYPE_LABEL, type Hub } from "@/lib/events/hubs";
+import type { NormalizedEvent } from "@/lib/events/model";
+
+function ev(lat: number, lon: number): NormalizedEvent {
+  return {
+    id: "e", type: "quake", title: "e", place: { name: "e" },
+    geo: { lat, lon, precision: "EXACT" }, occurredAt: null,
+    severity: { tier: "S4", raw: 8 }, source: { id: "x", label: "X", attribution: "X" }, color: "#000",
+  };
+}
+
+const HUBS_TEST: Hub[] = [
+  { name: "A", type: "port", country: "X", lat: 0, lon: 0 },
+  { name: "B", type: "airport", country: "X", lat: 0, lon: 1 },   // ~111 km east
+  { name: "C", type: "manufacturing", country: "X", lat: 0, lon: 5 }, // ~556 km east
+];
+
+test("nearbyHubs returns hubs within radius, nearest first", () => {
+  const near = nearbyHubs(ev(0, 0), 200, HUBS_TEST);
+  expect(near.map((n) => n.hub.name)).toEqual(["A", "B"]); // C is out of range
+  expect(near[0].distanceKm).toBeCloseTo(0, 3);
+  expect(near[1].distanceKm).toBeGreaterThan(100);
+});
+
+test("a zero radius yields nothing", () => {
+  expect(nearbyHubs(ev(0, 0.5), 0, HUBS_TEST)).toEqual([]);
+});
+
+test("the curated HUBS set is well-formed and non-trivial", () => {
+  expect(HUBS.length).toBeGreaterThanOrEqual(40);
+  for (const h of HUBS) {
+    expect(typeof h.name).toBe("string");
+    expect(h.lat).toBeGreaterThanOrEqual(-90);
+    expect(h.lat).toBeLessThanOrEqual(90);
+    expect(h.lon).toBeGreaterThanOrEqual(-180);
+    expect(h.lon).toBeLessThanOrEqual(180);
+    expect(HUB_TYPE_LABEL[h.type]).toBeTruthy();
+  }
+  // A real event near Rotterdam should surface the port from the FULL curated set.
+  const names = nearbyHubs(ev(51.95, 4.14), 60).map((n) => n.hub.name);
+  expect(names.some((n) => n.includes("Rotterdam"))).toBe(true);
+});

--- a/tests/unit/events-open.test.ts
+++ b/tests/unit/events-open.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+import { openEvent, zoomForPrecision } from "@/lib/events/openEvent";
+import { mapViewStore, type PointView } from "@/lib/mapView";
+import { overlay } from "@/lib/overlay";
+import type { NormalizedEvent } from "@/lib/events/model";
+import type { SignalFeature } from "@/lib/signals/types";
+
+function ev(precision: NormalizedEvent["geo"]["precision"]): NormalizedEvent {
+  return {
+    id: "usgs:1", type: "quake", title: "M6.1 quake", place: { name: "Off coast" },
+    geo: { lat: 12.3, lon: -45.6, precision },
+    occurredAt: null, severity: { tier: "S3", raw: 6 },
+    source: { id: "earthquakes", label: "Earthquakes (USGS)", attribution: "USGS" },
+    color: "#b91c1c",
+  };
+}
+
+test("zoomForPrecision tightens as precision improves", () => {
+  expect(zoomForPrecision("EXACT")).toBeGreaterThan(zoomForPrecision("ADMIN"));
+  expect(zoomForPrecision("ADMIN")).toBeGreaterThan(zoomForPrecision("COUNTRY_CENTROID"));
+});
+
+test("openEvent flies to the event coords with a precision-based zoom", () => {
+  let got: PointView | null = null;
+  mapViewStore.registerFlyToPoint((v) => { got = v; });
+  overlay.close();
+  openEvent(ev("EXACT")); // no raw feature → flies but no dossier
+  expect(got).toEqual({ lat: 12.3, lon: -45.6, zoom: 6 });
+  expect(overlay.get().object).toBe(null);
+  mapViewStore.registerFlyToPoint(null);
+});
+
+test("openEvent opens the signal dossier when the raw feature is supplied", () => {
+  mapViewStore.registerFlyToPoint(() => {});
+  overlay.close();
+  const f: SignalFeature = { id: "usgs:1", lat: 12.3, lon: -45.6, title: "M6.1 quake", signalId: "earthquakes" };
+  openEvent(ev("EXACT"), f, "Earthquakes (USGS)");
+  const obj = overlay.get().object;
+  expect(obj?.id).toBe("usgs:1");
+  expect(obj?.kind).toBe("signal");
+  overlay.close();
+  mapViewStore.registerFlyToPoint(null);
+});

--- a/tests/unit/events-ops-config.test.ts
+++ b/tests/unit/events-ops-config.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "vitest";
+import {
+  readGroupBy,
+  readCollapsed,
+  collapseKey,
+  isCollapsed,
+  toggleCollapsed,
+  DEFAULT_GROUP_BY,
+} from "@/lib/events/opsConfig";
+
+test("readGroupBy accepts valid modes and defaults on junk", () => {
+  expect(readGroupBy({ evGroupBy: "type" })).toBe("type");
+  expect(readGroupBy({ evGroupBy: "region" })).toBe("region");
+  expect(readGroupBy({ evGroupBy: "none" })).toBe("none");
+  expect(readGroupBy({})).toBe(DEFAULT_GROUP_BY);
+  expect(readGroupBy({ evGroupBy: "garbage" })).toBe(DEFAULT_GROUP_BY);
+  expect(readGroupBy({ evGroupBy: 5 })).toBe(DEFAULT_GROUP_BY);
+});
+
+test("readCollapsed keeps only boolean entries, else {}", () => {
+  expect(readCollapsed({ evCollapsed: { "region:asia": true, "region:eu": false } })).toEqual({
+    "region:asia": true,
+    "region:eu": false,
+  });
+  expect(readCollapsed({ evCollapsed: { a: 1, b: "x", c: true } })).toEqual({ c: true });
+  expect(readCollapsed({})).toEqual({});
+  expect(readCollapsed({ evCollapsed: [1, 2] })).toEqual({});
+  expect(readCollapsed({ evCollapsed: null })).toEqual({});
+});
+
+test("collapseKey namespaces by mode so ids never collide", () => {
+  expect(collapseKey("region", "asia")).toBe("region:asia");
+  expect(collapseKey("type", "quake")).toBe("type:quake");
+});
+
+test("isCollapsed / toggleCollapsed round-trip", () => {
+  let c: Record<string, boolean> = {};
+  expect(isCollapsed(c, "region", "asia")).toBe(false); // absent = expanded
+  c = toggleCollapsed(c, "region", "asia");
+  expect(isCollapsed(c, "region", "asia")).toBe(true);
+  expect(isCollapsed(c, "region", "eu")).toBe(false); // untouched
+  c = toggleCollapsed(c, "region", "asia");
+  expect(isCollapsed(c, "region", "asia")).toBe(false);
+});
+
+test("toggleCollapsed is pure (does not mutate input)", () => {
+  const c = { "region:asia": true };
+  const next = toggleCollapsed(c, "region", "asia");
+  expect(c).toEqual({ "region:asia": true });
+  expect(next).toEqual({ "region:asia": false });
+});

--- a/tests/unit/events-regions.test.ts
+++ b/tests/unit/events-regions.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "vitest";
+import { regionOf, groupByRegion, groupByType, REGIONS, TYPE_ORDER } from "@/lib/events/regions";
+import type { NormalizedEvent, EventType } from "@/lib/events/model";
+
+function ev(id: string, lat: number, lon: number, type: EventType = "quake"): NormalizedEvent {
+  return {
+    id, type, title: id, place: { name: id },
+    geo: { lat, lon, precision: "EXACT" },
+    occurredAt: null,
+    severity: { tier: "S2", raw: 5 },
+    source: { id: "x", label: "X", attribution: "X" },
+    color: "#000",
+  };
+}
+
+test("regionOf places well-known cities in the intuitive bucket", () => {
+  expect(regionOf(35.68, 139.69)).toBe("asia");     // Tokyo
+  expect(regionOf(51.5, -0.12)).toBe("eu");         // London
+  expect(regionOf(30.04, 31.24)).toBe("mena");      // Cairo
+  expect(regionOf(34.05, -118.24)).toBe("na");      // Los Angeles
+  expect(regionOf(-23.55, -46.63)).toBe("latam");   // São Paulo
+  expect(regionOf(-33.87, 151.2)).toBe("oceania");  // Sydney
+  expect(regionOf(-1.29, 36.82)).toBe("africa");    // Nairobi
+  expect(regionOf(-77.85, 166.67)).toBe("polar");   // McMurdo
+});
+
+test("regionOf never throws on malformed coords", () => {
+  expect(regionOf(NaN, 10)).toBe("other");
+  expect(regionOf(0, Infinity)).toBe("other");
+  expect(regionOf(5, -150)).toBe("other"); // mid-Pacific, outside every box
+});
+
+test("groupByRegion returns non-empty buckets in REGIONS order with counts", () => {
+  const rows = [
+    ev("tokyo", 35.68, 139.69),
+    ev("osaka", 34.69, 135.5),
+    ev("london", 51.5, -0.12),
+    ev("la", 34.05, -118.24),
+  ];
+  const groups = groupByRegion(rows);
+  expect(groups.map((g) => g.key)).toEqual(["na", "eu", "asia"]); // REGIONS order
+  const asia = groups.find((g) => g.key === "asia")!;
+  expect(asia.events.length).toBe(2);
+  expect(asia.label).toBe(REGIONS.find((r) => r.id === "asia")!.label);
+});
+
+test("groupByType returns non-empty buckets in TYPE_ORDER", () => {
+  const rows = [
+    ev("q1", 0, 0, "quake"),
+    ev("c1", 0, 0, "cyclone"),
+    ev("q2", 0, 0, "quake"),
+  ];
+  const groups = groupByType(rows);
+  expect(groups.map((g) => g.key)).toEqual(["quake", "cyclone"]);
+  expect(TYPE_ORDER.indexOf("quake")).toBeLessThan(TYPE_ORDER.indexOf("cyclone"));
+  expect(groups[0].events.length).toBe(2);
+});


### PR DESCRIPTION
Turns the Disasters & Events widget into a professional monitoring tool.

- **Interactive map linking** — every feed row flies the shared globe to the event and opens its dossier.
- **Collapsible clusters** — group by region or hazard type with counts; persisted per instance.
- **Signal-to-noise filters** — min severity, min quake magnitude, hazard-type + region allow-sets (pure predicate); honest "N hidden by filters".
- **Asset & proximity matching** — operator POIs (form or click-to-add on the inset map, localStorage); haversine flags events reaching an asset, escalating them to **Direct Operational Threat** (styled + pinned).
- **Proactive alerting** — persisted rule, permission-gated Notification + optional Slack/PagerDuty/generic webhook POST; dormant-safe, de-duped with a silent baseline.
- **Downstream impact** — a clearly-labelled curated set (~48 ports/airports/hubs); severe events list nearby hubs "within N km (potential disruption)" — no invented closures.

New pure libs under `lib/events/*` + `lib/console/widgets/events*`. Verified: `tsc` clean, 669 tests (+32), full `next build` passes. No fabricated data.