### PR TITLE
feat(locate): bring /locate into the console as a widget

### DIFF
--- a/app/locate/page.tsx
+++ b/app/locate/page.tsx
@@ -7,12 +7,13 @@
 // reuses lib/basemaps + /api/geocode via the /api/geolocate route. Honest by
 // design — everything is labelled "estimated", with the method and a confidence.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { BASEMAPS } from "@/lib/basemaps";
-import type { GeolocateResponse, ResolvedCandidate, GeolocateMethod } from "@/lib/geolocate/types";
+import { useGeolocate } from "@/lib/geolocate/useGeolocate";
+import type { ResolvedCandidate, GeolocateMethod } from "@/lib/geolocate/types";
 import "./locate.css";
 
 const METHOD_LABEL: Record<GeolocateMethod, string> = {
@@ -21,74 +22,23 @@ const METHOD_LABEL: Record<GeolocateMethod, string> = {
 };
 
 export default function LocatePage() {
-  const [file, setFile] = useState<File | null>(null);
-  const [imageUrl, setImageUrl] = useState("");
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  // The upload → /api/geolocate → ranked-candidates state machine is shared with the
+  // console `locate` widget via useGeolocate; this page keeps its own inset map below.
+  const {
+    imageUrl,
+    previewUrl,
+    loading,
+    error,
+    result,
+    selected,
+    candidates,
+    canLocate,
+    pickFile,
+    onUrlChange,
+    locate,
+    select,
+  } = useGeolocate();
   const [dragging, setDragging] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<GeolocateResponse | null>(null);
-  const [selected, setSelected] = useState<number | null>(null);
-
-  const candidates = result?.candidates ?? [];
-
-  // ---- Image selection -----------------------------------------------------
-  const pickFile = useCallback((f: File | null) => {
-    if (!f) return;
-    setFile(f);
-    setImageUrl("");
-    setResult(null);
-    setError(null);
-    setSelected(null);
-    setPreviewUrl((old) => {
-      if (old?.startsWith("blob:")) URL.revokeObjectURL(old);
-      return URL.createObjectURL(f);
-    });
-  }, []);
-
-  const onUrlChange = useCallback((v: string) => {
-    setImageUrl(v);
-    setFile(null);
-    setResult(null);
-    setError(null);
-    setSelected(null);
-    setPreviewUrl((old) => {
-      if (old?.startsWith("blob:")) URL.revokeObjectURL(old);
-      return v.trim() ? v.trim() : null;
-    });
-  }, []);
-
-  // Revoke any blob URL on unmount.
-  useEffect(() => {
-    return () => {
-      if (previewUrl?.startsWith("blob:")) URL.revokeObjectURL(previewUrl);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // ---- Locate --------------------------------------------------------------
-  const locate = useCallback(async () => {
-    if (!file && !imageUrl.trim()) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
-    setSelected(null);
-    try {
-      const form = new FormData();
-      if (file) form.append("image", file);
-      else form.append("imageUrl", imageUrl.trim());
-
-      const res = await fetch("/api/geolocate", { method: "POST", body: form });
-      const body = (await res.json()) as GeolocateResponse;
-      setResult(body);
-      if (body.error && body.candidates.length === 0) setError(body.error);
-      else if (body.candidates.length > 0) setSelected(0);
-    } catch {
-      setError("Could not reach the geolocation service. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  }, [file, imageUrl]);
 
   return (
     <div className="loc-page">
@@ -116,7 +66,7 @@ export default function LocatePage() {
             pickFile={pickFile}
             locate={locate}
             loading={loading}
-            canLocate={Boolean(file || imageUrl.trim())}
+            canLocate={canLocate}
             method={result?.method}
           />
 
@@ -133,7 +83,7 @@ export default function LocatePage() {
                     c={c}
                     rank={i + 1}
                     active={selected === i}
-                    onClick={() => setSelected(i)}
+                    onClick={() => select(i)}
                   />
                 ))}
               </div>
@@ -141,7 +91,7 @@ export default function LocatePage() {
           )}
         </section>
 
-        <ResultMap candidates={candidates} selected={selected} onSelect={setSelected} />
+        <ResultMap candidates={candidates} selected={selected} onSelect={select} />
       </div>
     </div>
   );

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -112,7 +112,8 @@ export const BUILTIN_PRESETS: ConsolePreset[] = [
   // ── Explorer — relaxed, casual browsing ─────────────────────────────────
   { id: "explorer", title: "Explorer", icon: "🧭", blurb: "casual", build: () => compose("map2d", [
       { type: "cameras", segment: "left" }, { type: "events", segment: "left" },
-      { type: "news", segment: "right" }, { type: "headlines", segment: "bottom" },
+      { type: "news", segment: "right" }, { type: "locate", segment: "right" },
+      { type: "headlines", segment: "bottom" },
   ]) },
 ];
 

--- a/lib/console/widgets/index.ts
+++ b/lib/console/widgets/index.ts
@@ -6,5 +6,6 @@ import "@/lib/console/widgets/news";
 import "@/lib/console/widgets/satellites";
 import "@/lib/console/widgets/markets";
 import "@/lib/console/widgets/headlines";
+import "@/lib/console/widgets/locate";
 // Registers one generic monitor widget per global signal source (≈30 layers).
 import "@/lib/console/widgets/signals";

--- a/lib/console/widgets/locate.css
+++ b/lib/console/widgets/locate.css
@@ -1,0 +1,169 @@
+/* ===========================================================================
+   Locate widget — photo geolocation card + focus view. Widget-scoped styles only
+   (imported by lib/console/widgets/locate.tsx). Reuses the calm-LIGHT design tokens
+   from globals.css (--tn-*); adds nothing to the global sheet.
+   =========================================================================== */
+
+/* ---- Compact card ---- */
+.tnl { display: flex; flex-direction: column; gap: 8px; }
+
+.tnl-drop {
+  border: 1.5px dashed var(--tn-border-strong);
+  border-radius: 10px;
+  background: var(--tn-surface-2);
+  padding: 14px 12px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.tnl-drop:hover { border-color: var(--tn-accent); }
+.tnl-drop.is-drag { border-color: var(--tn-accent); background: var(--tn-accent-soft); }
+.tnl-drop p { margin: 2px 0; font-size: 12.5px; color: var(--tn-text-muted); }
+.tnl-drop strong { color: var(--tn-text); font-weight: 600; }
+.tnl-hint { font-size: 11px !important; color: var(--tn-text-faint) !important; }
+
+.tnl-thumb {
+  display: block;
+  width: 100%;
+  max-height: 120px;
+  object-fit: contain;
+  border-radius: 8px;
+  background: var(--tn-surface-solid);
+}
+
+.tnl-controls { display: flex; gap: 8px; align-items: center; }
+.tnl-url {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 9px;
+  border: 1px solid var(--tn-border-strong);
+  border-radius: 8px;
+  background: var(--tn-surface-solid);
+  color: var(--tn-text);
+  font-size: 12.5px;
+  font-family: inherit;
+}
+.tnl-url:focus { outline: 2px solid var(--tn-accent-soft); border-color: var(--tn-accent); }
+
+.tnl-btn {
+  appearance: none;
+  border: 1px solid var(--tn-accent);
+  background: var(--tn-accent);
+  color: #fff;
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 7px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  white-space: nowrap;
+}
+.tnl-btn:hover { background: var(--tn-accent-strong); border-color: var(--tn-accent-strong); }
+.tnl-btn:disabled { opacity: 0.5; cursor: default; }
+.tnl-btn-ghost { background: transparent; color: var(--tn-text-muted); border-color: var(--tn-border-strong); }
+.tnl-btn-ghost:hover { background: var(--tn-surface-2); color: var(--tn-text); border-color: var(--tn-border-strong); }
+
+.tnl-error {
+  font-size: 12px;
+  color: var(--tn-down);
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.2);
+  border-radius: 8px;
+  padding: 7px 9px;
+  line-height: 1.4;
+}
+.tnl-note {
+  font-size: 11px;
+  color: var(--tn-text-muted);
+  background: var(--tn-accent-soft);
+  border-radius: 8px;
+  padding: 7px 9px;
+  line-height: 1.4;
+}
+
+.tnl-results { display: flex; flex-direction: column; gap: 6px; }
+.tnl-cand {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  gap: 9px;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  background: var(--tn-surface-solid);
+  border: 1px solid var(--tn-border);
+  border-radius: 9px;
+  padding: 7px 10px;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.tnl-cand:hover { border-color: var(--tn-accent); }
+.tnl-cand.is-active { border-color: var(--tn-accent); box-shadow: 0 0 0 2px var(--tn-accent-soft); }
+
+.tnl-rank {
+  display: grid;
+  place-items: center;
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--tn-accent);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  font-family: var(--tn-mono);
+}
+.tnl-cand-main { min-width: 0; }
+.tnl-cand-place { font-size: 13px; font-weight: 600; }
+.tnl-cand-sub { font-size: 11.5px; color: var(--tn-text-muted); }
+.tnl-conf { font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums; }
+
+/* ---- Focus / detail view ---- */
+.tnl-detail { display: flex; flex-direction: column; gap: 14px; padding: 4px 2px; }
+.tnl-d-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+.tnl-d-title { font-size: 15px; font-weight: 650; letter-spacing: -0.01em; }
+.tnl-d-sub { font-size: 12px; color: var(--tn-text-muted); max-width: 60ch; margin-top: 2px; }
+.tnl-d-method { font-size: 11.5px; color: var(--tn-text-faint); white-space: nowrap; }
+
+.tnl-d-grid { display: grid; grid-template-columns: minmax(300px, 400px) 1fr; gap: 16px; align-items: start; }
+@media (max-width: 820px) { .tnl-d-grid { grid-template-columns: 1fr; } }
+
+.tnl-d-panel { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+.tnl-drop-lg { padding: 26px 16px; border-radius: 12px; }
+.tnl-drop-lg p { margin: 5px 0; font-size: 13px; }
+.tnl-thumb-lg { max-height: 260px; }
+
+.tnl-cand-lg { grid-template-columns: 26px 1fr auto; padding: 9px 12px; }
+.tnl-cand-lg .tnl-rank { width: 26px; height: 26px; font-size: 13px; }
+.tnl-cand-place { display: inline; }
+.tnl-cand-reason { display: block; font-size: 11.5px; color: var(--tn-text-faint); margin-top: 3px; line-height: 1.35; }
+.tnl-conf-col { text-align: right; }
+.tnl-conf-col .tnl-conf { font-size: 14px; }
+.tnl-conf-bar { width: 56px; height: 4px; border-radius: 2px; background: var(--tn-chip-bg); margin-top: 4px; overflow: hidden; }
+.tnl-conf-fill { display: block; height: 100%; background: var(--tn-accent); border-radius: 2px; }
+
+.tnl-d-map { position: relative; display: flex; flex-direction: column; gap: 8px; }
+.tnl-d-map-empty {
+  border: 1px solid var(--tn-border);
+  border-radius: 12px;
+  background: var(--tn-surface-2);
+  min-height: 200px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: var(--tn-text-faint);
+  font-size: 13px;
+  padding: 24px;
+}
+.tnl-d-export { display: flex; gap: 8px; }
+.tnl-d-export button {
+  appearance: none;
+  border: 1px solid var(--tn-border-strong);
+  background: var(--tn-surface-solid);
+  color: var(--tn-text-muted);
+  font-size: 12px;
+  font-family: inherit;
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.tnl-d-export button:hover { border-color: var(--tn-accent); color: var(--tn-text); }

--- a/lib/console/widgets/locate.detail.tsx
+++ b/lib/console/widgets/locate.detail.tsx
@@ -1,0 +1,195 @@
+"use client";
+// Locate focus view — the photo-geolocation console. Same upload → /api/geolocate flow
+// as the compact card (shared useGeolocate hook), opened up: a large drop zone + image
+// preview, a self-contained overview InsetMap that pins every estimate, a ranked list
+// with confidence bars + the model's reasoning, and a CSV / GeoJSON export of the hits.
+// Selecting a candidate flies BOTH the overview map (its own fit) and the shared globe
+// (mapViewStore.flyToPoint). Honest throughout — results are labelled estimates.
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { WidgetDetailProps } from "@/lib/console/registry";
+import { useGeolocate } from "@/lib/geolocate/useGeolocate";
+import { mapViewStore } from "@/lib/mapView";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
+import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
+import "./locate.css";
+
+// Photo geolocation is coarse — land the globe at a regional zoom, not street level.
+const FLY_ZOOM = 9;
+
+const METHOD_LABEL: Record<string, string> = {
+  "vision-ai": "vision-AI estimate",
+  "geo-model": "open geo-model (GeoCLIP)",
+};
+
+export default function LocateDetail(_props: WidgetDetailProps) {
+  const g = useGeolocate();
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { candidates, selected } = g;
+
+  // Fly the shared globe to the top estimate as soon as a fresh result lands.
+  useEffect(() => {
+    const top = candidates[0];
+    if (g.result && top) mapViewStore.flyToPoint({ lat: top.lat, lon: top.lon, zoom: FLY_ZOOM });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [g.result]);
+
+  const choose = (i: number) => {
+    g.select(i);
+    const c = candidates[i];
+    if (c) mapViewStore.flyToPoint({ lat: c.lat, lon: c.lon, zoom: FLY_ZOOM });
+  };
+
+  const points: InsetPoint[] = useMemo(
+    () => candidates.map((c, i) => ({ lat: c.lat, lon: c.lon, id: String(i), props: { name: c.place } })),
+    [candidates],
+  );
+
+  const exportRows = useMemo(
+    () => candidates.map((c, i) => ({
+      rank: i + 1,
+      place: c.place || "Unnamed location",
+      country: c.country ?? "",
+      lat: c.lat,
+      lon: c.lon,
+      confidence: c.confidence,
+    })),
+    [candidates],
+  );
+  const exportGeo = useMemo(
+    () => candidates.map((c) => ({
+      lat: c.lat,
+      lon: c.lon,
+      properties: { place: c.place, country: c.country ?? "", confidence: c.confidence },
+    })),
+    [candidates],
+  );
+
+  return (
+    <div className="tnl-detail">
+      <header className="tnl-d-head">
+        <div>
+          <div className="tnl-d-title">Photo geolocation</div>
+          <div className="tnl-d-sub">
+            Estimate where a photo was taken from its visual cues. Results are estimates, not GPS truth.
+          </div>
+        </div>
+        {g.method && <span className="tnl-d-method">{METHOD_LABEL[g.method] ?? g.method}</span>}
+      </header>
+
+      <div className="tnl-d-grid">
+        <section className="tnl-d-panel">
+          <div
+            className={`tnl-drop tnl-drop-lg${dragging ? " is-drag" : ""}`}
+            role="button"
+            tabIndex={0}
+            onClick={() => inputRef.current?.click()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
+            }}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDragging(true);
+            }}
+            onDragLeave={() => setDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setDragging(false);
+              const f = e.dataTransfer.files?.[0];
+              if (f && f.type.startsWith("image/")) g.pickFile(f);
+            }}
+          >
+            {g.previewUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img className="tnl-thumb tnl-thumb-lg" src={g.previewUrl} alt="Photo to geolocate" />
+            ) : (
+              <>
+                <p><strong>Drop a photo here</strong> or click to choose</p>
+                <p className="tnl-hint">JPEG / PNG / WebP · stays on the server, never stored</p>
+              </>
+            )}
+            <input
+              ref={inputRef}
+              type="file"
+              accept="image/*"
+              hidden
+              onChange={(e) => g.pickFile(e.target.files?.[0] ?? null)}
+            />
+          </div>
+
+          <div className="tnl-controls">
+            <input
+              className="tnl-url"
+              type="url"
+              placeholder="…or paste an image URL"
+              value={g.imageUrl}
+              onChange={(e) => g.onUrlChange(e.target.value)}
+            />
+            <button className="tnl-btn" onClick={g.locate} disabled={!g.canLocate || g.loading}>
+              {g.loading ? "Locating…" : "Locate"}
+            </button>
+            {(g.canLocate || candidates.length > 0) && (
+              <button className="tnl-btn tnl-btn-ghost" onClick={g.reset} disabled={g.loading}>
+                Clear
+              </button>
+            )}
+          </div>
+
+          {g.error && <div className="tnl-error">{g.error}</div>}
+          {g.note && candidates.length > 0 && <div className="tnl-note">{g.note}</div>}
+
+          {candidates.length > 0 && (
+            <div className="tnl-results">
+              {candidates.map((c, i) => {
+                const pct = Math.round(c.confidence * 100);
+                return (
+                  <button
+                    key={`${c.lat},${c.lon},${i}`}
+                    className={`tnl-cand tnl-cand-lg${selected === i ? " is-active" : ""}`}
+                    onClick={() => choose(i)}
+                    title="Fly the map here"
+                  >
+                    <span className="tnl-rank">{i + 1}</span>
+                    <span className="tnl-cand-main">
+                      <span className="tnl-cand-place">{c.place || "Unnamed location"}</span>
+                      {c.country && <span className="tnl-cand-sub"> · {c.country}</span>}
+                      <span className="tnl-cand-sub tn-num"> ({c.lat.toFixed(3)}, {c.lon.toFixed(3)})</span>
+                      {c.reasoning && <span className="tnl-cand-reason">{c.reasoning}</span>}
+                    </span>
+                    <span className="tnl-conf-col">
+                      <span className="tnl-conf tn-num">{pct}%</span>
+                      <span className="tnl-conf-bar"><span className="tnl-conf-fill" style={{ width: `${pct}%` }} /></span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {candidates.length === 0 && !g.loading && !g.error && (
+            <p className="tn-w-empty">Drop or link a photo to estimate where it was taken.</p>
+          )}
+        </section>
+
+        <section className="tnl-d-map">
+          {points.length > 0 ? (
+            <InsetMap points={points} height={360} onSelect={(id) => choose(Number(id))} />
+          ) : (
+            <div className="tnl-d-map-empty">Estimated locations will appear here as pins.</div>
+          )}
+          {candidates.length > 0 && (
+            <div className="tnl-d-export">
+              <button
+                onClick={() => downloadText(`${exportFilename("locate", Date.now())}.csv`, "text/csv", toCsv(exportRows))}
+              >⬇ CSV</button>
+              <button
+                onClick={() => downloadText(`${exportFilename("locate", Date.now())}.geojson`, "application/geo+json", toGeoJson(exportGeo))}
+              >⬇ GeoJSON</button>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/lib/console/widgets/locate.tsx
+++ b/lib/console/widgets/locate.tsx
@@ -1,0 +1,164 @@
+"use client";
+/**
+ * Locate widget — photo geolocation on the console. Drop / link a photo and it
+ * estimates WHERE it was taken (the same keyless "picarta.ai" flow as the /locate
+ * route, via POST /api/geolocate), then plots ranked candidates by flying the SHARED
+ * globe to them (mapViewStore.flyToPoint) instead of spinning up a second map. Honest
+ * by design — every hit is labelled an estimate with the model's own confidence.
+ *
+ * All the upload → locate state lives in the shared useGeolocate hook (reused by the
+ * page and the focus view); this file is just the compact card. The richer focus view
+ * with an overview map + confidence bars lives in ./locate.detail.
+ */
+import { useEffect, useRef, useState } from "react";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { useGeolocate } from "@/lib/geolocate/useGeolocate";
+import { mapViewStore } from "@/lib/mapView";
+import type { ResolvedCandidate } from "@/lib/geolocate/types";
+import LocateDetail from "./locate.detail";
+import "./locate.css";
+
+/** Fly the shared globe to an estimated candidate. Photo geolocation is coarse, so
+ *  land at a regional zoom rather than street level. */
+export function flyToCandidate(c: ResolvedCandidate): void {
+  mapViewStore.flyToPoint({ lat: c.lat, lon: c.lon, zoom: 9 });
+}
+
+function LocateBody(_props: WidgetBodyProps) {
+  const g = useGeolocate();
+  const report = useWidgetReport();
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { candidates, selected } = g;
+
+  // Report count + an export payload (CSV / GeoJSON of the estimates) to the frame.
+  useEffect(() => {
+    report({
+      alerts: [],
+      count: candidates.length,
+      freshLabel: candidates.length ? "estimate" : undefined,
+      export: {
+        name: "locate",
+        rows: candidates.map((c, i) => ({
+          rank: i + 1,
+          place: c.place || "Unnamed location",
+          country: c.country ?? "",
+          lat: c.lat,
+          lon: c.lon,
+          confidence: c.confidence,
+        })),
+        geo: candidates.map((c) => ({
+          lat: c.lat,
+          lon: c.lon,
+          properties: { place: c.place, country: c.country ?? "", confidence: c.confidence },
+        })),
+      },
+    });
+  }, [candidates, report]);
+
+  // Fly the globe to the top estimate as soon as a fresh result lands.
+  useEffect(() => {
+    if (g.result && candidates.length > 0) flyToCandidate(candidates[0]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [g.result]);
+
+  const choose = (i: number) => {
+    g.select(i);
+    const c = candidates[i];
+    if (c) flyToCandidate(c);
+  };
+
+  return (
+    <div className="tnl">
+      <div
+        className={`tnl-drop${dragging ? " is-drag" : ""}`}
+        role="button"
+        tabIndex={0}
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          const f = e.dataTransfer.files?.[0];
+          if (f && f.type.startsWith("image/")) g.pickFile(f);
+        }}
+      >
+        {g.previewUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img className="tnl-thumb" src={g.previewUrl} alt="Photo to geolocate" />
+        ) : (
+          <p><strong>Drop a photo</strong> or click to choose</p>
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => g.pickFile(e.target.files?.[0] ?? null)}
+        />
+      </div>
+
+      <div className="tnl-controls">
+        <input
+          className="tnl-url"
+          type="url"
+          placeholder="…or paste an image URL"
+          value={g.imageUrl}
+          onChange={(e) => g.onUrlChange(e.target.value)}
+        />
+        <button className="tnl-btn" onClick={g.locate} disabled={!g.canLocate || g.loading}>
+          {g.loading ? "Locating…" : "Locate"}
+        </button>
+      </div>
+
+      {g.error && <div className="tnl-error">{g.error}</div>}
+
+      {candidates.length > 0 && (
+        <div className="tnl-results">
+          {candidates.map((c, i) => (
+            <button
+              key={`${c.lat},${c.lon},${i}`}
+              className={`tnl-cand${selected === i ? " is-active" : ""}`}
+              onClick={() => choose(i)}
+              title="Fly the map here"
+            >
+              <span className="tnl-rank">{i + 1}</span>
+              <span className="tnl-cand-main">
+                <span className="tnl-cand-place">{c.place || "Unnamed location"}</span>
+                {c.country && <span className="tnl-cand-sub"> · {c.country}</span>}
+              </span>
+              <span className="tnl-conf tn-num">{Math.round(c.confidence * 100)}%</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {candidates.length === 0 && !g.loading && !g.error && (
+        <p className="tn-w-empty">Drop or link a photo to estimate where it was taken.</p>
+      )}
+
+      {g.note && candidates.length > 0 && <div className="tnl-note">{g.note}</div>}
+    </div>
+  );
+}
+
+export const LOCATE_WIDGET = {
+  id: "locate",
+  title: "Locate",
+  icon: "📍",
+  category: "Tools",
+  defaultHeight: 320,
+  defaultConfig: {},
+  component: LocateBody,
+  detail: LocateDetail,
+};
+registerWidget(LOCATE_WIDGET);

--- a/lib/geolocate/response.ts
+++ b/lib/geolocate/response.ts
@@ -1,0 +1,58 @@
+// Pure, defensive parsing of the /api/geolocate JSON body — client-side twin of the
+// route's own normalisation. The API route already returns a clean GeolocateResponse,
+// but the console widget and the /locate page both fetch it over the wire, where a
+// dormant backend, a proxy error page, or a truncated body could hand back anything.
+// Coercing here (never `as GeolocateResponse`) keeps the UI dormant-safe: a malformed
+// body resolves to zero candidates + a labelled note, never a throw or a bad pin.
+//
+// Nothing in this file performs I/O — it is unit-tested with zero network.
+
+import { clampConfidence, isValidCoord } from "./normalize";
+import type { GeolocateMethod, GeolocateResponse, ResolvedCandidate } from "./types";
+
+const METHODS: GeolocateMethod[] = ["vision-ai", "geo-model"];
+
+/** Trimmed non-empty string, or undefined. */
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v.trim() : undefined;
+}
+
+/** Coerce one wire row into a plottable ResolvedCandidate, or null if it has no
+ *  valid coordinates (an un-plottable row is dropped rather than faked to 0,0). */
+export function toResolvedCandidate(row: unknown): ResolvedCandidate | null {
+  if (!row || typeof row !== "object") return null;
+  const r = row as Record<string, unknown>;
+  const lat = r.lat;
+  const lon = r.lon;
+  if (!isValidCoord(lat, lon)) return null;
+  return {
+    place: str(r.place) ?? "",
+    country: str(r.country),
+    lat: lat as number,
+    lon: lon as number,
+    confidence: clampConfidence(r.confidence),
+    reasoning: str(r.reasoning),
+  };
+}
+
+/**
+ * Coerce an arbitrary fetched body into a safe GeolocateResponse. Total and pure —
+ * never throws. Unknown/absent methods fall back to "vision-ai" (the default backend);
+ * only candidates with in-range coordinates survive; error/note pass through when present.
+ */
+export function parseGeolocateResponse(body: unknown): GeolocateResponse {
+  const b = (body && typeof body === "object" ? body : {}) as Record<string, unknown>;
+  const list = Array.isArray(b.candidates) ? b.candidates : [];
+  const candidates = list
+    .map(toResolvedCandidate)
+    .filter((c): c is ResolvedCandidate => c !== null);
+  const method: GeolocateMethod = METHODS.includes(b.method as GeolocateMethod)
+    ? (b.method as GeolocateMethod)
+    : "vision-ai";
+  return {
+    candidates,
+    method,
+    error: str(b.error),
+    note: str(b.note),
+  };
+}

--- a/lib/geolocate/useGeolocate.ts
+++ b/lib/geolocate/useGeolocate.ts
@@ -1,0 +1,132 @@
+"use client";
+// Shared photo-geolocation state machine. Factored out of app/locate/page.tsx so the
+// standalone /locate route, the console `locate` widget, and its focus view all drive
+// the exact same upload → POST /api/geolocate → ranked-candidates flow from one place.
+//
+// Deliberately map-agnostic: the hook resolves candidates but never touches a map, so
+// each caller decides what to do with a selection (the page pins its own inset map; the
+// widget flies the shared globe via mapViewStore.flyToPoint). Dormant-safe — a failed or
+// malformed response resolves to an inline error, never a throw.
+
+import { useCallback, useEffect, useState } from "react";
+import { parseGeolocateResponse } from "./response";
+import type { GeolocateMethod, GeolocateResponse, ResolvedCandidate } from "./types";
+
+export interface UseGeolocate {
+  file: File | null;
+  imageUrl: string;
+  previewUrl: string | null;
+  loading: boolean;
+  error: string | null;
+  result: GeolocateResponse | null;
+  selected: number | null;
+  candidates: ResolvedCandidate[];
+  method?: GeolocateMethod;
+  note?: string;
+  canLocate: boolean;
+  pickFile: (f: File | null) => void;
+  onUrlChange: (v: string) => void;
+  locate: () => Promise<void>;
+  select: (i: number | null) => void;
+  reset: () => void;
+}
+
+export function useGeolocate(): UseGeolocate {
+  const [file, setFile] = useState<File | null>(null);
+  const [imageUrl, setImageUrl] = useState("");
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<GeolocateResponse | null>(null);
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const candidates = result?.candidates ?? [];
+
+  const pickFile = useCallback((f: File | null) => {
+    if (!f) return;
+    setFile(f);
+    setImageUrl("");
+    setResult(null);
+    setError(null);
+    setSelected(null);
+    setPreviewUrl((old) => {
+      if (old?.startsWith("blob:")) URL.revokeObjectURL(old);
+      return URL.createObjectURL(f);
+    });
+  }, []);
+
+  const onUrlChange = useCallback((v: string) => {
+    setImageUrl(v);
+    setFile(null);
+    setResult(null);
+    setError(null);
+    setSelected(null);
+    setPreviewUrl((old) => {
+      if (old?.startsWith("blob:")) URL.revokeObjectURL(old);
+      return v.trim() ? v.trim() : null;
+    });
+  }, []);
+
+  // Revoke any blob URL on unmount.
+  useEffect(() => {
+    return () => {
+      if (previewUrl?.startsWith("blob:")) URL.revokeObjectURL(previewUrl);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const locate = useCallback(async () => {
+    if (!file && !imageUrl.trim()) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setSelected(null);
+    try {
+      const form = new FormData();
+      if (file) form.append("image", file);
+      else form.append("imageUrl", imageUrl.trim());
+
+      const res = await fetch("/api/geolocate", { method: "POST", body: form });
+      const body = parseGeolocateResponse(await res.json());
+      setResult(body);
+      if (body.candidates.length > 0) setSelected(0);
+      else if (body.error) setError(body.error);
+      else setError("No location could be estimated from this image.");
+    } catch {
+      setError("Could not reach the geolocation service. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [file, imageUrl]);
+
+  const reset = useCallback(() => {
+    setFile(null);
+    setImageUrl("");
+    setResult(null);
+    setError(null);
+    setSelected(null);
+    setPreviewUrl((old) => {
+      if (old?.startsWith("blob:")) URL.revokeObjectURL(old);
+      return null;
+    });
+  }, []);
+
+  return {
+    file,
+    imageUrl,
+    previewUrl,
+    loading,
+    error,
+    result,
+    selected,
+    candidates,
+    method: result?.method,
+    note: result?.note,
+    canLocate: Boolean(file || imageUrl.trim()),
+    pickFile,
+    onUrlChange,
+    locate,
+    select: setSelected,
+    reset,
+  };
+}

--- a/tests/unit/console-presets.test.ts
+++ b/tests/unit/console-presets.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 import { BUILTIN_PRESETS, DEFAULT_PRESET_ID } from "@/lib/console/presets";
 import { SIGNALS } from "@/lib/signals/registry";
 
-const CORE_WIDGETS = new Set(["events", "news", "cameras", "aviation", "satellites", "markets", "headlines"]);
+const CORE_WIDGETS = new Set(["events", "news", "cameras", "aviation", "satellites", "markets", "headlines", "locate"]);
 const SIGNAL_WIDGETS = new Set(SIGNALS.map((s) => `signal:${s.id}`));
 
 // The persona lineup: one preset per major user type. Ids are stable (used by the

--- a/tests/unit/geolocate-response.test.ts
+++ b/tests/unit/geolocate-response.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { parseGeolocateResponse, toResolvedCandidate } from "@/lib/geolocate/response";
+
+describe("toResolvedCandidate", () => {
+  test("maps a valid row and clamps a percentage confidence", () => {
+    const c = toResolvedCandidate({
+      place: "Shibuya, Tokyo",
+      country: "Japan",
+      lat: 35.6595,
+      lon: 139.7005,
+      confidence: 78,
+      reasoning: "Japanese signage",
+    });
+    expect(c).not.toBeNull();
+    expect(c!.place).toBe("Shibuya, Tokyo");
+    expect(c!.country).toBe("Japan");
+    expect(c!.lat).toBeCloseTo(35.6595);
+    expect(c!.confidence).toBeCloseTo(0.78);
+    expect(c!.reasoning).toBe("Japanese signage");
+  });
+
+  test("defaults a missing place to empty string and drops empty extras", () => {
+    const c = toResolvedCandidate({ lat: 0, lon: 0, confidence: 0.2, country: "  ", reasoning: "" });
+    expect(c!.place).toBe("");
+    expect(c!.country).toBeUndefined();
+    expect(c!.reasoning).toBeUndefined();
+  });
+
+  test("returns null for out-of-range or missing coordinates", () => {
+    expect(toResolvedCandidate({ place: "X", lat: 999, lon: 5, confidence: 0.3 })).toBeNull();
+    expect(toResolvedCandidate({ place: "X", confidence: 0.3 })).toBeNull();
+    expect(toResolvedCandidate(null)).toBeNull();
+    expect(toResolvedCandidate("nope")).toBeNull();
+  });
+});
+
+describe("parseGeolocateResponse", () => {
+  test("parses a well-formed body, keeping only plottable candidates", () => {
+    const out = parseGeolocateResponse({
+      method: "geo-model",
+      note: "Estimated location — not a measurement.",
+      candidates: [
+        { place: "Paris", lat: 48.85, lon: 2.35, confidence: 0.9 },
+        { place: "Broken", lat: 200, lon: 2, confidence: 0.4 },
+      ],
+    });
+    expect(out.method).toBe("geo-model");
+    expect(out.note).toContain("Estimated");
+    expect(out.candidates.map((c) => c.place)).toEqual(["Paris"]);
+  });
+
+  test("falls back to vision-ai for an unknown/absent method", () => {
+    expect(parseGeolocateResponse({ candidates: [] }).method).toBe("vision-ai");
+    expect(parseGeolocateResponse({ method: "bogus", candidates: [] }).method).toBe("vision-ai");
+  });
+
+  test("passes an error message through and yields no candidates", () => {
+    const out = parseGeolocateResponse({ candidates: [], method: "vision-ai", error: "No backend is configured." });
+    expect(out.error).toBe("No backend is configured.");
+    expect(out.candidates).toEqual([]);
+  });
+
+  test("tolerates a non-object / empty / junk body without throwing", () => {
+    for (const junk of [null, undefined, "<html>502</html>", 42, [], { candidates: "nope" }]) {
+      const out = parseGeolocateResponse(junk);
+      expect(out.candidates).toEqual([]);
+      expect(out.method).toBe("vision-ai");
+      expect(out.error).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Brings the `/locate` photo-geolocation flow into the console as a registered `locate` widget (compact + focus view), reusing the shared globe (`mapViewStore.flyToPoint`) rather than embedding a second map.

- Extracts a shared `useGeolocate` hook + pure `parseGeolocateResponse` so the page, widget, and detail run the same upload -> `/api/geolocate` -> ranked-candidates flow.
- Registered via the existing `registerWidget` pattern (id `locate`, 📍, Tools); the ⌘K "Add Locate" command auto-derives; added to the Explorer persona. The `/locate` route still works.

New `lib/geolocate/*`, `lib/console/widgets/locate*`. Verified: `tsc` clean, 644 tests (+7), full `next build` passes. Dormant-safe when the geolocate backend is unconfigured.