### PR TITLE
feat(headlines): professional news monitoring (clustering, favicons, facets, boolean search)

### DIFF
--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -12,16 +12,22 @@ interface Feed {
   source: string;
 }
 
-// All four confirmed live 2026-06-27 (RSS 2.0). A dead one drops out silently.
+// All six confirmed live (RSS/RDF 2026-07-09). A dead one drops out silently.
+// The extra European broadcasters (DW, France 24) widen cross-source story
+// clustering and give the region/type facet matrix real diversity.
 const FEEDS: Feed[] = [
   { url: "https://feeds.bbci.co.uk/news/world/rss.xml", source: "BBC" },
   { url: "https://www.aljazeera.com/xml/rss/all.xml", source: "Al Jazeera" },
   { url: "https://feeds.npr.org/1001/rss.xml", source: "NPR" },
   { url: "https://www.theguardian.com/world/rss", source: "The Guardian" },
+  { url: "https://rss.dw.com/rdf/rss-en-world", source: "DW" },
+  { url: "https://www.france24.com/en/rss", source: "France 24" },
 ];
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
-const LIMIT = 30;
+// Higher than the docked list needs on purpose: the focus view clusters these
+// into stories, so more raw material = richer, better-corroborated mega-cards.
+const LIMIT = 60;
 
 let cache: NewsPayload | null = null;
 

--- a/app/api/news/synthesis/route.ts
+++ b/app/api/news/synthesis/route.ts
@@ -1,0 +1,84 @@
+// app/api/news/synthesis/route.ts
+import {
+  buildSynthesisPrompt,
+  parseSynthesisResponse,
+  synthesisKey,
+  type SynthesisInput,
+  type SynthesisPayload,
+  type SynthesisSource,
+} from "@/lib/news/synthesis";
+import { freellmConfig } from "@/lib/geolocate/config";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/news/synthesis { title, sources:[{source,title,description?}] } — a
+// neutral cross-source synthesis of a clustered story (consensus + discrepancies).
+// Grounded ONLY in the supplied headlines (no article fetch → no SSRF surface).
+// Dormant ({synthesis:null, dormant:true}) until FREELLMAPI_* is set. Dormant-safe:
+// any failure returns JSON, never a 5xx. Cached per cluster signature.
+
+const cache = new Map<string, SynthesisPayload>();
+
+function payload(p: SynthesisPayload): Response {
+  return Response.json(p);
+}
+
+function normalizeSources(raw: unknown): SynthesisSource[] {
+  if (!Array.isArray(raw)) return [];
+  const out: SynthesisSource[] = [];
+  for (const r of raw) {
+    if (!r || typeof r !== "object") continue;
+    const o = r as Record<string, unknown>;
+    const source = typeof o.source === "string" ? o.source : "";
+    const title = typeof o.title === "string" ? o.title : "";
+    if (!source || !title) continue;
+    const description = typeof o.description === "string" ? o.description.slice(0, 400) : undefined;
+    out.push({ source, title: title.slice(0, 300), description });
+    if (out.length >= 8) break; // cap prompt size
+  }
+  return out;
+}
+
+export async function POST(req: Request) {
+  let body: { title?: unknown; sources?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return payload({ synthesis: null, dormant: false, sourceCount: 0 });
+  }
+  const title = typeof body.title === "string" ? body.title.slice(0, 300) : "";
+  const sources = normalizeSources(body.sources);
+  const sourceCount = sources.length;
+
+  // Cross-source synthesis only makes sense with ≥2 outlets.
+  if (sourceCount < 2) return payload({ synthesis: null, dormant: false, sourceCount });
+
+  const input: SynthesisInput = { title, sources };
+  const key = synthesisKey(input);
+  const cached = cache.get(key);
+  if (cached) return payload(cached);
+
+  const cfg = freellmConfig();
+  if (!cfg) return payload({ synthesis: null, dormant: true, sourceCount });
+
+  try {
+    const r = await fetch(`${cfg.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${cfg.key}` },
+      body: JSON.stringify({
+        model: cfg.model,
+        messages: [{ role: "user", content: buildSynthesisPrompt(input) }],
+        temperature: 0.2,
+        max_tokens: 260,
+      }),
+      signal: AbortSignal.timeout(25_000),
+    });
+    if (!r.ok) throw new Error(`gateway ${r.status}`);
+    const synthesis = parseSynthesisResponse(await r.json());
+    const out: SynthesisPayload = { synthesis, dormant: false, sourceCount };
+    if (synthesis) cache.set(key, out);
+    return payload(out);
+  } catch {
+    return payload({ synthesis: null, dormant: false, sourceCount });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1366,6 +1366,92 @@ a { color: var(--tn-accent); }
 .tn-hd-export { margin-left: auto; font: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--tn-border); border-radius: 6px; background: transparent; color: var(--tn-accent); cursor: pointer; }
 .tn-hd-export:disabled { opacity: .4; cursor: default; }
 
+/* ── Headlines PRO focus detail (clustering board) ─────────────────── */
+.tn-hd-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.tn-hd-h-title { font-size: 15px; font-weight: 700; color: var(--tn-text); }
+.tn-hd-h-sub { font-size: 11.5px; color: var(--tn-text-faint); margin-top: 2px; }
+.tn-hd-h-sub b { color: var(--tn-text-muted); }
+.tn-hd-viewtoggle { display: inline-flex; gap: 2px; background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 8px; padding: 2px; flex: none; }
+.tn-hd-viewtoggle button { font: inherit; font-size: 12px; padding: 3px 10px; border: 0; border-radius: 6px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-hd-viewtoggle button.is-on { background: var(--tn-surface-solid); color: var(--tn-accent); box-shadow: var(--tn-shadow-sm); }
+
+/* toolbar: search on its own row, source chips wrapping below */
+.tn-hd-bar { display: flex; flex-direction: column; align-items: stretch; gap: 8px; margin-bottom: 10px; }
+.tn-hd-search { margin: 0; width: 100%; font: inherit; font-size: 13px; padding: 6px 10px; border: 1px solid var(--tn-border); border-radius: 6px; background: var(--tn-surface-2); color: var(--tn-text); }
+.tn-hd-chip { display: inline-flex; align-items: center; gap: 5px; font: inherit; font-size: 12px; padding: 3px 9px; border: 1px solid var(--tn-border); border-radius: 999px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-hd-chip.is-on { background: var(--tn-accent-soft); color: var(--tn-accent-strong); border-color: var(--tn-accent); }
+.tn-hd-chip-n { font-size: 10px; color: var(--tn-text-faint); font-variant-numeric: tabular-nums; }
+.tn-hd-chip.is-on .tn-hd-chip-n { color: var(--tn-accent); }
+
+/* facet matrix (region / type) */
+.tn-hd-facets { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 12px; margin-bottom: 12px; }
+.tn-hd-facet-row { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 6px; }
+.tn-hd-facet-label { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); }
+.tn-hd-fchip { font: inherit; font-size: 11.5px; padding: 2px 8px; border: 1px solid var(--tn-border); border-radius: 6px; background: transparent; color: var(--tn-text-muted); cursor: pointer; }
+.tn-hd-fchip.is-on { background: var(--tn-accent-soft); color: var(--tn-accent-strong); border-color: var(--tn-accent); }
+.tn-hd-clear { font: inherit; font-size: 11.5px; padding: 2px 8px; border: 0; background: transparent; color: var(--tn-accent); cursor: pointer; }
+
+/* volume + interactive hourly bars */
+.tn-hd-vol-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+.tn-hd-hint { font-size: 10.5px; color: var(--tn-text-faint); }
+.tn-hd-reset { font: inherit; font-size: 11px; padding: 1px 8px; border: 1px solid var(--tn-accent); border-radius: 999px; background: var(--tn-accent-soft); color: var(--tn-accent-strong); cursor: pointer; }
+.tn-hd-bars { display: block; overflow: visible; }
+.tn-hd-bars .tn-hd-bar-g { cursor: pointer; }
+.tn-hd-bar { fill: var(--tn-accent); transition: opacity .12s ease; }
+.tn-hd-bar-g:hover .tn-hd-bar { fill: var(--tn-accent-strong); }
+.tn-hd-bar.is-sel { fill: var(--tn-accent-strong); }
+.tn-hd-bar-tick { fill: var(--tn-text-faint); font-size: 8px; }
+
+/* favicons */
+.tn-hd-fav { display: inline-block; border-radius: 3px; object-fit: contain; vertical-align: middle; }
+.tn-hd-fav-fb { display: inline-flex; align-items: center; justify-content: center; background: var(--tn-accent-soft); color: var(--tn-accent-strong); font-weight: 700; line-height: 1; }
+
+/* cluster cards */
+.tn-hd-cards { display: grid; gap: 10px; }
+.tn-hd-card { padding: 10px 12px; border: 1px solid var(--tn-border); border-radius: 10px; background: var(--tn-surface-2); }
+.tn-hd-card.is-trending { border-color: var(--tn-accent); box-shadow: 0 0 0 1px var(--tn-accent-soft) inset; }
+.tn-hd-card-badges { display: flex; align-items: center; gap: 3px; margin-bottom: 6px; }
+.tn-hd-card-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-bottom: 4px; }
+.tn-hd-card-time { margin-left: auto; font-size: 11px; color: var(--tn-text-faint); }
+.tn-hd-badge { font-size: 10px; font-weight: 600; padding: 1px 7px; border-radius: 999px; white-space: nowrap; }
+.tn-hd-corrob { background: var(--tn-accent-soft); color: var(--tn-accent-strong); }
+.tn-hd-vel { background: rgba(22,163,74,.12); color: #16a34a; }
+.tn-hd-vel.is-trending { background: rgba(22,163,74,.2); }
+.tn-hd-upd { background: rgba(217,119,6,.16); color: #b45309; }
+.tn-hd-primary { background: rgba(15,23,42,.06); color: var(--tn-text-muted); border: 1px solid var(--tn-border); }
+.tn-hd-card-title { display: block; font-size: 14px; font-weight: 650; line-height: 1.3; color: var(--tn-text); text-decoration: none; }
+.tn-hd-card-title:hover { text-decoration: underline; }
+.tn-hd-card-lead-src { display: flex; align-items: center; gap: 4px; font-size: 11px; color: var(--tn-text-faint); margin-top: 3px; }
+.tn-hd-change { font-size: 11.5px; color: #b45309; margin: 4px 0 0; font-style: italic; }
+.tn-hd-more { margin-top: 6px; font: inherit; font-size: 11.5px; padding: 0; border: 0; background: transparent; color: var(--tn-accent); cursor: pointer; }
+.tn-hd-corrob-list { list-style: none; margin: 6px 0 0; padding: 6px 0 0; border-top: 1px dashed var(--tn-border); display: grid; gap: 6px; }
+.tn-hd-corrob-list li { display: grid; grid-template-columns: auto 1fr; align-items: baseline; gap: 4px 6px; }
+.tn-hd-corrob-title { grid-column: 2; font-size: 12.5px; color: var(--tn-text); text-decoration: none; }
+.tn-hd-corrob-title:hover { text-decoration: underline; }
+.tn-hd-corrob-list li > .tn-hd-fav { grid-row: 1; }
+.tn-hd-corrob-meta { grid-column: 2; font-size: 10.5px; color: var(--tn-text-faint); }
+
+/* cross-source synthesis */
+.tn-hd-synth-btn { margin-top: 8px; font: inherit; font-size: 11px; padding: 3px 9px; border: 1px solid var(--tn-accent); border-radius: 6px; background: var(--tn-accent-soft); color: var(--tn-accent-strong); cursor: pointer; }
+.tn-hd-synth-btn:disabled { opacity: .6; cursor: default; }
+.tn-hd-synth { margin-top: 8px; padding: 8px 10px; border-left: 2px solid var(--tn-accent); background: var(--tn-surface); border-radius: 4px; }
+.tn-hd-synth-h { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-accent); margin-bottom: 3px; }
+.tn-hd-synth p { margin: 0; font-size: 13px; color: var(--tn-text); }
+.tn-hd-synth-note { margin: 8px 0 0; font-size: 11px; color: var(--tn-text-faint); }
+
+/* dense table view */
+.tn-hd-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.tn-hd-table th { text-align: left; font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--tn-text-faint); padding: 4px 8px; border-bottom: 1px solid var(--tn-border); }
+.tn-hd-table td { padding: 6px 8px; border-bottom: 1px solid var(--tn-border); vertical-align: top; }
+.tn-hd-trow:hover { background: var(--tn-surface-2); }
+.tn-hd-tlink { color: var(--tn-text); text-decoration: none; }
+.tn-hd-tlink:hover { text-decoration: underline; }
+.tn-hd-tlink + .tn-hd-badge { margin-left: 6px; }
+.tn-hd-tsrc { display: inline-flex; align-items: center; gap: 3px; }
+.tn-hd-tcell-time { color: var(--tn-text-faint); white-space: nowrap; font-variant-numeric: tabular-nums; }
+.tn-hd-tcell-vel { color: #16a34a; white-space: nowrap; }
+.tn-hd-foot-note { font-size: 11px; color: var(--tn-text-faint); }
+
 /* ── Signals focus detail (W3) ─────────────────────────────────────── */
 .tn-sd { display: flex; flex-direction: column; gap: 14px; height: 100%; overflow: auto; padding: 4px 2px; color: var(--tn-text); }
 .tn-sd-head { display: flex; flex-direction: column; gap: 4px; }

--- a/components/news/HeadlineBars.tsx
+++ b/components/news/HeadlineBars.tsx
@@ -1,0 +1,86 @@
+"use client";
+// components/news/HeadlineBars.tsx
+// Interactive "headlines per hour" timeline — a dependency-free SVG bar strip
+// where each hour bucket is clickable to filter the feed to that hour (click the
+// active bar again, or the Reset control the parent renders, to clear). Kept
+// separate from components/Chart.tsx (that primitive is owned by the markets
+// stream) since this one needs per-bar hit targets + selection state.
+
+import type { TimeBin } from "@/lib/widgets/buckets";
+
+export function HeadlineBars({
+  bins,
+  selected,
+  onSelect,
+  height = 68,
+}: {
+  bins: TimeBin[];
+  /** start-ms of the selected bucket, or null. */
+  selected: number | null;
+  onSelect: (startMs: number | null) => void;
+  height?: number;
+}) {
+  if (!bins || bins.length === 0) return null;
+  const width = 720;
+  const padX = 4;
+  const padTop = 6;
+  const axis = 14; // room for hour ticks under the baseline
+  const max = Math.max(1, ...bins.map((b) => b.count));
+  const n = bins.length;
+  const slot = (width - padX * 2) / n;
+  const barW = Math.max(2, slot * 0.72);
+  const plotH = height - padTop - axis;
+  const baseY = height - axis;
+  const fmtHour = (t: number) => {
+    const d = new Date(t);
+    const h = d.getHours();
+    return `${h.toString().padStart(2, "0")}h`;
+  };
+
+  return (
+    <svg
+      className="tn-hd-bars"
+      viewBox={`0 0 ${width} ${height}`}
+      width="100%"
+      height={height}
+      preserveAspectRatio="none"
+      role="group"
+      aria-label="Headlines per hour, last 24 hours — click a bar to filter"
+    >
+      <line x1={padX} y1={baseY} x2={width - padX} y2={baseY} stroke="var(--tn-border, #1e293b)" strokeWidth="1" />
+      {bins.map((b, i) => {
+        const h = b.count > 0 ? Math.max(2, (b.count / max) * plotH) : 0;
+        const x = padX + i * slot + (slot - barW) / 2;
+        const y = baseY - h;
+        const isSel = selected === b.start;
+        const active = selected == null || isSel;
+        const label = `${fmtHour(b.start)} · ${b.count} headline${b.count === 1 ? "" : "s"}`;
+        return (
+          <g key={b.start} className="tn-hd-bar-g" onClick={() => onSelect(isSel ? null : b.start)}>
+            {/* full-height transparent hit target so thin/empty bars are still clickable */}
+            <rect x={padX + i * slot} y={padTop} width={slot} height={height - padTop} fill="transparent">
+              <title>{label}</title>
+            </rect>
+            {h > 0 && (
+              <rect
+                x={x}
+                y={y}
+                width={barW}
+                height={h}
+                rx={1}
+                className={`tn-hd-bar${isSel ? " is-sel" : ""}`}
+                opacity={active ? 1 : 0.35}
+              />
+            )}
+            {/* sparse hour ticks: every 6 buckets + the last */}
+            {(i % 6 === 0 || i === n - 1) && (
+              <text x={padX + i * slot + slot / 2} y={height - 3} className="tn-hd-bar-tick" textAnchor="middle">
+                {fmtHour(b.start)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/components/news/SourceIcon.tsx
+++ b/components/news/SourceIcon.tsx
@@ -1,0 +1,43 @@
+"use client";
+// components/news/SourceIcon.tsx
+// A source's brand favicon with a graceful text fallback. Uses the keyless Google
+// s2 favicon service; on any load error (or an unattributed source) it renders a
+// monogram chip instead — never a broken image.
+
+import { useState } from "react";
+import { faviconUrl, sourceInitial } from "@/lib/news/sources";
+
+export function SourceIcon({
+  name,
+  domain,
+  size = 16,
+  title,
+}: {
+  name: string;
+  domain: string | null;
+  size?: number;
+  title?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const url = faviconUrl(domain, 32);
+  const tip = title ?? name;
+  if (!url || failed) {
+    return (
+      <span className="tn-hd-fav tn-hd-fav-fb" style={{ width: size, height: size, fontSize: Math.round(size * 0.6) }} title={tip} aria-label={name}>
+        {sourceInitial(name)}
+      </span>
+    );
+  }
+  return (
+    <img
+      className="tn-hd-fav"
+      src={url}
+      width={size}
+      height={size}
+      alt=""
+      title={tip}
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/lib/console/widgets/headlines.detail.tsx
+++ b/lib/console/widgets/headlines.detail.tsx
@@ -1,20 +1,37 @@
 // lib/console/widgets/headlines.detail.tsx
 "use client";
-// Headlines focus view — a newsroom board. Reuses the SAME /api/news poll as the
-// docked widget, rendering deep: source filter + search, a recency-grouped feed with
-// snippets, an hourly volume strip (Task 6), on-demand AI summaries (Task 7), and a
-// sources footer + export (Task 8).
-import { useMemo, useState } from "react";
+// Headlines focus view — a newsroom clustering board. Reuses the SAME /api/news
+// poll as the docked widget and turns it into a professional monitor:
+//   • story clustering into source-badged mega-cards (lib/news/cluster)
+//   • per-cluster coverage velocity + primary-source + "Updated" flags
+//   • boolean search (AND / OR / -exclude / "phrase") over the feed
+//   • source / region / type facet matrix (lib/news/sources)
+//   • an interactive "headlines per hour" timeline that filters by hour
+//   • cards ⇄ dense table view (persisted), cross-source AI synthesis, CSV export
+// Every pure transform lives in a unit-tested lib/news/* module; this is the shell.
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { WidgetDetailProps } from "@/lib/console/registry";
 import type { NewsItem } from "@/lib/news";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
-import { countBy, timeBins } from "@/lib/widgets/buckets";
-import { Chart, type ChartPoint } from "@/components/Chart";
+import { shellLayoutStore } from "@/lib/console/store";
+import { timeBins } from "@/lib/widgets/buckets";
+import { clusterNews, type Cluster } from "@/lib/news/cluster";
+import { clusterVelocity, velocityLabel } from "@/lib/news/velocity";
+import { filterByQuery } from "@/lib/news/search";
+import { detectPrimarySource } from "@/lib/news/primary";
+import { sourceMeta } from "@/lib/news/sources";
+import { loadSnapshot, saveSnapshot, diffSnapshots, type Snapshot } from "@/lib/news/snapshot";
+import type { SynthesisPayload } from "@/lib/news/synthesis";
+import { SourceIcon } from "@/components/news/SourceIcon";
+import { HeadlineBars } from "@/components/news/HeadlineBars";
 import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
-interface NewsPayload { generatedAt: number; items: NewsItem[] }
+interface NewsPayload {
+  generatedAt: number;
+  items: NewsItem[];
+}
 const EMPTY: NewsPayload = { generatedAt: 0, items: [] };
-const SOURCES = ["BBC", "Al Jazeera", "NPR", "The Guardian"];
+const HOUR = 3_600_000;
 
 function rel(ts: number, now: number): string {
   if (!ts) return "";
@@ -23,127 +40,416 @@ function rel(ts: number, now: number): string {
   const h = Math.round(m / 60);
   return h < 48 ? `${h}h` : `${Math.round(h / 24)}d`;
 }
-function bucketOf(ts: number, now: number): "Last hour" | "Today" | "Earlier" {
-  const h = (now - ts) / 3_600_000;
-  if (ts && h < 1) return "Last hour";
-  if (ts && h < 24) return "Today";
-  return "Earlier";
-}
-const BUCKET_ORDER = ["Last hour", "Today", "Earlier"] as const;
+const itemText = (it: NewsItem) => `${it.title} ${it.description ?? ""} ${it.source}`;
 
-export default function HeadlinesDetail({ }: WidgetDetailProps) {
+type SynthState = { loading?: boolean; text?: string; note?: string };
+
+export default function HeadlinesDetail({ instanceId, config }: WidgetDetailProps) {
   const { data, status } = useJsonPoll<NewsPayload>("/api/news", 120_000, EMPTY);
   const items = useMemo(() => data.items ?? [], [data.items]);
-  const [srcFilter, setSrcFilter] = useState<string | null>(null);
-  const [query, setQuery] = useState("");
   const now = Date.now();
 
-  const counts = useMemo(() => countBy(items, (it) => it.source), [items]);
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return items.filter(
-      (it) =>
-        (srcFilter == null || it.source === srcFilter) &&
-        (!q || it.title.toLowerCase().includes(q) || (it.description ?? "").toLowerCase().includes(q)),
-    );
-  }, [items, srcFilter, query]);
+  // View mode (cards | table) — persisted via the widget config, like markets.
+  const view: "cards" | "table" = config.view === "table" ? "table" : "cards";
+  const setView = (v: "cards" | "table") => shellLayoutStore.configure(instanceId, { view: v });
 
-  const groups = useMemo(() => {
-    const by = new Map<string, NewsItem[]>();
-    for (const it of filtered) {
-      const b = bucketOf(it.ts, now);
-      const g = by.get(b) ?? [];
-      g.push(it);
-      by.set(b, g);
+  // Search + facet + timeline state (ephemeral).
+  const [query, setQuery] = useState("");
+  const [srcFilter, setSrcFilter] = useState<Set<string>>(new Set());
+  const [regionFilter, setRegionFilter] = useState<Set<string>>(new Set());
+  const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set());
+  const [selHour, setSelHour] = useState<number | null>(null);
+
+  // ---- Updated / correction tracking: diff current feed vs a persisted snapshot.
+  const prevSnapRef = useRef<Snapshot | null | undefined>(undefined);
+  const [updatedUrls, setUpdatedUrls] = useState<Set<string>>(new Set());
+  const [changes, setChanges] = useState<Record<string, { from: string; to: string }>>({});
+  useEffect(() => {
+    if (items.length === 0) return;
+    if (prevSnapRef.current === undefined) prevSnapRef.current = loadSnapshot();
+    const diffs = diffSnapshots(prevSnapRef.current, items);
+    if (diffs.length) {
+      setUpdatedUrls((prev) => {
+        const n = new Set(prev);
+        for (const d of diffs) n.add(d.url);
+        return n;
+      });
+      setChanges((prev) => {
+        const n = { ...prev };
+        for (const d of diffs) n[d.url] = { from: d.from, to: d.to };
+        return n;
+      });
     }
-    return BUCKET_ORDER.filter((b) => by.has(b)).map((b) => [b, by.get(b)!] as const);
-  }, [filtered, now]);
+    saveSnapshot(items);
+  }, [items]);
 
-  const volume: ChartPoint[] = useMemo(() => {
-    const ts = filtered.map((it) => it.ts).filter((n) => n > 0);
-    return timeBins(ts, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
-  }, [filtered, now]);
+  // ---- Pipeline: search → facet counts → facet filter → timeline → hour filter → cluster.
+  const afterSearch = useMemo(() => filterByQuery(items, query, itemText), [items, query]);
 
-  type SumState = { loading?: boolean; text?: string; note?: string };
-  const [summaries, setSummaries] = useState<Record<string, SumState>>({});
-  const summarize = (it: NewsItem) => {
-    if (summaries[it.url]?.loading || summaries[it.url]?.text) return;
-    setSummaries((s) => ({ ...s, [it.url]: { loading: true } }));
-    fetch("/api/news/summary", {
+  const facets = useMemo(() => {
+    const src = new Map<string, number>();
+    const region = new Map<string, number>();
+    const type = new Map<string, number>();
+    for (const it of afterSearch) {
+      const m = sourceMeta(it.source);
+      src.set(it.source, (src.get(it.source) ?? 0) + 1);
+      region.set(m.region, (region.get(m.region) ?? 0) + 1);
+      type.set(m.type, (type.get(m.type) ?? 0) + 1);
+    }
+    return { src, region, type };
+  }, [afterSearch]);
+
+  const afterFacets = useMemo(
+    () =>
+      afterSearch.filter((it) => {
+        const m = sourceMeta(it.source);
+        if (srcFilter.size && !srcFilter.has(it.source)) return false;
+        if (regionFilter.size && !regionFilter.has(m.region)) return false;
+        if (typeFilter.size && !typeFilter.has(m.type)) return false;
+        return true;
+      }),
+    [afterSearch, srcFilter, regionFilter, typeFilter],
+  );
+
+  const bins = useMemo(
+    () => timeBins(afterFacets.map((it) => it.ts).filter((n) => n > 0), HOUR, now, 24 * HOUR),
+    [afterFacets, now],
+  );
+  const hasVolume = bins.some((b) => b.count > 0);
+
+  const afterHour = useMemo(
+    () => (selHour == null ? afterFacets : afterFacets.filter((it) => it.ts >= selHour && it.ts < selHour + HOUR)),
+    [afterFacets, selHour],
+  );
+
+  const clusters = useMemo(() => clusterNews(afterHour), [afterHour]);
+
+  const totalSources = useMemo(() => new Set(items.map((it) => it.source)).size, [items]);
+
+  // ---- Cross-source AI synthesis (dormant-safe).
+  const [synth, setSynth] = useState<Record<string, SynthState>>({});
+  const [aiDormant, setAiDormant] = useState(false);
+  const synthesize = (c: Cluster) => {
+    const cur = synth[c.id];
+    if (cur?.loading || cur?.text) return;
+    setSynth((s) => ({ ...s, [c.id]: { loading: true } }));
+    fetch("/api/news/synthesis", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ url: it.url, title: it.title, source: it.source }),
+      body: JSON.stringify({
+        title: c.title,
+        sources: c.items.map((i) => ({ source: i.source, title: i.title, description: i.description })),
+      }),
     })
       .then((r) => r.json())
-      .then((d: { summary: string | null; dormant: boolean; source: string | null }) => {
-        const note = d.dormant
-          ? "AI summary needs the FREELLMAPI gateway — showing the snippet."
-          : d.summary
-            ? undefined
-            : "Couldn’t read this article — showing the snippet.";
-        setSummaries((s) => ({ ...s, [it.url]: { text: d.summary ?? it.description ?? "No preview available.", note } }));
+      .then((d: SynthesisPayload) => {
+        if (d.dormant) {
+          setAiDormant(true);
+          setSynth((s) => ({ ...s, [c.id]: { note: "Cross-source synthesis needs the FREELLMAPI gateway." } }));
+        } else if (d.synthesis) {
+          setSynth((s) => ({ ...s, [c.id]: { text: d.synthesis! } }));
+        } else {
+          setSynth((s) => ({ ...s, [c.id]: { note: "Synthesis unavailable for this story right now." } }));
+        }
       })
-      .catch(() => setSummaries((s) => ({ ...s, [it.url]: { text: it.description ?? "No preview available.", note: "Summary unavailable." } })));
+      .catch(() => setSynth((s) => ({ ...s, [c.id]: { note: "Synthesis unavailable." } })));
   };
 
+  // ---- Expand/collapse a cluster's full source list.
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const clearFacets = () => {
+    setSrcFilter(new Set());
+    setRegionFilter(new Set());
+    setTypeFilter(new Set());
+  };
+  const toggle = (set: Set<string>, setter: (s: Set<string>) => void, v: string) => {
+    const n = new Set(set);
+    if (n.has(v)) n.delete(v);
+    else n.add(v);
+    setter(n);
+  };
+  const anyFacet = srcFilter.size + regionFilter.size + typeFilter.size > 0;
+
+  // ---- Export: one row per member, tagged with its cluster (size + sources).
   const exportRows = useMemo(
-    () => filtered.map((it) => ({ source: it.source, title: it.title, url: it.url, ts: it.ts, description: it.description ?? "" })),
-    [filtered],
+    () =>
+      clusters.flatMap((c) =>
+        c.items.map((it) => ({
+          cluster: c.id,
+          clusterSize: c.sourceCount,
+          clusterSources: c.sources.join(" | "),
+          source: it.source,
+          title: it.title,
+          url: it.url,
+          ts: it.ts ? new Date(it.ts).toISOString() : "",
+          description: it.description ?? "",
+        })),
+      ),
+    [clusters],
   );
+
+  const regionKeys = [...facets.region.keys()].filter((r) => r !== "Other");
+  const typeKeys = [...facets.type.keys()];
 
   return (
     <div className="tn-hd">
-      <div className="tn-hd-bar">
-        <div className="tn-hd-chips">
-          <button className={srcFilter == null ? "is-on" : ""} onClick={() => setSrcFilter(null)}>All {items.length}</button>
-          {SOURCES.map((s) => (
-            <button key={s} className={srcFilter === s ? "is-on" : ""} onClick={() => setSrcFilter(s)}>{s} {counts[s] ?? 0}</button>
-          ))}
+      <header className="tn-hd-head">
+        <div>
+          <div className="tn-hd-h-title">World Headlines</div>
+          <div className="tn-hd-h-sub">
+            <b>{clusters.length}</b> {clusters.length === 1 ? "story" : "stories"} · {afterHour.length} headlines from{" "}
+            {totalSources} sources · updated {data.generatedAt ? rel(data.generatedAt, now) || "just now" : "—"} ago
+          </div>
         </div>
-        <input className="tn-hd-search" placeholder="Search headlines…" value={query} onChange={(e) => setQuery(e.target.value)} />
+        <div className="tn-hd-viewtoggle" role="tablist" aria-label="View">
+          <button role="tab" aria-selected={view === "cards"} className={view === "cards" ? "is-on" : ""} onClick={() => setView("cards")}>
+            ▤ Cards
+          </button>
+          <button role="tab" aria-selected={view === "table"} className={view === "table" ? "is-on" : ""} onClick={() => setView("table")}>
+            ▦ Table
+          </button>
+        </div>
+      </header>
+
+      <div className="tn-hd-bar">
+        <input
+          className="tn-hd-search"
+          placeholder='Search — AND · OR · -exclude · "phrase"'
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Boolean headline search"
+        />
+        <div className="tn-hd-chips">
+          {[...facets.src.entries()].map(([s, n]) => {
+            const m = sourceMeta(s);
+            return (
+              <button key={s} className={`tn-hd-chip${srcFilter.has(s) ? " is-on" : ""}`} onClick={() => toggle(srcFilter, setSrcFilter, s)}>
+                <SourceIcon name={s} domain={m.domain} size={13} />
+                {s} <span className="tn-hd-chip-n">{n}</span>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      {volume.some((p) => p.y > 0) && (
+      {(regionKeys.length > 1 || typeKeys.length > 1) && (
+        <div className="tn-hd-facets">
+          {regionKeys.length > 1 && (
+            <div className="tn-hd-facet-row">
+              <span className="tn-hd-facet-label">Region</span>
+              {regionKeys.map((r) => (
+                <button key={r} className={`tn-hd-fchip${regionFilter.has(r) ? " is-on" : ""}`} onClick={() => toggle(regionFilter, setRegionFilter, r)}>
+                  {r} <span className="tn-hd-chip-n">{facets.region.get(r)}</span>
+                </button>
+              ))}
+            </div>
+          )}
+          {typeKeys.length > 1 && (
+            <div className="tn-hd-facet-row">
+              <span className="tn-hd-facet-label">Type</span>
+              {typeKeys.map((t) => (
+                <button key={t} className={`tn-hd-fchip${typeFilter.has(t) ? " is-on" : ""}`} onClick={() => toggle(typeFilter, setTypeFilter, t)}>
+                  {t} <span className="tn-hd-chip-n">{facets.type.get(t)}</span>
+                </button>
+              ))}
+            </div>
+          )}
+          {anyFacet && (
+            <button className="tn-hd-clear" onClick={clearFacets}>
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
+
+      {hasVolume && (
         <div className="tn-hd-vol">
-          <div className="tn-hd-group-h">Headlines per hour · last 24h</div>
-          <Chart points={volume} height={80} up={null} />
+          <div className="tn-hd-vol-head">
+            <span className="tn-hd-group-h">Headlines per hour · last 24h</span>
+            {selHour != null ? (
+              <button className="tn-hd-reset" onClick={() => setSelHour(null)}>
+                ✕ Hour {new Date(selHour).getHours().toString().padStart(2, "0")}:00 — reset
+              </button>
+            ) : (
+              <span className="tn-hd-hint">click a bar to filter</span>
+            )}
+          </div>
+          <HeadlineBars bins={bins} selected={selHour} onSelect={setSelHour} />
         </div>
       )}
 
       {status === "loading" && items.length === 0 && <p className="tn-w-empty">Loading headlines…</p>}
-      {items.length > 0 && filtered.length === 0 && <p className="tn-w-empty">No headlines match.</p>}
+      {items.length > 0 && clusters.length === 0 && <p className="tn-w-empty">No headlines match.</p>}
 
-      {groups.map(([bucket, rows]) => (
-        <section key={bucket} className="tn-hd-group">
-          <h3 className="tn-hd-group-h">{bucket} · {rows.length}</h3>
-          <ul className="tn-hd-list">
-            {rows.map((it, i) => (
-              <li key={it.url || i} className="tn-hd-item">
-                <a className="tn-hd-title" href={it.url} target="_blank" rel="noreferrer">{it.title}</a>
-                <div className="tn-hd-meta"><span className="tn-hd-src">{it.source}</span>{it.ts ? ` · ${rel(it.ts, now)}` : ""}</div>
-                {it.description && <p className="tn-hd-snippet">{it.description}</p>}
-                <button className="tn-hd-sum-btn" onClick={() => summarize(it)} disabled={!!summaries[it.url]?.loading}>
-                  {summaries[it.url]?.loading ? "Summarising…" : "✨ AI summary"}
-                </button>
-                {summaries[it.url]?.text && (
-                  <div className="tn-hd-sum">
-                    <p>{summaries[it.url]!.text}</p>
-                    {summaries[it.url]!.note && <span className="tn-hd-sum-note">{summaries[it.url]!.note}</span>}
-                  </div>
-                )}
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))}
+      {view === "cards" && clusters.length > 0 && (
+        <div className="tn-hd-cards">
+          {clusters.map((c) => (
+            <ClusterCard
+              key={c.id}
+              c={c}
+              now={now}
+              open={openId === c.id}
+              onToggle={() => setOpenId((o) => (o === c.id ? null : c.id))}
+              updated={c.items.some((i) => updatedUrls.has(i.url))}
+              change={changes[c.lead.url] ?? c.items.map((i) => changes[i.url]).find(Boolean)}
+              synth={synth[c.id]}
+              aiDormant={aiDormant}
+              onSynthesize={() => synthesize(c)}
+            />
+          ))}
+        </div>
+      )}
+
+      {view === "table" && clusters.length > 0 && (
+        <table className="tn-hd-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Headline</th>
+              <th>Sources</th>
+              <th>Velocity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {clusters.map((c) => {
+              const vl = velocityLabel(clusterVelocity(c, now));
+              return (
+                <tr key={c.id} className="tn-hd-trow">
+                  <td className="tn-hd-tcell-time">{rel(c.latestTs, now) || "—"}</td>
+                  <td>
+                    <a href={c.lead.url} target="_blank" rel="noreferrer" className="tn-hd-tlink">
+                      {c.title}
+                    </a>
+                    {c.items.some((i) => updatedUrls.has(i.url)) && <span className="tn-hd-badge tn-hd-upd">Updated</span>}
+                  </td>
+                  <td>
+                    <span className="tn-hd-tsrc">
+                      {c.sources.slice(0, 5).map((s) => (
+                        <SourceIcon key={s} name={s} domain={sourceMeta(s).domain} size={14} />
+                      ))}
+                      {c.sourceCount > 1 && <span className="tn-hd-chip-n">×{c.sourceCount}</span>}
+                    </span>
+                  </td>
+                  <td className="tn-hd-tcell-vel">{vl ?? "—"}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
 
       <footer className="tn-hd-foot">
-        <span className="tn-hd-foot-src">BBC World · Al Jazeera · NPR · The Guardian — keyless RSS</span>
-        <button className="tn-hd-export" disabled={exportRows.length === 0}
-          onClick={() => downloadText(`${exportFilename("headlines", Date.now())}.csv`, "text/csv", toCsv(exportRows))}>
+        <span className="tn-hd-foot-src">Keyless RSS · stories grouped by shared-entity similarity</span>
+        {aiDormant && <span className="tn-hd-foot-note">AI synthesis dormant (no gateway)</span>}
+        <button
+          className="tn-hd-export"
+          disabled={exportRows.length === 0}
+          onClick={() => downloadText(`${exportFilename("headlines", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+        >
           ⬇ Export CSV
         </button>
       </footer>
     </div>
+  );
+}
+
+function ClusterCard({
+  c,
+  now,
+  open,
+  onToggle,
+  updated,
+  change,
+  synth,
+  aiDormant,
+  onSynthesize,
+}: {
+  c: Cluster;
+  now: number;
+  open: boolean;
+  onToggle: () => void;
+  updated: boolean;
+  change?: { from: string; to: string };
+  synth?: SynthState;
+  aiDormant: boolean;
+  onSynthesize: () => void;
+}) {
+  const vl = velocityLabel(clusterVelocity(c, now));
+  const trending = clusterVelocity(c, now)?.trending ?? false;
+  const primary = detectPrimarySource(c.lead) ?? c.items.map((i) => detectPrimarySource(i)).find(Boolean) ?? null;
+  const multi = c.sourceCount > 1;
+
+  return (
+    <article className={`tn-hd-card${trending ? " is-trending" : ""}`}>
+      <div className="tn-hd-card-badges">
+        {c.sources.slice(0, 6).map((s) => (
+          <SourceIcon key={s} name={s} domain={sourceMeta(s).domain} size={18} title={s} />
+        ))}
+        {c.sources.length > 6 && <span className="tn-hd-chip-n">+{c.sources.length - 6}</span>}
+      </div>
+
+      <div className="tn-hd-card-meta">
+        {multi && <span className="tn-hd-badge tn-hd-corrob">{c.sourceCount} sources</span>}
+        {vl && <span className={`tn-hd-badge tn-hd-vel${trending ? " is-trending" : ""}`}>▲ {vl}</span>}
+        {updated && (
+          <span className="tn-hd-badge tn-hd-upd" title={change ? `Was: ${change.from}` : "Headline changed since last seen"}>
+            Updated
+          </span>
+        )}
+        {primary && (
+          <span className="tn-hd-badge tn-hd-primary" title="Appears to reference a primary/official source">
+            {primary.label}
+          </span>
+        )}
+        <span className="tn-hd-card-time">{rel(c.latestTs, now)}</span>
+      </div>
+
+      <a className="tn-hd-card-title" href={c.lead.url} target="_blank" rel="noreferrer">
+        {c.title}
+      </a>
+      <div className="tn-hd-card-lead-src">
+        <SourceIcon name={c.lead.source} domain={sourceMeta(c.lead.source).domain} size={13} /> {c.lead.source}
+      </div>
+      {change && <p className="tn-hd-change">Updated from: “{change.from}”</p>}
+      {c.lead.description && <p className="tn-hd-snippet">{c.lead.description}</p>}
+
+      {multi && (
+        <>
+          <button className="tn-hd-more" onClick={onToggle} aria-expanded={open}>
+            {open ? "▾ Hide" : "▸ Show"} all {c.items.length} reports
+          </button>
+          {open && (
+            <ul className="tn-hd-corrob-list">
+              {c.items.map((it, i) => (
+                <li key={it.url || i}>
+                  <SourceIcon name={it.source} domain={sourceMeta(it.source).domain} size={13} />
+                  <a href={it.url} target="_blank" rel="noreferrer" className="tn-hd-corrob-title">
+                    {it.title}
+                  </a>
+                  <span className="tn-hd-corrob-meta">
+                    {it.source}
+                    {it.ts ? ` · ${rel(it.ts, now)}` : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+
+      {multi && !aiDormant && (
+        <button className="tn-hd-synth-btn" onClick={onSynthesize} disabled={!!synth?.loading}>
+          {synth?.loading ? "Synthesising…" : "✨ Cross-source synthesis"}
+        </button>
+      )}
+      {synth?.text && (
+        <div className="tn-hd-synth">
+          <span className="tn-hd-synth-h">Cross-source synthesis</span>
+          <p>{synth.text}</p>
+        </div>
+      )}
+      {synth?.note && <p className="tn-hd-synth-note">{synth.note}</p>}
+    </article>
   );
 }

--- a/lib/console/widgets/headlines.tsx
+++ b/lib/console/widgets/headlines.tsx
@@ -3,11 +3,12 @@
 // keyless /api/news payload (BBC / Al Jazeera / NPR / Guardian world feeds) and
 // lists the latest headlines with source + relative time, each linking out.
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { registerWidget } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
 import type { NewsItem } from "@/lib/news";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
+import { clusterNews } from "@/lib/news/cluster";
 import HeadlinesDetail from "@/lib/console/widgets/headlines.detail";
 
 interface NewsPayload {
@@ -30,11 +31,14 @@ function rel(ts: number, now: number): string {
 function HeadlinesBody() {
   const { data, status } = useJsonPoll<NewsPayload>("/api/news", 120_000, EMPTY);
   const items = data.items ?? [];
+  // Collapse same-event headlines into stories so the compact list shows one row
+  // per event with a source-count when several outlets corroborate it.
+  const stories = useMemo(() => clusterNews(items), [items]);
 
   const report = useWidgetReport();
   useEffect(() => {
-    report({ alerts: [], count: items.length, freshLabel: "live" });
-  }, [items.length, report]);
+    report({ alerts: [], count: stories.length, freshLabel: "live" });
+  }, [stories.length, report]);
 
   if (status === "loading" && items.length === 0) return <p className="tn-w-empty">Loading headlines…</p>;
   if (items.length === 0) return <p className="tn-w-empty">No headlines.</p>;
@@ -42,21 +46,22 @@ function HeadlinesBody() {
   const now = Date.now();
   return (
     <ul className="tn-w-list">
-      {items.slice(0, 60).map((it, i) => {
-        const r = rel(it.ts, now);
+      {stories.slice(0, 60).map((c, i) => {
+        const r = rel(c.lead.ts, now);
         return (
-          <li key={it.url || i}>
+          <li key={c.id || i}>
             <a
-              href={it.url}
+              href={c.lead.url}
               target="_blank"
               rel="noreferrer"
               className="tn-w-place"
               style={{ color: "inherit", textDecoration: "none" }}
             >
-              {it.title}
+              {c.title}
             </a>
             <span className="tn-w-muted">
-              {" "}· {it.source}
+              {" "}· {c.lead.source}
+              {c.sourceCount > 1 ? ` +${c.sourceCount - 1}` : ""}
               {r ? ` · ${r}` : ""}
             </span>
           </li>

--- a/lib/news/article.ts
+++ b/lib/news/article.ts
@@ -4,7 +4,7 @@
 // on the publisher's main domain, e.g. bbc.com — NOT the feeds.* host). This is a
 // SEPARATE list from lib/proxy/allowlist.ts (which is camera hosts only).
 
-const NEWS_DOMAINS = ["bbc.com", "bbc.co.uk", "theguardian.com", "aljazeera.com", "npr.org"];
+const NEWS_DOMAINS = ["bbc.com", "bbc.co.uk", "theguardian.com", "aljazeera.com", "npr.org", "dw.com", "france24.com"];
 
 /** https + hostname is one of NEWS_DOMAINS or a subdomain of one. */
 export function isNewsArticleUrl(raw: string): boolean {

--- a/lib/news/cluster.ts
+++ b/lib/news/cluster.ts
@@ -1,0 +1,146 @@
+// lib/news/cluster.ts
+// Story clustering: group headlines that describe the SAME event into one parent
+// "mega-card" carrying every source that reported it. PURE + node-testable.
+//
+// Method: normalise each title (drop the publisher suffix + punctuation), reduce
+// it to a set of significant tokens (stop-words removed), then greedily assign
+// each headline (newest-first) to the existing cluster whose LEAD headline it most
+// overlaps with — measured by Jaccard similarity, and only when they share at
+// least two significant tokens (so a single common word like "Iran" never fuses
+// two unrelated stories). No shared token → its own new cluster.
+
+import type { NewsItem } from "@/lib/news";
+
+// Function words + newsroom filler that carry no event identity.
+const STOP = new Set(
+  ("a an the of to in on at for and or but with from by as is are was were be been being this that " +
+    "these those over under after before amid into out up down not no more most least new latest " +
+    "breaking live update updates report reports says say said will would could can may might has have " +
+    "had its it he she they them his her their you we our us who what when where why how than then " +
+    "about across against among around between during through per via amid off onto upon")
+    .split(/\s+/),
+);
+
+// Publisher suffixes RSS titles sometimes append, e.g. " - BBC News", " | Reuters".
+const SUFFIX_RE =
+  /\s*[-|–—:]\s*(bbc(?:\s?news)?|al\s?jazeera|npr|the\s?guardian|guardian|dw|deutsche\s?welle|france\s?24|reuters|associated\s?press|ap|cnn|sky\s?news)\s*$/i;
+
+/** Pure: title → lower-cased, de-suffixed, punctuation-stripped canonical form. */
+export function normalizeTitle(title: string): string {
+  return (title ?? "")
+    .replace(SUFFIX_RE, "")
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Pure: title → set of significant tokens (≥3 chars, stop-words removed). */
+export function titleTokens(title: string): Set<string> {
+  const out = new Set<string>();
+  for (const w of normalizeTitle(title).split(" ")) {
+    if (w.length >= 3 && !STOP.has(w)) out.add(w);
+  }
+  return out;
+}
+
+/**
+ * Similarity between two token sets:
+ *  - `score`  = Jaccard (shared / union)
+ *  - `shared` = raw shared-token count
+ *  - `coeff`  = overlap coefficient (shared / min-size) — forgiving when two
+ *               outlets word the same event at very different lengths.
+ */
+export function overlap(a: Set<string>, b: Set<string>): { score: number; shared: number; coeff: number } {
+  if (a.size === 0 || b.size === 0) return { score: 0, shared: 0, coeff: 0 };
+  let shared = 0;
+  for (const x of a) if (b.has(x)) shared++;
+  const union = a.size + b.size - shared;
+  const minSize = Math.min(a.size, b.size);
+  return { score: union === 0 ? 0 : shared / union, shared, coeff: minSize === 0 ? 0 : shared / minSize };
+}
+
+export interface Cluster {
+  /** Stable-ish id — the lead (newest) headline's URL. */
+  id: string;
+  /** Lead (newest) headline's title, used as the card headline. */
+  title: string;
+  lead: NewsItem;
+  /** Every member, newest-first (includes the lead). */
+  items: NewsItem[];
+  /** Distinct source display names, first-seen order. */
+  sources: string[];
+  sourceCount: number;
+  latestTs: number;
+  earliestTs: number;
+}
+
+export interface ClusterOptions {
+  /** Minimum Jaccard to fuse (default 0.26). */
+  threshold?: number;
+  /** Minimum shared significant tokens to fuse (default 2). */
+  minShared?: number;
+}
+
+/**
+ * Fuse when the headlines clearly describe the same event. Two signals, either
+ * sufficient (both gated by ≥minShared shared tokens so one common word never
+ * fuses unrelated stories):
+ *   • Jaccard ≥ threshold — similar wording overall, OR
+ *   • overlap-coefficient ≥ 0.6 with ≥3 shared tokens — same core entities even
+ *     when one outlet's headline is much longer/differently phrased.
+ */
+function shouldMerge(o: { score: number; shared: number; coeff: number }, threshold: number, minShared: number): boolean {
+  if (o.shared < minShared) return false;
+  return o.score >= threshold || (o.coeff >= 0.6 && o.shared >= 3);
+}
+
+interface Work {
+  items: NewsItem[];
+  toks: Set<string>; // the LEAD headline's tokens (fixed — keeps clusters tight)
+}
+
+function finalize(w: Work): Cluster {
+  const items = [...w.items].sort((a, b) => (b.ts || 0) - (a.ts || 0));
+  const lead = items[0];
+  const sources: string[] = [];
+  for (const it of items) if (!sources.includes(it.source)) sources.push(it.source);
+  const tss = items.map((i) => i.ts || 0).filter((n) => n > 0);
+  return {
+    id: lead.url,
+    title: lead.title,
+    lead,
+    items,
+    sources,
+    sourceCount: sources.length,
+    latestTs: tss.length ? Math.max(...tss) : 0,
+    earliestTs: tss.length ? Math.min(...tss) : 0,
+  };
+}
+
+/**
+ * Pure: headlines → event clusters, newest-first (ties broken by source count).
+ * Deterministic for a given input ordering.
+ */
+export function clusterNews(items: NewsItem[], opts: ClusterOptions = {}): Cluster[] {
+  const threshold = opts.threshold ?? 0.26;
+  const minShared = opts.minShared ?? 2;
+  const sorted = [...items].sort((a, b) => (b.ts || 0) - (a.ts || 0));
+  const work: Work[] = [];
+  for (const it of sorted) {
+    const toks = titleTokens(it.title);
+    let best: Work | null = null;
+    let bestScore = 0;
+    for (const w of work) {
+      const o = overlap(toks, w.toks);
+      if (shouldMerge(o, threshold, minShared) && o.score > bestScore) {
+        bestScore = o.score;
+        best = w;
+      }
+    }
+    if (best) best.items.push(it);
+    else work.push({ items: [it], toks });
+  }
+  return work.map(finalize).sort((a, b) => b.latestTs - a.latestTs || b.sourceCount - a.sourceCount);
+}

--- a/lib/news/primary.ts
+++ b/lib/news/primary.ts
@@ -1,0 +1,44 @@
+// lib/news/primary.ts
+// Best-effort "primary source" detection. Surfaces when a headline appears to be
+// built on an official/primary document (a government statement, press release,
+// court ruling, treaty/whitepaper, sanctions list …) so an analyst can tell a
+// first-hand document from downstream commentary. PURE + node-testable.
+//
+// Honesty: RSS gives us only title/description/url, so this is a HIGH-PRECISION
+// heuristic — a direct link to an official domain, or specific documentary
+// phrasing. When nothing strong matches we return null and the UI shows no tag
+// (we never guess).
+
+import type { NewsItem } from "@/lib/news";
+
+export interface PrimarySource {
+  kind: "official" | "statement" | "press-release" | "document";
+  label: string;
+}
+
+// Official / primary-document domains. If a feed ever links straight to one of
+// these, that's a first-hand source.
+const OFFICIAL_HOST =
+  /(^|\.)(gov|mil)(\.[a-z]{2})?$|(^|\.)(un|who|imf|worldbank|icj-cij|icc-cpi|nato|oecd|wto|iaea)\.(org|int)$|(^|\.)europa\.eu$|(^|\.)europarl\.europa\.eu$/i;
+
+// Specific documentary phrasings (kept tight to stay high-precision).
+const CUES: { re: RegExp; kind: PrimarySource["kind"]; label: string }[] = [
+  { re: /\bpress release\b/i, kind: "press-release", label: "Press release" },
+  { re: /\b(official statement|full statement|statement from|readout|communiqu[eé])\b/i, kind: "statement", label: "Official statement" },
+  { re: /\b(white ?paper|treaty text|full text of the|resolution text|executive order|court (ruling|filing)|full ruling|sanctions list)\b/i, kind: "document", label: "Primary document" },
+];
+
+/** Pure: item → its primary-source tag, or null when there's no strong signal. */
+export function detectPrimarySource(item: Pick<NewsItem, "title" | "description" | "url">): PrimarySource | null {
+  // 1) A direct link to an official/primary domain is the strongest signal.
+  try {
+    const host = new URL(item.url).hostname.toLowerCase();
+    if (OFFICIAL_HOST.test(host)) return { kind: "official", label: "Official source" };
+  } catch {
+    /* unparseable url — fall through to text cues */
+  }
+  // 2) Documentary phrasing in the title/description.
+  const text = `${item.title ?? ""} ${item.description ?? ""}`;
+  for (const c of CUES) if (c.re.test(text)) return { kind: c.kind, label: c.label };
+  return null;
+}

--- a/lib/news/search.ts
+++ b/lib/news/search.ts
@@ -1,0 +1,107 @@
+// lib/news/search.ts
+// A small boolean search grammar for the headlines feed. PURE + node-testable.
+//
+// Supported:
+//   plain words   → all required (implicit AND)
+//   "quoted"      → exact phrase (spaces preserved)
+//   -term / -"…"  → exclude
+//   OR            → separates alternative AND-groups (uppercase, standalone)
+//   AND           → optional, ignored (AND is already implicit between terms)
+//
+// A text matches when ANY OR-group matches; a group matches when every include
+// term is present and no exclude term is. An empty query matches everything.
+
+export interface QueryGroup {
+  include: string[];
+  exclude: string[];
+}
+export interface Query {
+  groups: QueryGroup[];
+  raw: string;
+}
+
+interface Token {
+  type: "or" | "term";
+  text?: string;
+  negate?: boolean;
+}
+
+function tokenize(raw: string): Token[] {
+  const tokens: Token[] = [];
+  const s = raw ?? "";
+  let i = 0;
+  while (i < s.length) {
+    const ch = s[i];
+    if (ch === " " || ch === "\t" || ch === "\n") {
+      i++;
+      continue;
+    }
+    let negate = false;
+    if (ch === "-") {
+      // A leading '-' negates the following word/phrase (but "-" alone is literal).
+      const next = s[i + 1];
+      if (next && next !== " ") {
+        negate = true;
+        i++;
+      }
+    }
+    if (s[i] === '"') {
+      // Quoted phrase — read until the closing quote (or end of string).
+      const end = s.indexOf('"', i + 1);
+      const text = end === -1 ? s.slice(i + 1) : s.slice(i + 1, end);
+      i = end === -1 ? s.length : end + 1;
+      if (text.trim()) tokens.push({ type: "term", text: text.trim(), negate });
+      continue;
+    }
+    // Bare word — read until whitespace.
+    let j = i;
+    while (j < s.length && s[j] !== " " && s[j] !== "\t" && s[j] !== "\n") j++;
+    const word = s.slice(i, j);
+    i = j;
+    if (!word) continue;
+    if (!negate && word === "OR") tokens.push({ type: "or" });
+    else if (!negate && word === "AND") continue; // implicit — ignore
+    else tokens.push({ type: "term", text: word, negate });
+  }
+  return tokens;
+}
+
+/** Pure: raw query string → a normalised group structure. */
+export function parseQuery(raw: string): Query {
+  const groups: QueryGroup[] = [];
+  let cur: QueryGroup = { include: [], exclude: [] };
+  let has = false;
+  for (const t of tokenize(raw)) {
+    if (t.type === "or") {
+      if (has) {
+        groups.push(cur);
+        cur = { include: [], exclude: [] };
+        has = false;
+      }
+      continue;
+    }
+    has = true;
+    if (t.negate) cur.exclude.push(t.text!);
+    else cur.include.push(t.text!);
+  }
+  if (has) groups.push(cur);
+  return { groups, raw: raw ?? "" };
+}
+
+/** Pure: does `text` satisfy the query? Empty query → true. */
+export function matchQuery(q: Query, text: string): boolean {
+  if (q.groups.length === 0) return true;
+  const hay = (text ?? "").toLowerCase();
+  return q.groups.some((g) => {
+    for (const inc of g.include) if (!hay.includes(inc.toLowerCase())) return false;
+    for (const exc of g.exclude) if (hay.includes(exc.toLowerCase())) return false;
+    return true;
+  });
+}
+
+/** Convenience: filter items by a raw query over a caller-supplied text projection. */
+export function filterByQuery<T>(items: T[], raw: string, text: (t: T) => string): T[] {
+  const q = parseQuery(raw);
+  if (q.groups.length === 0) return items;
+  return items.filter((it) => matchQuery(q, text(it)));
+}

--- a/lib/news/snapshot.ts
+++ b/lib/news/snapshot.ts
@@ -1,0 +1,48 @@
+// lib/news/snapshot.ts
+// Updated / correction tracking. We keep a small last-seen snapshot (url → title)
+// in localStorage; on each load we diff the current feed against it to flag
+// headlines whose wording changed since we last saw them (a common signal of a
+// live-updated or corrected story). PURE diff here + node-testable; the
+// persistence wrapper (below) is SSR-safe and only runs in the browser.
+
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export type Snapshot = Record<string, string>; // url -> last-seen title
+
+export interface Change {
+  url: string;
+  from: string;
+  to: string;
+}
+
+/** Pure: current items → a fresh snapshot (last title wins per url). */
+export function snapshotOf(items: { url: string; title: string }[]): Snapshot {
+  const s: Snapshot = {};
+  for (const it of items) if (it.url) s[it.url] = it.title;
+  return s;
+}
+
+/** Pure: titles that changed vs the previous snapshot (empty when no prior snapshot). */
+export function diffSnapshots(prev: Snapshot | null, items: { url: string; title: string }[]): Change[] {
+  if (!prev) return [];
+  const out: Change[] = [];
+  for (const it of items) {
+    if (!it.url) continue;
+    const before = prev[it.url];
+    if (before != null && before !== it.title) out.push({ url: it.url, from: before, to: it.title });
+  }
+  return out;
+}
+
+const KEY = "tn.news.snapshot.v1";
+const VERSION = 1;
+
+/** Browser: load the previous snapshot (null on miss / SSR). */
+export function loadSnapshot(): Snapshot | null {
+  return loadPersisted<Snapshot>(KEY, VERSION);
+}
+
+/** Browser: persist the current snapshot (bounded — one entry per current url). */
+export function saveSnapshot(items: { url: string; title: string }[]): void {
+  savePersisted(KEY, VERSION, snapshotOf(items));
+}

--- a/lib/news/sources.ts
+++ b/lib/news/sources.ts
@@ -1,0 +1,62 @@
+// lib/news/sources.ts
+// Source identity: display name → brand domain, region and outlet type. Powers
+// the favicons + source badges on cluster mega-cards and the region/type filter
+// matrix. PURE + node-testable.
+//
+// Honesty rules: only outlets we can actually attribute get a domain/region/type;
+// an unknown source degrades to a domainless, region-"Other" meta (no favicon, no
+// fabricated attribution). There is deliberately NO political-leaning axis — we
+// cannot source that credibly, so we omit it rather than invent it.
+
+export interface SourceMeta {
+  name: string;
+  /** Brand domain for the favicon, or null when we can't attribute the source. */
+  domain: string | null;
+  /** Coarse geographic home of the outlet. "Other" when unknown. */
+  region: string;
+  /** Honest outlet type (public broadcaster / newspaper / newswire / …). */
+  type: string;
+}
+
+// Keyed by the lower-cased display name the feed carries. Kept small + honest.
+// Extra well-known keyless outlets are pre-mapped so that IF a feed is added the
+// badge/region/type already resolve — no fabrication, just attribution.
+const TABLE: Record<string, Omit<SourceMeta, "name">> = {
+  "bbc": { domain: "bbc.com", region: "UK", type: "Public broadcaster" },
+  "bbc news": { domain: "bbc.com", region: "UK", type: "Public broadcaster" },
+  "al jazeera": { domain: "aljazeera.com", region: "Middle East", type: "Broadcaster" },
+  "npr": { domain: "npr.org", region: "US", type: "Public radio" },
+  "the guardian": { domain: "theguardian.com", region: "UK", type: "Newspaper" },
+  "guardian": { domain: "theguardian.com", region: "UK", type: "Newspaper" },
+  "dw": { domain: "dw.com", region: "Europe", type: "Public broadcaster" },
+  "deutsche welle": { domain: "dw.com", region: "Europe", type: "Public broadcaster" },
+  "france 24": { domain: "france24.com", region: "Europe", type: "Public broadcaster" },
+  "reuters": { domain: "reuters.com", region: "International", type: "Newswire" },
+  "associated press": { domain: "apnews.com", region: "International", type: "Newswire" },
+  "ap": { domain: "apnews.com", region: "International", type: "Newswire" },
+  "cnn": { domain: "cnn.com", region: "US", type: "Broadcaster" },
+  "al arabiya": { domain: "alarabiya.net", region: "Middle East", type: "Broadcaster" },
+  "cbc": { domain: "cbc.ca", region: "North America", type: "Public broadcaster" },
+  "sky news": { domain: "news.sky.com", region: "UK", type: "Broadcaster" },
+};
+
+/** Pure: display name → its attribution metadata (never throws; degrades to "Other"). */
+export function sourceMeta(name: string): SourceMeta {
+  const key = (name ?? "").trim().toLowerCase();
+  const hit = TABLE[key];
+  if (hit) return { name: name ?? "", ...hit };
+  return { name: name ?? "", domain: null, region: "Other", type: "News" };
+}
+
+/** Keyless favicon URL for a brand domain, or null when unattributed. */
+export function faviconUrl(domain: string | null, size = 32): string | null {
+  if (!domain) return null;
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=${size}`;
+}
+
+/** Single-letter monogram used as the graceful favicon fallback (drops a leading "The "). */
+export function sourceInitial(name: string): string {
+  const s = (name ?? "").trim().replace(/^the\s+/i, "");
+  const m = s.match(/[a-z0-9]/i);
+  return m ? m[0].toUpperCase() : "?";
+}

--- a/lib/news/synthesis.ts
+++ b/lib/news/synthesis.ts
@@ -1,0 +1,56 @@
+// lib/news/synthesis.ts
+// Pure prompt builder + response parser for cross-source AI synthesis: given the
+// headlines (and snippets) several outlets ran on the SAME event, ask a neutral
+// editor to state the shared consensus and flag any discrepancies. Mirrors
+// lib/news/summary.ts — honesty-guarded, node-testable; the network call lives in
+// the route. Grounded ONLY in the supplied headlines (no article fetch, so no
+// SSRF surface). Dormant-safe upstream when no gateway is configured.
+
+export interface SynthesisSource {
+  source: string;
+  title: string;
+  description?: string;
+}
+
+export interface SynthesisInput {
+  title: string;
+  sources: SynthesisSource[];
+}
+
+export interface SynthesisPayload {
+  synthesis: string | null;
+  dormant: boolean;
+  sourceCount: number;
+}
+
+/** Pure: cluster headlines → the chat prompt sent to the gateway. */
+export function buildSynthesisPrompt(input: SynthesisInput): string {
+  const lines = input.sources.map((s, i) => {
+    const snip = s.description ? ` — ${s.description}` : "";
+    return `${i + 1}. [${s.source}] ${s.title}${snip}`;
+  });
+  return [
+    "You are a neutral news desk editor. Several outlets are covering the same event.",
+    "Below are their headlines (and any snippets). In 3-4 short, factual sentences:",
+    "first state the consensus — what all the sources agree happened; then note any",
+    "discrepancies, differing emphasis, or details only some outlets report.",
+    "Use ONLY the text provided. Do not add facts, figures, or opinions not present in it. Do not speculate.",
+    "",
+    `Event: ${input.title}`,
+    "",
+    "Coverage:",
+    ...lines,
+  ].join("\n");
+}
+
+/** Pure: gateway chat-completion response → synthesis text, or null. */
+export function parseSynthesisResponse(json: unknown): string | null {
+  const content = (json as { choices?: { message?: { content?: unknown } }[] })?.choices?.[0]?.message?.content;
+  return typeof content === "string" && content.trim() ? content.trim() : null;
+}
+
+/** Stable cache key for a synthesis request (order-independent over sources). */
+export function synthesisKey(input: SynthesisInput): string {
+  const parts = input.sources.map((s) => `${s.source}:${s.title}`).sort();
+  return `${input.title}|${parts.join("|")}`;
+}

--- a/lib/news/velocity.ts
+++ b/lib/news/velocity.ts
@@ -1,0 +1,40 @@
+// lib/news/velocity.ts
+// Coverage velocity: how fast is a story being picked up? Counts the DISTINCT
+// sources that published into a cluster inside a recent window (default 10m).
+// PURE + node-testable. Honest: with no parseable timestamps we return null
+// (no fabricated momentum), and the UI simply omits the indicator.
+
+import type { Cluster } from "./cluster";
+
+export interface Velocity {
+  /** Distinct sources with an item inside the window. */
+  recentSources: number;
+  /** Distinct sources across the whole cluster. */
+  totalSources: number;
+  windowMin: number;
+  /** ≥2 distinct sources within the window = a genuine corroboration surge. */
+  trending: boolean;
+}
+
+/** Pure: cluster → velocity, or null when the cluster has no usable timestamps. */
+export function clusterVelocity(cluster: Cluster, now: number, windowMs = 10 * 60_000): Velocity | null {
+  const withTs = cluster.items.filter((i) => i.ts > 0);
+  if (withTs.length === 0) return null;
+  const recent = new Set<string>();
+  for (const it of withTs) {
+    const age = now - it.ts;
+    if (age >= 0 && age <= windowMs) recent.add(it.source);
+  }
+  return {
+    recentSources: recent.size,
+    totalSources: cluster.sourceCount,
+    windowMin: Math.round(windowMs / 60000),
+    trending: recent.size >= 2,
+  };
+}
+
+/** Short "+N sources in Xm" label, or null when there's nothing recent to show. */
+export function velocityLabel(v: Velocity | null): string | null {
+  if (!v || v.recentSources <= 0) return null;
+  return `+${v.recentSources} source${v.recentSources === 1 ? "" : "s"} in ${v.windowMin}m`;
+}

--- a/tests/unit/news-cluster.test.ts
+++ b/tests/unit/news-cluster.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "vitest";
+import { normalizeTitle, titleTokens, overlap, clusterNews } from "@/lib/news/cluster";
+import type { NewsItem } from "@/lib/news";
+
+const it = (title: string, source: string, ts: number, url = `https://x/${Math.random()}`): NewsItem => ({
+  title,
+  source,
+  url,
+  ts,
+});
+
+test("normalizeTitle strips publisher suffix + punctuation and lower-cases", () => {
+  expect(normalizeTitle("Big story unfolds - BBC News")).toBe("big story unfolds");
+  expect(normalizeTitle("Something happens | Reuters")).toBe("something happens");
+  expect(normalizeTitle("It’s a Test, really!")).toBe("its a test really");
+});
+
+test("titleTokens drops short words + stop-words", () => {
+  const t = titleTokens("The US strikes Iran after an attack");
+  expect(t.has("strikes")).toBe(true);
+  expect(t.has("iran")).toBe(true);
+  expect(t.has("attack")).toBe(true);
+  expect(t.has("the")).toBe(false);
+  expect(t.has("us")).toBe(false); // 2 chars
+  expect(t.has("after")).toBe(false); // stop word
+});
+
+test("overlap returns jaccard + shared count + overlap coefficient", () => {
+  const a = new Set(["ukraine", "licence", "patriot", "build"]);
+  const b = new Set(["ukraine", "licence", "patriot", "produce"]);
+  const o = overlap(a, b);
+  expect(o.shared).toBe(3);
+  expect(o.score).toBeCloseTo(3 / 5, 5);
+  expect(o.coeff).toBeCloseTo(3 / 4, 5); // shared / min-size
+  expect(overlap(new Set(), a)).toEqual({ score: 0, shared: 0, coeff: 0 });
+});
+
+test("clusterNews groups a cross-source story and keeps unrelated ones apart", () => {
+  const items: NewsItem[] = [
+    it("US gives Ukraine licence to build Patriot missiles", "BBC", 100),
+    it("Ukraine to get licence to produce Patriot systems", "France 24", 300),
+    it("Patriot missiles: Ukraine granted licence to build", "Al Jazeera", 200),
+    it("Bucknell coach charged in hazing death case", "NPR", 250),
+  ];
+  const clusters = clusterNews(items);
+  expect(clusters).toHaveLength(2);
+
+  const patriot = clusters.find((c) => c.sourceCount === 3)!;
+  expect(patriot).toBeTruthy();
+  expect(patriot.sources.sort()).toEqual(["Al Jazeera", "BBC", "France 24"]);
+  // lead is the newest (France 24 @ 300)
+  expect(patriot.lead.source).toBe("France 24");
+  expect(patriot.latestTs).toBe(300);
+  expect(patriot.earliestTs).toBe(100);
+
+  const lone = clusters.find((c) => c.sourceCount === 1)!;
+  expect(lone.lead.source).toBe("NPR");
+});
+
+test("differently-phrased cross-source headlines fuse via the overlap-coefficient rule", () => {
+  const items: NewsItem[] = [
+    it("Jordan air defences intercept and destroy multiple Iranian ballistic missiles fired overnight", "Al Jazeera", 400),
+    it("Jordan downs three Iranian missiles", "France 24", 380),
+  ];
+  // Jaccard is only ~0.23 (the long headline dilutes the union), but the short
+  // headline's core entities (jordan/iranian/missiles) are ≥60% contained — same event.
+  const clusters = clusterNews(items);
+  expect(clusters).toHaveLength(1);
+  expect(clusters[0].sourceCount).toBe(2);
+});
+
+test("a single shared token does not fuse unrelated stories", () => {
+  const items: NewsItem[] = [
+    it("Iran holds parliamentary elections", "BBC", 100),
+    it("Iran football team qualifies for final", "NPR", 90),
+  ];
+  const clusters = clusterNews(items);
+  expect(clusters).toHaveLength(2); // only "iran" in common → not merged
+});
+
+test("clusterNews is dormant-safe on empty input", () => {
+  expect(clusterNews([])).toEqual([]);
+});

--- a/tests/unit/news-primary.test.ts
+++ b/tests/unit/news-primary.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import { detectPrimarySource } from "@/lib/news/primary";
+
+const at = (url: string) => ({ title: "", description: "", url });
+
+test("official / primary-document domains are detected", () => {
+  expect(detectPrimarySource(at("https://www.state.gov/press/x"))?.kind).toBe("official");
+  expect(detectPrimarySource(at("https://www.gov.uk/government/news/x"))?.kind).toBe("official");
+  expect(detectPrimarySource(at("https://www.un.org/press/en/x"))?.kind).toBe("official");
+});
+
+test("documentary phrasing in the headline is detected", () => {
+  expect(detectPrimarySource({ title: "Kremlin issues official statement on ceasefire", url: "https://bbc.com/x" })?.kind).toBe("statement");
+  expect(detectPrimarySource({ title: "Firm announces merger in press release", url: "https://bbc.com/x" })?.kind).toBe("press-release");
+  expect(detectPrimarySource({ title: "UN publishes white paper on climate", url: "https://bbc.com/x" })?.kind).toBe("document");
+});
+
+test("ordinary news gets no primary-source tag (no over-tagging)", () => {
+  expect(detectPrimarySource({ title: "Local team wins the match", url: "https://theguardian.com/x" })).toBeNull();
+  expect(detectPrimarySource({ title: "Weather turns cold across Europe", url: "https://npr.org/x" })).toBeNull();
+});
+
+test("unparseable url is safe", () => {
+  expect(detectPrimarySource({ title: "Something", url: "not a url" })).toBeNull();
+});

--- a/tests/unit/news-search.test.ts
+++ b/tests/unit/news-search.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { parseQuery, matchQuery, filterByQuery } from "@/lib/news/search";
+
+const m = (q: string, text: string) => matchQuery(parseQuery(q), text);
+
+test("implicit AND requires every term", () => {
+  expect(m("iran strikes", "US strikes Iran overnight")).toBe(true);
+  expect(m("iran strikes", "US strikes Syria overnight")).toBe(false);
+});
+
+test("OR separates alternative groups", () => {
+  const q = parseQuery("iran OR ukraine");
+  expect(q.groups).toHaveLength(2);
+  expect(m("iran OR ukraine", "Ukraine war latest")).toBe(true);
+  expect(m("iran OR ukraine", "Markets rally in Tokyo")).toBe(false);
+});
+
+test("-term excludes", () => {
+  expect(m("strikes -iran", "US strikes Syria")).toBe(true);
+  expect(m("strikes -iran", "US strikes Iran")).toBe(false);
+});
+
+test('"quoted phrase" matches contiguously', () => {
+  expect(m('"patriot missiles"', "US sends patriot missiles to Kyiv")).toBe(true);
+  expect(m('"patriot missiles"', "patriot systems and missiles")).toBe(false);
+});
+
+test("AND keyword is a no-op; empty query matches all", () => {
+  expect(m("iran AND strikes", "Iran strikes reported")).toBe(true);
+  expect(m("", "anything at all")).toBe(true);
+  expect(parseQuery("   ").groups).toHaveLength(0);
+});
+
+test("case-insensitive matching", () => {
+  expect(m("IRAN", "the iran report")).toBe(true);
+});
+
+test("filterByQuery filters a projection and passes through on empty", () => {
+  const rows = [{ t: "Iran strikes" }, { t: "Ukraine talks" }];
+  expect(filterByQuery(rows, "ukraine", (r) => r.t)).toEqual([{ t: "Ukraine talks" }]);
+  expect(filterByQuery(rows, "", (r) => r.t)).toBe(rows);
+});

--- a/tests/unit/news-snapshot.test.ts
+++ b/tests/unit/news-snapshot.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "vitest";
+import { snapshotOf, diffSnapshots } from "@/lib/news/snapshot";
+
+test("snapshotOf maps url → title (skips blank urls)", () => {
+  expect(snapshotOf([{ url: "a", title: "T1" }, { url: "b", title: "T2" }, { url: "", title: "X" }])).toEqual({
+    a: "T1",
+    b: "T2",
+  });
+});
+
+test("diffSnapshots flags changed titles only", () => {
+  const prev = { a: "Old headline", b: "Unchanged" };
+  const now = [
+    { url: "a", title: "Old headline (updated)" },
+    { url: "b", title: "Unchanged" },
+    { url: "c", title: "Brand new" }, // new url is not a "change"
+  ];
+  expect(diffSnapshots(prev, now)).toEqual([{ url: "a", from: "Old headline", to: "Old headline (updated)" }]);
+});
+
+test("no prior snapshot → no changes (honest, no baseline)", () => {
+  expect(diffSnapshots(null, [{ url: "a", title: "T" }])).toEqual([]);
+});

--- a/tests/unit/news-sources.test.ts
+++ b/tests/unit/news-sources.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "vitest";
+import { sourceMeta, faviconUrl, sourceInitial } from "@/lib/news/sources";
+
+test("sourceMeta attributes known outlets with region + type", () => {
+  expect(sourceMeta("BBC")).toMatchObject({ domain: "bbc.com", region: "UK", type: "Public broadcaster" });
+  expect(sourceMeta("Al Jazeera").region).toBe("Middle East");
+  expect(sourceMeta("NPR").region).toBe("US");
+  expect(sourceMeta("The Guardian").type).toBe("Newspaper");
+  expect(sourceMeta("France 24").region).toBe("Europe");
+  expect(sourceMeta("Reuters").type).toBe("Newswire");
+});
+
+test("sourceMeta is case-insensitive on the display name", () => {
+  expect(sourceMeta("bbc").domain).toBe("bbc.com");
+  expect(sourceMeta("  the guardian ").domain).toBe("theguardian.com");
+});
+
+test("unknown source degrades honestly (no fabricated attribution)", () => {
+  const m = sourceMeta("Some Blog");
+  expect(m.domain).toBeNull();
+  expect(m.region).toBe("Other");
+  expect(faviconUrl(m.domain)).toBeNull();
+});
+
+test("faviconUrl builds a keyless icon URL", () => {
+  expect(faviconUrl("bbc.com", 32)).toBe("https://www.google.com/s2/favicons?domain=bbc.com&sz=32");
+  expect(faviconUrl(null)).toBeNull();
+});
+
+test("sourceInitial gives a stable monogram fallback", () => {
+  expect(sourceInitial("BBC")).toBe("B");
+  expect(sourceInitial("The Guardian")).toBe("G"); // leading "The" dropped
+  expect(sourceInitial("")).toBe("?");
+});

--- a/tests/unit/news-synthesis.test.ts
+++ b/tests/unit/news-synthesis.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { buildSynthesisPrompt, parseSynthesisResponse, synthesisKey } from "@/lib/news/synthesis";
+
+const input = {
+  title: "US strikes Iran",
+  sources: [
+    { source: "BBC", title: "US launches strikes on Iran", description: "Overnight action" },
+    { source: "Al Jazeera", title: "US strikes Iran for a second night" },
+  ],
+};
+
+test("buildSynthesisPrompt lists every source with its headline", () => {
+  const p = buildSynthesisPrompt(input);
+  expect(p).toContain("[BBC] US launches strikes on Iran — Overnight action");
+  expect(p).toContain("[Al Jazeera] US strikes Iran for a second night");
+  expect(p).toContain("consensus");
+  expect(p).toContain("discrepancies");
+});
+
+test("parseSynthesisResponse extracts trimmed content or null", () => {
+  expect(parseSynthesisResponse({ choices: [{ message: { content: "  Consensus text.  " } }] })).toBe("Consensus text.");
+  expect(parseSynthesisResponse({ choices: [] })).toBeNull();
+  expect(parseSynthesisResponse({})).toBeNull();
+  expect(parseSynthesisResponse(null)).toBeNull();
+});
+
+test("synthesisKey is order-independent over sources", () => {
+  const reordered = { title: input.title, sources: [input.sources[1], input.sources[0]] };
+  expect(synthesisKey(input)).toBe(synthesisKey(reordered));
+});

--- a/tests/unit/news-velocity.test.ts
+++ b/tests/unit/news-velocity.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+import { clusterNews } from "@/lib/news/cluster";
+import { clusterVelocity, velocityLabel } from "@/lib/news/velocity";
+import type { NewsItem } from "@/lib/news";
+
+const NOW = 1_700_000_000_000;
+const mk = (title: string, source: string, ageMin: number): NewsItem => ({
+  title,
+  source,
+  url: `https://x/${source}/${ageMin}`,
+  ts: NOW - ageMin * 60_000,
+});
+
+test("clusterVelocity counts distinct sources inside the window", () => {
+  const items = [
+    mk("Major quake hits coastal city", "BBC", 2),
+    mk("Quake hits coastal city hard", "NPR", 5),
+    mk("Coastal city quake kills dozens", "Al Jazeera", 30), // outside 10m window
+  ];
+  const cluster = clusterNews(items)[0];
+  const v = clusterVelocity(cluster, NOW)!;
+  expect(v.recentSources).toBe(2); // BBC + NPR within 10m
+  expect(v.totalSources).toBe(3);
+  expect(v.trending).toBe(true);
+  expect(velocityLabel(v)).toBe("+2 sources in 10m");
+});
+
+test("no recent sources → no label", () => {
+  const items = [mk("Old story about markets", "BBC", 90)];
+  const cluster = clusterNews(items)[0];
+  const v = clusterVelocity(cluster, NOW)!;
+  expect(v.recentSources).toBe(0);
+  expect(velocityLabel(v)).toBeNull();
+});
+
+test("no timestamps → null velocity (honest degrade)", () => {
+  const items: NewsItem[] = [{ title: "Story with no date", source: "BBC", url: "https://x/1", ts: 0 }];
+  const cluster = clusterNews(items)[0];
+  expect(clusterVelocity(cluster, NOW)).toBeNull();
+  expect(velocityLabel(null)).toBeNull();
+});


### PR DESCRIPTION
Turns World Headlines into a power-user monitoring feed.

- **Story clustering** — same-event headlines collapse into mega-cards with source badges (pure Jaccard/overlap similarity, tuned on live data).
- **Source favicons** — keyless Google s2 with monogram fallback.
- **Card <-> table toggle** (persisted), **coverage velocity** ("+N sources in 10m"), and an **interactive timeline** (click an hour to filter the feed).
- **Boolean search** — AND/OR/`-exclude`/"phrase" (pure parser).
- **Region/type facet matrix** (honest source map; no invented political-leaning axis).
- Dormant-safe **cross-source AI synthesis**, **primary-source extraction**, and **updated/correction tracking**.

New `lib/news/*` + `components/news/*`; added DW + France 24 feeds and raised the merge cap for real cross-source material. Verified: `tsc` clean, 669 tests (+32), live-verified end-to-end. No fabricated sources/leanings/velocity.