### PR TITLE
feat(shell): drop the visible live-pulse from the navbar; rebrand tit…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -95,7 +95,7 @@ a { color: var(--tn-accent); }
   border-bottom: 1px solid var(--tn-border);
   color: var(--tn-text);
 }
-.tn-topbar-left { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.tn-topbar-left { display: flex; align-items: center; gap: 10px; min-width: 0; flex: 1; }
 .tn-wordmark { font-size: 16px; font-weight: 700; letter-spacing: -0.01em; }
 .tn-wordmark-accent { color: var(--tn-accent); }
 .tn-tagline { font-size: 11.5px; color: var(--tn-text-faint); white-space: nowrap; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,13 +2,13 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "World Monitor — live global situational-awareness map",
+  title: "OpenData — live global situational-awareness map",
   description:
     "A live satellite globe of the world's cameras, aircraft, satellites and global signals — hazards, conflict, infrastructure, markets and news on one map.",
-  applicationName: "World Monitor",
+  applicationName: "OpenData",
   // app/manifest.ts is auto-linked by Next; this is the explicit reference.
   manifest: "/manifest.webmanifest",
-  appleWebApp: { capable: true, title: "World Monitor", statusBarStyle: "default" },
+  appleWebApp: { capable: true, title: "OpenData", statusBarStyle: "default" },
   icons: {
     icon: [
       { url: "/icons/icon-192.png", sizes: "192x192", type: "image/png" },

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -6,8 +6,8 @@ import type { MetadataRoute } from "next";
 // app. Icons are the committed globe marks under public/icons (see scripts/gen-icons.mjs).
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "World Monitor — live global intelligence",
-    short_name: "World Monitor",
+    name: "OpenData — live global intelligence",
+    short_name: "OpenData",
     description:
       "A calm live globe of the world's cameras, planes, satellites and global signals — hazards, conflict, infrastructure and markets.",
     id: "/",

--- a/components/shell/StatusBar.tsx
+++ b/components/shell/StatusBar.tsx
@@ -1,99 +1,28 @@
 "use client";
 // Top status bar — the global chrome that recedes while the map stays the hero.
 //
-// Layout (left → right):
-//   Brand (OpenData)  ·  live-data pulse  ·  [ central board pill ]  ·  ⌘K | profile | settings
+// Layout (left → right):  OpenData wordmark · [ central board pill ] · ⌘K | settings | profile
 //
-// The map-view controls (3D/2D + basemap) moved onto the map itself (see
-// components/console/MapControls.tsx); language, theme and layout-sharing moved into
-// the Settings drawer (opened from the gear). What remains in the bar is identity
-// (brand + profile), the single central board switcher, and the ⌘K entry point — a
-// far calmer header than the old variant-pill + basemap + utility pile.
+// The live-data pulse (camera/plane/sat counts) was removed from the visible bar for
+// calm; the canonical machine-readable count line survives as a visually-hidden span
+// (kept for the e2e smoke test + screen readers). Map-view controls live on the map;
+// language / theme / share / Telegram live in the Settings drawer.
 
 import { useState } from "react";
 import { useMetrics } from "@/lib/metrics";
-import { useFreshness, classifyFreshness, type FreshState } from "@/lib/freshness";
-import { useNow } from "@/lib/shell/useNow";
-import { useT } from "@/lib/i18n/store";
-import type { StringKey } from "@/lib/i18n/catalog";
 import PresetPill from "@/components/shell/PresetPill";
 import ProfileMenu from "@/components/shell/ProfileMenu";
 import SettingsPanel from "@/components/shell/SettingsPanel";
 
-type Health = { labelKey: StringKey; tone: "live" | "degraded" | "down" | "connecting" };
-
-function deriveHealth(states: FreshState[]): Health {
-  if (states.some((s) => s === "down" || s === "stale")) return { labelKey: "healthDegraded", tone: "degraded" };
-  if (states.every((s) => s === "unknown")) return { labelKey: "healthConnecting", tone: "connecting" };
-  if (states.some((s) => s === "lagging")) return { labelKey: "healthLagging", tone: "degraded" };
-  return { labelKey: "healthLive", tone: "live" };
-}
-
-/** Compact thousands formatter: 13456 → "13.5k", small numbers pass through unchanged. */
-function fmtCount(n: number): string {
-  if (n >= 10_000) return `${(n / 1_000).toFixed(1)}k`;
-  return n.toLocaleString();
-}
-
-/**
- * Single-line live-data pulse: camera online/total, plane count, satellite count, and
- * a health dot on one baseline — glanceable at desktop widths, hidden on mobile.
- */
-function LivePulse({
-  camerasOnline,
-  camerasTotal,
-  planes,
-  satellites,
-  health,
-  t,
-}: {
-  camerasOnline: number;
-  camerasTotal: number;
-  planes: number;
-  satellites: number;
-  health: Health;
-  t: (k: StringKey) => string;
-}) {
-  return (
-    <div className="tn-top-pulse" aria-label="Live data counts">
-      <span className="tn-top-pulse-item tn-num" title={t("metricCamerasOnline")}>
-        {camerasTotal ? `${fmtCount(camerasOnline)} / ${fmtCount(camerasTotal)}` : "—"}
-        <span className="tn-top-pulse-lbl">cam</span>
-      </span>
-      <span className="tn-top-pulse-dot" aria-hidden />
-      <span className="tn-top-pulse-item tn-num" title={t("metricPlanes")}>
-        {fmtCount(planes)}
-        <span className="tn-top-pulse-lbl">{t("metricPlanes")}</span>
-      </span>
-      <span className="tn-top-pulse-dot" aria-hidden />
-      <span className="tn-top-pulse-item tn-num" title={t("metricSatellites")}>
-        {fmtCount(satellites)}
-        <span className="tn-top-pulse-lbl">sat</span>
-      </span>
-      <span
-        className={`tn-top-health-badge tn-top-health-${health.tone}`}
-        title={t(health.labelKey)}
-        aria-label={t(health.labelKey)}
-        role="img"
-      />
-    </div>
-  );
-}
-
 export default function StatusBar({ onOpenPalette }: { onOpenPalette: () => void }) {
   const m = useMetrics();
-  const fresh = useFreshness();
-  const t = useT();
-  const now = useNow(5000); // re-evaluate health a couple of times per minute
-  const health = deriveHealth(fresh.map((r) => classifyFreshness(r, now)));
-
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   return (
     <>
       <header className="tn-topbar" role="banner">
         {/* Canonical machine-readable pulse — visually hidden, kept for the e2e smoke
-            test and screen readers; the visible LivePulse below mirrors it. */}
+            test and screen readers. */}
         <span data-testid="stat-line" className="tn-sr-only">
           {m.camerasTotal.toLocaleString()} cameras · {m.planes.toLocaleString()} planes ·{" "}
           {m.satellites.toLocaleString()} satellites
@@ -106,24 +35,11 @@ export default function StatusBar({ onOpenPalette }: { onOpenPalette: () => void
           </span>
         </div>
 
-        {/* ── Live data pulse (grows to fill remaining space) ─────────────── */}
-        <div className="tn-topbar-metrics">
-          <LivePulse
-            camerasOnline={m.camerasOnline}
-            camerasTotal={m.camerasTotal}
-            planes={m.planes}
-            satellites={m.satellites}
-            health={health}
-            t={t}
-          />
-        </div>
-
         {/* ── Central board switcher (absolutely centred over the bar) ─────── */}
         <PresetPill />
 
         {/* ── Entry points + identity ──────────────────────────────────────── */}
-        {/* ⌘K · Settings · Profile — the avatar sits at the very edge, with the
-            settings gear and ⌘K to its left. */}
+        {/* ⌘K · Settings · Profile — the avatar sits at the very edge. */}
         <div className="tn-topbar-right">
           <button
             type="button"


### PR DESCRIPTION
…le to OpenData

Remove the camera/plane/sat pulse from the top bar for calm (the hidden stat-line span stays for the e2e smoke test + screen readers); the right cluster now rides to the edge via flex on the brand. Rename the document title / applicationName / PWA manifest from World Monitor to OpenData.