### PR TITLE
feat(signals): honest, interactive signal detail — kill dead cells, c…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1572,7 +1572,18 @@ a { color: var(--tn-accent); }
 .tn-sd-stat { font-size: 12px; color: var(--tn-text-muted); }
 .tn-sd-delta.up { color: #16a34a; } .tn-sd-delta.down { color: #dc2626; }
 .tn-sd-spark { max-width: 320px; }
-.tn-sd-panels { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+/* Honest feed-freshness badge — the provenance signal every pro user demanded. */
+.tn-sd-fresh { display: inline-flex; align-items: center; gap: 4px; margin-left: 8px; font-size: 11px; font-weight: 600; padding: 1px 7px; border-radius: 999px; background: var(--tn-chip-bg); }
+.tn-sd-fresh-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--tn-unknown); }
+.tn-sd-fresh.is-live { color: var(--tn-live); } .tn-sd-fresh.is-live .tn-sd-fresh-dot { background: var(--tn-live); }
+.tn-sd-fresh.is-lagging { color: var(--tn-lagging); } .tn-sd-fresh.is-lagging .tn-sd-fresh-dot { background: var(--tn-lagging); }
+.tn-sd-fresh.is-stale { color: var(--tn-down); } .tn-sd-fresh.is-stale .tn-sd-fresh-dot { background: var(--tn-down); }
+.tn-sd-fresh.is-none { color: var(--tn-text-faint); }
+/* The location map gets its own full-width row (clickable dots ↔ rows). */
+.tn-sd-mappanel { display: flex; flex-direction: column; gap: 6px; }
+.tn-sd-mappanel > h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 0; }
+.tn-sd-maphint { text-transform: none; letter-spacing: 0; font-weight: 400; color: var(--tn-text-faint); }
+.tn-sd-panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 14px; }
 @media (max-width: 720px) { .tn-sd-panels { grid-template-columns: 1fr; } }
 .tn-sd-panel h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); margin: 0 0 6px; }
 .tn-sd-bars { display: flex; align-items: flex-end; gap: 4px; height: 120px; }
@@ -1583,6 +1594,7 @@ a { color: var(--tn-accent); }
 .tn-sd-table td { padding: 5px 8px; border-bottom: 1px solid var(--tn-border); }
 .tn-sd-row { cursor: pointer; }
 .tn-sd-row:hover { background: var(--tn-surface-2); }
+.tn-sd-row.is-selected { background: var(--tn-accent-soft); box-shadow: inset 3px 0 0 var(--tn-accent); }
 .tn-sd-drill { background: var(--tn-surface-2); }
 .tn-sd-drill dl { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 6px 0; }
 .tn-sd-drill dt { color: var(--tn-accent); text-transform: uppercase; font-size: 10px; letter-spacing: .06em; font-weight: 600; }
@@ -1594,7 +1606,7 @@ a { color: var(--tn-accent); }
 .tn-sd-actions button:disabled { opacity: .4; cursor: default; }
 
 /* ── Signals FOCUS overhaul — KPI cards, filter bar, chart axes, map legend, value chips ── */
-.tn-sd-kpis { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.tn-sd-kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; }
 .tn-sd-kpi { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 8px; padding: 8px 10px; }
 .tn-sd-kpi-label { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--tn-text-faint); }
 .tn-sd-kpi-value { font-size: 18px; font-weight: 700; color: var(--tn-text); line-height: 1.2; }

--- a/components/InsetMap.tsx
+++ b/components/InsetMap.tsx
@@ -24,6 +24,7 @@ export default function InsetMap({
   onSelect,
   onMapClick,
   track,
+  selectedId,
 }: {
   points: InsetPoint[];
   height?: number;
@@ -32,6 +33,8 @@ export default function InsetMap({
   onMapClick?: (lat: number, lon: number) => void;
   /** Optional ground-track polyline: [lon,lat] segments (already antimeridian-split). */
   track?: [number, number][][];
+  /** Highlights the matching point (enlarged, accent ring) — kept in sync with a row selection. */
+  selectedId?: string;
 }) {
   const boxRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
@@ -107,6 +110,17 @@ export default function InsetMap({
       if (key !== fitKeyRef.current) { fit(map, points, track); fitKeyRef.current = key; }
     }
   }, [points, track]);
+
+  // Highlight the selected point (enlarged + accent ring) whenever the selection changes.
+  // Data-driven paint keyed off the feature id; an empty id matches nothing → all default.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded() || !map.getLayer(LAYER)) return;
+    const sel = selectedId ?? "";
+    map.setPaintProperty(LAYER, "circle-radius", ["case", ["==", ["get", "id"], sel], 9, 6]);
+    map.setPaintProperty(LAYER, "circle-stroke-color", ["case", ["==", ["get", "id"], sel], "#0e7d97", "#0b1220"]);
+    map.setPaintProperty(LAYER, "circle-stroke-width", ["case", ["==", ["get", "id"], sel], 3, 1]);
+  }, [selectedId, points]);
 
   return <div ref={boxRef} className="tn-inset-map" style={{ width: "100%", height }} />;
 }

--- a/lib/console/signals/signalDetail.ts
+++ b/lib/console/signals/signalDetail.ts
@@ -63,7 +63,10 @@ export function distribution(features: SignalFeature[]): Distribution {
     else if (s === "warn") warn++;
     else other++;
   }
-  if (critical > 0 || warn > 0) {
+  // A severity BAR is only informative when a non-trivial share is actually graded —
+  // otherwise a single false-positive keyword match (e.g. a vessel nav-status) turns
+  // the whole panel into a meaningless all-"Other" chart. Require ≥2 graded features.
+  if (critical + warn >= 2) {
     return { kind: "severity", bins: [
       { label: "Severe", count: critical },
       { label: "Warning", count: warn },
@@ -135,6 +138,26 @@ export function relativeAge(ts: string | undefined, now: number): string {
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h`;
   return `${Math.floor(h / 24)}d`;
+}
+
+export type FreshnessState = "live" | "lagging" | "stale" | "none";
+
+/**
+ * Honest feed freshness for the provenance badge: compares the last successful
+ * poll against the source's own refresh cadence. "live" within ~1.5× the cadence,
+ * "lagging" up to ~4×, "stale" beyond, "none" when never fetched. Lets the header
+ * say WHY a quiet map is quiet — a fresh calm vs a dead feed — which every pro user
+ * said was make-or-break for trust.
+ */
+export function freshness(updatedAt: number | null | undefined, refreshMs: number, now: number): { state: FreshnessState; label: string } {
+  if (!updatedAt) return { state: "none", label: "no data yet" };
+  const ageMs = Math.max(0, now - updatedAt);
+  const mins = Math.round(ageMs / 60_000);
+  const label = mins < 1 ? "updated just now" : `updated ${mins}m ago`;
+  const cadence = Number.isFinite(refreshMs) && refreshMs > 0 ? refreshMs : 300_000;
+  if (ageMs <= cadence * 1.5) return { state: "live", label };
+  if (ageMs <= cadence * 4) return { state: "lagging", label };
+  return { state: "stale", label };
 }
 
 export interface DetailFilter {

--- a/lib/console/widgets/signals.detail.tsx
+++ b/lib/console/widgets/signals.detail.tsx
@@ -23,7 +23,7 @@ import { openSignalFeature } from "@/lib/widgets/openSignal";
 import { humaniseKey } from "@/lib/text/humanise";
 import {
   distribution, timeModel, sortFeatures, relativeAge, filterDetailFeatures, detailKpis, rowValue,
-  type SortKey,
+  freshness, type SortKey,
 } from "@/lib/console/signals/signalDetail";
 import { rowMetric } from "@/lib/console/signals/signalCard";
 import { makeAssetDetail } from "./cables.detail";
@@ -114,8 +114,23 @@ export function makeSignalDetail(source: SignalSource) {
     const timePoints: ChartPoint[] = timeBins(tm.values, 60 * 60_000, now, 24 * 60 * 60_000).map((b) => ({ x: b.start, y: b.count }));
     const timeMax = Math.max(0, ...timePoints.map((p) => p.y));
     const mapPoints: InsetPoint[] = filtered.map((f) => ({ lat: f.lat, lon: f.lon, id: f.id, color: f.color ?? source.color, props: { title: f.title } }));
-    const freshAge = updatedAt ? `${Math.max(0, Math.round((now - updatedAt) / 60000))}m ago` : "—";
     const filterActive = query.trim() !== "" || minValue > 0;
+    const fresh = freshness(updatedAt, source.refreshMs, now);
+    // Which analytics panels carry a real signal for THIS source — dead panels
+    // ("declares no magnitude or severity", "no timestamped features") are hidden,
+    // not shown empty, so the layout matches what the data can actually say.
+    const showDist = dist.kind !== "none";
+    const showTime = timePoints.some((p) => p.y > 0);
+
+    // Click a map dot → select its row, scroll it into view and open its drill-down
+    // (bidirectional with the selected-dot highlight). This is what makes the dots feel
+    // clickable instead of inert.
+    const selectFromMap = (id: string) => {
+      setOpen(id);
+      if (typeof document !== "undefined") {
+        requestAnimationFrame(() => document.getElementById(`sdrow-${id}`)?.scrollIntoView({ block: "nearest", behavior: "smooth" }));
+      }
+    };
 
     const exportRows = rows.map((f) => ({ id: f.id, title: f.title, magnitude: f.props?.magnitude ?? "", value: rowValue(f, metric) ?? "", lat: f.lat, lon: f.lon, ts: f.ts ?? "", link: f.link ?? "" }));
     const exportGeo = rows.map((f) => ({ lat: f.lat, lon: f.lon, properties: { id: f.id, title: f.title, ...(f.props ?? {}) } }));
@@ -136,7 +151,8 @@ export function makeSignalDetail(source: SignalSource) {
       <div className="tn-sd">
         <header className="tn-sd-head">
           <div className="tn-sd-title">{source.label}</div>
-          <div className="tn-sd-stat"><b>{scoped.length}</b> of {features.length} in {scope.label} · updated {freshAge}
+          <div className="tn-sd-stat"><b>{scoped.length}</b> of {features.length} in {scope.label}
+            <span className={`tn-sd-fresh is-${fresh.state}`} title={`Feed cadence ${Math.round(source.refreshMs / 60000)}m`}><i className="tn-sd-fresh-dot" />{fresh.state === "live" ? "live" : fresh.label}</span>
             {delta !== 0 && <span className={`tn-sd-delta ${delta > 0 ? "up" : "down"}`}> {delta > 0 ? "▲" : "▼"}{Math.abs(delta)}</span>}
           </div>
           {spark.length >= 2 && <div className="tn-sd-spark"><Chart points={spark} height={40} up={null} /></div>}
@@ -149,16 +165,20 @@ export function makeSignalDetail(source: SignalSource) {
               <div className="tn-sd-kpi-value">{kpis.inView}</div>
               <div className="tn-sd-kpi-sub">{filterActive ? `of ${scoped.length} in scope` : "in scope"}</div>
             </div>
-            <div className="tn-sd-kpi">
-              <div className="tn-sd-kpi-label">Peak</div>
-              <div className="tn-sd-kpi-value">{kpis.peak ? kpis.peak.label : "—"}</div>
-              <div className="tn-sd-kpi-sub">{hasMetric ? "metric max" : kpis.peak ? "magnitude" : "no scale"}</div>
-            </div>
-            <div className="tn-sd-kpi">
-              <div className="tn-sd-kpi-label">24h Δ</div>
-              <div className={`tn-sd-kpi-value ${changeCls}`}>{kpis.change24h}</div>
-              <div className="tn-sd-kpi-sub">count vs ≤24h ago</div>
-            </div>
+            {kpis.peak && (
+              <div className="tn-sd-kpi">
+                <div className="tn-sd-kpi-label">Peak</div>
+                <div className="tn-sd-kpi-value">{kpis.peak.label}</div>
+                <div className="tn-sd-kpi-sub">{hasMetric ? "metric max" : "magnitude"}</div>
+              </div>
+            )}
+            {kpis.change24h !== "—" && (
+              <div className="tn-sd-kpi">
+                <div className="tn-sd-kpi-label">24h Δ</div>
+                <div className={`tn-sd-kpi-value ${changeCls}`}>{kpis.change24h}</div>
+                <div className="tn-sd-kpi-sub">count vs ≤24h ago</div>
+              </div>
+            )}
           </div>
         )}
 
@@ -196,51 +216,51 @@ export function makeSignalDetail(source: SignalSource) {
         {status !== "loading" && scoped.length === 0 && <p className="tn-w-empty">Nothing in {scope.label}.</p>}
         {scoped.length > 0 && filtered.length === 0 && <p className="tn-w-empty">No features match the filter.</p>}
 
-        {filtered.length > 0 && (
-          <div className="tn-sd-panels">
-            <div className="tn-sd-panel">
-              <h3>Locations</h3>
-              {mapPoints.length > 0 ? <InsetMap points={mapPoints} height={200} onSelect={(id) => setOpen(id)} />
-                : <p className="tn-w-empty">No mappable features.</p>}
-              {(dist.kind === "severity" || valueRange) && (
-                <div className="tn-sd-legend">
-                  {dist.kind === "severity" ? (
-                    <>
-                      <span className="tn-sd-legend-item"><i className="tn-sd-swatch" style={{ background: SEV_SEVERE }} />Severe</span>
-                      <span className="tn-sd-legend-item"><i className="tn-sd-swatch" style={{ background: SEV_WARNING }} />Warning</span>
-                      <span className="tn-sd-legend-item"><i className="tn-sd-swatch tn-sd-swatch-other" />Other</span>
-                    </>
-                  ) : valueRange ? (
-                    <div className="tn-sd-legend-grad">
-                      <span className="tn-sd-bar-label">{valueRange.min}</span>
-                      <span className="tn-sd-gradbar" style={{ background: `linear-gradient(90deg, ${withAlpha(source.color, 0.15)}, ${source.color})` }} />
-                      <span className="tn-sd-bar-label">{valueRange.max}{metric?.unit ?? ""}</span>
-                    </div>
-                  ) : null}
-                </div>
-              )}
-            </div>
-            <div className="tn-sd-panel">
-              <h3>{dist.kind === "magnitude" ? "Magnitude distribution" : dist.kind === "severity" ? "Severity" : "Distribution"}</h3>
-              {dist.kind !== "none" ? (
-                <>
-                  <div className="tn-sd-plot">
-                    <div className="tn-sd-yaxis"><span>{distMax}</span><span>0</span></div>
-                    <div className="tn-sd-plot-body">
-                      <div className="tn-sd-bars">
-                        {dist.bins.map((b, i) => (
-                          <div key={i} className="tn-sd-bar" style={{ height: `${(b.count / distMax) * 100}%` }} title={`${b.label}: ${b.count}`} />
-                        ))}
-                      </div>
-                      <div className="tn-sd-binlabels">{dist.bins.map((b, i) => <span key={i} className="tn-sd-bar-label" style={{ flex: 1 }}>{b.label}</span>)}</div>
-                    </div>
+        {filtered.length > 0 && mapPoints.length > 0 && (
+          <div className="tn-sd-mappanel">
+            <h3>Locations <span className="tn-sd-maphint">· click a dot to find its row</span></h3>
+            <InsetMap points={mapPoints} height={220} selectedId={open ?? undefined} onSelect={selectFromMap} />
+            {(dist.kind === "severity" || valueRange) && (
+              <div className="tn-sd-legend">
+                {dist.kind === "severity" ? (
+                  <>
+                    <span className="tn-sd-legend-item"><i className="tn-sd-swatch" style={{ background: SEV_SEVERE }} />Severe</span>
+                    <span className="tn-sd-legend-item"><i className="tn-sd-swatch" style={{ background: SEV_WARNING }} />Warning</span>
+                    <span className="tn-sd-legend-item"><i className="tn-sd-swatch tn-sd-swatch-other" />Other</span>
+                  </>
+                ) : valueRange ? (
+                  <div className="tn-sd-legend-grad">
+                    <span className="tn-sd-bar-label">{valueRange.min}</span>
+                    <span className="tn-sd-gradbar" style={{ background: `linear-gradient(90deg, ${withAlpha(source.color, 0.15)}, ${source.color})` }} />
+                    <span className="tn-sd-bar-label">{valueRange.max}{metric?.unit ?? ""}</span>
                   </div>
-                </>
-              ) : <p className="tn-w-empty">This source declares no magnitude or severity.</p>}
-            </div>
-            <div className="tn-sd-panel">
-              <h3>Over the last 24h {tm.undated > 0 && <span className="tn-sd-bar-label">· {tm.undated} undated</span>}</h3>
-              {timePoints.some((p) => p.y > 0) ? (
+                ) : null}
+              </div>
+            )}
+          </div>
+        )}
+
+        {filtered.length > 0 && (showDist || showTime) && (
+          <div className="tn-sd-panels">
+            {showDist && (
+              <div className="tn-sd-panel">
+                <h3>{dist.kind === "magnitude" ? "Magnitude distribution" : "Severity"}</h3>
+                <div className="tn-sd-plot">
+                  <div className="tn-sd-yaxis"><span>{distMax}</span><span>0</span></div>
+                  <div className="tn-sd-plot-body">
+                    <div className="tn-sd-bars">
+                      {dist.bins.map((b, i) => (
+                        <div key={i} className="tn-sd-bar" style={{ height: `${(b.count / distMax) * 100}%` }} title={`${b.label}: ${b.count}`} />
+                      ))}
+                    </div>
+                    <div className="tn-sd-binlabels">{dist.bins.map((b, i) => <span key={i} className="tn-sd-bar-label" style={{ flex: 1 }}>{b.label}</span>)}</div>
+                  </div>
+                </div>
+              </div>
+            )}
+            {showTime && (
+              <div className="tn-sd-panel">
+                <h3>Over the last 24h {tm.undated > 0 && <span className="tn-sd-bar-label">· {tm.undated} undated</span>}</h3>
                 <div className="tn-sd-plot">
                   <div className="tn-sd-yaxis"><span>{timeMax}</span><span>0</span></div>
                   <div className="tn-sd-plot-body">
@@ -248,8 +268,8 @@ export function makeSignalDetail(source: SignalSource) {
                     <div className="tn-sd-xaxis"><span>−24h</span><span>−12h</span><span>now</span></div>
                   </div>
                 </div>
-              ) : <p className="tn-w-empty">No timestamped features in the window.</p>}
-            </div>
+              </div>
+            )}
           </div>
         )}
 
@@ -271,7 +291,7 @@ export function makeSignalDetail(source: SignalSource) {
                 const age = relativeAge(f.ts, now);
                 return (
                   <Fragment key={f.id}>
-                    <tr className="tn-sd-row" onClick={() => setOpen(isOpen ? null : f.id)}>
+                    <tr id={`sdrow-${f.id}`} className={`tn-sd-row${isOpen ? " is-selected" : ""}`} onClick={() => setOpen(isOpen ? null : f.id)}>
                       <td>
                         <span className="tn-sd-val">
                           <i className="tn-sd-dot" style={{ background: f.color ?? source.color }} />


### PR DESCRIPTION
…lickable map, freshness

The one shared signal-detail template forced earthquake furniture (magnitude / severity / "when") onto ~30 layers, so most opened to dead cells: "PEAK — no scale", a "declares no magnitude or severity" panel, "no timestamped features", and a location map whose dots did nothing. This raises the floor for every layer at once — the first step of the persona-validated redesign (be honest, be interactive) before the per-archetype work.

- Dead cells now vanish instead of showing empty: the Peak KPI hides when the source has no scalar; the 24h Δ hides when uncomputable; the distribution and "over the last 24h" panels render only when they carry a real signal.
- Distribution: a severity bar needs >=2 genuinely-graded features, so a single false-positive keyword match no longer paints a meaningless all-"Other" chart.
- The location map gets its own full-width row and its dots are now live: click a dot to select + scroll to + highlight its table row (bidirectional with a new enlarged/accent-ringed selected marker in InsetMap).
- Provenance: an honest live / lagging / stale freshness badge in the header (computed from the feed's own cadence) so a quiet map reads as fresh-calm, not a dead feed — the trust signal every professional persona demanded.

tsc clean, 804 unit tests pass.