### PR TITLE
Signals: a monitor row said its number twice, and printed over the next one

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1527,10 +1527,17 @@ a { color: var(--tn-accent); }
 .tn-w-mag{flex:none;font-family:var(--tn-mono);font-size:11px;color:var(--tn-text-muted)}
 /* Monitor-row severity marks: a proportional MetricBar, or a coloured dot when the
    source declares no scalar. One severity ramp (the feature colour) drives both. */
-.tn-w-bar{flex:none;display:inline-flex;align-items:center;gap:6px;width:66px}
-.tn-w-bar-track{position:relative;flex:1;height:5px;border-radius:3px;background:var(--tn-border);overflow:hidden}
+/* The value column sizes to its content. It was a FIXED 66px, of which the track
+   took 30 and the number got what was left - so any unit longer than a couple of
+   characters (" articles", " ft", " MW") overflowed the box and printed straight
+   over the place name beside it: "51 articlesIran", "16 articlesNew Delhi". The
+   row's own 6px gap could not help, because the text had already escaped its
+   parent. min-width keeps the column aligned down a card; max-width stops a long
+   unit from eating the row it is meant to annotate. */
+.tn-w-bar{flex:none;display:inline-flex;align-items:center;gap:6px;min-width:66px;max-width:46%}
+.tn-w-bar-track{position:relative;flex:none;width:30px;height:5px;border-radius:3px;background:var(--tn-border);overflow:hidden}
 .tn-w-bar-fill{position:absolute;left:0;top:0;bottom:0;border-radius:3px;box-shadow:inset 0 0 0 1px rgba(0,0,0,.14)}
-.tn-w-bar-num{flex:none;font-family:var(--tn-mono);font-size:10.5px;font-variant-numeric:tabular-nums;color:var(--tn-text);min-width:20px;text-align:right}
+.tn-w-bar-num{flex:none;font-family:var(--tn-mono);font-size:10.5px;font-variant-numeric:tabular-nums;color:var(--tn-text);min-width:20px;text-align:right;white-space:nowrap}
 .tn-w-dot{flex:none;width:8px;height:8px;border-radius:50%;box-shadow:inset 0 0 0 1px rgba(0,0,0,.12)}
 
 /* ====================================================================   Widget body — camera grid (Task 11 Cameras widget)

--- a/lib/console/signals/signalCard.ts
+++ b/lib/console/signals/signalCard.ts
@@ -40,9 +40,99 @@ export interface SignalRow {
   metric?: RowMetric;
 }
 
-/** Compact numeric label: integers bare, else one decimal. */
+/** Compact numeric label: integers bare, else one decimal. Thousands are grouped —
+ *  the displacement card was rendering a bare `4176592` beside a title that had
+ *  already grouped the same number, so the row showed both spellings at once. */
 function fmtMetric(v: number): string {
-  return Number.isInteger(v) ? String(v) : v.toFixed(1);
+  return Number.isInteger(v) ? groupDigits(v) : v.toFixed(1);
+}
+
+// ── The row label ───────────────────────────────────────────────────────────
+//
+// A monitor row is `[bar] <value> <title> · <age>`, and the value column is the
+// one the eye scans. Every source composed its `title` before that column
+// existed, so most of them restate the value inside it and the scan column
+// carries nothing:
+//
+//   5.5        M 5.5 - 69 km SSW of Chirilagua, El Salvador
+//   55 AQI     London - AQI 55 (Moderate)
+//   31.5 °C    London - 32°C * Clear          <- and the two numbers DISAGREE
+//   4,176,592  United States - 4,176,592 displaced
+//   47         Nigeria - instability >=47/100 (floor, 3/4 factors)
+//
+// Five of six reviewers flagged this independently, and one named the weather
+// row specifically: a page that argues with itself about the temperature in
+// London is a page whose numbers about Sudan you stop believing.
+//
+// The fix is HERE and not in the ~20 adapters, because `title` has a second
+// audience: it is the map's pin label (components/WorldMap.tsx), where there is
+// no value column and stripping the magnitude would make the label useless. The
+// duplication only exists in the row, so it is removed in the row.
+//
+// Conservative by construction: it strips only a number it can actually find,
+// and returns the title untouched whenever the result would be empty or
+// implausibly short. A row that keeps a redundant number is a cosmetic problem;
+// a row that has lost its place name is a broken row.
+
+/** Every plausible spelling of a number as an adapter might have written it. */
+function numberForms(v: number): string[] {
+  const forms = new Set<string>([
+    String(v), groupDigits(v), v.toFixed(0), v.toFixed(1), String(Math.round(v)),
+  ]);
+  // Adapters routinely round for display (weather prints Math.round(temp)), so
+  // the title's number is often NOT the metric's raw value.
+  if (Number.isFinite(v)) forms.add(groupDigits(Math.round(v)));
+  return [...forms].filter(Boolean).sort((a, b) => b.length - a.length);
+}
+
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * The title with the metric's own value removed, when it can be removed cleanly.
+ * PURE and unit-tested against the real strings above.
+ */
+export function rowLabel(title: string, metric?: RowMetric): string {
+  if (!metric || !title) return title;
+
+  // A unit as adapters actually write it: "°C", "%", or a short word ("AQI",
+  // "displaced", "kt"). Optional, because plenty of titles state a bare number.
+  const UNIT = String.raw`(?:\s*(?:°[A-Za-z]?|%|[A-Za-z]{1,9}))?`;
+  // A denominator, for scores written as a bounded fraction ("≥47/100").
+  const DENOM = String.raw`(?:\s*\/\s*\d+)?`;
+
+  let out = title;
+  for (const num of numberForms(metric.value)) {
+    const n = escapeRe(num);
+    // BOTH boundaries matter. Without the trailing one, a metric of 5.5 (whose
+    // rounded form is "6") turns "Route 66 Interchange" into "Route 6
+    // Interchange" — silently corrupting a place name, which is far worse than
+    // the duplication being removed. The leading lookbehind stops a match
+    // starting mid-number.
+    const OPEN = String.raw`(?<![\w.,])`;
+    const CLOSE = String.raw`(?![\d.,])`;
+
+    // A leading "M 5.5 — " stanza: the value, then the separator dividing it
+    // from the place it belongs to.
+    const lead = new RegExp(`^\\s*(?:[A-Za-z]{1,4}\\s+)?[≥≤~<>]?${n}${CLOSE}${UNIT}${DENOM}\\s*[—–\\-·:]\\s*`, "u");
+    if (lead.test(out)) { out = out.replace(lead, ""); break; }
+
+    // An inline restatement: "AQI 55", "32°C", "≥47/100", "4,176,592 displaced".
+    const inline = new RegExp(`\\s*${OPEN}(?:[A-Za-z]{1,4}\\s+)?[≥≤~<>]?${n}${CLOSE}${UNIT}${DENOM}`, "u");
+    if (inline.test(out)) { out = out.replace(inline, " "); break; }
+  }
+
+  const tidy = out
+    .replace(/\(\s*\)/g, "")               // parens emptied by the removal
+    .replace(/\s*\(\s*/g, " (")
+    .replace(/\s{2,}/g, " ")
+    .replace(/^[\s—–\-·:,]+/u, "")         // a separator left leading
+    .replace(/[\s—–\-·:,]+$/u, "")         // …or trailing
+    .replace(/([—–\-·:])\s*\1+/gu, "$1")   // doubled separators
+    .trim();
+
+  // A stripped-to-nothing row has lost its place name, which is worse than the
+  // duplication this function exists to remove.
+  return tidy.length >= 2 ? tidy : title;
 }
 
 /**

--- a/lib/console/widgets/signals.tsx
+++ b/lib/console/widgets/signals.tsx
@@ -15,7 +15,7 @@ import type { SignalSource } from "@/lib/signals/types";
 import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { useScope } from "@/lib/shell/scope";
-import { projectSignal } from "@/lib/console/signals/signalCard";
+import { projectSignal, rowLabel } from "@/lib/console/signals/signalCard";
 import { signalHelp } from "@/lib/console/help";
 import { useSignalFeed } from "@/lib/console/signals/useSignalFeed";
 import { useCapabilityStatus } from "@/lib/sources/useStatus";
@@ -220,7 +220,22 @@ function makeSignalBody(source: SignalSource) {
       );
     }
     if (projected.shown === 0) {
-      return <p className="tn-w-empty">Nothing in {scope.label}.</p>;
+      // "Nothing in World." beside a header badge reading 8 is the contradiction
+      // reviewers reported: the badge counts the FEED, the body counts what
+      // survived the active scope, and printing only the second makes a filtered
+      // card indistinguishable from a dead one. A duty officer's words for it:
+      // "an empty panel I cannot prove is truly empty is worse than no panel".
+      //
+      // The genuinely-zero case is unchanged. Only the case where the feed has
+      // rows and the scope hid them gains a sentence, and that sentence names
+      // both numbers so the disagreement resolves itself on screen.
+      return projected.total > 0 ? (
+        <p className="tn-w-empty">
+          {projected.totalLabel} in the feed, none inside {scope.label}.
+        </p>
+      ) : (
+        <p className="tn-w-empty">Nothing in {scope.label}.</p>
+      );
     }
 
     const now = Date.now();
@@ -241,7 +256,10 @@ function makeSignalBody(source: SignalSource) {
               ) : (
                 <span className="tn-w-dot" style={{ background: r.color || "var(--tn-text-faint, #94a3b8)" }} aria-hidden />
               )}
-              <span className="tn-w-place">{r.title}</span>
+              {/* rowLabel, not r.title: the title also serves as the map's pin
+                  label, where there is no value column and the magnitude has to
+                  stay. In the row it was said twice. See lib/console/signals/signalCard. */}
+              <span className="tn-w-place">{rowLabel(r.title, r.metric)}</span>
               {rel && <span className="tn-w-muted"> · {rel}</span>}
             </li>
           );

--- a/tests/unit/signal-row-label.test.ts
+++ b/tests/unit/signal-row-label.test.ts
@@ -1,0 +1,95 @@
+// tests/unit/signal-row-label.test.ts
+//
+// Every string asserted here was READ OFF THE RUNNING APP, not invented. They are
+// the rows six independent reviewers flagged: the value column repeats what the
+// title already says, so the first characters of every row carry no information,
+// and in the weather case the two copies disagree with each other.
+
+import { describe, expect, it } from "vitest";
+import { rowLabel, rowMetric } from "@/lib/console/signals/signalCard";
+import type { SignalFeature } from "@/lib/signals/types";
+
+const m = (value: number, label: string) => ({ value, domain: [0, 100] as [number, number], label });
+
+describe("rowLabel — the real rows", () => {
+  it("drops the leading magnitude stanza from a USGS quake", () => {
+    // Chip reads "5.5"; the title said it again, first thing.
+    expect(rowLabel("M 5.5 — 69 km SSW of Chirilagua, El Salvador", m(5.5, "5.5")))
+      .toBe("69 km SSW of Chirilagua, El Salvador");
+  });
+
+  it("drops the restated AQI and keeps the category", () => {
+    // The parenthesis stays. Unwrapping it would be a second, unrelated edit to
+    // the adapter's wording, and "London — (Moderate)" already reads fine once
+    // the number is not said twice.
+    expect(rowLabel("London — AQI 55 (Moderate)", m(55, "55 AQI")))
+      .toBe("London — (Moderate)");
+  });
+
+  it("drops the ROUNDED temperature, which is not the metric's own value", () => {
+    // The chip carries 31.5; the title carried Math.round(31.5) = 32. Matching only
+    // the raw value would leave the disagreement on screen, which is the whole
+    // reason this row was reported.
+    expect(rowLabel("London — 32°C ☀ Clear", m(31.5, "31.5 °C")))
+      .toBe("London — ☀ Clear");
+  });
+
+  it("drops the grouped displacement count and the word that was its unit", () => {
+    // "displaced" goes with the number it qualified; the card is already titled
+    // Forced Displacement, so the row is left saying the one thing it should.
+    expect(rowLabel("United States — 4,176,592 displaced", m(4176592, "4,176,592")))
+      .toBe("United States");
+  });
+
+  it("drops an instability score written as a bounded fraction", () => {
+    expect(rowLabel("Nigeria — instability ≥47/100 (floor, 3/4 factors)", m(47, "47")))
+      .toBe("Nigeria — instability (floor, 3/4 factors)");
+  });
+});
+
+describe("rowLabel — leaves alone what it cannot improve", () => {
+  it("returns the title unchanged when the source declares no metric", () => {
+    // GDELT's title is the bare place name — its row collided for a different
+    // reason (a fixed-width value column overflowing), not duplication.
+    expect(rowLabel("Iran", undefined)).toBe("Iran");
+  });
+
+  it("returns the title unchanged when the number is not in it", () => {
+    expect(rowLabel("Kyiv, Kyyiv, Misto, Ukraine", m(45, "45 articles")))
+      .toBe("Kyiv, Kyyiv, Misto, Ukraine");
+  });
+
+  it("keeps a title that is ONLY the number rather than emptying the row", () => {
+    // Losing the place name is worse than keeping a redundant one.
+    expect(rowLabel("47", m(47, "47"))).toBe("47");
+  });
+
+  it("does not strip a digit that is part of the place name", () => {
+    expect(rowLabel("Route 66 Interchange", m(5.5, "5.5"))).toBe("Route 66 Interchange");
+  });
+
+  it("handles an empty title without throwing", () => {
+    expect(rowLabel("", m(5, "5"))).toBe("");
+  });
+});
+
+describe("rowMetric — the value column's own formatting", () => {
+  const feat = (props: Record<string, unknown>): SignalFeature => ({
+    id: "x", title: "t", lat: 0, lon: 0, props,
+  } as SignalFeature);
+
+  it("groups thousands so the chip and the title cannot spell one number two ways", () => {
+    const r = rowMetric(feat({ displacedCount: 4176592 }), { field: "displacedCount", domain: [0, 5_000_000] });
+    expect(r?.label).toBe("4,176,592");
+  });
+
+  it("keeps one decimal for non-integers", () => {
+    const r = rowMetric(feat({ magnitude: 5.53 }), { field: "magnitude", domain: [2, 8] });
+    expect(r?.label).toBe("5.5");
+  });
+
+  it("appends the declared unit", () => {
+    const r = rowMetric(feat({ usAqi: 55 }), { field: "usAqi", domain: [0, 300], unit: " AQI" });
+    expect(r?.label).toBe("55 AQI");
+  });
+});

--- a/tests/unit/signals-displacement.test.ts
+++ b/tests/unit/signals-displacement.test.ts
@@ -42,7 +42,9 @@ test("declares a real numeric displaced-count metric that rowMetric resolves", (
 
   expect(DISPLACEMENT_SOURCE.metric).toEqual({ field: "displacedCount", domain: [0, 5_000_000] });
   const m = rowMetric(afg, DISPLACEMENT_SOURCE.metric);
-  expect(m).toEqual({ value: 3_220_946, domain: [0, 5_000_000], label: "3220946" });
+  // Grouped. An ungrouped "3220946" sat beside a title that had already written
+  // the same number as "3,220,946" — one row, one number, two spellings.
+  expect(m).toEqual({ value: 3_220_946, domain: [0, 5_000_000], label: "3,220,946" });
 });
 
 test("displacement colour ramps by total", () => {

--- a/tests/unit/signals-military-air.test.ts
+++ b/tests/unit/signals-military-air.test.ts
@@ -38,7 +38,7 @@ test("declares an altitude metric that resolves to a finite number", () => {
   const resolved = rowMetric(c17, metric)!;
   expect(resolved.value).toBe(15000);
   expect(resolved.domain).toEqual([0, 45000]);
-  expect(resolved.label).toBe("15000 ft");
+  expect(resolved.label).toBe("15,000 ft"); // grouped: an altitude is read, not parsed
 
   // "ground" maps to a genuine 0 ft — still a finite metric, not a dot.
   const grounded = out.find((f) => f.id === "mil:abc123")!;

--- a/tests/unit/signals-nuclear.test.ts
+++ b/tests/unit/signals-nuclear.test.ts
@@ -82,7 +82,7 @@ test("adds a numeric outputMw prop that the declared metric resolves to a bar", 
 
   // rowMetric reads the real scalar (not the radius proxy) and formats the label.
   const bar = rowMetric(way!, NUCLEAR_SOURCE.metric);
-  expect(bar).toEqual({ value: 1180, domain: [0, 8000], label: "1180 MW" });
+  expect(bar).toEqual({ value: 1180, domain: [0, 8000], label: "1,180 MW" });
 
   // The unnamed / capacity-less plant carries no outputMw and no bar.
   const capacityless = out.find((f) => f.id === "nuclear:node/6443114600");


### PR DESCRIPTION
Independent of #84 - different files, no overlap, either can merge first.

Five of six persona reviewers flagged the same thing without seeing each other's findings. The value column - the one the eye scans down a card - repeats what the title already says, so the first characters of every row carry no information:

| chip | title, as rendered |
|---|---|
| `5.5` | `M 5.5 - 69 km SSW of Chirilagua, El Salvador` |
| `55 AQI` | `London - AQI 55 (Moderate)` |
| `31.5 °C` | `London - 32°C ☀ Clear` |
| `4176592` | `United States - 4,176,592 displaced` |
| `47` | `Nigeria - instability ≥47/100 (floor, 3/4 factors)` |

Two of those disagree with themselves. The weather row is the one that costs most, and a reviewer put it plainly: *a page that argues with itself about the temperature in London is a page whose numbers about Sudan you stop believing.* The chip carried the raw 31.5, the title carried `Math.round(31.5)`.

## Fixed in the row, not in the twenty adapters

`title` has a second audience: it is the map's pin label (`components/WorldMap.tsx`), where there is no value column and stripping the magnitude would leave "69 km SSW of Chirilagua" on a pin with no idea how big it was. The duplication exists only in the row, so `rowLabel` removes it only in the row. Pure, and unit-tested against the five real strings above.

**It refuses a lot, on purpose.** The dangerous version of this function corrupts a place name: a metric of 5.5 has `"6"` among its plausible spellings, and without a trailing boundary `Route 66 Interchange` becomes `Route 6 Interchange`. Both boundaries are asserted, and anything that would strip to nothing returns the title untouched - a redundant number is cosmetic, a row with no place name is broken.

Verified in the running app: `5.5 | 69 km SSW of Chirilagua, El Salvador`, `49 | Nigeria - instability (floor, 3/4 factors)`.

## The collision was a different bug

`51 articlesIran` and `16 articlesNew Delhi` are not duplication - GDELT's title is the bare place name. `.tn-w-bar` was a **fixed 66px**, of which the track took 30, so any unit longer than a couple of characters (`" articles"`, `" ft"`, `" MW"`) overflowed the box and printed straight over the place name beside it. The row's own 6px gap could not help, because the text had already escaped its parent. The column now sizes to content between a min and a max.

Measured after: `7 articles` now has a real **6px gap** before `Tehran, Tehran, Iran`.

## Also

- `fmtMetric` groups thousands, so an altitude reads `15,000 ft` and the displacement chip stops spelling a number differently from the title beside it. Three tests pinned the ungrouped form and are updated - they described the old formatting, they were not catching a bug.
- An empty card that is empty *for a reason* now says the reason. A body reading "Nothing in World." under a header badge reading 8 made a scope-filtered card indistinguishable from a dead feed. Where the feed has rows, the sentence names both numbers.

## Verified

- `npx tsc --noEmit && npm test` - 222 files, 1,624 tests.
- In the browser on the earthquake, instability, protests and military-air cards: duplication gone, gap present on every row that had none, no row emptied.

## Not in this PR

The remaining empty-state work: distinguishing a genuine zero from a feed that failed from a layer with no API key. The locked-capability case is already handled by `capabilityBadge`; a *failed* fetch and a real zero still read alike, and fixing that properly needs the last-success timestamp surfaced per source.