### PR TITLE
fix(mobile): make the console workspace scrollable and stop clipping the dossier

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4611,3 +4611,76 @@ body:has(.tn-terminal[data-tnx-skin="light"]) { background: #eef1f5; color: #101
     width: calc(100% + 8px); height: 34px;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   MOBILE — RE-ASSERTED OVER THE TERMINAL SKIN
+   ══════════════════════════════════════════════════════════════════════════
+   The `@media (max-width: 900px)` pass much earlier in this sheet is correct and
+   was measured; on the shipped skin it is DEAD CODE. Every rule it writes is
+   re-set by the `.tn-terminal …` block, which is later in the sheet and carries
+   (0,2,0) against the mobile rules' (0,1,0). A media query adds NO specificity,
+   so the skin wins at every width — including 390px.
+
+   Measured on prod (provenance-online.vercel.app) at 390x844, tour dismissed:
+
+     .tn-cw-shell  overflow-y: hidden   scrollHeight 5998 / clientHeight 662
+     wheel 2500px over the workspace -> scrollTop stayed 0
+
+   The default BRIEF board carries four widgets. One (WHAT'S ABNORMAL) was
+   partly visible — 273px of its 572px. DISASTERS & EVENTS, WORLD HEADLINES and
+   CAMERAS all began below the shell's clipped edge and NO gesture could reach
+   them: `overflow: hidden` is not scrollable by touch, wheel or trackpad.
+
+   So this block re-states the mobile intent with selectors that match the skin's
+   specificity, from a later position in the sheet. It is scoped to the skin on
+   purpose — it is not a second mobile pass, it is the first one made to apply.
+   Anything added to the `.tn-terminal` section from here on that also appears in
+   the 900px block above needs re-asserting HERE too, or it will silently die the
+   same way.
+   ────────────────────────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  /* The workspace becomes one vertical scroller, as the 900px block intended.
+     `overscroll-behavior-y: contain` stops a fling at the end of the list from
+     chaining into the document and dragging the whole console. */
+  .tn-terminal .tn-cw-shell,
+  .tn-cw-shell.tn-terminal {
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+  }
+
+  /* The grid sizes to its stacked content instead of being pinned to the band's
+     height — that pin is what made scrollHeight exceed clientHeight with no way
+     to scroll. `align-content: start` keeps the rows packed at the top rather
+     than stretched across a now-taller box. */
+  .tn-terminal .tn-seg {
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+    align-content: start;
+    align-items: start;
+  }
+
+  /* A slot clipped to its desktop grid row re-creates the porthole one level
+     down. `position: relative` is deliberately NOT touched — the .tn-rz handles
+     resolve against it (see the note on .tn-terminal .tn-seg-slot above). */
+  .tn-terminal .tn-seg-slot { overflow: visible; }
+
+  /* Resize handles are eight invisible 10px drag bands pinned to every card
+     edge. There is no hover on touch, so they never reveal themselves, and card
+     height is CSS-derived here anyway — they are dead controls that sit exactly
+     where a thumb starts a swipe. Hidden for the same reason .tn-grip and
+     .tn-cw-resize* already are in the 900px block. */
+  .tn-terminal .tn-rz { display: none; }
+
+  /* iOS Safari zooms the page in on focus of any field under 16px and does not
+     zoom back out. The skin set 10.5px and `min-height: 0`, which also cancelled
+     the 44px target the 900px block gives this same input. */
+  .tn-terminal .tnx-stage-search .tn-mapsearch-input {
+    font-size: 16px;
+    min-height: 44px;
+  }
+}

--- a/app/provenance.css
+++ b/app/provenance.css
@@ -938,6 +938,39 @@
 .pv-dossier div + div {
   margin-top: 0.1rem;
 }
+
+/* ── The dossier on a narrow stage ─────────────────────────────────────────
+   `.pv-dossier` chases the marker: pinned to dead centre with a fixed 1.6rem
+   offset and a 13rem min-width. That is fine on a wide stage and broken on a
+   phone. Measured on prod at 375px CSS width, the stage is 335px and the card
+   starts at x=193, so its right edge lands at 401px — 66px past a stage that is
+   `overflow: hidden`. It overhung the bottom by a further 40px. The result:
+   `public domain` rendered as "public doma" and the whole `recorded` row was
+   cut off.
+
+   The card IS this section's payoff — the caption underneath it reads "now it
+   is a place on a map, with its source attached", and the attached source was
+   the unreadable part. So below 40rem it stops chasing the marker and sits as a
+   full-width plate at the foot of the stage, with the marker pinging above it.
+   Nothing is hidden and the beat still reads. */
+@media (max-width: 40rem) {
+  .pv-marker-stage {
+    /* Room for marker + plate without the plate landing on the marker. */
+    min-height: 17rem;
+    max-height: none;
+    align-items: flex-start;
+    padding-top: 4.5rem;
+  }
+  .pv-dossier {
+    left: 0.75rem;
+    right: 0.75rem;
+    top: auto;
+    bottom: 0.75rem;
+    margin: 0;
+    min-width: 0;
+  }
+}
+
 .pv-caption {
   font-size: 1rem;
   line-height: 1.55;


### PR DESCRIPTION
On a 390x844 phone, three of the four widgets on the default BRIEF board could not
be reached by any gesture. This fixes that and three smaller things that share its
cause.

## What was wrong

`.tn-cw-shell` computed to `overflow-y: hidden` with a scrollHeight of 5,998px
inside a 662px box. Measured on prod at 390x844 with the tour dismissed, a 2,500px
wheel over the workspace moved `scrollTop` by 0. `overflow: hidden` is not
scrollable by touch, wheel or trackpad, so everything below the cut was unreachable
by any input a phone has.

Only WHAT'S ABNORMAL was visible, and only 273px of its 572px. DISASTERS & EVENTS,
WORLD HEADLINES and CAMERAS all began below the clipped edge.

## Why

There is already a careful mobile pass in `globals.css` -- `@media (max-width: 900px)`,
with dvh units, 44px targets, and measurements recorded in its comments. On the
shipped terminal skin, none of it applies.

Its rules are (0,1,0). The `.tn-terminal ...` block is (0,2,0) and later in the
sheet. **A media query adds no specificity**, so the skin wins at every width,
including 390px, and re-applies `display: block` and `overflow: hidden`. The skin's
own comment states the mechanism while claiming it for a different rule:

> "Specificity here is (0,2,0), equal to that rule, and this block is later in the
> sheet, so it wins."

The same override cost two more things:

- the map search input kept `font-size: 10.5px`. iOS Safari zooms the page in on
  focus of any field under 16px and does not zoom back out on blur.
- that rule's `min-height: 0` cancelled the 44px target the 900px block gives the
  same input, leaving the control 16px tall.

## What this does

Re-states the mobile intent from the end of the sheet with skin-matching selectors.
It is not a second mobile pass -- it is the first one made to apply. Also hides the
eight `.tn-rz` resize handles at mobile widths: they only reveal on `:hover`, which
touch does not have, and card height is CSS-derived here, so they were dead 10px
drag bands sitting exactly where a thumb starts a swipe.

Separately, in `provenance.css`: `.pv-dossier` chases the marker with a fixed
1.6rem offset and a 13rem min-width. At 375px the stage is 335px, so the card
started at x=193 and overhung a stage that is `overflow: hidden` by 66px right and
47px bottom. "licence public domain" rendered as "public doma" and the `recorded`
row was cut off entirely -- directly above a caption reading "now it is a place on
a map, with its source attached". Below 40rem it now sits as a full-width plate at
the foot of the stage.

## How it was verified

Each block was injected into the live production page and re-measured in the same
session, before and after:

| Measurement | Live prod | With fix |
|---|---|---|
| workspace `overflow-y` | hidden | auto |
| scrollTop after 2,500px wheel | 0 | 1,000 |
| widgets reachable (BRIEF board) | 1 of 4 | 4 of 4 |
| search input font-size | 10.5px | 16px |
| search input height | 16px | 44px |
| dossier overhang right / bottom | +66 / +47px | -13 / -5px |
| dossier card width | 208px | 310px |

Note on method: an earlier round of gesture tests was invalid because the
onboarding tour's veil covers the viewport and absorbs the events. Every number
above was taken with the tour dismissed.

CSS only -- no markup, tokens or behaviour touched; 106 insertions, no deletions.
The AGPL section 13 repo links in the site footer and `TerminalHeader` are
untouched and reachable at every width.

## Not covered

Left open deliberately, as density judgement calls rather than defects: 84 tap
targets under 44px across the console, three toolbars that scroll sideways with no
affordance (the board pills hide 122px), and 225px of stacked chrome before the map
begins.

Build gate not run -- this branch is in a worktree without `node_modules`, and
`npm run e2e` writes the shared `.next` that other work is using. The change is
CSS-only, so tsc and vitest would not exercise it.
