### PR TITLE
feat(console): anomaly-first spine — a cross-layer "What's abnormal" …

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1683,6 +1683,18 @@ a { color: var(--tn-accent); }
 .tn-ais-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 7px; vertical-align: middle; }
 .tn-sd-more { font-size: 11px; color: var(--tn-text-faint); text-align: center; padding: 6px 0; }
 
+/* ── "What's abnormal" anomaly-triage widget — cross-layer ranked feed ── */
+.tn-anom-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.tn-anom-row { display: flex; align-items: center; gap: 9px; width: 100%; background: none; border: 0; text-align: left; padding: 5px 4px; border-radius: 6px; cursor: pointer; color: var(--tn-text); }
+.tn-anom-row:hover { background: var(--tn-surface-2); }
+.tn-anom-sev { flex: none; width: 42px; height: 6px; border-radius: 4px; background: var(--tn-chip-bg); overflow: hidden; }
+.tn-anom-sev > i { display: block; height: 100%; border-radius: 4px; }
+.tn-anom-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.tn-anom-title { font-size: 12px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-anom-meta { font-size: 11px; color: var(--tn-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-anom-layer { font-weight: 700; }
+.tn-anom .tn-anom-list { gap: 1px; }
+
 /* ── OSINT recon tools (Tools preset) — shared target input + result renderers ── */
 .tn-recon { display: flex; flex-direction: column; gap: 8px; font-size: 12px; }
 .tn-recon-target { display: flex; align-items: center; gap: 6px; }

--- a/lib/console/anomaly/anomaly.ts
+++ b/lib/console/anomaly/anomaly.ts
@@ -1,0 +1,104 @@
+// Cross-layer "what's abnormal right now" ranking — the anomaly-first spine. Reads
+// the live features across several signal layers and surfaces only the genuinely
+// NOTABLE ones (severity above a floor), ranked by a composite of real-metric
+// severity + recency. Pure + node-testable: the widget supplies the live features,
+// this decides what rises to the top. No fabrication — severity comes from each
+// source's declared metric (else the shared magnitude proxy), never invented.
+
+import type { SignalFeature, SignalMetric } from "@/lib/signals/types";
+import { rowMetric } from "@/lib/console/signals/signalCard";
+
+export interface AnomalyInput {
+  id: string;
+  label: string;
+  color: string;
+  metric?: SignalMetric;
+  features: SignalFeature[];
+}
+
+export interface AnomalyRow {
+  id: string;
+  title: string;
+  layerId: string;
+  layerLabel: string;
+  /** 0..1 metric-normalised severity. */
+  severity: number;
+  /** 0..1 composite of severity + recency (the ranking key). */
+  score: number;
+  /** Human value label, e.g. "M6.2" / "Kp 6" / "82%"; "" when the layer has no metric. */
+  valueLabel: string;
+  color: string;
+  ts: string;
+  ageMs: number | null;
+  lat: number;
+  lon: number;
+  feature: SignalFeature;
+}
+
+const HOUR = 3_600_000;
+
+/** 0..1 severity for a feature under a layer's metric, else the 0–10 magnitude proxy. */
+export function featureSeverity(f: SignalFeature, metric?: SignalMetric): { sev: number; label: string } {
+  if (metric) {
+    const m = rowMetric(f, metric);
+    if (m) {
+      const bot = metric.domain[0];
+      const span = (metric.domain[1] - bot) || 1;
+      return { sev: Math.max(0, Math.min(1, (m.value - bot) / span)), label: m.label };
+    }
+  }
+  const mag = Number(f.props?.magnitude);
+  if (Number.isFinite(mag) && mag > 0) return { sev: Math.max(0, Math.min(1, mag / 10)), label: "" };
+  return { sev: 0, label: "" };
+}
+
+/** Recency weight from an ISO ts: fresh → 1, decaying with age, undated → 0.4. */
+export function recencyWeight(ts: string | undefined, now: number): { w: number; ageMs: number | null } {
+  if (!ts) return { w: 0.4, ageMs: null };
+  const t = Date.parse(ts);
+  if (!Number.isFinite(t)) return { w: 0.4, ageMs: null };
+  const age = Math.max(0, now - t);
+  if (age < HOUR) return { w: 1, ageMs: age };
+  if (age < 6 * HOUR) return { w: 0.8, ageMs: age };
+  if (age < 24 * HOUR) return { w: 0.6, ageMs: age };
+  if (age < 3 * 24 * HOUR) return { w: 0.45, ageMs: age };
+  return { w: 0.3, ageMs: age };
+}
+
+export interface RankOpts {
+  /** Severity floor below which an item is "routine", not an anomaly (default 0.45). */
+  minSeverity?: number;
+  /** Max rows returned (default 15). */
+  cap?: number;
+}
+
+/** Rank the most ABNORMAL items across layers; only items above minSeverity surface. */
+export function rankAnomalies(inputs: AnomalyInput[], now: number, opts: RankOpts = {}): AnomalyRow[] {
+  const minSev = opts.minSeverity ?? 0.45;
+  const cap = opts.cap ?? 15;
+  const rows: AnomalyRow[] = [];
+  for (const inp of inputs) {
+    for (const f of inp.features) {
+      const { sev, label } = featureSeverity(f, inp.metric);
+      if (sev < minSev) continue; // routine — filtered out of the anomaly feed
+      const { w, ageMs } = recencyWeight(f.ts, now);
+      rows.push({
+        id: f.id,
+        title: f.title,
+        layerId: inp.id,
+        layerLabel: inp.label,
+        severity: sev,
+        score: sev * 0.7 + w * 0.3,
+        valueLabel: label,
+        color: f.color ?? inp.color,
+        ts: f.ts ?? "",
+        ageMs,
+        lat: f.lat,
+        lon: f.lon,
+        feature: f,
+      });
+    }
+  }
+  rows.sort((a, b) => b.score - a.score || (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0));
+  return rows.slice(0, cap);
+}

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -40,7 +40,7 @@ function compose(stage: ShellLayout["stage"], specs: { type: string; segment: Se
 export const BUILTIN_PRESETS: ConsolePreset[] = [
   // ── World Overview — the calm landing board (a bit of everything) ────────
   { id: "overview", title: "World Overview", icon: "🌐", blurb: "a bit of everything", build: () => compose("map2d", [
-      { type: "signal:instability", segment: "left" }, { type: "events", segment: "left" }, { type: "signal:gdacs", segment: "left" },
+      { type: "anomaly", segment: "left" }, { type: "signal:instability", segment: "left" }, { type: "events", segment: "left" }, { type: "signal:gdacs", segment: "left" },
       { type: "cameras", segment: "right" }, { type: "markets", segment: "right" }, { type: "locate", segment: "right" },
       { type: "headlines", segment: "bottom" },
   ]) },

--- a/lib/console/widgets/anomaly.tsx
+++ b/lib/console/widgets/anomaly.tsx
@@ -1,0 +1,150 @@
+"use client";
+// "What's abnormal" — the anomaly-first triage widget. Reads a curated set of the
+// highest-signal layers, ranks the genuinely notable items across ALL of them
+// (real-metric severity + recency, routine stuff filtered out) into one feed that
+// answers "what should I look at right now?" — with provenance + freshness + a
+// click-to-fly. Pure ranking lives in lib/console/anomaly/anomaly.ts.
+import { useEffect, useMemo } from "react";
+import { registerWidget, type WidgetBodyProps, type WidgetDetailProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { useSignalFeatures } from "@/lib/widgets/useSignalFeatures";
+import { getSignal } from "@/lib/signals/registry";
+import { rankAnomalies, type AnomalyInput, type AnomalyRow } from "@/lib/console/anomaly/anomaly";
+import { openSignalFeature } from "@/lib/widgets/openSignal";
+import { useScope, withinScope } from "@/lib/shell/scope";
+import { useNow, formatAge } from "@/lib/shell/useNow";
+import { signalsStore } from "@/lib/signals/store";
+import { shellLayoutStore } from "@/lib/console/store";
+import InsetMap from "@/components/InsetMap";
+import type { InsetPoint } from "@/lib/map/inset";
+
+// The curated layers scanned for anomalies — high-signal, metric-bearing sources
+// spanning natural hazards, space weather, macro-instability and infrastructure.
+const ANOMALY_IDS = ["earthquakes", "gdacs", "tropical-cyclones", "floods", "wildfires", "space-weather", "instability", "internet-outages"];
+
+/** Subscribe to the fixed curated set (unrolled → hook order is stable) and rank. */
+function useAnomalyRows(now: number, cap: number): { rows: AnomalyRow[]; updatedAt: number | null; loading: boolean } {
+  const quakes = useSignalFeatures("earthquakes", true);
+  const gdacs = useSignalFeatures("gdacs", true);
+  const cyclones = useSignalFeatures("tropical-cyclones", true);
+  const floods = useSignalFeatures("floods", true);
+  const fires = useSignalFeatures("wildfires", true);
+  const space = useSignalFeatures("space-weather", true);
+  const instab = useSignalFeatures("instability", true);
+  const outages = useSignalFeatures("internet-outages", true);
+  const feeds = [quakes, gdacs, cyclones, floods, fires, space, instab, outages];
+
+  const scope = useScope();
+  const rows = useMemo(() => {
+    const inputs: AnomalyInput[] = ANOMALY_IDS.map((id, i) => {
+      const s = getSignal(id);
+      return {
+        id,
+        label: s?.label ?? id,
+        color: s?.color ?? "#64748b",
+        metric: s?.metric,
+        features: feeds[i].features.filter((f) => withinScope(f.lat, f.lon, scope)),
+      };
+    });
+    return rankAnomalies(inputs, now, { cap });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope, cap, now, ...feeds.map((f) => f.updatedAt)]);
+
+  const updatedAt = Math.max(0, ...feeds.map((f) => f.updatedAt ?? 0)) || null;
+  const loading = feeds.some((f) => f.status === "loading") && updatedAt == null;
+  return { rows, updatedAt, loading };
+}
+
+function AnomalyList({ rows, now }: { rows: AnomalyRow[]; now: number }) {
+  return (
+    <ul className="tn-anom-list">
+      {rows.map((r) => (
+        <li key={`${r.layerId}:${r.id}`}>
+          <button type="button" className="tn-anom-row" onClick={() => openSignalFeature(r.feature, r.layerLabel)}>
+            <span className="tn-anom-sev" title={`severity ${(r.severity * 100).toFixed(0)}%`}>
+              <i style={{ width: `${Math.max(8, r.severity * 100)}%`, background: r.color }} />
+            </span>
+            <span className="tn-anom-main">
+              <span className="tn-anom-title">{r.title}</span>
+              <span className="tn-anom-meta">
+                <span className="tn-anom-layer" style={{ color: r.color }}>{r.layerLabel}</span>
+                {r.valueLabel && <> · <b>{r.valueLabel}</b></>}
+                {r.ageMs != null && <> · {formatAge(r.ageMs)} ago</>}
+              </span>
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function AnomalyBody(_p: WidgetBodyProps) {
+  const now = useNow(30_000);
+  const { rows, loading } = useAnomalyRows(now, 12);
+  const report = useWidgetReport();
+  useEffect(() => { report({ alerts: [], count: rows.length, freshLabel: "live" }); }, [rows.length, report]);
+
+  if (loading && rows.length === 0) return <p className="tn-w-empty">Scanning layers…</p>;
+  if (rows.length === 0) return <p className="tn-w-empty">All quiet — nothing abnormal across the monitored layers.</p>;
+  return <AnomalyList rows={rows} now={now} />;
+}
+
+function AnomalyDetail(_p: WidgetDetailProps) {
+  const now = useNow(30_000);
+  const { rows, updatedAt, loading } = useAnomalyRows(now, 24);
+  const showOnMap = () => { for (const id of ANOMALY_IDS) signalsStore.set(id, true); shellLayoutStore.unfocus(); };
+  const mapPoints: InsetPoint[] = rows.map((r) => ({ lat: r.lat, lon: r.lon, id: r.id, color: r.color, props: { title: r.title } }));
+  const bands = useMemo(() => ({
+    critical: rows.filter((r) => r.severity >= 0.8).length,
+    elevated: rows.filter((r) => r.severity >= 0.6 && r.severity < 0.8).length,
+    layers: new Set(rows.map((r) => r.layerId)).size,
+  }), [rows]);
+
+  return (
+    <div className="tn-sd tn-anom">
+      <header className="tn-sd-head">
+        <div className="tn-sd-title">What&apos;s abnormal</div>
+        <div className="tn-sd-stat"><b>{rows.length}</b> notable across {ANOMALY_IDS.length} layers
+          {updatedAt && <span className="tn-sd-fresh is-live"><i className="tn-sd-fresh-dot" />live</span>}
+        </div>
+      </header>
+
+      {rows.length > 0 && (
+        <div className="tn-sd-kpis">
+          <div className="tn-sd-kpi"><div className="tn-sd-kpi-label">Critical</div><div className="tn-sd-kpi-value">{bands.critical}</div><div className="tn-sd-kpi-sub">severity ≥ 80%</div></div>
+          <div className="tn-sd-kpi"><div className="tn-sd-kpi-label">Elevated</div><div className="tn-sd-kpi-value">{bands.elevated}</div><div className="tn-sd-kpi-sub">60–80%</div></div>
+          <div className="tn-sd-kpi"><div className="tn-sd-kpi-label">Layers hit</div><div className="tn-sd-kpi-value">{bands.layers}</div><div className="tn-sd-kpi-sub">of {ANOMALY_IDS.length} scanned</div></div>
+        </div>
+      )}
+
+      {loading && rows.length === 0 && <p className="tn-w-empty">Scanning layers…</p>}
+      {!loading && rows.length === 0 && <p className="tn-w-empty">All quiet — nothing abnormal across the monitored layers right now.</p>}
+
+      {mapPoints.length > 0 && (
+        <div className="tn-sd-mappanel">
+          <h3>Where <span className="tn-sd-maphint">· the notable items, sized-in by severity</span></h3>
+          <InsetMap points={mapPoints} height={220} />
+        </div>
+      )}
+
+      {rows.length > 0 && <AnomalyList rows={rows} now={now} />}
+
+      <footer className="tn-sd-foot">
+        <span className="tn-sd-attr">Composited from {ANOMALY_IDS.length} keyless layers · severity from each source&apos;s real metric</span>
+        <span className="tn-sd-actions"><button onClick={showOnMap}>🗺 Light all layers</button></span>
+      </footer>
+    </div>
+  );
+}
+
+registerWidget({
+  id: "anomaly",
+  title: "What's abnormal",
+  icon: "🧭",
+  category: "Synthesis",
+  defaultHeight: 260,
+  defaultConfig: {},
+  component: AnomalyBody,
+  detail: AnomalyDetail,
+});

--- a/lib/console/widgets/index.ts
+++ b/lib/console/widgets/index.ts
@@ -11,3 +11,5 @@ import "@/lib/console/widgets/locate";
 import "@/lib/console/widgets/signals";
 // Registers the six passive-OSINT "Tools" recon widgets (dns/whois/certs/bgp/ports/threat).
 import "@/lib/console/widgets/recon";
+// Registers the cross-layer "What's abnormal" anomaly-triage widget.
+import "@/lib/console/widgets/anomaly";

--- a/tests/unit/anomaly.test.ts
+++ b/tests/unit/anomaly.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+import { rankAnomalies, featureSeverity, recencyWeight, type AnomalyInput } from "@/lib/console/anomaly/anomaly";
+import type { SignalFeature, SignalMetric } from "@/lib/signals/types";
+
+const NOW = Date.parse("2026-07-10T12:00:00Z");
+const METRIC: SignalMetric = { field: "mag", domain: [0, 9], unit: "" };
+const f = (id: string, mag: number, ts?: string): SignalFeature => ({
+  id, lat: 1, lon: 2, title: id, signalId: "quakes", color: "#f00", ts, props: { mag },
+});
+const input = (features: SignalFeature[]): AnomalyInput => ({ id: "quakes", label: "Quakes", color: "#f00", metric: METRIC, features });
+
+test("featureSeverity normalises the real metric, else the magnitude proxy", () => {
+  expect(featureSeverity(f("a", 9), METRIC).sev).toBeCloseTo(1);
+  expect(featureSeverity(f("b", 4.5), METRIC).sev).toBeCloseTo(0.5);
+  expect(featureSeverity(f("c", 6), METRIC).label).toBe("6");
+  // No metric → falls back to props.magnitude / 10.
+  const g: SignalFeature = { id: "g", lat: 0, lon: 0, title: "g", signalId: "x", props: { magnitude: 8 } };
+  expect(featureSeverity(g).sev).toBeCloseTo(0.8);
+});
+
+test("recencyWeight decays with age and is honest about undated items", () => {
+  expect(recencyWeight("2026-07-10T11:30:00Z", NOW).w).toBe(1); // 30m
+  expect(recencyWeight("2026-07-10T04:00:00Z", NOW).w).toBe(0.6); // 8h
+  expect(recencyWeight(undefined, NOW).w).toBe(0.4);
+});
+
+test("rankAnomalies filters routine items below the severity floor", () => {
+  const rows = rankAnomalies([input([f("big", 8), f("mid", 6), f("small", 3)])], NOW);
+  // mag 3 → 0.33 severity, below the 0.45 floor → dropped.
+  expect(rows.map((r) => r.id)).toEqual(["big", "mid"]);
+  expect(rows[0].valueLabel).toBe("8");
+});
+
+test("rankAnomalies ranks by severity then recency; newer wins on a tie", () => {
+  const rows = rankAnomalies([input([f("old", 6, "2026-07-01T00:00:00Z"), f("new", 6, "2026-07-10T11:45:00Z")])], NOW);
+  expect(rows.map((r) => r.id)).toEqual(["new", "old"]); // same severity, fresher first
+  expect(rows[0].score).toBeGreaterThan(rows[1].score);
+});
+
+test("rankAnomalies caps output and carries layer identity", () => {
+  const many = Array.from({ length: 30 }, (_, i) => f(`q${i}`, 8));
+  const rows = rankAnomalies([input(many)], NOW, { cap: 5 });
+  expect(rows).toHaveLength(5);
+  expect(rows[0].layerLabel).toBe("Quakes");
+  expect(rows[0].layerId).toBe("quakes");
+});

--- a/tests/unit/console-presets.test.ts
+++ b/tests/unit/console-presets.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 import { BUILTIN_PRESETS, DEFAULT_PRESET_ID } from "@/lib/console/presets";
 import { SIGNALS, signalsByGroup } from "@/lib/signals/registry";
 
-const CORE_WIDGETS = new Set(["events", "news", "cameras", "aviation", "satellites", "markets", "headlines", "locate"]);
+const CORE_WIDGETS = new Set(["events", "news", "cameras", "aviation", "satellites", "markets", "headlines", "locate", "anomaly"]);
 const SIGNAL_WIDGETS = new Set(SIGNALS.map((s) => `signal:${s.id}`));
 // The OSINT "Tools" board's query→response recon widgets (not live signal layers).
 const RECON_WIDGETS = new Set(["recon:dns", "recon:whois", "recon:certs", "recon:bgp", "recon:ports", "recon:threat"]);


### PR DESCRIPTION
…triage feed

The console showed every layer separately; nothing answered "what should I look at right now?". Add a synthesis widget that reads the highest-signal layers at once and surfaces only the genuinely notable items, ranked across all of them.

- anomaly.ts (new, pure): rankAnomalies composites severity (from each source's REAL declared metric, else the magnitude proxy) with recency, filters out routine items below a severity floor, and ranks the rest. featureSeverity/recencyWeight are pure + unit-tested. No fabrication — severity is the real metric, never invented.
- anomaly.tsx (new): the "What's abnormal" widget — a docked triage feed (severity bar
  + title + layer provenance + value + age + click-to-fly) and an expanded detail with Critical/Elevated/Layers-hit KPIs and a located map. Scans 8 layers (quakes, GDACS, cyclones, floods, wildfires, space weather, instability, internet outages), scoped to the active view. Honest all-clear when nothing is abnormal.
- Leads the World Overview board so the landing view opens on triage, not raw layers.

tsc clean, 859 unit tests pass.