### PR TITLE
perf(api): let the edge answer repeat visitors on the read-only routes

### DIFF
--- a/app/api/cameras/route.ts
+++ b/app/api/cameras/route.ts
@@ -1,7 +1,19 @@
 import { getRegistry } from "@/lib/sources/registry";
 import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
+import { edgeCacheControl } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Shared-cache lifetime for the camera list. The registry itself is already
+ * stale-while-revalidate server-side, so this is about not paying an invocation per
+ * visitor, not about protecting the upstreams.
+ *
+ * 60 s is safe for this body specifically because every time it carries is ABSOLUTE
+ * (`lastSampledAt`), so a cached copy cannot under-report a camera's age — the client
+ * subtracts from its own clock. Positions and names move on the order of days.
+ */
+const CAMERAS_TTL_MS = 60_000;
 
 export async function GET() {
   const cams = await getRegistry();
@@ -17,5 +29,8 @@ export async function GET() {
     region: c.region, road: c.road, refreshSeconds: c.refreshSeconds,
     attribution: c.attribution, license: c.license, lastSampledAt: c.lastSampledAt,
   }));
-  return Response.json({ count: cameras.length, cameras });
+  return Response.json(
+    { count: cameras.length, cameras },
+    { headers: { "Cache-Control": edgeCacheControl(CAMERAS_TTL_MS, 300_000) } },
+  );
 }

--- a/app/api/coverage/route.ts
+++ b/app/api/coverage/route.ts
@@ -1,7 +1,17 @@
 import { getRegistry, feedHealth, CAMERA_FEED_COUNT } from "@/lib/sources/registry";
 import { groupCoverage } from "@/lib/coverage";
+import { edgeCacheControl } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Matches the camera list's shared-cache lifetime — the two are computed from the
+ * same registry, so letting them expire at different rates would let the Coverage
+ * panel and the map disagree about how many feeds answered.
+ *
+ * `generatedAt` is absolute, so a cached copy states its own age correctly.
+ */
+const COVERAGE_TTL_MS = 60_000;
 
 // Honest per-source camera coverage: total + currently-online, grouped by source.
 // A tiny payload (one row per source) so the Coverage panel never re-fetches the
@@ -19,16 +29,19 @@ export async function GET() {
   const coverage = groupCoverage(cams.map((c) => ({ source: c.source, available: c.available })));
   const health = feedHealth();
   const answered = health.filter((h) => h.ok).length;
-  return Response.json({
-    generatedAt: Date.now(),
-    ...coverage,
-    feeds: {
-      answered,
-      total: CAMERA_FEED_COUNT || health.length,
-      // Feeds serving last-good data because this round failed. Their cameras are
-      // still counted in `total` above, so the caller can say so.
-      stale: health.filter((h) => h.stale).map((h) => h.key),
-      detail: health,
+  return Response.json(
+    {
+      generatedAt: Date.now(),
+      ...coverage,
+      feeds: {
+        answered,
+        total: CAMERA_FEED_COUNT || health.length,
+        // Feeds serving last-good data because this round failed. Their cameras are
+        // still counted in `total` above, so the caller can say so.
+        stale: health.filter((h) => h.stale).map((h) => h.key),
+        detail: health,
+      },
     },
-  });
+    { headers: { "Cache-Control": edgeCacheControl(COVERAGE_TTL_MS, 300_000) } },
+  );
 }

--- a/app/api/planes/route.ts
+++ b/app/api/planes/route.ts
@@ -1,7 +1,21 @@
 import { fetchAircraftSnapshot } from "@/lib/sources/opensky";
 import { describeCoverage } from "@/lib/signals/coverage";
+import { edgeCacheControl } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Shared-cache lifetime, deliberately far shorter than the 240 s upstream cadence.
+ *
+ * This body is the one read response carrying a RELATIVE age (`staleness.ageMs`),
+ * and a cached copy freezes that number while the clock keeps running — so the TTL
+ * is the maximum amount by which this endpoint can under-report staleness. 20 s
+ * against a 240 s refresh keeps that error under 10% of one cycle, which is inside
+ * what the staleness gate already tolerates. Do not raise it to "save invocations"
+ * without also making the age absolute; the saving is small and the cost is the
+ * freshness claim.
+ */
+const PLANES_TTL_MS = 20_000;
 
 /**
  * Headroom for the adsb.lol fallback sweep, which is rate-limit-paced and budgets
@@ -49,11 +63,14 @@ export const maxDuration = 30;
  */
 export async function GET() {
   const { planes, coverage, staleness, source } = await fetchAircraftSnapshot();
-  return Response.json({
-    count: planes.length,
-    ...(source ? { source } : {}),
-    ...(coverage ? { coverage: describeCoverage(coverage) } : {}),
-    ...(staleness ? { staleness } : {}),
-    planes,
-  });
+  return Response.json(
+    {
+      count: planes.length,
+      ...(source ? { source } : {}),
+      ...(coverage ? { coverage: describeCoverage(coverage) } : {}),
+      ...(staleness ? { staleness } : {}),
+      planes,
+    },
+    { headers: { "Cache-Control": edgeCacheControl(PLANES_TTL_MS) } },
+  );
 }

--- a/app/api/signals/[id]/route.ts
+++ b/app/api/signals/[id]/route.ts
@@ -2,6 +2,7 @@ import { getSignal } from "@/lib/signals/registry";
 import { describeCoverage, readCoverage } from "@/lib/signals/coverage";
 import type { SignalFeature } from "@/lib/signals/types";
 import { cacheTtlMs } from "@/lib/signals/cacheTtl";
+import { edgeCacheControl } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
 // Most adapters are a single fast upstream call. A few (e.g. submarine cables,
@@ -46,6 +47,22 @@ function payload(features: SignalFeature[]) {
   };
 }
 
+/**
+ * The shared-cache lifetime is the SAME value the in-process cache above uses, so
+ * the edge and the server expire together. Deriving both from `cacheTtlMs` means a
+ * layer's cadence is declared once, on the adapter, and a new layer inherits correct
+ * caching with no route edit — the property the whole registry is built on.
+ *
+ * The empty-result rule carries over for free: a layer returning nothing is held for
+ * at most EMPTY_RETRY_MS, so a dormant upstream is re-asked promptly instead of a
+ * six-hour blank being pinned at the edge.
+ */
+function cacheHeaders(refreshMs: number, features: SignalFeature[]) {
+  return {
+    "Cache-Control": edgeCacheControl(cacheTtlMs(refreshMs, features.length === 0)),
+  };
+}
+
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -56,7 +73,9 @@ export async function GET(
 
   const hit = cache.get(id);
   if (hit && Date.now() - hit.at < cacheTtlMs(source.refreshMs, hit.features.length === 0)) {
-    return Response.json(payload(hit.features));
+    return Response.json(payload(hit.features), {
+      headers: cacheHeaders(source.refreshMs, hit.features),
+    });
   }
 
   let features: SignalFeature[] = [];
@@ -67,5 +86,7 @@ export async function GET(
     features = hit?.features ?? [];
   }
   cache.set(id, { at: Date.now(), features });
-  return Response.json(payload(features));
+  return Response.json(payload(features), {
+    headers: cacheHeaders(source.refreshMs, features),
+  });
 }

--- a/lib/http/cache.ts
+++ b/lib/http/cache.ts
@@ -1,0 +1,50 @@
+// Edge-cache policy for the read-only API routes.
+//
+// WHY THIS EXISTS. Every read route was `force-dynamic` with no Cache-Control, so
+// the Vercel edge reported X-Vercel-Cache: MISS on every request and each visitor
+// cost a serverless invocation. The upstreams were never at risk (Next's Data Cache
+// and the per-id caches already dedupe those), but the invocation was paid per
+// person. A shared-cache TTL lets the edge answer repeat visitors outright.
+//
+// THE HONESTY CONSTRAINT. This product's claim is that it tells you how old a
+// reading is, so a cache must never outlive the cadence of the data inside it.
+// Two rules follow, and both are load-bearing:
+//
+//   1. The TTL is DERIVED from the source's own declared refresh interval, never
+//      invented here. Caching a 60 s feed for 5 minutes would make the freshness
+//      indicators lie, which is the one defect this project exists to avoid.
+//   2. A body carrying a RELATIVE age (planes ship `staleness.ageMs`) freezes that
+//      number while real time keeps moving, so a cached copy under-reports age by
+//      up to the TTL. Absolute timestamps (cameras' `lastSampledAt`) do not have
+//      this problem — the client subtracts from the current clock. Routes with a
+//      relative age must therefore keep a TTL far below the tolerance of the number
+//      they carry; see the call sites.
+//
+// `s-maxage` is a SHARED-cache directive: browsers ignore it, so a visitor's own
+// tab still revalidates while the CDN absorbs the fan-out. That is the behaviour we
+// want, and it is why this is one header rather than a Cache-Control/CDN-Cache-
+// Control pair.
+
+/** Lower bound. A sub-second shared TTL buys nothing and reads as a mistake. */
+export const MIN_TTL_SECONDS = 1;
+
+/**
+ * Build a `Cache-Control` value for a read-only JSON response.
+ *
+ * @param ttlMs      how long the edge may serve this without re-asking — pass the
+ *                   source's own refresh interval, not a guess.
+ * @param staleForMs how long a stale copy may still be served while a refresh runs
+ *                   behind it. Defaults to the TTL itself, which keeps the worst
+ *                   case at two intervals old and never silently exceeds it.
+ */
+export function edgeCacheControl(ttlMs: number, staleForMs?: number): string {
+  const ttl = toSeconds(ttlMs);
+  const swr = toSeconds(staleForMs ?? ttlMs);
+  return `public, s-maxage=${ttl}, stale-while-revalidate=${swr}`;
+}
+
+/** ms → whole seconds, floored, never below MIN_TTL_SECONDS. Non-finite input is treated as the floor. */
+export function toSeconds(ms: number): number {
+  if (!Number.isFinite(ms) || ms <= 0) return MIN_TTL_SECONDS;
+  return Math.max(MIN_TTL_SECONDS, Math.floor(ms / 1000));
+}

--- a/tests/unit/http-cache.test.ts
+++ b/tests/unit/http-cache.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { edgeCacheControl, toSeconds, MIN_TTL_SECONDS } from "@/lib/http/cache";
+
+describe("toSeconds", () => {
+  it("floors milliseconds to whole seconds", () => {
+    expect(toSeconds(60_000)).toBe(60);
+    expect(toSeconds(1_999)).toBe(1);
+    expect(toSeconds(240_000)).toBe(240);
+  });
+
+  it("never returns less than the floor, however small the input", () => {
+    expect(toSeconds(0)).toBe(MIN_TTL_SECONDS);
+    expect(toSeconds(-5)).toBe(MIN_TTL_SECONDS);
+    expect(toSeconds(10)).toBe(MIN_TTL_SECONDS);
+  });
+
+  it("treats non-finite input as the floor rather than emitting NaN into a header", () => {
+    expect(toSeconds(Number.NaN)).toBe(MIN_TTL_SECONDS);
+    expect(toSeconds(Number.POSITIVE_INFINITY)).toBe(MIN_TTL_SECONDS);
+  });
+});
+
+describe("edgeCacheControl", () => {
+  it("emits a shared-cache directive at the interval it was given", () => {
+    expect(edgeCacheControl(60_000)).toBe(
+      "public, s-maxage=60, stale-while-revalidate=60",
+    );
+  });
+
+  it("defaults the stale window to the TTL, so the worst case is two intervals old", () => {
+    expect(edgeCacheControl(30_000)).toBe(
+      "public, s-maxage=30, stale-while-revalidate=30",
+    );
+  });
+
+  it("accepts an explicit stale window", () => {
+    expect(edgeCacheControl(20_000, 60_000)).toBe(
+      "public, s-maxage=20, stale-while-revalidate=60",
+    );
+  });
+
+  it("uses s-maxage, not max-age, so a browser tab still revalidates", () => {
+    const header = edgeCacheControl(60_000);
+    expect(header).toContain("s-maxage=");
+    expect(header).not.toMatch(/(^|[^-])max-age=/);
+  });
+
+  it("never emits a zero or negative TTL", () => {
+    expect(edgeCacheControl(0)).toBe(
+      `public, s-maxage=${MIN_TTL_SECONDS}, stale-while-revalidate=${MIN_TTL_SECONDS}`,
+    );
+  });
+});


### PR DESCRIPTION
Posted to r/osinttools tonight, so this is about the traffic shape that follows one link: a burst of first-time visitors, each of whom was costing a serverless invocation on every read route.

## What was wrong

Every read route was `force-dynamic` with no `Cache-Control`, so the edge reported `X-Vercel-Cache: MISS` on all of them. Measured on production before the change:

| Endpoint | Raw | Over the wire | Edge |
|---|---|---|---|
| `/api/cameras` | 2.1 MB | 156 KB (br) | MISS |
| `/api/planes` | 1.3 MB | 195 KB (br) | MISS |
| `/api/signals/earthquakes` | 87 KB | 13 KB (br) | MISS |

Brotli is applied, so **bandwidth was never the exposure and this is not a bandwidth fix**. It is an invocation fix. Faster cold arrivals are a side effect.

## The constraint this had to respect

The product's claim is that it tells you how old a reading is, so a cache must never outlive the cadence of the data inside it. Two rules fall out:

1. **TTLs are derived, not invented.** For signals the edge reuses the exact `cacheTtlMs` the in-process cache already uses, so the two expire together and a new adapter inherits correct caching with no route edit. The empty-result rule comes free — a dormant layer is re-asked within `EMPTY_RETRY_MS` rather than a six-hour blank being pinned at the edge.
2. **Relative ages cap the TTL.** `/api/planes` is the one body carrying `staleness.ageMs`, which a cached copy freezes while the clock moves — so its TTL is the maximum amount by which the endpoint can under-report staleness. 20 s against a 240 s refresh keeps that under 10% of a cycle. Cameras and coverage carry *absolute* timestamps, so they cannot misstate their own age and sit at 60 s.

`s-maxage` is shared-cache only, so a visitor's own tab still revalidates while the CDN absorbs the fan-out — hence one header rather than a `Cache-Control` / `CDN-Cache-Control` pair.

## Gates

- `npx tsc --noEmit` — no errors in source. (Two pre-existing errors remain in stale `.next/types` artifacts referencing `app/page.js`, which moved to `app/(site)/page.tsx`. Untouched here because several dev servers from parallel sessions are live in this working directory.)
- `vitest` — **1726/1726 across 229 files**, including 8 new cases for the policy function.
- `npm run build` — compiles successfully; the type-check step trips on the same stale artifact above.

## Verify after merge

```
curl -sI https://provenance-online.vercel.app/api/cameras | grep -i "cache-control\|x-vercel-cache"
```

Second call should report `X-Vercel-Cache: HIT`.