### PR TITLE
fix(map): recover from a basemap that fails to load instead of showing a black stage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,4 @@
-/* ===========================================================================
-   TrafficNerd v2 — calm light console shell.
+/* ====================================================================   TrafficNerd v2 — calm light console shell.
    Light is the default identity; dark survives as an optional [data-theme]
    toggle. Real typography for text; monospace (.tn-num) reserved for numerics.
    =========================================================================== */
@@ -462,8 +461,7 @@ a { color: var(--tn-accent); }
 .tn-coverage-foot { margin: 14px 2px 2px; font-size: 10.5px; color: var(--tn-text-faint); line-height: 1.45; }
 @media (prefers-reduced-motion: reduce) { .tn-coverage { animation: none; } }
 
-/* ===========================================================================
-   Responsive / mobile shell (M6).
+/* ====================================================================   Responsive / mobile shell (M6).
    The globe stays the full-bleed hero; the left rail and right dossier become
    bottom sheets so the console is usable one-handed. Pure CSS over the existing
    stores/components — no component rebuild.
@@ -514,8 +512,7 @@ a { color: var(--tn-accent); }
   .tn-rail, .tn-dossier { animation: none; }
 }
 
-/* ===========================================================================
-   Markets slide-in (crypto, keyless · CoinGecko). Opt-in right-side panel,
+/* ====================================================================   Markets slide-in (crypto, keyless · CoinGecko). Opt-in right-side panel,
    reusing the dossier surface. Calm: up = green, down = red, no neon.
    =========================================================================== */
 .tn-markets {
@@ -570,8 +567,7 @@ a { color: var(--tn-accent); }
 @media (prefers-reduced-motion: reduce) { .tn-markets { animation: none; } }
 @media (max-width: 520px) { .tn-markets { left: 10px; width: auto; } }
 
-/* ===========================================================================
-   Bottom news ticker — a thin, calm, dismissible headline strip that sits just
+/* ====================================================================   Bottom news ticker — a thin, calm, dismissible headline strip that sits just
    above the freshness ticker. Gentle marquee, pauses on hover.
    =========================================================================== */
 .tn-news {
@@ -605,8 +601,7 @@ a { color: var(--tn-accent); }
 }
 @media (max-width: 600px) { .tn-news-label { display: none; } }
 
-/* ===========================================================================
-   Breaking-alert banner — one honest, dismissible alert under the top bar.
+/* ====================================================================   Breaking-alert banner — one honest, dismissible alert under the top bar.
    =========================================================================== */
 .tn-alert {
   position: fixed; top: calc(var(--tn-topbar-h) + 10px); left: 50%; transform: translateX(-50%);
@@ -640,8 +635,7 @@ a { color: var(--tn-accent); }
 @media (prefers-reduced-motion: reduce) { .tn-alert { animation: none; } }
 @media (max-width: 720px) { .tn-alert { width: calc(100vw - 20px); } .tn-alert-detail { display: none; } }
 
-/* =========================================================================
-   Batch D — platform/UX chrome: monitor presets, time-window filter, language
+/* ==================================================================   Batch D — platform/UX chrome: monitor presets, time-window filter, language
    switcher, and the saved-places (watchlist) slide-in. All reuse the calm-light
    tokens above; nothing introduces a new colour.
    ========================================================================= */
@@ -1129,8 +1123,7 @@ a { color: var(--tn-accent); }
   border: 1px solid var(--tn-border); box-shadow: var(--tn-shadow-sm);
 }
 
-/* ===========================================================================
-   WidgetFrame chrome — Task 6
+/* ====================================================================   WidgetFrame chrome — Task 6
    =========================================================================== */
 /* Translucent glass card — theme-aware surface + ink so widgets read in dark too
    (the body's .tn-w-* rows already use tokens; the frame chrome now matches). */
@@ -1171,15 +1164,13 @@ a { color: var(--tn-accent); }
 .tn-cw-resize-xy{position:absolute;right:0;bottom:0;width:12px;height:12px;cursor:nwse-resize;z-index:3}
 .tn-cw-resize-xy::after{content:"";position:absolute;right:2px;bottom:2px;width:6px;height:6px;border-right:2px solid var(--tn-text-faint);border-bottom:2px solid var(--tn-text-faint)}
 
-/* ===========================================================================
-   StageHost + WorldClock + StageSwitch — Task 8
+/* ====================================================================   StageHost + WorldClock + StageSwitch — Task 8
    =========================================================================== */
 .tn-stage-switch{display:inline-flex;gap:2px;background:#fff;border:1px solid #d7dee6;border-radius:7px;padding:2px}
 .tn-stage-switch button{border:0;background:none;font-size:11px;font-weight:700;color:#5a6470;padding:2px 8px;border-radius:5px;cursor:pointer}
 .tn-stage-switch button.is-on{background:#27313b;color:#fff}
 
-/* ===========================================================================
-   ConsoleWorkspace + Segment — Task 7
+/* ====================================================================   ConsoleWorkspace + Segment — Task 7
    =========================================================================== */
 /* The map is a framed panel sized to the CENTRE box: it insets by the segment
    size-vars so it fills only the gap between the floating panels and reflows the
@@ -1194,6 +1185,19 @@ a { color: var(--tn-accent); }
 .tn-stage-loading{position:absolute;inset:0;display:flex;align-items:center;
   justify-content:center;background:var(--tn-surface-solid);color:var(--tn-text-muted);
   font-size:13px;letter-spacing:.02em}
+/* Basemap load notice — sits low-centre over the map, clear of the top breaking
+   banner and the bottom-right attribution/nav controls. */
+.tn-map-notice{position:absolute;left:50%;transform:translateX(-50%);bottom:116px;z-index:30;
+  display:flex;align-items:center;gap:10px;max-width:min(560px,calc(100% - 32px));
+  padding:8px 14px;border-radius:999px;border:1px solid var(--tn-border);
+  background:var(--tn-surface-solid);color:var(--tn-text);font-size:13px;
+  box-shadow:0 6px 22px rgba(20,28,38,.18)}
+.tn-map-notice button{border:1px solid var(--tn-border);background:transparent;
+  color:var(--tn-accent);font:inherit;padding:2px 10px;border-radius:999px;cursor:pointer}
+.tn-map-notice button:hover{background:var(--tn-surface)}
+.tn-map-notice button{white-space:nowrap}
+/* The world clock is hidden below 900px, so the notice can sit lower there. */
+@media (max-width: 900px){ .tn-map-notice{bottom:56px} }
 .tn-cw-col{position:absolute;top:10px;bottom:10px;z-index:15;overflow:hidden;display:flex}
 .tn-cw-col-left{left:10px}
 .tn-cw-col-right{right:10px}
@@ -1217,8 +1221,7 @@ a { color: var(--tn-accent); }
 .maplibregl-ctrl-bottom-right{right:12px;bottom:12px}
 .maplibregl-ctrl-bottom-left{bottom:12px;left:12px}
 
-/* ===========================================================================
-   Widget body — shared table primitives (Task 9 Aviation widget)
+/* ====================================================================   Widget body — shared table primitives (Task 9 Aviation widget)
    =========================================================================== */
 .tn-w-table{width:100%;border-collapse:collapse;font-size:12px;table-layout:fixed}
 .tn-w-table tr{border-bottom:1px solid var(--tn-border)}
@@ -1228,8 +1231,7 @@ a { color: var(--tn-accent); }
 .tn-w-num{font-family:var(--tn-mono);text-align:right;color:var(--tn-text-muted)}
 .tn-w-empty{padding:12px 8px;font-size:12px;color:var(--tn-text-muted);text-align:center}
 
-/* ===========================================================================
-   Widget body — list primitives (Task 10 Disasters & Events widget)
+/* ====================================================================   Widget body — list primitives (Task 10 Disasters & Events widget)
    =========================================================================== */
 .tn-w-list{list-style:none;margin:0;padding:0;font-size:12px}
 .tn-w-list li{display:flex;align-items:center;gap:6px;padding:4px 6px;border-bottom:1px solid var(--tn-border);line-height:1.4}
@@ -1245,8 +1247,7 @@ a { color: var(--tn-accent); }
 .tn-w-bar-num{flex:none;font-family:var(--tn-mono);font-size:10.5px;font-variant-numeric:tabular-nums;color:var(--tn-text);min-width:20px;text-align:right}
 .tn-w-dot{flex:none;width:8px;height:8px;border-radius:50%;box-shadow:inset 0 0 0 1px rgba(0,0,0,.12)}
 
-/* ===========================================================================
-   Widget body — camera grid (Task 11 Cameras widget)
+/* ====================================================================   Widget body — camera grid (Task 11 Cameras widget)
    =========================================================================== */
 .tn-cam-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:6px;padding:6px}
 .tn-cam-cell{display:flex;flex-direction:column;gap:3px;background:var(--tn-surface-2);border:1px solid var(--tn-border);border-radius:8px;overflow:hidden}
@@ -1254,8 +1255,7 @@ a { color: var(--tn-accent); }
 
 .tn-cam-empty{font-size:11px;color:#9aa6b2;text-align:center;padding:14px}
 
-/* ===========================================================================
-   Widget body — Live Video News (Task 12)
+/* ====================================================================   Widget body — Live Video News (Task 12)
    NOTE: prefix is `tn-newsw` (news-WIDGET), NOT `tn-news` — the bottom news
    TICKER already owns `.tn-news` with position:fixed + backdrop-blur, so reusing
    it made this in-segment widget escape to a full-viewport blurred overlay.
@@ -1271,8 +1271,7 @@ a { color: var(--tn-accent); }
 .tn-newsw-picker button{text-align:left;border:0;background:none;padding:5px 9px;font-size:11px;cursor:pointer}
 .tn-newsw-cat{color:#9aa6b2;font-size:9px;float:right}.tn-newsw-custom{margin:6px 9px;padding:4px;font-size:11px;border:1px solid #e1e8ef;border-radius:5px}
 
-/* ===========================================================================
-   News-video FOCUS view (W6) — prefix `tn-nv`. Theme-token chrome (dark-capable,
+/* ====================================================================   News-video FOCUS view (W6) — prefix `tn-nv`. Theme-token chrome (dark-capable,
    unlike the light-hardcoded `.tn-newsw-*` docked widget). Media letterboxes use a
    dark literal (video looks correct in both themes, mirroring the docked screen).
    =========================================================================== */
@@ -1330,8 +1329,7 @@ a { color: var(--tn-accent); }
 .tn-nv-add button:disabled,.tn-nv-actions button:disabled{opacity:.5;cursor:default}
 .tn-nv-err{font-size:10px;color:#e5484d}
 
-/* ===========================================================================
-   Global capacity toast (Task 15) — calm bottom-centre pill, auto-dismisses
+/* ====================================================================   Global capacity toast (Task 15) — calm bottom-centre pill, auto-dismisses
    =========================================================================== */
 .tn-toast{position:fixed;left:50%;bottom:28px;transform:translateX(-50%);z-index:1200;max-width:90vw;background:#2b3640;color:#fff;font:13px/1.4 -apple-system,"Segoe UI",Roboto,sans-serif;padding:9px 16px;border-radius:999px;box-shadow:0 6px 24px rgba(20,28,38,.28);animation:tn-toast-in .18s ease-out}
 @keyframes tn-toast-in{from{opacity:0;transform:translate(-50%,8px)}to{opacity:1;transform:translate(-50%,0)}}
@@ -2018,8 +2016,7 @@ a { color: var(--tn-accent); }
 .tn-mk-actions button { background: var(--tn-surface-2); border: 1px solid var(--tn-border); border-radius: 6px; padding: 4px 10px; font-size: 12px; color: var(--tn-text); cursor: pointer; }
 .tn-mk-actions button:disabled { opacity: .4; cursor: default; }
 
-/* ===========================================================================
-   Navbar / OpenData overhaul (M2) — central board pill · profile · settings drawer
+/* ====================================================================   Navbar / OpenData overhaul (M2) — central board pill · profile · settings drawer
    · floated map-view controls
    =========================================================================== */
 

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -31,6 +31,12 @@ import { mapViewStore, useMapView, type RegionView, type PointView, type DiveVie
 import { cameraFeed } from "@/lib/cameras/classify";
 import { CAMERA_FEED_META, cameraRegionColor, WEBCAM_COLOR } from "@/lib/icons/svg";
 import { BASEMAPS, type BasemapKey } from "@/lib/basemaps";
+import {
+  STYLE_LOAD_TIMEOUT_MS,
+  classifyMapError,
+  nextRecoveryStep,
+  type MapLoadStatus,
+} from "@/lib/map/resilience";
 import { toCameraFC, toPlaneFC, toTrailFC, toSatelliteFC, toWebcamFC, toSignalFC, toSignalLineFC, toSignalFillFC } from "@/lib/map/features";
 import { toCountryLabelFC, buildCountryObject, type CountryProps } from "@/lib/geo/country";
 import { loadCameraIcons, loadPlaneIcons, loadSatelliteIcons, loadWebcamIcons, loadSignalIcons } from "@/lib/map/icons";
@@ -181,6 +187,12 @@ export default function WorldMap() {
   const mapRef = useRef<maplibregl.Map | null>(null);
   const thumbMgrRef = useRef<{ update(): void; destroy(): void } | null>(null);
   const readyRef = useRef(false);
+  // Basemap load resilience (lib/map/resilience.ts). The "Light" basemap is a REMOTE
+  // style URL, so one flaky fetch used to leave a permanent black rectangle with
+  // nothing on screen explaining it. These drive retry → fallback → an honest notice.
+  const styleAttemptsRef = useRef(0);
+  const styleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [loadStatus, setLoadStatus] = useState<MapLoadStatus>({ kind: "ok" });
   const rafRef = useRef(0);
   const interactUntilRef = useRef(0);
   const terrainRef = useRef(true);
@@ -1038,6 +1050,108 @@ export default function WorldMap() {
     }
   }, []);
 
+  // --- Basemap load resilience ---------------------------------------------
+  // `style.load` -> addAppLayers() -> readyRef=true is the ONLY signal that the
+  // basemap actually came up. If it never fires we get a black stage with no
+  // error, so arm a watchdog around every style load and recover from it.
+
+  const clearStyleWatchdog = useCallback(() => {
+    if (styleTimerRef.current) clearTimeout(styleTimerRef.current);
+    styleTimerRef.current = null;
+  }, []);
+
+  /**
+   * Switch basemap from a RECOVERY path.
+   *
+   * The normal basemap effect bails while `readyRef` is false — which is exactly
+   * the state we are in when a style has failed to load. Left to that effect, a
+   * fallback would update the store and the notice would claim "showing Satellite
+   * instead" while nothing had actually changed. So drive setStyle directly here
+   * when the effect would have skipped it, and let the effect handle the normal
+   * case so we never issue setStyle twice.
+   */
+  const applyBasemapNow = useCallback(
+    (key: BasemapKey) => {
+      const map = mapRef.current;
+      const effectWillHandleIt = readyRef.current;
+      mapViewStore.setBasemap(key); // keep the basemap switcher UI in sync
+      if (!map || effectWillHandleIt) return;
+      readyRef.current = false;
+      try {
+        map.setStyle(BASEMAPS[key].style, { diff: false });
+      } catch {
+        /* torn down mid-swap — the unmount cleanup handles it */
+      }
+      armStyleWatchdogRef.current();
+    },
+    [],
+  );
+
+  /** Decide and perform the next recovery step. Safe to call more than once. */
+  const runRecovery = useCallback(() => {
+    const map = mapRef.current;
+    if (!map || readyRef.current) return; // a style is up — nothing to recover
+    clearStyleWatchdog();
+    const basemap = mapViewStore.get().basemap;
+    const step = nextRecoveryStep(styleAttemptsRef.current, basemap, BASEMAPS);
+    if (step.action === "retry") {
+      setLoadStatus({ kind: "retrying", attempt: styleAttemptsRef.current });
+      styleTimerRef.current = setTimeout(() => {
+        const m = mapRef.current;
+        if (!m || readyRef.current) return;
+        styleAttemptsRef.current += 1;
+        try {
+          m.setStyle(BASEMAPS[mapViewStore.get().basemap].style, { diff: false });
+        } catch {
+          /* torn down mid-retry — the unmount cleanup handles it */
+        }
+        armStyleWatchdogRef.current();
+      }, step.delayMs);
+    } else if (step.action === "fallback") {
+      // Switch to an INLINE style (one that cannot fail to fetch) and say so.
+      setLoadStatus({ kind: "fallback", from: basemap, to: step.to });
+      styleAttemptsRef.current = 0;
+      applyBasemapNow(step.to);
+    } else {
+      setLoadStatus({ kind: "lost" });
+    }
+  }, [clearStyleWatchdog]);
+
+  const armStyleWatchdog = useCallback(() => {
+    clearStyleWatchdog();
+    styleTimerRef.current = setTimeout(runRecovery, STYLE_LOAD_TIMEOUT_MS);
+  }, [clearStyleWatchdog, runRecovery]);
+
+  // The retry path re-arms the watchdog from inside runRecovery, which is defined
+  // first — go through a ref so neither callback has to depend on the other.
+  const armStyleWatchdogRef = useRef(armStyleWatchdog);
+  armStyleWatchdogRef.current = armStyleWatchdog;
+
+  /**
+   * Called after every style.load. addAppLayers() is what sets readyRef, so a
+   * rejection there means we have a style but no pins — still broken, so leave the
+   * watchdog running rather than declaring success.
+   */
+  const onStyleSettled = useCallback(() => {
+    if (!readyRef.current) return;
+    clearStyleWatchdog();
+    styleAttemptsRef.current = 0;
+    // Keep a "fallback" notice on screen — the user is looking at a different
+    // basemap than they asked for and deserves to know why. Clear the transient
+    // "retrying" state, which has served its purpose.
+    setLoadStatus((s) => (s.kind === "fallback" ? s : { kind: "ok" }));
+  }, [clearStyleWatchdog]);
+
+  /** Manual "Try again" from the notice. */
+  const retryBasemap = useCallback(
+    (key: BasemapKey) => {
+      styleAttemptsRef.current = 0;
+      setLoadStatus({ kind: "retrying", attempt: 0 });
+      applyBasemapNow(key);
+    },
+    [applyBasemapNow],
+  );
+
   // --- Init (once) ---------------------------------------------------------
   useEffect(() => {
     if (mapRef.current || !containerRef.current) return;
@@ -1111,8 +1225,25 @@ export default function WorldMap() {
     map.on("sourcedata", onThumbSource);
 
     map.on("style.load", () => {
-      void addAppLayers(map);
+      void addAppLayers(map).then(onStyleSettled, onStyleSettled);
     });
+
+    // MapLibre reports a dead style CDN and a single missing tile through the SAME
+    // event, so classify before acting — raster basemaps 404 tiles routinely (poles,
+    // past maxzoom) and recovering on those would thrash the map. Only a failed
+    // style DOCUMENT, while we have no working style, triggers recovery — and it
+    // does so IMMEDIATELY rather than waiting out the watchdog, since we already
+    // know the load failed.
+    map.on("error", (e) => {
+      if (classifyMapError(e as unknown as { error?: { message?: string } }) !== "style") return;
+      runRecovery();
+    });
+
+    // A lost WebGL context cannot be recovered in place — say so rather than
+    // leaving a frozen canvas that looks like a hung app.
+    map.getCanvas().addEventListener("webglcontextlost", () => setLoadStatus({ kind: "lost" }));
+
+    armStyleWatchdog();
     // Engage/disengage 3D terrain as we cross the mercator threshold (see syncTerrain).
     map.on("zoom", () => syncTerrain(map));
 
@@ -1178,6 +1309,7 @@ export default function WorldMap() {
       map.off("sourcedata", onThumbSource);
       thumbMgr.destroy();
       thumbMgrRef.current = null;
+      clearStyleWatchdog(); // never let a pending retry fire at a removed map
       map.remove();
       mapRef.current = null;
       readyRef.current = false;
@@ -1202,8 +1334,11 @@ export default function WorldMap() {
     const map = mapRef.current;
     if (!map || !readyRef.current) return;
     readyRef.current = false;
+    styleAttemptsRef.current = 0;
     map.setStyle(BASEMAPS[basemap].style, { diff: false });
-  }, [basemap]);
+    // A user-chosen basemap can fail to load just like the first one did.
+    armStyleWatchdog();
+  }, [basemap, armStyleWatchdog]);
 
   // Terrain toggle.
   useEffect(() => {
@@ -1401,6 +1536,28 @@ export default function WorldMap() {
   return (
     <div className="world-map">
       <div ref={containerRef} className="map-canvas" />
+
+      {/* Basemap load notice. A basemap that fails to load used to leave a silent
+          black rectangle; say what happened and offer a way back. */}
+      {loadStatus.kind !== "ok" && (
+        <div className="tn-map-notice" role="status" aria-live="polite">
+          {loadStatus.kind === "retrying" && <span>Basemap is slow to load — retrying…</span>}
+          {loadStatus.kind === "fallback" && (
+            <>
+              <span>
+                Couldn&apos;t load the {BASEMAPS[loadStatus.from].label} basemap. Showing{" "}
+                {BASEMAPS[loadStatus.to].label} instead.
+              </span>
+              <button type="button" onClick={() => retryBasemap(loadStatus.from)}>
+                Try again
+              </button>
+            </>
+          )}
+          {loadStatus.kind === "lost" && (
+            <span>The map couldn&apos;t start in this browser. Reload the page to try again.</span>
+          )}
+        </div>
+      )}
 
       {/* Right-click "Add pin here" menu, positioned at the cursor over the map. */}
       {pinMenu && (

--- a/lib/map/resilience.ts
+++ b/lib/map/resilience.ts
@@ -1,0 +1,118 @@
+// Map load resilience — the pure decision logic behind WorldMap's recovery from a
+// basemap that fails to load.
+//
+// WHY THIS EXISTS. The map had no `map.on("error")` handler and no retry anywhere.
+// The "Light" basemap is a REMOTE style URL (basemaps.cartocdn.com), so a single
+// flaky fetch means `style.load` never fires, addAppLayers() never runs, and the
+// user is left with a permanent black rectangle and no pins — with nothing on
+// screen explaining it. This is the single most-reported failure on both competing
+// products in this category, and we had identical exposure.
+//
+// Everything here is pure and unit-tested; WorldMap owns the MapLibre side effects.
+
+import type { BasemapKey } from "@/lib/basemaps";
+
+/** How long to wait for `style.load` before treating the basemap as failed. */
+export const STYLE_LOAD_TIMEOUT_MS = 9000;
+
+/** Style load attempts (the initial try plus retries) before falling back. */
+export const MAX_STYLE_ATTEMPTS = 3;
+
+export type MapErrorKind =
+  /** The style document itself failed — fatal, nothing renders. Recover. */
+  | "style"
+  /** A tile/sprite/glyph 404'd or timed out — cosmetic and often transient. Ignore. */
+  | "tile"
+  /** Anything else — log, don't act. */
+  | "other";
+
+interface MapErrorLike {
+  error?: { status?: number; message?: string } | null;
+  sourceId?: string;
+  /** MapLibre attaches the failing tile's id for tile-level errors. */
+  tile?: unknown;
+}
+
+/**
+ * Classify a MapLibre `error` event.
+ *
+ * MapLibre reports a dead CDN and a single missing tile through the SAME event, so
+ * without this a retry loop would thrash on ordinary tile misses (a raster basemap
+ * 404s tiles constantly at the poles and past a source's maxzoom). Only a failure
+ * to load the style DOCUMENT justifies tearing the map down and retrying.
+ */
+export function classifyMapError(e: MapErrorLike | null | undefined): MapErrorKind {
+  if (!e) return "other";
+  // A tile-scoped error carries the tile it belongs to, or a sourceId. Either way
+  // the style is alive and the map is usable, so never recover on these.
+  if (e.tile != null || e.sourceId) return "tile";
+
+  const msg = (e.error?.message ?? "").toLowerCase();
+  if (!msg) return "other";
+  // MapLibre surfaces a failed style fetch as a load/parse error naming the style.
+  if (msg.includes("style")) return "style";
+  // A bare failed fetch with no source/tile context is the style document request.
+  if (msg.includes("failed to fetch") || msg.includes("networkerror")) return "style";
+  return "other";
+}
+
+/**
+ * Backoff before re-attempting a style load. Deliberately short — the user is
+ * staring at an empty stage, so a slow backoff reads as a broken product.
+ * `attempt` is 1-based (the number of attempts already made).
+ */
+export function retryDelayMs(attempt: number): number {
+  const schedule = [600, 1800];
+  return schedule[Math.min(Math.max(attempt, 1), schedule.length) - 1];
+}
+
+/** True when the basemap's style is fetched over the network (and so can fail). */
+export function isRemoteStyle(
+  key: BasemapKey,
+  styles: Record<BasemapKey, { style: string | object }>,
+): boolean {
+  return typeof styles[key]?.style === "string";
+}
+
+/**
+ * The basemap to fall back to when `key` will not load.
+ *
+ * Only ever falls back to a basemap whose style is INLINE, because a remote style
+ * is exactly what just failed — falling back to another URL could fail the same
+ * way and strand the user again. Returns null when `key` is already inline (its
+ * style cannot fail to load, so there is nothing to fall back from).
+ */
+export function fallbackBasemap(
+  key: BasemapKey,
+  styles: Record<BasemapKey, { style: string | object }>,
+): BasemapKey | null {
+  if (!isRemoteStyle(key, styles)) return null;
+  const inline = (Object.keys(styles) as BasemapKey[]).filter(
+    (k) => k !== key && !isRemoteStyle(k, styles),
+  );
+  // Prefer satellite (the product default) when it qualifies.
+  if (inline.includes("satellite" as BasemapKey)) return "satellite" as BasemapKey;
+  return inline[0] ?? null;
+}
+
+export type MapLoadStatus =
+  | { kind: "ok" }
+  | { kind: "retrying"; attempt: number }
+  | { kind: "fallback"; from: BasemapKey; to: BasemapKey }
+  | { kind: "lost" };
+
+/**
+ * Decide what to do when a style has failed to load.
+ * `attempts` = how many load attempts have already been made for this basemap.
+ */
+export function nextRecoveryStep(
+  attempts: number,
+  basemap: BasemapKey,
+  styles: Record<BasemapKey, { style: string | object }>,
+): { action: "retry"; delayMs: number } | { action: "fallback"; to: BasemapKey } | { action: "give-up" } {
+  if (attempts < MAX_STYLE_ATTEMPTS) {
+    return { action: "retry", delayMs: retryDelayMs(attempts) };
+  }
+  const to = fallbackBasemap(basemap, styles);
+  return to ? { action: "fallback", to } : { action: "give-up" };
+}

--- a/tests/unit/map-resilience.test.ts
+++ b/tests/unit/map-resilience.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_STYLE_ATTEMPTS,
+  classifyMapError,
+  fallbackBasemap,
+  isRemoteStyle,
+  nextRecoveryStep,
+  retryDelayMs,
+} from "@/lib/map/resilience";
+import { BASEMAPS, type BasemapKey } from "@/lib/basemaps";
+
+// Mirrors the real registry shape: positron is a remote style URL, the other two
+// are inline StyleSpecifications.
+const STYLES = BASEMAPS as unknown as Record<BasemapKey, { style: string | object }>;
+
+describe("classifyMapError", () => {
+  it("treats a tile-scoped error as cosmetic, never fatal", () => {
+    // Raster basemaps 404 tiles constantly (poles, past maxzoom). Recovering on
+    // these would thrash the map for every ordinary miss.
+    expect(classifyMapError({ error: { status: 404 }, tile: {} })).toBe("tile");
+    expect(classifyMapError({ error: { status: 404 }, sourceId: "esri-imagery" })).toBe("tile");
+  });
+
+  it("treats a failed style document as fatal", () => {
+    expect(classifyMapError({ error: { message: "Failed to fetch" } })).toBe("style");
+    expect(classifyMapError({ error: { message: "Unable to parse style" } })).toBe("style");
+    expect(classifyMapError({ error: { message: "NetworkError when loading" } })).toBe("style");
+  });
+
+  it("prefers the tile classification even when the message mentions the style", () => {
+    // sourceId present => the style is alive; only a tile failed.
+    expect(classifyMapError({ error: { message: "style tile failed" }, sourceId: "x" })).toBe("tile");
+  });
+
+  it("does not act on unknown or empty errors", () => {
+    expect(classifyMapError(null)).toBe("other");
+    expect(classifyMapError(undefined)).toBe("other");
+    expect(classifyMapError({})).toBe("other");
+    expect(classifyMapError({ error: { message: "something odd" } })).toBe("other");
+  });
+});
+
+describe("isRemoteStyle / fallbackBasemap", () => {
+  it("knows which real basemaps can fail to load", () => {
+    expect(isRemoteStyle("positron", STYLES)).toBe(true);
+    expect(isRemoteStyle("satellite", STYLES)).toBe(false);
+    expect(isRemoteStyle("topo", STYLES)).toBe(false);
+  });
+
+  it("falls back from the remote Light basemap to inline satellite", () => {
+    expect(fallbackBasemap("positron", STYLES)).toBe("satellite");
+  });
+
+  it("never falls back from an inline basemap (its style cannot fail)", () => {
+    expect(fallbackBasemap("satellite", STYLES)).toBeNull();
+    expect(fallbackBasemap("topo", STYLES)).toBeNull();
+  });
+
+  it("never falls back to another remote style", () => {
+    const allRemote = {
+      positron: { style: "https://a/style.json" },
+      satellite: { style: "https://b/style.json" },
+      topo: { style: "https://c/style.json" },
+    } as Record<BasemapKey, { style: string | object }>;
+    expect(fallbackBasemap("positron", allRemote)).toBeNull();
+  });
+});
+
+describe("retryDelayMs", () => {
+  it("backs off, and stays short enough that the stage never looks dead", () => {
+    expect(retryDelayMs(1)).toBe(600);
+    expect(retryDelayMs(2)).toBe(1800);
+    expect(retryDelayMs(2)).toBeGreaterThan(retryDelayMs(1));
+  });
+
+  it("clamps out-of-range attempts instead of returning undefined", () => {
+    expect(retryDelayMs(0)).toBe(600);
+    expect(retryDelayMs(99)).toBe(1800);
+  });
+});
+
+describe("nextRecoveryStep", () => {
+  it("retries while attempts remain", () => {
+    expect(nextRecoveryStep(1, "positron", STYLES)).toEqual({ action: "retry", delayMs: 600 });
+    expect(nextRecoveryStep(2, "positron", STYLES)).toEqual({ action: "retry", delayMs: 1800 });
+  });
+
+  it("falls back once the attempts are spent", () => {
+    expect(nextRecoveryStep(MAX_STYLE_ATTEMPTS, "positron", STYLES)).toEqual({
+      action: "fallback",
+      to: "satellite",
+    });
+  });
+
+  it("gives up rather than looping when there is nothing to fall back to", () => {
+    expect(nextRecoveryStep(MAX_STYLE_ATTEMPTS, "satellite", STYLES)).toEqual({ action: "give-up" });
+  });
+});


### PR DESCRIPTION
**Stacked on #78** (base is `fix/blank-centre-stage`, so the diff shows only this change). GitHub retargets this to `main` automatically once #78 merges.

## The gap

`WorldMap` had **no `map.on("error")` handler and no retry anywhere**, while the "Light" basemap is a **remote style URL** (`basemaps.cartocdn.com`). One flaky fetch meant `style.load` never fired, `addAppLayers()` never ran, and the user was left with a permanent black rectangle and no pins, with nothing on screen explaining it.

This is the single most-reported failure on both competing products in this category:

- worldmonitor **#1031** - "Map not rendering (black screen) - CORS error blocking basemaps.cartocdn.com style.json"
- osiris **#250** - "Black map on cold start: /api/proxy-tiles 500s... and MapLibre never retries" - the only high-reaction open issue on that repo.

We had identical exposure and no mitigation at all.

## What this adds

**`lib/map/resilience.ts`** - pure, unit-tested decision logic:

- `classifyMapError()` separates a dead style document from ordinary tile misses. MapLibre reports both through the same event, and raster basemaps 404 tiles routinely (poles, past a source maxzoom), so recovering on those would thrash the map.
- `nextRecoveryStep()` drives retry -> fallback -> give-up.
- `fallbackBasemap()` only ever falls back to a basemap whose style is **inline**, because a remote style is exactly what just failed.

**`WorldMap`** - a watchdog around every style load (initial and every basemap swap); an error handler that triggers recovery *immediately* on a fatal style error rather than waiting the watchdog out; `webglcontextlost` handling; and a visible notice explaining what happened, with a **Try again** action. The watchdog is cleared on unmount so a pending retry can never fire at a removed map. Success is keyed on `readyRef` (set by `addAppLayers`), so a style that loads but fails to add layers is still correctly treated as broken.

## A bug the test caught

The first version set `mapViewStore.setBasemap()` and let the existing basemap effect do the `setStyle`. But that effect early-returns while `readyRef.current` is false, which is exactly the state during a failed load. So the notice claimed "Showing Satellite instead" while nothing had actually switched. `applyBasemapNow()` now drives `setStyle` directly on the recovery path and defers to the effect on the normal path, so `setStyle` is never issued twice.

## Verification

Simulated a dead CDN with Playwright (aborting the Positron style request) against a real production build:

| Scenario | Result |
|---|---|
| CDN up (control) | Positron loads, 118 layers, **no notice** - no false positives |
| CDN dead | notice at ~1-3s, genuine fallback to satellite, **27 layers rendering**, message "Couldn't load the Light basemap. Showing Satellite instead." + Try again |

Also confirmed the notice clears the world clock (it overlapped it at first) and reads correctly once the first-visit tour is dismissed.

Gates: `tsc` clean, `npm test` **930/930** (+13), `next build` green.
