### PR TITLE
feat(news): add keyless Liveuamap Telegram feed as a news source

### DIFF
--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,4 +1,5 @@
 import { parseRss, mergeNews, type NewsItem, type NewsPayload } from "@/lib/news";
+import { parseTelegram } from "@/lib/news/telegram";
 
 export const dynamic = "force-dynamic";
 
@@ -24,6 +25,17 @@ const FEEDS: Feed[] = [
   { url: "https://www.france24.com/en/rss", source: "France 24" },
 ];
 
+// Keyless Telegram channels, scraped from their public t.me/s web preview (no API,
+// no key). Merged into the same stream as the RSS feeds; attribution stays honest
+// via lib/news/sources.ts ("OSINT monitor"). Add a channel = add a line here.
+interface TgChannel {
+  url: string;
+  source: string;
+}
+const TELEGRAM: TgChannel[] = [
+  { url: "https://t.me/s/liveuamap", source: "Liveuamap" },
+];
+
 const CACHE_TTL_MS = 5 * 60 * 1000;
 // Higher than the docked list needs on purpose: the focus view clusters these
 // into stories, so more raw material = richer, better-corroborated mega-cards.
@@ -44,11 +56,32 @@ async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
   }
 }
 
+async function fetchTelegram(ch: TgChannel): Promise<NewsItem[]> {
+  try {
+    // t.me/s serves its HTML only to browser-like clients, so use a browser UA.
+    const res = await fetch(ch.url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+        Accept: "text/html",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return [];
+    return parseTelegram(await res.text(), ch.source);
+  } catch {
+    return []; // a dead channel contributes nothing
+  }
+}
+
 export async function GET() {
   if (cache && Date.now() - cache.generatedAt < CACHE_TTL_MS) {
     return Response.json(cache);
   }
-  const lists = await Promise.all(FEEDS.map(fetchFeed));
+  const lists = await Promise.all([
+    ...FEEDS.map(fetchFeed),
+    ...TELEGRAM.map(fetchTelegram),
+  ]);
   const items = mergeNews(lists, LIMIT);
   // Keep the last good list if a transient outage emptied everything.
   if (items.length === 0 && cache && cache.items.length > 0) {

--- a/lib/news/sources.ts
+++ b/lib/news/sources.ts
@@ -38,6 +38,10 @@ const TABLE: Record<string, Omit<SourceMeta, "name">> = {
   "al arabiya": { domain: "alarabiya.net", region: "Middle East", type: "Broadcaster" },
   "cbc": { domain: "cbc.ca", region: "North America", type: "Public broadcaster" },
   "sky news": { domain: "news.sky.com", region: "UK", type: "Broadcaster" },
+  // Open-source conflict monitor scraped from its keyless Telegram channel. Typed
+  // "OSINT monitor" — NOT a vetted newswire — so the badge is honest about the
+  // unverified, self-published provenance rather than implying wire-grade sourcing.
+  "liveuamap": { domain: "liveuamap.com", region: "International", type: "OSINT monitor" },
 };
 
 /** Pure: display name → its attribution metadata (never throws; degrades to "Other"). */

--- a/lib/news/telegram.ts
+++ b/lib/news/telegram.ts
@@ -1,0 +1,82 @@
+// Keyless Telegram channel → NewsItem[]. Telegram serves a public, keyless web
+// preview of any public channel at https://t.me/s/<channel> (plain HTML, no API,
+// no key, no login). We scrape that, exactly like the RSS parser scrapes XML — a
+// small tag-scanning parser (no DOMParser, no deps), pure + node-testable against
+// a captured fixture.
+//
+// PROVENANCE: a Telegram channel is an UNVERIFIED, self-published source (not a
+// vetted newswire). We attribute it honestly via lib/news/sources.ts (type
+// "OSINT monitor") and never present it as corroborated. Each post links out to
+// the poster's own article when it carries one, else to the Telegram permalink.
+
+import type { NewsItem } from "@/lib/news";
+
+const ENTITIES: Record<string, string> = {
+  "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#39;": "'", "&apos;": "'", "&nbsp;": " ",
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&(amp|lt|gt|quot|#39|apos|nbsp);/g, (m) => ENTITIES[m] ?? m)
+    .replace(/&#(\d+);/g, (_, d) => {
+      const n = Number(d);
+      return Number.isFinite(n) ? String.fromCodePoint(n) : _;
+    })
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+}
+
+/** Message text HTML → plain headline: drop <a>…</a> (the trailing source URL that
+ *  Telegram renders as link text), strip remaining tags, decode entities, collapse. */
+function cleanText(rawHtml: string): string {
+  let s = rawHtml.replace(/<a\b[^>]*>[\s\S]*?<\/a>/gi, " "); // link + its URL-as-text
+  s = s.replace(/<br\s*\/?>/gi, " ");
+  s = s.replace(/<[^>]+>/g, " "); // any remaining inline markup (<b>, <i>, <tg-emoji>…)
+  s = decodeEntities(s);
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/** Parse one message block (between two data-post anchors) → NewsItem, or null when
+ *  it carries no text (media-only posts are skipped, like parseRss skips no-title). */
+function parseBlock(block: string, post: string, source: string): NewsItem | null {
+  const textM = block.match(/<div class="tgme_widget_message_text[^"]*"[^>]*>([\s\S]*?)<\/div>/i);
+  if (!textM) return null;
+  const rawText = textM[1];
+
+  // Prefer the first embedded external article link (liveuamap posts append the
+  // source story), but never a t.me link — that's the permalink, handled below.
+  const linkM = rawText.match(/<a\b[^>]*href="(https?:\/\/[^"]+)"/i);
+  const articleUrl = linkM && !/^https?:\/\/(t\.me|telegram\.(me|org))\//i.test(linkM[1])
+    ? decodeEntities(linkM[1])
+    : undefined;
+
+  const title = cleanText(rawText);
+  if (!title) return null;
+
+  const timeM = block.match(/<time[^>]*datetime="([^"]+)"/i);
+  const parsed = timeM ? Date.parse(timeM[1]) : NaN;
+  const ts = Number.isFinite(parsed) ? parsed : 0;
+
+  const permalink = `https://t.me/${post}`; // post = "channel/123"
+  return { title, source, url: articleUrl ?? permalink, ts };
+}
+
+/**
+ * Pure: a t.me/s/<channel> HTML page → NewsItem[]. Slices the document into
+ * per-message blocks on each `data-post="channel/123"` anchor. Never throws;
+ * empty/garbage input → []. `source` is the display name (e.g. "Liveuamap").
+ */
+export function parseTelegram(html: string | null | undefined, source: string): NewsItem[] {
+  if (!html) return [];
+  const anchors: { post: string; start: number }[] = [];
+  const re = /data-post="([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) anchors.push({ post: m[1], start: m.index });
+
+  const out: NewsItem[] = [];
+  for (let i = 0; i < anchors.length; i++) {
+    const end = i + 1 < anchors.length ? anchors[i + 1].start : html.length;
+    const item = parseBlock(html.slice(anchors[i].start, end), anchors[i].post, source);
+    if (item) out.push(item);
+  }
+  return out;
+}

--- a/tests/fixtures/telegram-liveuamap.html
+++ b/tests/fixtures/telegram-liveuamap.html
@@ -1,0 +1,31 @@
+<!-- Faithful (trimmed) slice of https://t.me/s/liveuamap — the keyless public web
+     preview Telegram serves for a public channel. Three messages: one with an
+     embedded liveuamap article link, one text-only, one photo-only (no text). -->
+<section class="tgme_channel_history js-message_history">
+  <div class="tgme_widget_message_wrap js-widget_message_wrap">
+    <div class="tgme_widget_message text_not_supported_wrap js-widget_message" data-post="liveuamap/12205" data-view="eyJ0">
+      <div class="tgme_widget_message_text js-message_text" dir="auto">Lebanese Ministry of Health: Four people killed in an Israeli airstrike targeting the town of Nabatieh al-Fawqa in the south Lebanon <a href="https://lebanon.liveuamap.com/en/2026/6-july-12-lebanese-ministry-of-health-four-people-killed" target="_blank" rel="noopener">https://lebanon.liveuamap.com/en/2026/6-july-12-lebanese-ministry-of-health-four-people-killed</a></div>
+      <div class="tgme_widget_message_footer compact js-message_footer">
+        <div class="tgme_widget_message_info short js-message_info">
+          <a class="tgme_widget_message_date" href="https://t.me/liveuamap/12205"><time datetime="2026-07-06T13:00:01+00:00" class="time">13:00</time></a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="tgme_widget_message_wrap js-widget_message_wrap">
+    <div class="tgme_widget_message text_not_supported_wrap js-widget_message" data-post="liveuamap/12206" data-view="eyJ0">
+      <div class="tgme_widget_message_text js-message_text" dir="auto">Ukraine: explosions reported near Kharkiv city center &amp; ongoing power outages</div>
+      <div class="tgme_widget_message_footer compact js-message_footer">
+        <a class="tgme_widget_message_date" href="https://t.me/liveuamap/12206"><time datetime="2026-07-07T07:58:24+00:00" class="time">07:58</time></a>
+      </div>
+    </div>
+  </div>
+  <div class="tgme_widget_message_wrap js-widget_message_wrap">
+    <div class="tgme_widget_message text_not_supported_wrap js-widget_message" data-post="liveuamap/12207" data-view="eyJ0">
+      <a class="tgme_widget_message_photo_wrap" style="background-image:url('https://cdn.telegram.org/file/photo.jpg')" href="https://t.me/liveuamap/12207"></a>
+      <div class="tgme_widget_message_footer compact js-message_footer">
+        <a class="tgme_widget_message_date" href="https://t.me/liveuamap/12207"><time datetime="2026-07-07T09:10:00+00:00" class="time">09:10</time></a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/tests/unit/news-sources.test.ts
+++ b/tests/unit/news-sources.test.ts
@@ -10,6 +10,12 @@ test("sourceMeta attributes known outlets with region + type", () => {
   expect(sourceMeta("Reuters").type).toBe("Newswire");
 });
 
+test("liveuamap is attributed honestly as an OSINT monitor (not a wire)", () => {
+  const m = sourceMeta("Liveuamap");
+  expect(m).toMatchObject({ domain: "liveuamap.com", region: "International", type: "OSINT monitor" });
+  expect(faviconUrl(m.domain)).toContain("liveuamap.com");
+});
+
 test("sourceMeta is case-insensitive on the display name", () => {
   expect(sourceMeta("bbc").domain).toBe("bbc.com");
   expect(sourceMeta("  the guardian ").domain).toBe("theguardian.com");

--- a/tests/unit/telegram.test.ts
+++ b/tests/unit/telegram.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseTelegram } from "@/lib/news/telegram";
+
+const html = readFileSync(
+  fileURLToPath(new URL("../fixtures/telegram-liveuamap.html", import.meta.url)),
+  "utf8",
+);
+
+test("parseTelegram turns channel posts into NewsItems, skipping media-only posts", () => {
+  const items = parseTelegram(html, "Liveuamap");
+  expect(items).toHaveLength(2); // the photo-only post (no text) is skipped
+  expect(items.every((i) => i.source === "Liveuamap")).toBe(true);
+});
+
+test("prefers the embedded article link, and strips its URL out of the headline", () => {
+  const [first] = parseTelegram(html, "Liveuamap");
+  expect(first.title).toContain("Lebanese Ministry of Health");
+  expect(first.title).not.toContain("http"); // the trailing source URL is not part of the headline
+  expect(first.url).toBe(
+    "https://lebanon.liveuamap.com/en/2026/6-july-12-lebanese-ministry-of-health-four-people-killed",
+  );
+  expect(first.ts).toBe(Date.parse("2026-07-06T13:00:01+00:00"));
+});
+
+test("falls back to the t.me permalink when a post has no external link, and decodes entities", () => {
+  const second = parseTelegram(html, "Liveuamap")[1];
+  expect(second.title).toBe(
+    "Ukraine: explosions reported near Kharkiv city center & ongoing power outages",
+  );
+  expect(second.url).toBe("https://t.me/liveuamap/12206");
+  expect(second.ts).toBe(Date.parse("2026-07-07T07:58:24+00:00"));
+});
+
+test("empty / junk input degrades to [] (dormant-safe)", () => {
+  expect(parseTelegram("", "Liveuamap")).toEqual([]);
+  expect(parseTelegram(null, "Liveuamap")).toEqual([]);
+  expect(parseTelegram("<html>no messages here</html>", "Liveuamap")).toEqual([]);
+});


### PR DESCRIPTION
Scrapes the public t.me/s/liveuamap web preview (no key, no API, no login) and parses each post into a NewsItem via a pure, fixture-tested parseTelegram: headline text, the embedded liveuamap article link (t.me permalink as fallback), and the ISO timestamp. Merged into the existing /api/news stream and attributed honestly in lib/news/sources.ts as an "OSINT monitor" — unverified, self-published, not a newswire. Dormant-safe: a blocked/dead channel resolves to []. Verified against the live 118KB page (20/20 posts, all with deep article links). tsc clean; 864 tests pass (5 new).