### PR TITLE
feat(map): central place search + droppable pins with a pin navigator

### DIFF
--- a/app/api/geocode/route.ts
+++ b/app/api/geocode/route.ts
@@ -8,6 +8,7 @@ export const dynamic = "force-dynamic";
 // safe: any upstream failure returns an empty result set, never a 5xx, so a flaky
 // community geocoder can never crash the search box.
 const PHOTON = "https://photon.komoot.io/api";
+const PHOTON_REVERSE = "https://photon.komoot.io/reverse";
 const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 const REFERER = "https://trafficnerd.app";
 const TTL_MS = 5 * 60 * 1000;
@@ -19,13 +20,39 @@ const cache = new Map<string, CacheEntry>();
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const q = (url.searchParams.get("q") ?? "").trim();
+  const lat = url.searchParams.get("lat");
+  const lon = url.searchParams.get("lon");
+  const hasCoord = lat != null && lon != null && Number.isFinite(Number(lat)) && Number.isFinite(Number(lon));
+
+  // REVERSE mode — coordinates but no query: name the place under a dropped pin.
+  // Dormant-safe (empty results on any failure); the caller keeps its coord label.
+  if (q.length < 2 && hasCoord) {
+    const key = `rev|${Number(lat).toFixed(4)},${Number(lon).toFixed(4)}`;
+    const hit = cache.get(key);
+    if (hit && Date.now() - hit.at < TTL_MS) return Response.json(hit.body);
+    const upstream = new URL(PHOTON_REVERSE);
+    upstream.searchParams.set("lat", lat as string);
+    upstream.searchParams.set("lon", lon as string);
+    upstream.searchParams.set("limit", "1");
+    try {
+      const res = await fetch(upstream, {
+        headers: { Accept: "application/json", "User-Agent": UA, Referer: REFERER },
+        signal: AbortSignal.timeout(8000),
+      });
+      if (!res.ok) return Response.json({ results: [] });
+      const body = { results: normalizePhoton(await res.json(), 1) };
+      cache.set(key, { at: Date.now(), body });
+      return Response.json(body);
+    } catch {
+      return Response.json({ results: [] });
+    }
+  }
+
   if (q.length < 2) return Response.json({ results: [] });
 
   const limit = Math.min(Math.max(Number(url.searchParams.get("limit")) || 8, 1), 15);
   // Optional viewport bias (Photon proximity-ranks results around lat/lon).
-  const lat = url.searchParams.get("lat");
-  const lon = url.searchParams.get("lon");
-  const biased = lat != null && lon != null && Number.isFinite(Number(lat)) && Number.isFinite(Number(lon));
+  const biased = hasCoord;
 
   const key = `${q.toLowerCase()}|${limit}|${biased ? `${lat},${lon}` : ""}`;
   const hit = cache.get(key);

--- a/app/globals.css
+++ b/app/globals.css
@@ -2042,3 +2042,72 @@ a { color: var(--tn-accent); }
 }
 .tn-track-stop:hover { border-color: var(--tn-down); color: var(--tn-down); }
 @media (prefers-reduced-motion: reduce) { .tn-track-dot { animation: none; } }
+
+/* ── Central globe search bar (drops pins) — see MapSearch ──────────────────── */
+.tn-mapsearch {
+  position: absolute; top: 12px; left: 50%; transform: translateX(-50%); z-index: 6;
+  width: clamp(240px, 36vw, 400px); pointer-events: auto;
+}
+.tn-mapsearch-bar {
+  display: flex; align-items: center; gap: 8px; padding: 7px 12px;
+  border-radius: 12px; background: var(--tn-surface); border: 1px solid var(--tn-border);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, .18);
+}
+.tn-mapsearch-icon { font-size: 15px; color: var(--tn-text-muted); }
+.tn-mapsearch-input {
+  flex: 1; border: 0; background: none; outline: none; font-size: 13px; color: var(--tn-text);
+}
+.tn-mapsearch-input::placeholder { color: var(--tn-text-faint); }
+.tn-mapsearch-results {
+  margin-top: 6px; border-radius: 12px; overflow: hidden; background: var(--tn-surface);
+  border: 1px solid var(--tn-border); box-shadow: 0 10px 28px rgba(0, 0, 0, .22); max-height: 320px; overflow-y: auto;
+}
+.tn-mapsearch-item {
+  display: flex; align-items: center; gap: 8px; width: 100%; text-align: left;
+  border: 0; background: none; padding: 8px 12px; cursor: pointer; color: var(--tn-text); font-size: 13px;
+}
+.tn-mapsearch-item:hover { background: var(--tn-surface-2); }
+.tn-mapsearch-item-pin { font-size: 12px; flex: 0 0 auto; }
+.tn-mapsearch-item-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tn-mapsearch-item-meta { font-size: 11px; color: var(--tn-text-faint); flex: 0 0 auto; }
+.tn-mapsearch-status { padding: 8px 12px; font-size: 12px; color: var(--tn-text-muted); }
+
+/* ── Pin navigator (top-right, below the map-view buttons) — see PinNavigator ── */
+.tn-pinnav {
+  position: absolute; top: 52px; right: 10px; z-index: 6;
+  display: flex; align-items: center; gap: 2px; padding: 3px; pointer-events: auto;
+  border-radius: 11px; background: var(--tn-surface); border: 1px solid var(--tn-border);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, .18); max-width: min(60vw, 300px);
+}
+.tn-pinnav-step, .tn-pinnav-del {
+  border: 0; background: none; cursor: pointer; color: var(--tn-text-muted);
+  font-size: 12px; padding: 4px 7px; border-radius: 7px;
+}
+.tn-pinnav-step:hover:not(:disabled), .tn-pinnav-del:hover:not(:disabled) { background: var(--tn-surface-2); color: var(--tn-text); }
+.tn-pinnav-step:disabled, .tn-pinnav-del:disabled { opacity: .35; cursor: default; }
+.tn-pinnav-del:hover:not(:disabled) { color: var(--tn-down); }
+.tn-pinnav-body {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 1px; min-width: 0;
+  border: 0; background: none; cursor: pointer; padding: 2px 6px; border-radius: 7px; color: var(--tn-text);
+}
+.tn-pinnav-body:hover { background: var(--tn-surface-2); }
+.tn-pinnav-count { font-size: 10px; font-weight: 700; color: var(--tn-accent); letter-spacing: .02em; }
+.tn-pinnav-label { font-size: 12px; max-width: 180px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tn-pinnav-clear {
+  border: 0; background: none; cursor: pointer; color: var(--tn-text-faint); font-size: 11px; padding: 4px 7px; border-radius: 7px;
+}
+.tn-pinnav-clear:hover { color: var(--tn-down); background: var(--tn-surface-2); }
+
+/* ── Right-click "Add pin here" menu ───────────────────────────────────────── */
+.tn-pinmenu {
+  position: absolute; z-index: 7; display: flex; flex-direction: column; gap: 2px; padding: 4px;
+  border-radius: 10px; background: var(--tn-surface); border: 1px solid var(--tn-border);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .24); pointer-events: auto;
+}
+.tn-pinmenu-add {
+  border: 0; background: none; cursor: pointer; text-align: left; font-size: 13px; font-weight: 600;
+  color: var(--tn-text); padding: 6px 10px; border-radius: 7px; white-space: nowrap;
+}
+.tn-pinmenu-add:hover { background: var(--tn-surface-2); color: var(--tn-accent); }
+.tn-pinmenu-coord { font-size: 10px; color: var(--tn-text-faint); padding: 0 10px 4px; }
+@media (max-width: 640px) { .tn-mapsearch { width: min(70vw, 320px); } }

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -22,6 +22,7 @@ import { loadedCamerasStore } from "@/lib/cameras/loaded";
 import { useSatellites } from "@/lib/satellites/useSatellites";
 import { usePlanes, type PlaneTrail, type PlanesLayer } from "@/lib/planes/usePlanes";
 import { trackStore, useTrack, type TrackState } from "@/lib/planes/track";
+import { pinsStore, useMapPins, type MapPin } from "@/lib/map/pins";
 import { useLayers, layersStore, ACTIVE_LAYERS, type LayerState } from "@/lib/layers";
 import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
 import { metricsStore } from "@/lib/metrics";
@@ -73,6 +74,10 @@ const TRAIL_LAYER = "trail-lines";
 // own source so it updates independently of the plane layer and survives restyles.
 const TRACK_SRC = "track-highlight";
 const TRACK_RING_LAYER = "track-ring";
+// User-dropped pins (search bar + right-click). Rendered on top of everything.
+const PIN_SRC = "user-pins";
+const PIN_DOT_LAYER = "user-pin-dots";
+const PIN_LABEL_LAYER = "user-pin-labels";
 const SAT_SRC = "satellites";
 const SAT_GLOW_LAYER = "satellite-glow";
 const SAT_LAYER = "satellite-core";
@@ -118,6 +123,18 @@ function toTrackFC(o: WorldObject | null | undefined): GeoJSON.FeatureCollection
   };
 }
 
+/** User pins → point features (with the active flag driving the highlight paint). */
+function toPinFC(pins: MapPin[], activeId: string | null): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: pins.map((p) => ({
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [p.lon, p.lat] },
+      properties: { label: p.label, active: p.id === activeId ? 1 : 0 },
+    })),
+  };
+}
+
 // The Light (Positron) vector basemap ships its own country names; the Satellite
 // and Topographic rasters don't. Our name labels show only on the rasters.
 const isRasterBasemap = (b: BasemapKey): boolean => b !== "positron";
@@ -155,11 +172,15 @@ export default function WorldMap() {
   const trackingRef = useRef<TrackState>({ id: null, label: "", mode: "follow" });
   const trackedObjectRef = useRef<WorldObject | null>(null);
   const followMoveRef = useRef(false);
+  // Latest user pins, so addAppLayers can re-seed the pin source after a restyle.
+  const pinsRef = useRef<{ pins: MapPin[]; activeId: string | null }>({ pins: [], activeId: null });
   // A deep-linked object id (?obj=) waiting to be resolved once its layer's data
   // has streamed in — see the restore effect below. Cleared after it opens.
   const pendingObjRef = useRef<string | null>(null);
 
   const [pts, setPts] = useState<Pt[]>([]);
+  // Right-click "Add pin here" menu — screen position + the geo point under it.
+  const [pinMenu, setPinMenu] = useState<{ x: number; y: number; lat: number; lon: number } | null>(null);
 
   // Live-layer data is lifted into state from gating <…Feed> children so that a
   // hidden layer's hook (and its fetch/tick) is unmounted entirely — see the
@@ -184,6 +205,8 @@ export default function WorldMap() {
   const layers = useLayers();
   const track = useTrack();
   trackingRef.current = track; // keep the spin loop / input handlers current without a re-subscribe
+  const pins = useMapPins();
+  pinsRef.current = pins;
   const camFilter = useCameraFilter();
   const signalsState = useSignals();
   // Global time-window filter (M-final): trims time-stamped signals by recency.
@@ -410,6 +433,7 @@ export default function WorldMap() {
       ensureGeoJSON(map, WEBCAM_SRC, toWebcamFC(webcamsRef.current), WEBCAM_CLUSTER);
       ensureGeoJSON(map, PLANE_SRC, toPlaneFC(planesRef.current));
       ensureGeoJSON(map, TRACK_SRC, toTrackFC(trackedObjectRef.current));
+      ensureGeoJSON(map, PIN_SRC, toPinFC(pinsRef.current.pins, pinsRef.current.activeId));
       ensureGeoJSON(map, SIGNAL_FILL_SRC, toSignalFillFC(signalsRef.current));
       ensureGeoJSON(map, SIGNAL_LINE_SRC, toSignalLineFC(signalsRef.current));
       ensureGeoJSON(map, SIGNAL_SRC, toSignalFC(signalsRef.current));
@@ -826,6 +850,44 @@ export default function WorldMap() {
         });
       }
 
+      // User pins — drawn on top of every data layer. The active pin reads larger
+      // and fully-opaque; its label rides above the dot. Data-driven off `active`.
+      if (!map.getLayer(PIN_DOT_LAYER)) {
+        map.addLayer({
+          id: PIN_DOT_LAYER,
+          type: "circle",
+          source: PIN_SRC,
+          paint: {
+            "circle-radius": ["case", ["==", ["get", "active"], 1], 8, 6],
+            "circle-color": "#e0483b",
+            "circle-opacity": ["case", ["==", ["get", "active"], 1], 1, 0.85],
+            "circle-stroke-color": "#ffffff",
+            "circle-stroke-width": ["case", ["==", ["get", "active"], 1], 3, 2],
+          },
+        });
+      }
+      if (!map.getLayer(PIN_LABEL_LAYER)) {
+        map.addLayer({
+          id: PIN_LABEL_LAYER,
+          type: "symbol",
+          source: PIN_SRC,
+          layout: {
+            "text-field": ["get", "label"],
+            "text-font": ["Open Sans Regular"],
+            "text-size": 12,
+            "text-offset": [0, 1.2],
+            "text-anchor": "top",
+            "text-optional": true,
+            "text-max-width": 12,
+          },
+          paint: {
+            "text-color": "#b91c1c",
+            "text-halo-color": "#ffffff",
+            "text-halo-width": 1.4,
+          },
+        });
+      }
+
       applyVisibility(map, layersRef.current);
       readyRef.current = true;
     },
@@ -857,6 +919,28 @@ export default function WorldMap() {
       const plane = planesRef.current.find((p) => p.id === id);
       if (plane) overlay.open(plane);
     });
+
+    // Right-click anywhere on the map → the "Add pin here" menu at the cursor.
+    map.on("contextmenu", (e) => {
+      e.preventDefault();
+      setPinMenu({ x: e.point.x, y: e.point.y, lat: e.lngLat.lat, lon: e.lngLat.lng });
+    });
+    // Any left-click / drag dismisses the menu; a click on a pin makes it active.
+    map.on("click", () => setPinMenu(null));
+    map.on("movestart", () => setPinMenu(null));
+    map.on("click", PIN_DOT_LAYER, (e) => {
+      e.preventDefault?.();
+      const feat = e.features?.[0];
+      if (!feat) return;
+      // Match by coordinates (the source carries no id in props) to activate it.
+      const [lon, lat] = (feat.geometry as GeoJSON.Point).coordinates as [number, number];
+      const hit = pinsRef.current.pins.find((p) => Math.abs(p.lat - lat) < 1e-6 && Math.abs(p.lon - lon) < 1e-6);
+      if (hit) pinsStore.setActive(hit.id);
+    });
+    const pinEnter = () => { map.getCanvas().style.cursor = "pointer"; };
+    const pinLeave = () => { map.getCanvas().style.cursor = ""; };
+    map.on("mouseenter", PIN_DOT_LAYER, pinEnter);
+    map.on("mouseleave", PIN_DOT_LAYER, pinLeave);
     map.on("click", SAT_LAYER, (e) => {
       const id = (e.features?.[0]?.properties as { id?: string })?.id;
       const sat = satsRef.current.find((s) => s.id === id);
@@ -1169,6 +1253,13 @@ export default function WorldMap() {
     }
   }, [track, planesLayer]);
 
+  // User pins → source update (search bar / right-click / navigator all flow here).
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !readyRef.current) return;
+    (map.getSource(PIN_SRC) as GeoJSONSource | undefined)?.setData(toPinFC(pins.pins, pins.activeId));
+  }, [pins]);
+
   // Restore a deep-linked dossier (?obj=) once its layer's data has streamed in.
   // Planes/satellites stream after first paint, so this retries on each data tick
   // until the id resolves, then clears the pending marker. A stale id (a landed
@@ -1264,9 +1355,31 @@ export default function WorldMap() {
 
   const trackedFound = track.id ? planesLayer.objects.some((o) => o.id === track.id) : false;
 
+  // Drop a pin at a point (right-click menu). Labels with coords immediately, then
+  // upgrades to a place name if a reverse geocode resolves (dormant-safe).
+  const addPinHere = useCallback((lat: number, lon: number) => {
+    const pin = pinsStore.add(lat, lon);
+    setPinMenu(null);
+    mapViewStore.flyToPoint({ lat, lon, zoom: Math.max(mapRef.current?.getZoom() ?? 4, 4) });
+    fetch(`/api/geocode?lat=${lat}&lon=${lon}`)
+      .then((r) => r.json())
+      .then((d) => { const name = (d?.results?.[0]?.name as string) || ""; if (name) pinsStore.relabel(pin.id, name); })
+      .catch(() => {});
+  }, []);
+
   return (
     <div className="world-map">
       <div ref={containerRef} className="map-canvas" />
+
+      {/* Right-click "Add pin here" menu, positioned at the cursor over the map. */}
+      {pinMenu && (
+        <div className="tn-pinmenu" style={{ left: pinMenu.x, top: pinMenu.y }} role="menu">
+          <button type="button" className="tn-pinmenu-add" onClick={() => addPinHere(pinMenu.lat, pinMenu.lon)}>
+            📍 Add pin here
+          </button>
+          <div className="tn-pinmenu-coord">{pinMenu.lat.toFixed(4)}, {pinMenu.lon.toFixed(4)}</div>
+        </div>
+      )}
 
       {/* Tracking chip — persists across board/widget changes because the track lives
           in an external store; the map just reflects it. Recenter appears once the

--- a/components/console/ConsoleWorkspace.tsx
+++ b/components/console/ConsoleWorkspace.tsx
@@ -7,6 +7,8 @@ import Segment from "@/components/console/Segment";
 import StageHost from "@/components/console/StageHost";
 import MapControls from "@/components/console/MapControls";
 import WorldClock from "@/components/console/WorldClock";
+import MapSearch from "@/components/console/MapSearch";
+import PinNavigator from "@/components/console/PinNavigator";
 
 // Full-bleed console: the map is a 100%×100% base layer and the three widget
 // segments FLOAT over it as translucent glass columns (the calm-glass identity the
@@ -45,6 +47,8 @@ export default function ConsoleWorkspace() {
       <div className="tn-cw-stage">
         <StageHost stage={layout.stage} />
         {showMapOverlays && <MapControls />}
+        {showMapOverlays && <MapSearch />}
+        {showMapOverlays && <PinNavigator />}
         {showMapOverlays && <WorldClock />}
       </div>
 

--- a/components/console/MapSearch.tsx
+++ b/components/console/MapSearch.tsx
@@ -1,0 +1,128 @@
+"use client";
+// The central place-search bar floated over the top-centre of the globe. Type a
+// place → keyless Photon geocode (debounced) → pick a match → it drops a PIN there
+// and flies the camera to it. Pins accumulate (see lib/map/pins) and are walked with
+// the PinNavigator; you can also drop one by right-clicking the map. Calm .tn-* look;
+// dormant-safe (a flaky geocoder shows an inline note, never throws).
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { mapViewStore } from "@/lib/mapView";
+import { pinsStore } from "@/lib/map/pins";
+import type { GeocodeResult } from "@/lib/geo/geocode";
+
+const DEBOUNCE_MS = 350; // keeps us under the community geocoder's ~1 req/s
+
+// Choose a fly-to zoom from a result's extent: wide areas frame out, points zoom in.
+function zoomForResult(r: GeocodeResult): number {
+  if (!r.bbox) return 11;
+  const [w, s, e, n] = r.bbox;
+  const span = Math.max(Math.abs(e - w), Math.abs(n - s));
+  if (span > 4) return 5;
+  if (span > 1) return 7;
+  if (span > 0.2) return 9;
+  if (span > 0.04) return 11;
+  return 13;
+}
+
+export default function MapSearch() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<GeocodeResult[]>([]);
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const reqRef = useRef(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => {
+    reqRef.current++;
+    setOpen(false);
+    setStatus(null);
+  }, []);
+
+  // Debounced geocode.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      setOpen(false);
+      setStatus(null);
+      return;
+    }
+    const t = setTimeout(() => {
+      const myReq = ++reqRef.current;
+      setOpen(true);
+      setStatus("Searching…");
+      fetch(`/api/geocode?q=${encodeURIComponent(q)}`)
+        .then((r) => r.json())
+        .then((d) => {
+          if (myReq !== reqRef.current) return;
+          const rs = (d.results as GeocodeResult[]) ?? [];
+          setResults(rs);
+          setStatus(rs.length ? null : "No matching places.");
+        })
+        .catch(() => {
+          if (myReq !== reqRef.current) return;
+          setResults([]);
+          setStatus("Search is unavailable right now.");
+        });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  // Close on outside click.
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) close();
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [close]);
+
+  const pick = (r: GeocodeResult) => {
+    pinsStore.add(r.lat, r.lon, r.name); // drop a pin + make it active
+    mapViewStore.flyToPoint({ lat: r.lat, lon: r.lon, zoom: zoomForResult(r) });
+    setQuery("");
+    setResults([]);
+    close();
+  };
+
+  return (
+    <div className="tn-mapsearch" ref={rootRef}>
+      <div className="tn-mapsearch-bar">
+        <span className="tn-mapsearch-icon" aria-hidden>⌕</span>
+        <input
+          className="tn-mapsearch-input"
+          type="search"
+          placeholder="Search a place — drop a pin"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => { if (results.length) setOpen(true); }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") { e.preventDefault(); close(); }
+            else if (e.key === "Enter" && results[0]) { e.preventDefault(); pick(results[0]); }
+          }}
+          aria-label="Search for a place and drop a pin"
+        />
+      </div>
+
+      {open && (results.length > 0 || status != null) && (
+        <div className="tn-mapsearch-results" role="listbox" aria-label="Search results">
+          {results.map((r) => (
+            <button
+              key={`${r.name}:${r.lat},${r.lon}`}
+              type="button"
+              role="option"
+              aria-selected={false}
+              className="tn-mapsearch-item"
+              onClick={() => pick(r)}
+            >
+              <span className="tn-mapsearch-item-pin" aria-hidden>📍</span>
+              <span className="tn-mapsearch-item-name">{r.name}</span>
+              {r.type && <span className="tn-mapsearch-item-meta">{r.type}</span>}
+            </button>
+          ))}
+          {status && <div className="tn-mapsearch-status">{status}</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/console/PinNavigator.tsx
+++ b/components/console/PinNavigator.tsx
@@ -1,0 +1,55 @@
+"use client";
+// The pin navigator — a compact control by the map-view buttons that flicks through
+// your dropped pins. Shows "n / total" + the active pin's label, ◀ ▶ to walk them
+// (flying the camera to each), a "locate" tap to re-centre on the active pin, and ✕
+// to drop it. Hidden when there are no pins. Reads the shared pinsStore, so it stays
+// in sync with the search bar and right-click adds. (Mounted only over a live map.)
+
+import { useMapPins, pinsStore, type MapPin } from "@/lib/map/pins";
+import { mapViewStore } from "@/lib/mapView";
+
+function flyTo(pin: MapPin | null) {
+  if (pin) mapViewStore.flyToPoint({ lat: pin.lat, lon: pin.lon, zoom: 9 });
+}
+
+export default function PinNavigator() {
+  const { pins, activeId } = useMapPins();
+  if (pins.length === 0) return null;
+
+  const idx = pins.findIndex((p) => p.id === activeId);
+  const active = idx >= 0 ? pins[idx] : null;
+
+  return (
+    <div className="tn-pinnav" role="group" aria-label="Map pins">
+      <button
+        type="button" className="tn-pinnav-step" aria-label="Previous pin"
+        onClick={() => flyTo(pinsStore.cycle(-1))} disabled={pins.length < 2}
+      >◀</button>
+
+      <button
+        type="button" className="tn-pinnav-body" title="Fly to this pin"
+        onClick={() => flyTo(active ?? pinsStore.cycle(1))}
+      >
+        <span className="tn-pinnav-count">📍 {idx >= 0 ? idx + 1 : "–"}/{pins.length}</span>
+        <span className="tn-pinnav-label">{active ? active.label : "Select a pin"}</span>
+      </button>
+
+      <button
+        type="button" className="tn-pinnav-step" aria-label="Next pin"
+        onClick={() => flyTo(pinsStore.cycle(1))} disabled={pins.length < 2}
+      >▶</button>
+
+      <button
+        type="button" className="tn-pinnav-del" aria-label="Remove this pin" title="Remove this pin"
+        onClick={() => active && pinsStore.remove(active.id)} disabled={!active}
+      >✕</button>
+
+      {pins.length > 1 && (
+        <button
+          type="button" className="tn-pinnav-clear" title="Clear all pins"
+          onClick={() => pinsStore.clear()}
+        >Clear</button>
+      )}
+    </div>
+  );
+}

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -30,6 +30,7 @@ import { profileStore } from "@/lib/shell/profile";
 import { telegramStore } from "@/lib/shell/telegram";
 import { notificationsStore } from "@/lib/shell/notifications";
 import { trackStore } from "@/lib/planes/track";
+import { pinsStore } from "@/lib/map/pins";
 import { applyPreset, DEFAULT_PRESET_ID } from "@/lib/console/presets";
 import { decodeLayout } from "@/lib/console/share";
 import "@/lib/console/widgets";
@@ -59,6 +60,7 @@ export default function ConsoleShell() {
     telegramStore.hydrate();
     notificationsStore.hydrate();
     trackStore.hydrate();
+    pinsStore.hydrate();
     const c = new URLSearchParams(window.location.search).get("c");
     if (c) { const l = decodeLayout(c); if (l) shellLayoutStore.replace(l); }
     else if (shellLayoutStore.get().widgets.length === 0) applyPreset(DEFAULT_PRESET_ID); // first-run seed

--- a/lib/map/pins.ts
+++ b/lib/map/pins.ts
@@ -1,0 +1,130 @@
+"use client";
+// User map pins — the dropped markers the central search bar and the right-click
+// "Add pin here" menu create, and the pin navigator flicks through. Lives outside
+// the map so pins persist across board/widget changes and reloads; WorldMap just
+// renders them and the navigator drives fly-to. Keyless + self-contained.
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export interface MapPin {
+  id: string;
+  lat: number;
+  lon: number;
+  label: string;
+}
+
+export interface PinsState {
+  pins: MapPin[];
+  /** The pin the navigator is focused on / the map highlights, or null. */
+  activeId: string | null;
+}
+
+const KEY = "tn.map.pins.v1";
+const VERSION = 1;
+
+let state: PinsState = { pins: [], activeId: null };
+let seq = 0;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+  savePersisted(KEY, VERSION, state);
+}
+
+function makeId(): string {
+  seq += 1;
+  // Date.now is fine in app (browser) code; the +seq guards against same-ms adds.
+  return `pin-${Date.now().toString(36)}-${seq}`;
+}
+
+/**
+ * PURE: the index to move to when cycling. Wraps around; from "nothing selected"
+ * a forward step lands on the first pin and a backward step on the last. Returns
+ * -1 for an empty list. Unit-tested.
+ */
+export function cycleIndex(len: number, current: number, dir: 1 | -1): number {
+  if (len <= 0) return -1;
+  if (current < 0) return dir === 1 ? 0 : len - 1;
+  return (current + dir + len) % len;
+}
+
+/** A short "lat, lon" fallback label for a hand-dropped pin. */
+export function coordLabel(lat: number, lon: number): string {
+  return `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+}
+
+export const pinsStore = {
+  get(): PinsState {
+    return state;
+  },
+  /** Add a pin (from search or right-click) and make it the active one. */
+  add(lat: number, lon: number, label?: string): MapPin {
+    const pin: MapPin = { id: makeId(), lat, lon, label: (label ?? "").trim() || coordLabel(lat, lon) };
+    state = { pins: [...state.pins, pin], activeId: pin.id };
+    emit();
+    return pin;
+  },
+  remove(id: string) {
+    const idx = state.pins.findIndex((p) => p.id === id);
+    if (idx < 0) return;
+    const pins = state.pins.filter((p) => p.id !== id);
+    let activeId = state.activeId;
+    if (activeId === id) activeId = pins.length ? pins[Math.min(idx, pins.length - 1)].id : null;
+    state = { pins, activeId };
+    emit();
+  },
+  clear() {
+    if (state.pins.length === 0) return;
+    state = { pins: [], activeId: null };
+    emit();
+  },
+  setActive(id: string | null) {
+    if (state.activeId === id) return;
+    state = { ...state, activeId: id };
+    emit();
+  },
+  /** Give an existing pin a better label (e.g. once a reverse-geocode resolves). */
+  relabel(id: string, label: string) {
+    const l = label.trim();
+    if (!l) return;
+    let changed = false;
+    const pins = state.pins.map((p) => (p.id === id ? ((changed = true), { ...p, label: l }) : p));
+    if (!changed) return;
+    state = { ...state, pins };
+    emit();
+  },
+  /** Move the active selection forward/back and return the newly active pin. */
+  cycle(dir: 1 | -1): MapPin | null {
+    const { pins } = state;
+    if (pins.length === 0) return null;
+    const cur = pins.findIndex((p) => p.id === state.activeId);
+    const pin = pins[cycleIndex(pins.length, cur, dir)];
+    state = { ...state, activeId: pin.id };
+    emit();
+    return pin;
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  hydrate() {
+    const saved = loadPersisted<PinsState>(KEY, VERSION);
+    if (saved && Array.isArray(saved.pins)) {
+      const pins = saved.pins.filter(
+        (p): p is MapPin =>
+          !!p && typeof p.id === "string" &&
+          Number.isFinite(p.lat) && Number.isFinite(p.lon) && typeof p.label === "string",
+      );
+      const activeId = pins.some((p) => p.id === saved.activeId) ? saved.activeId : null;
+      state = { pins, activeId };
+    }
+    emit();
+  },
+};
+
+export function useMapPins(): PinsState {
+  return useSyncExternalStore(pinsStore.subscribe, pinsStore.get, pinsStore.get);
+}

--- a/tests/unit/map-pins.test.ts
+++ b/tests/unit/map-pins.test.ts
@@ -1,0 +1,56 @@
+import { expect, test, beforeEach } from "vitest";
+import { pinsStore, cycleIndex, coordLabel } from "@/lib/map/pins";
+
+beforeEach(() => pinsStore.clear());
+
+test("cycleIndex wraps and handles the empty/unselected cases", () => {
+  expect(cycleIndex(0, -1, 1)).toBe(-1);
+  expect(cycleIndex(3, -1, 1)).toBe(0); // nothing selected → first
+  expect(cycleIndex(3, -1, -1)).toBe(2); // nothing selected → last
+  expect(cycleIndex(3, 2, 1)).toBe(0); // wrap forward
+  expect(cycleIndex(3, 0, -1)).toBe(2); // wrap back
+  expect(cycleIndex(3, 1, 1)).toBe(2);
+});
+
+test("coordLabel formats to 3dp", () => {
+  expect(coordLabel(51.50735, -0.12776)).toBe("51.507, -0.128");
+});
+
+test("add() appends and activates; empty label falls back to coords", () => {
+  const a = pinsStore.add(51.5, -0.12, "London");
+  expect(pinsStore.get().pins).toHaveLength(1);
+  expect(pinsStore.get().activeId).toBe(a.id);
+  const b = pinsStore.add(48.85, 2.35, "");
+  expect(b.label).toBe("48.850, 2.350");
+  expect(pinsStore.get().activeId).toBe(b.id);
+});
+
+test("cycle() walks the list and wraps", () => {
+  const a = pinsStore.add(1, 1, "A");
+  const b = pinsStore.add(2, 2, "B");
+  pinsStore.setActive(a.id);
+  expect(pinsStore.cycle(1)?.id).toBe(b.id);
+  expect(pinsStore.cycle(1)?.id).toBe(a.id); // wrap
+  expect(pinsStore.cycle(-1)?.id).toBe(b.id); // wrap back
+});
+
+test("remove() keeps a sensible active selection", () => {
+  const a = pinsStore.add(1, 1, "A");
+  const b = pinsStore.add(2, 2, "B");
+  const c = pinsStore.add(3, 3, "C");
+  pinsStore.setActive(b.id);
+  pinsStore.remove(b.id);
+  expect(pinsStore.get().pins.map((p) => p.id)).toEqual([a.id, c.id]);
+  expect(pinsStore.get().activeId).toBe(c.id); // fell to the next in place
+  pinsStore.remove(c.id);
+  pinsStore.remove(a.id);
+  expect(pinsStore.get().activeId).toBeNull();
+});
+
+test("relabel updates only the matching pin", () => {
+  const a = pinsStore.add(1, 1, "old");
+  pinsStore.relabel(a.id, "New Place");
+  expect(pinsStore.get().pins[0].label).toBe("New Place");
+  pinsStore.relabel(a.id, "   "); // blank ignored
+  expect(pinsStore.get().pins[0].label).toBe("New Place");
+});


### PR DESCRIPTION
A central search bar over the globe geocodes a place (keyless Photon) and drops a persisted PIN there, flying the camera to it. Pins also drop by right-clicking the map (Add-pin-here menu, reverse-geocoded to a place name). A compact pin navigator by the 3D/2D controls flicks through pins (◀ ▶, fly-to, remove, clear). Pins live in lib/map/pins (persisted, keyed outside the map) so they survive board/widget changes and reload; WorldMap renders them as a top marker+label layer with the active pin highlighted. Adds reverse mode to /api/geocode. Pure cycle/label helpers unit-tested.