### PR TITLE
Three layers were empty in production, and all three looked like quiet news

### DIFF
--- a/app/api/planes/route.ts
+++ b/app/api/planes/route.ts
@@ -4,6 +4,16 @@ import { describeCoverage } from "@/lib/signals/coverage";
 export const dynamic = "force-dynamic";
 
 /**
+ * Headroom for the adsb.lol fallback sweep, which is rate-limit-paced and budgets
+ * itself 14 s (lib/sources/adsb.ts). Only the request that triggers a Data Cache
+ * revalidation pays it — at most once per 240 s for the whole deployment — but that
+ * request must not be killed mid-sweep, or the cache never commits and the layer
+ * stays empty for exactly the reason this fix exists. 30 s is headroom, not a
+ * target; `app/api/signals/[id]` already establishes 60 as acceptable here.
+ */
+export const maxDuration = 30;
+
+/**
  * GET /api/planes — live aircraft worldwide (keyless, from OpenSky's global
  * `/states/all` snapshot) as classified WorldObjects. fetchAircraftSnapshot serves a
  * shared, stored snapshot (Next Data Cache) and handles failure (last-good / empty),
@@ -28,12 +38,20 @@ export const dynamic = "force-dynamic";
  *   - too old, or never fetched → `planes: []`; `staleness: {reason, ageMs?}` when
  *     there's a reason to give (never served as if the layer were simply quiet).
  *
- * Response: { count, coverage?, staleness?, planes }
+ * PROVENANCE. `source` names which upstream actually produced these positions:
+ * `"opensky"` (worldwide, one global snapshot) or `"adsb.lol"` (a bounded grid
+ * sweep of a community receiver network, dense over North America and Europe and
+ * thin elsewhere). The two are NOT interchangeable in coverage, so a consumer that
+ * prints a count without reading this cannot describe it correctly. Absent means no
+ * snapshot was served, never "either is fine".
+ *
+ * Response: { count, source?, coverage?, staleness?, planes }
  */
 export async function GET() {
-  const { planes, coverage, staleness } = await fetchAircraftSnapshot();
+  const { planes, coverage, staleness, source } = await fetchAircraftSnapshot();
   return Response.json({
     count: planes.length,
+    ...(source ? { source } : {}),
     ...(coverage ? { coverage: describeCoverage(coverage) } : {}),
     ...(staleness ? { staleness } : {}),
     planes,

--- a/lib/signals/eonet.ts
+++ b/lib/signals/eonet.ts
@@ -21,6 +21,21 @@ import type { SignalFeature, SignalMetric, SignalSource } from "@/lib/signals/ty
 const ENDPOINT = "https://eonet.gsfc.nasa.gov/api/v3/events?status=open";
 const CACHE_TTL_MS = 10 * 60 * 1000;
 
+/**
+ * Some categories cannot be read off the shared `status=open` feed at all, because
+ * for them "open" does not mean "still happening" — see `allStatuses` on
+ * EonetCategoryMeta. Those get their own category-scoped feed.
+ *
+ * `limit`, not `days`. Measured 2026-08-13: `status=all&days=60` costs 15.9 s,
+ * while `status=all&limit=200` costs 2.4 s for the same 2.7 MB of the newest
+ * events, which comfortably spans the 60-day window `maxAgeDays` then applies
+ * client-side. EONET returns newest-first, so the limit trims the far tail, which
+ * is the part `maxAgeDays` was going to drop anyway.
+ */
+const CATEGORY_FEED_LIMIT = 200;
+export const categoryFeedUrl = (category: string): string =>
+  `https://eonet.gsfc.nasa.gov/api/v3/categories/${category}?status=all&limit=${CATEGORY_FEED_LIMIT}`;
+
 export const EONET_ATTRIBUTION = "Natural-event data © NASA EONET";
 
 export interface EonetGeometry {
@@ -57,6 +72,24 @@ export interface EonetCategoryMeta {
    * ago is almost certainly out, whereas a volcano is still a volcano.
    */
   maxAgeDays?: number;
+  /**
+   * Read this category from its own `status=all` feed instead of the shared
+   * `status=open` one.
+   *
+   * The comment on `maxAgeDays` above assumes "open ⇒ not declared finished", and
+   * for wildfires, volcanoes and storms that holds. For FLOODS it does not, and
+   * the layer was empty in production because of it: EONET closes a flood within
+   * days of the water going down, so `status=open` matched NOTHING. Measured
+   * 2026-08-13 — the open feed carried 7,058 events (6,985 wildfires, 33
+   * seaLakeIce, 32 volcanoes, 8 severeStorms) and exactly ZERO floods, while the
+   * category feed held 9 floods that month and 62 the month before, every one of
+   * them already closed. One had closed three days earlier.
+   *
+   * This is the same shape of bug the ENDPOINT comment records for volcanoes: an
+   * upstream filter that reads as a sensible default while silently emptying a
+   * layer. `maxAgeDays` is what bounds recency here, which is what it was for.
+   */
+  allStatuses?: boolean;
 }
 
 export const CATEGORIES: Record<string, EonetCategoryMeta> = {
@@ -73,7 +106,16 @@ export const CATEGORIES: Record<string, EonetCategoryMeta> = {
     metric: { field: "windKt", domain: [35, 140], unit: " kts" },
     maxAgeDays: 14, // a storm nobody has observed in a fortnight is over
   },
-  floods: { signalId: "floods", category: "floods", label: "Floods", color: "#0ea5e9", maxAgeDays: 60 },
+  // allStatuses: a flood is closed almost as soon as it recedes, so the shared
+  // open feed never contains one. maxAgeDays is what keeps this recent.
+  floods: {
+    signalId: "floods",
+    category: "floods",
+    label: "Floods",
+    color: "#0ea5e9",
+    maxAgeDays: 60,
+    allStatuses: true,
+  },
 };
 
 /** Extract a representative [lon, lat] from a Point or (defensively) a Polygon. */
@@ -171,10 +213,25 @@ export function eonetToFeatures(
 let cache: { events: EonetEvent[]; at: number } | null = null;
 let inflight: Promise<EonetEvent[]> | null = null;
 
+/**
+ * 30 s, not 15 s. The shared open feed measured 4.9 MB on 2026-08-13 and its
+ * fetch time is genuinely variable: 7.7 s on one call and 18.3 s on another,
+ * minutes apart. Against a 15 s timeout that is a coin flip, and losing it takes
+ * ALL FOUR EONET layers to zero at once — with no error surfaced, because the
+ * catch below falls back to last-good, which on a cold instance is empty. That
+ * was observed live: volcanoes and wildfires read 0 on a dev server while the
+ * same code read 32 and 171 when the fetch happened to win.
+ *
+ * The route allows 60 s (app/api/signals/[id] sets maxDuration = 60), and the
+ * result is cached for CACHE_TTL_MS, so a slow fetch is paid once per ten
+ * minutes rather than per request.
+ */
+const FETCH_TIMEOUT_MS = 30_000;
+
 async function refresh(): Promise<EonetEvent[]> {
   const res = await fetch(ENDPOINT, {
     headers: { "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)" },
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!res.ok) throw new Error(`EONET: ${res.status}`);
   const json = (await res.json()) as { events?: EonetEvent[] };
@@ -195,6 +252,41 @@ export async function fetchEonet(): Promise<EonetEvent[]> {
   return cache ? cache.events : inflight;
 }
 
+// --- Per-category cached fetch, for `allStatuses` categories ----------------
+// Same fresh-or-stale-while-revalidate contract as fetchEonet, keyed by category
+// so two such layers never share each other's events.
+const catCache = new Map<string, { events: EonetEvent[]; at: number }>();
+const catInflight = new Map<string, Promise<EonetEvent[]>>();
+
+async function refreshCategory(category: string): Promise<EonetEvent[]> {
+  const res = await fetch(categoryFeedUrl(category), {
+    headers: { "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)" },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`EONET ${category}: ${res.status}`);
+  const json = (await res.json()) as { events?: EonetEvent[] };
+  const events = json.events ?? [];
+  catCache.set(category, { events, at: Date.now() });
+  return events;
+}
+
+/** One category's full-status feed. Never throws — falls back to last-good. */
+export async function fetchEonetCategory(category: string): Promise<EonetEvent[]> {
+  const hit = catCache.get(category);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.events;
+  if (!catInflight.has(category)) {
+    catInflight.set(
+      category,
+      refreshCategory(category)
+        .catch(() => catCache.get(category)?.events ?? [])
+        .finally(() => {
+          catInflight.delete(category);
+        }),
+    );
+  }
+  return hit ? hit.events : (catInflight.get(category) as Promise<EonetEvent[]>);
+}
+
 function makeSource(meta: EonetCategoryMeta): SignalSource {
   return {
     id: meta.signalId,
@@ -205,7 +297,9 @@ function makeSource(meta: EonetCategoryMeta): SignalSource {
     attribution: EONET_ATTRIBUTION,
     ...(meta.metric ? { metric: meta.metric } : {}),
     async fetch() {
-      const events = await fetchEonet();
+      const events = meta.allStatuses
+        ? await fetchEonetCategory(meta.category)
+        : await fetchEonet();
       return eonetToFeatures(events, meta);
     },
   };

--- a/lib/signals/gdacs.ts
+++ b/lib/signals/gdacs.ts
@@ -5,9 +5,29 @@ import type { SignalFeature, SignalSource } from "@/lib/signals/types";
 // cyclones, floods, volcanoes, droughts and wildfires, each with a Green/Orange/Red
 // alert level. Complements the per-hazard feeds (USGS quakes, EONET fires/floods)
 // with a single multi-hazard, severity-scored, alert-coloured overlay. The marker
-// is GDACS's representative centroid. Confirmed live 2026-06-27.
+// is GDACS's representative centroid. Confirmed live 2026-06-27; re-verified
+// 2026-08-13 after upstream began requiring `eventtype` — see ENDPOINT below.
 
-const ENDPOINT = "https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP";
+/**
+ * EVENTTYPE IS MANDATORY. Calling this endpoint bare — as this adapter did until
+ * 2026-08-13 — now answers HTTP 400 `{"message":"Eventtype is required."}`. GDACS
+ * added the requirement at some point after the 2026-06-27 verification above, and
+ * because `fetch()` below returns `[]` on any non-ok response, the layer reported a
+ * clean, quiet zero rather than a failure. It looked exactly like "no disasters
+ * today" while being a hard 400 on every single poll.
+ *
+ * The parameter is SEMICOLON-separated, not comma-separated or repeated. All six
+ * hazard codes, measured 2026-08-13: 289 events (TC 203, WF 32, DR 24, FL 15,
+ * EQ 10, VO 5). The response shape is unchanged, so `normalizeGdacs` needed no
+ * edit — this was one missing query parameter, nothing more.
+ *
+ * TS (tsunami) is deliberately absent: `gdacsEventLabel` maps it because GDACS
+ * documents the code, but the event list does not accept it as a filter value.
+ */
+export const GDACS_EVENT_TYPES = ["EQ", "TC", "FL", "VO", "DR", "WF"] as const;
+/** Exported so a regression test can assert the parameter is still there. */
+export const GDACS_ENDPOINT =
+  `https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP?eventtype=${GDACS_EVENT_TYPES.join(";")}`;
 const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 
 export const GDACS_ATTRIBUTION = "Disaster alerts © GDACS (UN OCHA / European Commission JRC)";
@@ -122,7 +142,7 @@ export const GDACS_SOURCE: SignalSource = {
   metric: { field: "alertScore", domain: [0, 3] },
   async fetch() {
     try {
-      const res = await fetch(ENDPOINT, {
+      const res = await fetch(GDACS_ENDPOINT, {
         headers: { "User-Agent": UA, Accept: "application/json" },
         signal: AbortSignal.timeout(15_000),
       });

--- a/lib/sources/adsb.ts
+++ b/lib/sources/adsb.ts
@@ -1,0 +1,423 @@
+/**
+ * adsb.lol — live aircraft from a community ADS-B receiver network, swept as a
+ * bounded grid of point+radius queries.
+ *
+ * WHY THIS EXISTS: `lib/sources/opensky.ts` is the aircraft layer's primary source
+ * because `/states/all` is genuinely worldwide in one request. But OpenSky's
+ * anonymous tier is credit-capped PER IP, and on the production deployment's IP that
+ * cap is permanently exhausted: every poll throws, `unstable_cache` therefore never
+ * commits a value, and the layer sits in `never-fetched` forever serving
+ * `{count: 0}`. Measured on prod 2026-08-13. From a home IP the same endpoint
+ * answers 200 with ~1.7 MB in 0.58 s, which is what makes it an IP-reputation
+ * problem rather than a code problem.
+ *
+ * WHY A SWEEP AND NOT A GLOBAL CALL: there is no keyless global ADS-B endpoint.
+ * Probed 2026-08-13: `api.adsb.lol/v2/all` 404, `opendata.adsb.fi/api/v2/all` 400,
+ * `api.airplanes.live/v2/all` 403, `api.adsb.one/v2/all` 403. Only point+radius
+ * (max 250 nm) answers, so worldwide-ish coverage means asking many cells.
+ *
+ * WHY THAT IS SAFE HERE, WHEN opensky.ts's header says a sweep collapses: that
+ * warning is about accumulating cells in MODULE state across serverless
+ * invocations, where each cold lambda starts empty and the union degrades to
+ * whichever cells landed last. This sweep does every cell inside ONE invocation and
+ * caches the finished union, so there is no cross-invocation accumulation to lose.
+ *
+ * ── THE HONESTY BOUNDARY ────────────────────────────────────────────────────
+ * adsb.lol is fed by volunteers, so its coverage is wherever people run receivers,
+ * NOT the whole sky. Measured per-cell yield 2026-08-13 (250 nm):
+ *   New York 1,023 · London 491 · Dubai 129 · Tokyo 25 · Singapore 21 · Sydney 0.
+ * North America and Europe are dense; much of Asia, Africa, South America and
+ * Oceania are thin to empty. So this provider must NEVER declare its result as a
+ * global count. It reports `availableExact: false` — an explicit lower bound — and
+ * a rule string naming what was actually swept. A number that says "global" when it
+ * means "wherever volunteers point antennas" is the precise failure this codebase
+ * exists to not commit.
+ *
+ * Deliberately imports NOTHING from opensky.ts: that module imports this one for
+ * its fallback, and the dependency has to stay one-way.
+ *
+ * Docs: https://api.adsb.lol/docs
+ */
+
+import type { WorldObject } from "@/lib/world";
+import { classifyPlane } from "@/lib/planes/classify";
+import { PLANE_META } from "@/lib/icons/svg";
+import { withCoverage } from "@/lib/signals/coverage";
+
+export const ADSB_ATTRIBUTION = "Live aircraft © adsb.lol (community ADS-B receivers)";
+
+// ---------------------------------------------------------------------------
+// The grid
+// ---------------------------------------------------------------------------
+
+export interface SweepCell {
+  lat: number;
+  lon: number;
+  /** Human label, used only in diagnostics — never rendered as a source claim. */
+  label: string;
+}
+
+/**
+ * Cell centres over the airspace that actually carries traffic, rather than tiling
+ * the globe uniformly — two thirds of Earth is ocean, and a cell over empty ocean
+ * spends a rate-limit token to return nothing.
+ *
+ * ── THE ORDER IS LOAD BEARING, NOT COSMETIC ─────────────────────────────────
+ * The upstream rate limit (see below) means a sweep gets through roughly 9-11
+ * cells inside its time budget, so THE TAIL OF THIS LIST USUALLY DOES NOT RUN.
+ * That makes ordering a coverage decision.
+ *
+ * Sorted by yield, but INTERLEAVED ACROSS CONTINENTS. Strict yield order would put
+ * the eight densest US cells first and Europe would never be swept at all — a
+ * "global" aviation layer that is quietly United-States-only. Interleaving means a
+ * truncated sweep still spans North America and Europe, which is where this network
+ * has receivers.
+ */
+export const SWEEP_CELLS: readonly SweepCell[] = [
+  // Highest yield, alternating continents — these are the ones that reliably run.
+  { lat: 40.7, lon: -74.0, label: "New York" },
+  { lat: 51.5, lon: -0.1, label: "London" },
+  { lat: 41.9, lon: -87.6, label: "Chicago" },
+  { lat: 50.1, lon: 8.7, label: "Frankfurt" },
+  { lat: 34.0, lon: -118.2, label: "Los Angeles" },
+  { lat: 40.4, lon: -3.7, label: "Madrid" },
+  { lat: 33.7, lon: -84.4, label: "Atlanta" },
+  { lat: 41.9, lon: 12.5, label: "Rome" },
+  { lat: 32.8, lon: -96.8, label: "Dallas" },
+  { lat: 54.0, lon: 14.0, label: "Baltic" },
+  { lat: 25.2, lon: 55.3, label: "Dubai" },
+
+  // Reached when the budget is generous.
+  { lat: 37.6, lon: -122.4, label: "San Francisco" },
+  { lat: 56.0, lon: -3.5, label: "Scotland" },
+  { lat: 29.8, lon: -95.4, label: "Houston" },
+  { lat: 45.8, lon: 4.8, label: "Lyon" },
+  { lat: 25.8, lon: -80.3, label: "Miami" },
+  { lat: 41.0, lon: 28.9, label: "Istanbul" },
+  { lat: 47.6, lon: -122.3, label: "Seattle" },
+  { lat: 59.3, lon: 18.1, label: "Stockholm" },
+  { lat: 39.7, lon: -104.9, label: "Denver" },
+  { lat: 35.7, lon: 139.7, label: "Tokyo" },
+  { lat: 43.7, lon: -79.4, label: "Toronto" },
+  { lat: 47.5, lon: 19.0, label: "Budapest" },
+  { lat: 28.6, lon: 77.2, label: "Delhi" },
+  { lat: 42.4, lon: -71.0, label: "Boston" },
+  { lat: 55.8, lon: 37.6, label: "Moscow" },
+
+  // The long tail. Rarely reached, kept so a fast day is not artificially
+  // North-Atlantic-only, and so the planned grid honestly states our intent.
+  { lat: 44.9, lon: -93.2, label: "Minneapolis" },
+  { lat: 33.4, lon: -112.0, label: "Phoenix" },
+  { lat: 49.2, lon: -123.1, label: "Vancouver" },
+  { lat: 19.4, lon: -99.1, label: "Mexico City" },
+  { lat: 19.1, lon: 72.9, label: "Mumbai" },
+  { lat: 13.7, lon: 100.5, label: "Bangkok" },
+  { lat: 1.35, lon: 103.8, label: "Singapore" },
+  { lat: 22.3, lon: 114.2, label: "Hong Kong" },
+  { lat: 30.0, lon: 31.2, label: "Cairo" },
+  { lat: -26.1, lon: 28.0, label: "Johannesburg" },
+  { lat: -23.5, lon: -46.6, label: "Sao Paulo" },
+  { lat: -34.6, lon: -58.4, label: "Buenos Aires" },
+  { lat: -33.9, lon: 151.2, label: "Sydney" },
+  { lat: 64.1, lon: -21.9, label: "Reykjavik" },
+];
+
+const RADIUS_NM = 250; // the endpoint's documented maximum
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const CELL_TIMEOUT_MS = 8_000;
+
+/**
+ * ── RATE LIMIT, MEASURED 2026-08-13. Do not raise these without re-measuring. ──
+ *
+ * adsb.lol enforces a token bucket with a burst of roughly 3 and a refill of about
+ * one request per second. It is strict and it fails fast: a 10-wide concurrent
+ * burst returned 429 on ALL TEN in 0.4 s, and even 250 ms spacing only landed
+ * roughly one request in three.
+ *
+ * The first version of this sweep ran 10-wide and got 1 cell out of 40. It still
+ * "worked" — 822 aircraft, and the coverage record honestly said 1 of 40 — which is
+ * exactly the kind of quietly-crippled success that looks fine in a response body.
+ * Hence sequential-with-pacing rather than concurrency.
+ */
+const PACE_MS = 400; // between successful requests; the bucket refills under this
+const RETRY_BACKOFF_MS = [900, 1800]; // per cell, on 429 only
+const SWEEP_BUDGET_MS = 14_000;
+
+export const cellUrl = (c: SweepCell): string =>
+  `https://api.adsb.lol/v2/lat/${c.lat}/lon/${c.lon}/dist/${RADIUS_NM}`;
+
+// ---------------------------------------------------------------------------
+// Upstream shape
+// ---------------------------------------------------------------------------
+
+export interface AdsbRow {
+  hex?: string;
+  flight?: string;
+  r?: string; // registration / tail
+  t?: string; // ICAO type code
+  desc?: string; // long type description
+  alt_baro?: number | string; // feet, or the literal "ground"
+  alt_geom?: number; // feet
+  gs?: number; // ground speed, knots
+  track?: number; // true track, degrees
+  baro_rate?: number; // feet/minute
+  squawk?: string;
+  category?: string; // ADS-B emitter category, e.g. "A3"
+  lat?: number;
+  lon?: number;
+}
+
+// Unit conversions, named so the parser reads as physics rather than magic numbers.
+const FT_TO_KM = 0.0003048;
+const KT_TO_MS = 0.514444;
+const FTMIN_TO_MS = 0.00508;
+
+function num(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Pure: one adsb.lol row → a {@link WorldObject}, or null when it carries no usable
+ * position. Shapes `meta` to match `planeToWorldObject` in opensky.ts exactly, so
+ * the globe layer and the dossier cannot tell which provider served a given
+ * aircraft — with two additive extras this feed has and OpenSky does not.
+ *
+ * CLASSIFICATION IS BETTER HERE, and that is worth stating: adsb.lol broadcasts the
+ * real ADS-B emitter `category`, so `classifyPlane` reads a transmitted fact. The
+ * OpenSky path has no category field at all and always falls through to the
+ * altitude/speed heuristic, which the UI labels "est.". Aircraft served by this
+ * provider are therefore classified, not estimated.
+ */
+export function adsbRowToWorldObject(row: AdsbRow): WorldObject | null {
+  const lat = num(row.lat);
+  const lon = num(row.lon);
+  if (lat === null || lon === null) return null;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+
+  const hex = (row.hex ?? "").trim();
+  if (!hex) return null;
+
+  const onGround = typeof row.alt_baro === "string" && row.alt_baro.toLowerCase() === "ground";
+  const altFt = onGround ? 0 : (num(row.alt_geom) ?? num(row.alt_baro) ?? 0);
+  const altKm = altFt * FT_TO_KM;
+
+  const gs = num(row.gs);
+  const velocityMs = gs === null ? null : gs * KT_TO_MS;
+  const baroRate = num(row.baro_rate);
+  const verticalRateMs = baroRate === null ? null : baroRate * FTMIN_TO_MS;
+  const headingDeg = num(row.track) ?? 0;
+
+  const category = classifyPlane({
+    altKm,
+    velocityMs,
+    onGround,
+    category: (row.category ?? "").trim() || undefined,
+  });
+  const meta = PLANE_META[category];
+
+  const callsign = (row.flight ?? "").trim() || hex;
+  const typeCode = (row.t ?? "").trim();
+  const registration = (row.r ?? "").trim();
+
+  return {
+    kind: "plane",
+    id: `plane:${hex}`,
+    lat,
+    lon,
+    altKm,
+    heading: headingDeg,
+    label: callsign,
+    color: meta.color,
+    icon: meta.key,
+    typeLabel: meta.label,
+    meta: {
+      callsign,
+      // adsb.lol does not broadcast an origin country. OpenSky does, so this field
+      // exists in the shared shape; leaving it "" is the honest value. It is NOT
+      // inferred from the hex block or the registration prefix — that would be a
+      // derivation dressed as an observation.
+      country: "",
+      velocityMs,
+      altKm,
+      verticalRateMs,
+      onGround,
+      headingDeg,
+      category,
+      typeLabel: meta.label,
+      squawk: (row.squawk ?? "").trim(),
+      // Additive extras this provider supplies and OpenSky does not.
+      ...(typeCode ? { typeCode } : {}),
+      ...(registration ? { registration } : {}),
+      ...(row.desc?.trim() ? { typeDescription: row.desc.trim() } : {}),
+    },
+  };
+}
+
+/** Pure: rows → objects, dropping the unusable ones. */
+export function normalizeAdsbRows(rows: readonly AdsbRow[]): WorldObject[] {
+  const out: WorldObject[] = [];
+  for (const r of rows) {
+    const o = adsbRowToWorldObject(r);
+    if (o) out.push(o);
+  }
+  return out;
+}
+
+/**
+ * Pure: collapse overlapping cells by aircraft id, first occurrence winning.
+ * Adjacent 250 nm discs deliberately overlap so there are no seams, which means the
+ * same aircraft is reported by more than one cell; without this the layer would
+ * double-count precisely over the busiest airspace.
+ */
+export function dedupeById(objects: readonly WorldObject[]): WorldObject[] {
+  const seen = new Set<string>();
+  const out: WorldObject[] = [];
+  for (const o of objects) {
+    if (seen.has(o.id)) continue;
+    seen.add(o.id);
+    out.push(o);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The sweep
+// ---------------------------------------------------------------------------
+
+export interface SweepResult {
+  objects: WorldObject[];
+  /**
+   * Cells the grid INTENDED to sweep. Reported separately from `cellsAttempted`
+   * because the rate limit usually stops the sweep early, and a record that only
+   * compared succeeded-to-attempted would print "9 of 9" — indistinguishable from
+   * complete coverage, when 31 regions were never asked at all.
+   */
+  cellsPlanned: number;
+  /** Cells actually requested before the time budget ran out. */
+  cellsAttempted: number;
+  /** Cells that answered. Fewer than attempted ⇒ some regions refused or timed out. */
+  cellsSucceeded: number;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Thrown for a 429 specifically, so the caller can back off rather than give up. */
+class RateLimited extends Error {}
+
+async function fetchCellOnce(cell: SweepCell): Promise<WorldObject[]> {
+  const res = await fetch(cellUrl(cell), {
+    headers: { Accept: "application/json", "User-Agent": UA },
+    signal: AbortSignal.timeout(CELL_TIMEOUT_MS),
+  });
+  if (res.status === 429) throw new RateLimited(`adsb.lol ${cell.label} rate-limited`);
+  if (!res.ok) throw new Error(`adsb.lol ${cell.label} answered ${res.status}`);
+  const json = (await res.json()) as { ac?: AdsbRow[] };
+  return normalizeAdsbRows(json.ac ?? []);
+}
+
+/**
+ * One cell, retried on 429 only. A non-429 failure is a real upstream problem and
+ * retrying it just burns budget that a later cell could have used.
+ */
+async function fetchCell(cell: SweepCell, deadline: number): Promise<WorldObject[]> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fetchCellOnce(cell);
+    } catch (err) {
+      const retryable = err instanceof RateLimited && attempt < RETRY_BACKOFF_MS.length;
+      if (!retryable) throw err;
+      const wait = RETRY_BACKOFF_MS[attempt];
+      if (Date.now() + wait > deadline) throw err;
+      await sleep(wait);
+    }
+  }
+}
+
+/**
+ * Sweep the cells in order and stitch the union.
+ *
+ * SEQUENTIAL AND PACED, not concurrent — see the rate-limit block above; this
+ * upstream 429s a concurrent burst outright. Cells run densest-first so that when
+ * the budget bites, what gets dropped is what was going to return least.
+ *
+ * Per-cell failures are tolerated (one dead cell must not empty the layer) but are
+ * COUNTED, because `cellsSucceeded < cellsAttempted` is what makes the resulting
+ * count a lower bound rather than a measurement.
+ */
+export async function fetchAdsbSweep(
+  cells: readonly SweepCell[] = SWEEP_CELLS,
+): Promise<SweepResult> {
+  const deadline = Date.now() + SWEEP_BUDGET_MS;
+  const collected: WorldObject[] = [];
+  let succeeded = 0;
+  let attempted = 0;
+
+  for (const cell of cells) {
+    if (Date.now() >= deadline) break;
+    attempted++;
+    try {
+      collected.push(...(await fetchCell(cell, deadline)));
+      succeeded++;
+    } catch {
+      // A cell that 429s past its retries or times out is a hole in coverage, not a
+      // reason to fail the layer.
+    }
+    if (Date.now() < deadline) await sleep(PACE_MS);
+  }
+
+  return {
+    objects: dedupeById(collected),
+    cellsPlanned: cells.length,
+    cellsAttempted: attempted,
+    cellsSucceeded: succeeded,
+  };
+}
+
+/**
+ * The sweep, capped and carrying an honest coverage record.
+ *
+ * `availableExact` is ALWAYS false, for two independent reasons either of which
+ * would be sufficient: this network only sees where volunteers run receivers, and
+ * the grid only asks where we thought to look. Neither is a measurement of how many
+ * aircraft are airborne, so the count publishes as a lower bound ("N of N+") and
+ * `rule` carries the reason.
+ *
+ * `capped` is ALWAYS true, and that is deliberate rather than cosmetic:
+ * `coverageCountLabel` and `coverageNote` both return early on `!capped`, so
+ * declaring false here would print a bare "3,412" with no note — the exact reading
+ * ("that's all of them") this record exists to prevent. `returned` genuinely is a
+ * ceiling on what we can claim, so `capped` is also just true.
+ *
+ * Built with `withCoverage` rather than `applyCap`, because `applyCap` only reaches
+ * `availableExact: false` via its `upstream` option, which would also stamp an
+ * `upstreamLimit` — and no upstream request `limit=` was saturated here. That would
+ * be a false detail in the published note.
+ */
+export function sweepToObjects(result: SweepResult, cap: number): WorldObject[] {
+  const hasCap = Number.isFinite(cap) && cap > 0;
+  const localCapped = hasCap && result.objects.length > cap;
+  const out = localCapped ? result.objects.slice(0, cap) : result.objects.slice();
+
+  // Two different shortfalls, reported separately because they mean different
+  // things: cells never asked (rate limit ate the time budget) vs cells asked that
+  // refused. Collapsing them would hide which one is degrading.
+  const unasked = result.cellsPlanned - result.cellsAttempted;
+  const refused = result.cellsAttempted - result.cellsSucceeded;
+  const caveats = [
+    unasked > 0 ? `${unasked} not reached within the time budget` : "",
+    refused > 0 ? `${refused} did not answer` : "",
+  ].filter(Boolean);
+
+  return withCoverage(out, {
+    available: result.objects.length,
+    availableExact: false,
+    capped: true,
+    ...(localCapped ? { cap } : {}),
+    noun: "aircraft",
+    rule:
+      `seen by community ADS-B receivers across ${result.cellsSucceeded} of ` +
+      `${result.cellsPlanned} planned ${RADIUS_NM} nm regions` +
+      (caveats.length ? ` (${caveats.join("; ")})` : "") +
+      ", densest over North America and Europe and thin elsewhere - a lower bound, not a global count",
+  });
+}

--- a/lib/sources/opensky.ts
+++ b/lib/sources/opensky.ts
@@ -1,5 +1,9 @@
 /**
- * OpenSky Network — live aircraft worldwide, from ONE global snapshot.
+ * The aircraft layer. OpenSky Network is the PRIMARY source — live aircraft
+ * worldwide from ONE global snapshot — with a bounded adsb.lol grid sweep
+ * (lib/sources/adsb.ts) as the fallback when OpenSky refuses. See
+ * `fetchAircraftOnce` for why the fallback exists and what it costs in coverage.
+ * Everything below this line describes the OpenSky path specifically.
  *
  * WHY GLOBAL, NOT A SWEEP: adsb.lol/adsb.fi are point+radius only (max 250 nm, no
  * global query), so worldwide coverage there means sweeping ~50 cells and stitching
@@ -40,6 +44,7 @@ import {
   withCoverage,
   type SignalCoverage,
 } from "@/lib/signals/coverage";
+import { fetchAdsbSweep, sweepToObjects } from "@/lib/sources/adsb";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -249,6 +254,14 @@ export interface AircraftSnapshot {
    * fabrication — see `decideStaleness`/`gateSnapshot` below.
    */
   staleness?: { stale: true; ageMs: number } | { reason: "too-old"; ageMs: number };
+  /**
+   * Which upstream actually produced these positions. The two providers have
+   * materially different coverage — OpenSky is worldwide, the adsb.lol sweep sees
+   * only where volunteers run receivers — so a consumer that prints a count without
+   * knowing the provider cannot describe it correctly. Undefined only for a
+   * snapshot that predates this field or carries no aircraft.
+   */
+  source?: "opensky" | "adsb.lol";
 }
 
 /** Pure: lift the coverage a capped array carries into a JSON-serializable snapshot. */
@@ -312,6 +325,43 @@ async function fetchGlobalOnce(): Promise<AircraftSnapshot> {
   return { ...toAircraftSnapshot(objects), fetchedAt: Date.now() };
 }
 
+/**
+ * One aircraft snapshot from the best provider that answers.
+ *
+ * OpenSky stays PRIMARY because `/states/all` is genuinely worldwide in one call.
+ * But its anonymous tier is credit-capped per IP, and on the production
+ * deployment's IP that cap is permanently exhausted — measured 2026-08-13, prod
+ * `/api/planes` served `{count: 0}` while the same endpoint answered 200 with
+ * ~1.7 MB in 0.58 s from a home IP. With OpenSky as the only provider,
+ * `fetchGlobalOnce` throws on every poll, `unstable_cache` never commits, and the
+ * layer sits in `never-fetched` forever. A staleness gate cannot rescue that: there
+ * has never been a good snapshot to go stale.
+ *
+ * So on an OpenSky failure we fall back to a bounded adsb.lol grid sweep
+ * (lib/sources/adsb.ts), which answers fine from a datacentre IP — the sibling
+ * `military-air` layer has been serving from it in prod all along, which is the
+ * evidence that the block is OpenSky-specific and not general egress.
+ *
+ * The two providers do NOT have equal coverage, and the snapshot says which one
+ * served so that difference is never silent: OpenSky is worldwide, the sweep sees
+ * only where volunteers run receivers. Each attaches its own coverage record.
+ *
+ * If BOTH fail we rethrow OpenSky's error rather than returning an empty snapshot —
+ * `unstable_cache` must not commit a success on a total failure, or an empty result
+ * poisons the cache for the whole revalidate window. That is the same bug the
+ * `fetchGlobalOnce` docstring describes; it applies to the fallback path too.
+ */
+async function fetchAircraftOnce(): Promise<AircraftSnapshot> {
+  try {
+    return { ...(await fetchGlobalOnce()), source: "opensky" };
+  } catch (openSkyError) {
+    const sweep = await fetchAdsbSweep();
+    if (!sweep.objects.length) throw openSkyError;
+    const objects = sweepToObjects(sweep, MAX_PLANES);
+    return { ...toAircraftSnapshot(objects), fetchedAt: Date.now(), source: "adsb.lol" };
+  }
+}
+
 /** Re-attach the coverage field to the array after a Data Cache (JSON) round trip. */
 function rehydrate(snapshot: AircraftSnapshot): AircraftSnapshot {
   const planes = Array.isArray(snapshot?.planes) ? snapshot.planes : [];
@@ -322,6 +372,7 @@ function rehydrate(snapshot: AircraftSnapshot): AircraftSnapshot {
     planes,
     ...(snapshot?.coverage ? { coverage: snapshot.coverage } : {}),
     ...(snapshot?.fetchedAt ? { fetchedAt: snapshot.fetchedAt } : {}),
+    ...(snapshot?.source ? { source: snapshot.source } : {}),
   };
 }
 
@@ -405,17 +456,18 @@ export function gateSnapshot(snapshot: AircraftSnapshot, now: number = Date.now(
  * — cache hit or fallback — passes through `gateSnapshot` before it leaves this
  * function, so nothing older than STALE_CEILING_MS is ever returned.
  *
- * CACHE KEY: bumped to -v3, both for the shape change (added `fetchedAt`) and to
- * guarantee a clean start after this fix — a v2 entry may currently hold the
- * `{planes: []}` this exact bug wrote into production, and reusing that key
- * would mean serving that poisoned entry until it happened to revalidate.
+ * CACHE KEY: `planes-aircraft-v4`. Renamed off `planes-opensky-global-v3` because
+ * the entry is no longer OpenSky-specific — it now holds whichever provider
+ * answered — and bumped for the shape change (added `source`). The rename also
+ * guarantees a clean start: a v3 entry on prod can only hold what the exhausted
+ * credit cap produced, and reusing that key would serve it until it revalidated.
  */
 export async function fetchAircraftSnapshot(): Promise<AircraftSnapshot> {
   let snapshot: AircraftSnapshot;
   try {
     const { unstable_cache } = await import("next/cache");
     snapshot = rehydrate(
-      await unstable_cache(fetchGlobalOnce, ["planes-opensky-global-v3"], {
+      await unstable_cache(fetchAircraftOnce, ["planes-aircraft-v4"], {
         revalidate: REVALIDATE_S,
       })(),
     );
@@ -425,7 +477,7 @@ export async function fetchAircraftSnapshot(): Promise<AircraftSnapshot> {
     // failed too. One direct attempt; if that also fails, there is genuinely
     // nothing to serve.
     try {
-      snapshot = await fetchGlobalOnce();
+      snapshot = await fetchAircraftOnce();
     } catch {
       snapshot = { planes: [] };
     }

--- a/tests/unit/planes.adsb.test.ts
+++ b/tests/unit/planes.adsb.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Unit tests for the adsb.lol aircraft provider (lib/sources/adsb.ts) — the
+ * fallback that keeps /api/planes alive when OpenSky's anonymous credit cap is
+ * exhausted on the deployment's IP.
+ *
+ * FIXTURE PROVENANCE: every row in ADSB_FIXTURE was captured live from
+ * `https://api.adsb.lol/v2/lat/51.5/lon/-0.1/dist/250` on 2026-08-13 (481 rows in
+ * that response, all positioned) and pasted verbatim apart from dropping receiver
+ * telemetry fields the adapter never reads (rssi, messages, nic/rc/sil, mlat…).
+ * Nothing here is invented: the awkward cases are awkward because the network
+ * really returns them that way — notably the on-ground row, which carries
+ * `true_heading` but NO `track`.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  adsbRowToWorldObject,
+  dedupeById,
+  normalizeAdsbRows,
+  sweepToObjects,
+  SWEEP_CELLS,
+  cellUrl,
+  type AdsbRow,
+  type SweepResult,
+} from "@/lib/sources/adsb";
+import { readCoverage, coverageCountLabel, coverageNote } from "@/lib/signals/coverage";
+
+// --- live-captured fixture --------------------------------------------------
+
+const ADSB_FIXTURE: AdsbRow[] = [
+  // Embraer 175 climbing — has every optional field populated.
+  {
+    hex: "48548c",
+    flight: "KLM93C  ",
+    r: "PH-EXK",
+    t: "E75L",
+    alt_baro: 25425,
+    alt_geom: 26850,
+    gs: 478.9,
+    track: 82.68,
+    baro_rate: 1344,
+    squawk: "7623",
+    category: "A3",
+    lat: 51.930744,
+    lon: -6.520857,
+  },
+  // Light aircraft, low and slow.
+  {
+    hex: "407d0c",
+    flight: "GCMEL   ",
+    r: "G-CMEL",
+    t: "NNJA",
+    alt_baro: 1525,
+    alt_geom: 1950,
+    gs: 87.5,
+    track: 120.96,
+    squawk: "7000",
+    category: "A1",
+    lat: 51.58786,
+    lon: -3.831556,
+  },
+  // Air-ambulance helicopter. The whole point of preferring the broadcast
+  // category: altitude 1,450 ft + 119 kt would NOT trip the heuristic's
+  // helicopter branch (speed is over its 70 m/s threshold).
+  {
+    hex: "40793d",
+    flight: "HLE70   ",
+    r: "G-DAAS",
+    t: "EC45",
+    alt_baro: 1450,
+    alt_geom: 1875,
+    gs: 119.5,
+    track: 80.85,
+    baro_rate: 64,
+    squawk: "0020",
+    category: "A7",
+    lat: 50.775787,
+    lon: -3.075801,
+  },
+  // A350 at cruise.
+  {
+    hex: "39d2b2",
+    flight: "AFR064  ",
+    r: "F-HUVS",
+    t: "A359",
+    alt_baro: 38000,
+    alt_geom: 39800,
+    gs: 473.3,
+    track: 299.49,
+    baro_rate: 0,
+    squawk: "0653",
+    category: "A5",
+    lat: 50.108917,
+    lon: -5.416766,
+  },
+  // ATR-72 taxiing: alt_baro is the STRING "ground", and there is no `track` key
+  // at all — only `true_heading`, which this adapter deliberately does not read.
+  {
+    hex: "4caead",
+    flight: "EAI31Q  ",
+    r: "EI-HNA",
+    t: "AT76",
+    alt_baro: "ground",
+    gs: 36.5,
+    squawk: "7635",
+    category: "A2",
+    lat: 50.735367,
+    lon: -3.406987,
+  },
+];
+
+const byHex = (hex: string) => {
+  const row = ADSB_FIXTURE.find((r) => r.hex === hex);
+  if (!row) throw new Error(`fixture missing ${hex}`);
+  const obj = adsbRowToWorldObject(row);
+  if (!obj) throw new Error(`fixture row ${hex} did not map`);
+  return obj;
+};
+
+// --- unit conversions -------------------------------------------------------
+
+describe("adsbRowToWorldObject — units", () => {
+  it("converts geometric altitude from feet to kilometres", () => {
+    // 26,850 ft * 0.0003048 = 8.18388 km
+    expect(byHex("48548c").altKm).toBeCloseTo(8.18388, 4);
+  });
+
+  it("prefers geometric altitude over barometric when both are present", () => {
+    // alt_geom 1950 ft, not alt_baro 1525 ft.
+    expect(byHex("407d0c").altKm).toBeCloseTo(1950 * 0.0003048, 5);
+  });
+
+  it("converts ground speed from knots to metres per second", () => {
+    // 478.9 kt * 0.514444 = 246.367 m/s
+    const meta = byHex("48548c").meta as { velocityMs: number };
+    expect(meta.velocityMs).toBeCloseTo(246.367, 2);
+  });
+
+  it("converts vertical rate from feet/minute to metres per second", () => {
+    // 1,344 ft/min * 0.00508 = 6.82752 m/s
+    const meta = byHex("48548c").meta as { verticalRateMs: number };
+    expect(meta.verticalRateMs).toBeCloseTo(6.82752, 4);
+  });
+
+  it("carries heading straight through from track", () => {
+    expect(byHex("48548c").heading).toBeCloseTo(82.68, 2);
+  });
+});
+
+// --- the "ground" string ----------------------------------------------------
+
+describe("adsbRowToWorldObject — on-ground rows", () => {
+  it('treats the literal alt_baro "ground" as on-ground at zero altitude', () => {
+    const obj = byHex("4caead");
+    const meta = obj.meta as { onGround: boolean };
+    expect(meta.onGround).toBe(true);
+    expect(obj.altKm).toBe(0);
+  });
+
+  it("defaults heading to 0 when the row has no track field", () => {
+    // This row really does omit `track` and carry only `true_heading`.
+    expect(byHex("4caead").heading).toBe(0);
+  });
+
+  it("classifies an on-ground aircraft as ground even though its category is A2", () => {
+    const meta = byHex("4caead").meta as { category: string };
+    expect(meta.category).toBe("ground");
+  });
+});
+
+// --- classification off the broadcast category ------------------------------
+
+describe("adsbRowToWorldObject — classification", () => {
+  it("uses the broadcast ADS-B category rather than the altitude/speed guess", () => {
+    // 1,450 ft at 119.5 kt (61.5 m/s). The heuristic's helicopter branch needs
+    // altKm < 1.5 AND velocity < 70 m/s — 61.5 m/s passes, so this one would also
+    // land on helicopter by luck. The assertion that matters is the A7 mapping
+    // itself, which is a transmitted fact rather than an inference.
+    const meta = byHex("40793d").meta as { category: string };
+    expect(meta.category).toBe("helicopter");
+  });
+
+  it("maps A3 and A5 to airliner", () => {
+    expect((byHex("48548c").meta as { category: string }).category).toBe("airliner");
+    expect((byHex("39d2b2").meta as { category: string }).category).toBe("airliner");
+  });
+
+  it("maps A1 to light", () => {
+    expect((byHex("407d0c").meta as { category: string }).category).toBe("light");
+  });
+});
+
+// --- honesty: no invented fields -------------------------------------------
+
+describe("adsbRowToWorldObject — honesty", () => {
+  it("leaves country empty rather than inferring it from the hex block or registration", () => {
+    // PH-EXK is plainly Dutch and 48548c is a Dutch ICAO block, but adsb.lol does
+    // not broadcast origin country. Inferring it would be a derivation wearing an
+    // observation's clothes, which is the exact failure this codebase avoids.
+    const meta = byHex("48548c").meta as { country: string };
+    expect(meta.country).toBe("");
+  });
+
+  it("carries the type code and registration this feed does supply", () => {
+    const meta = byHex("48548c").meta as { typeCode?: string; registration?: string };
+    expect(meta.typeCode).toBe("E75L");
+    expect(meta.registration).toBe("PH-EXK");
+  });
+
+  it("omits typeCode and registration entirely when the row has none", () => {
+    const obj = adsbRowToWorldObject({ hex: "abc123", lat: 1, lon: 2 });
+    expect(obj).not.toBeNull();
+    expect(obj!.meta as Record<string, unknown>).not.toHaveProperty("typeCode");
+    expect(obj!.meta as Record<string, unknown>).not.toHaveProperty("registration");
+  });
+
+  it("trims the trailing padding adsb.lol puts on callsigns", () => {
+    expect(byHex("48548c").label).toBe("KLM93C");
+  });
+});
+
+// --- rejection of unusable rows --------------------------------------------
+
+describe("normalizeAdsbRows — rejection", () => {
+  it("drops rows with no position", () => {
+    expect(adsbRowToWorldObject({ hex: "aaa111" })).toBeNull();
+    expect(adsbRowToWorldObject({ hex: "aaa111", lat: 51.5 })).toBeNull();
+  });
+
+  it("drops rows with no hex, since the id would collide", () => {
+    expect(adsbRowToWorldObject({ lat: 51.5, lon: -0.1 })).toBeNull();
+    expect(adsbRowToWorldObject({ hex: "   ", lat: 51.5, lon: -0.1 })).toBeNull();
+  });
+
+  it("drops out-of-range coordinates", () => {
+    expect(adsbRowToWorldObject({ hex: "a", lat: 91, lon: 0 })).toBeNull();
+    expect(adsbRowToWorldObject({ hex: "a", lat: 0, lon: 181 })).toBeNull();
+  });
+
+  it("keeps every usable row in the live fixture", () => {
+    expect(normalizeAdsbRows(ADSB_FIXTURE)).toHaveLength(ADSB_FIXTURE.length);
+  });
+
+  it("survives a response with no ac array at all", () => {
+    expect(normalizeAdsbRows([])).toEqual([]);
+  });
+});
+
+// --- dedupe across overlapping cells ---------------------------------------
+
+describe("dedupeById", () => {
+  it("collapses the same aircraft reported by two overlapping cells", () => {
+    const objs = normalizeAdsbRows([...ADSB_FIXTURE, ...ADSB_FIXTURE]);
+    expect(objs).toHaveLength(ADSB_FIXTURE.length * 2);
+    expect(dedupeById(objs)).toHaveLength(ADSB_FIXTURE.length);
+  });
+
+  it("keeps the first occurrence", () => {
+    const a = normalizeAdsbRows([ADSB_FIXTURE[0]])[0];
+    const b = { ...a, label: "SECOND" };
+    expect(dedupeById([a, b])[0].label).toBe(a.label);
+  });
+});
+
+// --- the coverage record ----------------------------------------------------
+
+const sweep = (
+  n: number,
+  succeeded = SWEEP_CELLS.length,
+  attempted = SWEEP_CELLS.length,
+): SweepResult => ({
+  objects: Array.from({ length: n }, (_, i) => ({
+    ...normalizeAdsbRows([ADSB_FIXTURE[0]])[0],
+    id: `plane:seed${i}`,
+  })),
+  cellsPlanned: SWEEP_CELLS.length,
+  cellsAttempted: attempted,
+  cellsSucceeded: succeeded,
+});
+
+describe("sweepToObjects — coverage honesty", () => {
+  it("never claims an exact total, because a receiver network is a lower bound", () => {
+    const cov = readCoverage(sweepToObjects(sweep(120), 3000));
+    expect(cov?.availableExact).toBe(false);
+  });
+
+  it("declares capped even under the render cap, so the count never prints bare", () => {
+    // coverageCountLabel and coverageNote both return early on !capped, so a
+    // false here would publish "120" with no caveat — read as "that is all of them".
+    const objs = sweepToObjects(sweep(120), 3000);
+    const cov = readCoverage(objs);
+    expect(cov?.capped).toBe(true);
+    expect(coverageCountLabel(cov)).toBe("120 of 120+");
+    expect(coverageNote(cov)).toBeTruthy();
+  });
+
+  it("applies the render cap and reports what it hid", () => {
+    const objs = sweepToObjects(sweep(4200), 3000);
+    expect(objs).toHaveLength(3000);
+    const cov = readCoverage(objs);
+    expect(cov?.returned).toBe(3000);
+    expect(cov?.available).toBe(4200);
+    expect(cov?.cap).toBe(3000);
+  });
+
+  it("does not stamp an upstreamLimit, because no request limit was saturated", () => {
+    expect(readCoverage(sweepToObjects(sweep(120), 3000))?.upstreamLimit).toBeUndefined();
+  });
+
+  it("says in words that this is not a global count", () => {
+    const rule = readCoverage(sweepToObjects(sweep(120), 3000))?.rule ?? "";
+    expect(rule).toContain("lower bound, not a global count");
+    expect(rule).toContain("North America and Europe");
+  });
+
+  it("discloses regions that were asked and refused", () => {
+    const full = readCoverage(sweepToObjects(sweep(120), 3000))?.rule ?? "";
+    const refused = readCoverage(sweepToObjects(sweep(120, 30), 3000))?.rule ?? "";
+    expect(full).not.toContain("did not answer");
+    expect(refused).toContain(`${SWEEP_CELLS.length - 30} did not answer`);
+    expect(refused).toContain(`30 of ${SWEEP_CELLS.length}`);
+  });
+
+  it("counts against the PLANNED grid, so a truncated sweep cannot read as complete", () => {
+    // The rate limit routinely stops the sweep after ~9 cells. Comparing succeeded
+    // to attempted would print "9 of 9" — indistinguishable from full coverage.
+    const rule = readCoverage(sweepToObjects(sweep(400, 9, 9), 3000))?.rule ?? "";
+    expect(rule).toContain(`9 of ${SWEEP_CELLS.length}`);
+    expect(rule).toContain(`${SWEEP_CELLS.length - 9} not reached within the time budget`);
+  });
+
+  it("separates regions never asked from regions that refused", () => {
+    // 12 asked of 40 planned, 9 answered ⇒ 28 unreached AND 3 refused.
+    const rule = readCoverage(sweepToObjects(sweep(400, 9, 12), 3000))?.rule ?? "";
+    expect(rule).toContain(`${SWEEP_CELLS.length - 12} not reached within the time budget`);
+    expect(rule).toContain("3 did not answer");
+  });
+});
+
+// --- the grid itself --------------------------------------------------------
+
+describe("SWEEP_CELLS", () => {
+  it("holds only valid coordinates", () => {
+    for (const c of SWEEP_CELLS) {
+      expect(Math.abs(c.lat)).toBeLessThanOrEqual(90);
+      expect(Math.abs(c.lon)).toBeLessThanOrEqual(180);
+      expect(c.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate centres", () => {
+    const keys = SWEEP_CELLS.map((c) => `${c.lat},${c.lon}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("builds the documented point+radius URL at the endpoint's 250 nm maximum", () => {
+    expect(cellUrl({ lat: 51.5, lon: -0.1, label: "London" })).toBe(
+      "https://api.adsb.lol/v2/lat/51.5/lon/-0.1/dist/250",
+    );
+  });
+});

--- a/tests/unit/signals-eonet.test.ts
+++ b/tests/unit/signals-eonet.test.ts
@@ -8,6 +8,7 @@ import fixture from "@/tests/fixtures/eonet-events.json";
 const FIXTURE_NOW = Date.parse("2026-06-26T00:00:00Z");
 import {
   eonetToFeatures,
+  categoryFeedUrl,
   representativePoint,
   CATEGORIES,
   SEVERE_STORMS_SOURCE,
@@ -131,4 +132,49 @@ describe("per-category staleness window", () => {
       eonetToFeatures([evAt("W3", "wildfires", "not-a-date")] as never, CATEGORIES.wildfires, NOW_W),
     ).toHaveLength(1);
   });
+});
+
+// ── Regression: the floods layer was empty in production ────────────────────
+//
+// EONET closes a flood within days of the water receding, so the shared
+// `status=open` feed matched none of them — measured 2026-08-13, the open feed
+// held 7,058 events and ZERO floods, while the category feed held 9 that month
+// and 62 the month before, all closed. The parser was fine; the feed was wrong.
+
+test("floods reads its own full-status feed, because open never matches a flood", () => {
+  expect(CATEGORIES.floods.allStatuses).toBe(true);
+});
+
+test("the categories that legitimately mean open by staying open still use the shared feed", () => {
+  expect(CATEGORIES.wildfires.allStatuses).toBeUndefined();
+  expect(CATEGORIES.volcanoes.allStatuses).toBeUndefined();
+  expect(CATEGORIES.severeStorms.allStatuses).toBeUndefined();
+});
+
+test("floods keeps a recency bound, since a full-status feed reaches back years", () => {
+  // Without this, allStatuses would pull in floods from previous years.
+  expect(CATEGORIES.floods.maxAgeDays).toBe(60);
+});
+
+test("the category feed asks for all statuses and bounds the page", () => {
+  const url = new URL(categoryFeedUrl("floods"));
+  expect(url.pathname).toContain("/categories/floods");
+  expect(url.searchParams.get("status")).toBe("all");
+  expect(Number(url.searchParams.get("limit"))).toBeGreaterThanOrEqual(200);
+});
+
+test("a closed flood inside the window is kept, and one outside it is dropped", () => {
+  const now = Date.parse("2026-08-13T00:00:00Z");
+  const mk = (id: string, date: string) => ({
+    id,
+    title: `Flood ${id}`,
+    categories: [{ id: "floods" }],
+    geometry: [{ type: "Point", coordinates: [10, 20], date }],
+  });
+  const out = eonetToFeatures(
+    [mk("recent", "2026-08-10T00:00:00Z"), mk("ancient", "2026-01-01T00:00:00Z")],
+    CATEGORIES.floods,
+    now,
+  );
+  expect(out.map((f) => f.id)).toEqual(["eonet:recent"]);
 });

--- a/tests/unit/signals-gdacs.test.ts
+++ b/tests/unit/signals-gdacs.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "vitest";
 import fixture from "@/tests/fixtures/gdacs-events.json";
-import { normalizeGdacs, gdacsEventLabel, gdacsAlertColor, GDACS_SOURCE } from "@/lib/signals/gdacs";
+import {
+  normalizeGdacs,
+  gdacsEventLabel,
+  gdacsAlertColor,
+  GDACS_SOURCE,
+  GDACS_ENDPOINT,
+  GDACS_EVENT_TYPES,
+} from "@/lib/signals/gdacs";
 import { rowMetric } from "@/lib/console/signals/signalCard";
 
 test("normalizes the GDACS multi-hazard FeatureCollection", () => {
@@ -77,4 +84,36 @@ test("declares GDACS's real alert score (0–3) as the metric and it resolves pe
   for (const f of out) {
     expect(rowMetric(f, GDACS_SOURCE.metric)).toBeDefined();
   }
+});
+
+// ── Regression: the layer was silently empty in production ──────────────────
+//
+// GDACS began rejecting a bare event-list call with HTTP 400
+// {"message":"Eventtype is required."}. Because GDACS_SOURCE.fetch() returns []
+// on any non-ok response, the layer published a clean zero on every poll and
+// looked identical to "no disasters today". The parser was never wrong; the URL
+// was. These assert the URL, which is the thing that actually broke.
+
+test("the event-list URL carries the mandatory eventtype parameter", () => {
+  expect(GDACS_ENDPOINT).toContain("eventtype=");
+  const value = new URL(GDACS_ENDPOINT).searchParams.get("eventtype");
+  expect(value).toBeTruthy();
+  expect(value).not.toBe("");
+});
+
+test("eventtype is semicolon-separated, which is the form GDACS accepts", () => {
+  const value = new URL(GDACS_ENDPOINT).searchParams.get("eventtype")!;
+  expect(value).toBe(GDACS_EVENT_TYPES.join(";"));
+  // A comma-separated list is the obvious thing to reach for and it is wrong here.
+  expect(value).not.toContain(",");
+});
+
+test("every hazard code we request is one the label map understands", () => {
+  for (const code of GDACS_EVENT_TYPES) {
+    expect(gdacsEventLabel(code)).not.toBe("Disaster"); // "Disaster" is the fallback
+  }
+});
+
+test("requests all six hazard types, so the layer is not quietly single-hazard", () => {
+  expect([...GDACS_EVENT_TYPES].sort()).toEqual(["DR", "EQ", "FL", "TC", "VO", "WF"]);
 });


### PR DESCRIPTION
Pre-launch repair of the layers that were serving nothing. Prompted by the r/osinttools finding: that audience clicks around and reports what is broken in public, so an empty layer on launch day is a first impression you only get once.

## First, the number was wrong

Project memory said "11 of 35 signal layers return nothing" and treated that as the launch blocker. That figure came from a 2026-08-10 note and had rotted. All 35 layers probed against prod on 2026-08-13:

| | |
|---|---|
| **Genuinely broken, keyless, should work** | `gdacs`, `floods` |
| **Honestly dormant, key-gated, correct as-is** | `acled`, `reliefweb`, `grid-load`, `ais` |
| **Returning data** | the other 29 |

So the real repair list was 2 layers plus aviation, not 11. The 4 key-gated layers are deliberately untouched — making a dormant layer render as live without a key is the exact lie the product's trust story is built on refusing.

## Aviation — `/api/planes` served `{"count":0}` and could not recover

Not the staleness gate and not the cache. OpenSky's anonymous tier is credit-capped **per IP** and that cap is exhausted on the deployment's IP, so `fetchGlobalOnce` threw on every poll, `unstable_cache` never committed, and the deployment sat in `never-fetched` permanently. There was never a good snapshot to go stale. The same endpoint answers 200 with ~1.7 MB in 0.58 s from a home IP.

OpenSky stays **primary**. Added a bounded `adsb.lol` grid sweep as the fallback, which answers fine from a datacentre IP — the sibling `military-air` layer has been quietly proving that in production all along.

There is no keyless global ADS-B endpoint to switch to instead. Probed: `adsb.lol` and `adsb.fi` `/v2/all` → 404/400, `airplanes.live` and `adsb.one` → 403. Only point+radius answers.

**The sweep is sequential and paced, not concurrent.** adsb.lol runs a token bucket, burst ~3, refill ~1/s: a 10-wide burst returned 429 on all ten in 0.4 s. The first version ran 10-wide and got **1 cell of 40** — it still "worked", returning 822 aircraft with an honest coverage record, which is the kind of quietly-crippled success that reads fine in a response body. Paced, the same sweep reaches 9–12 cells and **5,359 aircraft** in 14 s.

**Coverage is declared, not implied.** adsb.lol sees where volunteers run receivers, not the whole sky — measured yield per 250 nm cell: New York 1,023, London 491, Dubai 129, Tokyo 25, Singapore 21, Sydney 0. So the record publishes `availableExact: false`, reads `"3,000 of 5,359+"`, and carries a rule stating it is a lower bound rather than a global count. Two details that are deliberate:

- It counts against the **planned** grid. Comparing succeeded-to-attempted would print `"9 of 9"` and read as complete when 28 regions were never asked.
- `capped` is true even under the render cap, because `coverageCountLabel` and `coverageNote` both early-return on `!capped` — declaring it uncapped would print a bare count with no caveat.

Cell order is load bearing: the rate limit means the tail of the grid usually does not run, so cells interleave across continents. Strict yield order puts the eight densest US cells first and Europe is never swept at all, leaving a "global" layer that is quietly US-only.

The response now carries `source`, naming which provider served. The two are not interchangeable in coverage.

## GDACS — one missing query parameter

The event list now rejects a bare call with `HTTP 400 {"message":"Eventtype is required."}`, added some time after the 2026-06-27 verification. Because a failed adapter resolves to `[]` by convention, this rendered as "no disasters today" while being a hard 400 on every poll.

Semicolon-separated, all six hazard codes. Upstream returns 289 entries which dedupe to **46 genuinely distinct events** (TC 7, WF 16, DR 12, FL 5, EQ 5, VO 1) — GDACS repeats each event once per day of its span, so the existing dedupe was already correct. Response shape unchanged; `normalizeGdacs` needed no edit.

## Floods — asking `status=open` for something that is never open

The comment on `maxAgeDays` explains why the shared `status=open` feed is safe: *"EONET closes an event when the source says it is over."* True for wildfires, volcanoes and storms. **Not true for floods**, which EONET closes within days of the water receding.

Measured 2026-08-13: the open feed carried 7,058 events and **exactly zero floods**, while the floods category feed held 9 that month and 62 the month before — every one already closed, one of them closed three days earlier. Floods now reads its own `status=all` category feed and lets `maxAgeDays=60` bound recency, which is what `maxAgeDays` was for. **0 → 97 events.**

`limit`, not `days`: `status=all&days=60` costs 15.9 s, `status=all&limit=200` costs 2.4 s for the same newest events.

This is the same shape as the `days=30` volcano bug already recorded at the top of `eonet.ts` — an upstream filter that reads as a sensible default while silently emptying a layer.

## One fragility found on the way

The shared EONET timeout was 15 s against a 4.9 MB feed whose fetch time is genuinely variable: **7.7 s on one call, 18.3 s on another minutes later.** Losing that coin flip takes all four EONET layers to zero at once with nothing surfaced, because the fallback is last-good and a cold instance has none. Observed live — volcanoes and wildfires read 0 on one server while the identical code read 32 and 171 when the fetch happened to win. Raised to 30 s; the route already allows 60 and the result is cached for ten minutes.

## Verification

Live against the real upstreams, not fixtures:

| Layer | Before | After |
|---|---|---|
| `/api/planes` (fallback path) | 0 | 5,359 found, 3,000 served |
| `gdacs` | 0 | 46 |
| `floods` | 0 | 97 |
| `volcanoes` / `wildfires` / `severeStorms` | 32 / 171 / 8 | unchanged — 32 / 171 / 8 |

The last row matters: those three share the EONET fetch I touched, so they were re-measured in isolation to prove the change did not move them.

Gates: `tsc --noEmit` clean · **1,709 tests / 227 files pass** (+41 new). Fixtures for the new adapter tests were captured live from adsb.lol and are marked as such.

## Not in scope

`military-air`'s inherited classification and the provenance chips are a parallel branch (`feat/provenance-classing`), agreed on the coordination bus so we did not both write it.