### PR TITLE
feat(analytics): add Vercel Web Analytics

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# @vercel/analytics declares SvelteKit as an optional peer, which npm tries to
+# resolve and conflicts with Vitest's Vite 5 even though this app doesn't use
+# Svelte. Legacy peer resolution skips that phantom conflict. Vercel honors this.
+legacy-peer-deps=true

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -30,7 +31,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     // Calm LIGHT by default; the shell flips data-theme on the client for the
     // optional dark toggle. Setting it here keeps SSR markup matching first paint.
     <html lang="en" data-theme="light">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "trafficnerd-v2",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "h3-js": "^4.4.0",
         "hls.js": "^1.6.16",
         "maplibre-gl": "^5.24.0",
@@ -1152,7 +1153,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.1"
@@ -1566,6 +1567,48 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
@@ -1914,6 +1957,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2168,7 +2212,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
       "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.1"
@@ -2187,7 +2231,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "h3-js": "^4.4.0",
     "hls.js": "^1.6.16",
     "maplibre-gl": "^5.24.0",


### PR DESCRIPTION
Wire @vercel/analytics into the root layout via the /next entry so the single-page shell's client-side URL changes get tracked. Add .npmrc with legacy-peer-deps=true: @vercel/analytics declares SvelteKit as an optional peer that npm tries to resolve, which conflicts with Vitest's Vite 5 even though the app uses no Svelte. Keeps local and Vercel installs consistent.