### PR TITLE
Let a Windy region ask for more pages, and register Brazil

### DIFF
--- a/docs/superpowers/specs/2026-08-14-brazil-sources-design.md
+++ b/docs/superpowers/specs/2026-08-14-brazil-sources-design.md
@@ -1,0 +1,137 @@
+# Brazil coverage — design
+
+> Research sweep and every figure below: live-verified 2026-08-13/14. Counts rot;
+> re-measure before quoting one anywhere. Companion research:
+> `docs/superpowers/research/camera-sources.md` (which never covered South America).
+
+## Why
+
+Brazil was invisible in this product. A sweep of the open-source landscape found
+that almost every route in is closed, and the two that are open were being
+throttled by our own defaults rather than by the upstreams.
+
+Measured tonight:
+
+| Route | Verdict |
+|---|---|
+| Windy webcams | **OPEN** — 135 Brazilian webcams in the bbox, but our region paging surfaced only 10 |
+| CET São Paulo | **OPEN** — keyless JPEG snapshots, 11 registered / 10 actually refreshing |
+| YouTube live streams | **OPEN** — 146 Brazilian streams across 47 channels, no coordinates |
+| Toll-road concessionaires (Ecovias, Arteris, Rota das Bandeiras, ViaPaulista) | **CLOSED** — hard 403 to a real Chromium, two different WAFs |
+| Motiva / AutoBAn (ex-CCR) | **CLOSED** — `CamerasAoVivo.aspx` is now a 404; live cameras withdrawn |
+| Rio de Janeiro | **CLOSED** — no camera dataset in data.rio's 2,021; `api.dados.rio` 503; the COR API times out from here and from two third-party proxies |
+| DNIT (federal highways) | **CLOSED** — `servicos.dnit.gov.br` / `vgeo.dnit.gov.br` do not resolve |
+| dados.gov.br, ArcGIS Online | **CLOSED** — no camera datasets; only hobbyist uploads of 6 and 12 rows |
+
+Brazil is a ~290-camera country for us. That is the honest ceiling, not a
+starting point, and it is an order of magnitude below what one Castle Rock
+adapter yields in the US.
+
+## Two traps this design exists to avoid
+
+**Freshness, not status code, is the liveness test for snapshot feeds.** 205 of
+CET-SP's `cams/{id}` folders return HTTP 200 JPEGs. Only 10 were modified within
+8 minutes of the check; the rest are abandoned stills last written between 2017
+and 2025 that still serve 200. Counting 200s would have reported "205 São Paulo
+cameras" and been wrong by 195. `vwCamerasWeb` and the site's own `gCams` array
+both say 11, because they count *registered*, not *refreshing* — folder 22 last
+updated 25 Feb 2026. The registry count measures the wrong thing.
+
+**A per-region override that only one fan-out reads is a field that does
+nothing.** `WINDY_REGIONS` is consumed by two separate loops. `planPageJobs()`
+exists so the paging arithmetic has exactly one implementation.
+
+## Scope
+
+Four changes, one PR each, each branched off the latest `main`.
+
+### 1. `feat/windy-brazil-region`
+
+`PAGES_PER_REGION = 2` ceilings **every** region at 100 webcams and reports no
+shortfall. The `latin-america` bbox spans a continent, and its first 100 rows
+came back 49 Chile / 15 Argentina / 11 Mexico / **10 Brazil**.
+
+- `WindyRegion` gains an optional `pages`.
+- `planPageJobs()` — pure, unit-tested — expands regions into page requests, and
+  both fan-outs call it.
+- A `brazil` region, `bbox [5.3, -34.7, -33.8, -74.0]`, `pages: 5` (250 capacity
+  against a measured total of 206, i.e. headroom, not a number tuned to today).
+  It overlaps `latin-america` deliberately; the fan-out dedupes by `webcamId`, so
+  overlap costs requests, not correctness.
+- `PAGES_PER_REGION` and `LIMIT` are exported so tests derive the expected
+  request count from the registry instead of hard-coding "14 regions × 2".
+
+**Verified end to end:** `/api/webcams` returns 1,358 webcams of which **136 are
+BR** — second only to the US. Was 10.
+
+### 2. `feat/cetsp-cameras`
+
+A 12th camera adapter, following `lib/sources/estonia.ts`.
+
+- List: the `gCams` array inlined in `https://cameras.cetsp.com.br/View/Cam.aspx`
+  (`pasta`, `titulo`, `subTitulo`, `detalhe`).
+- Image: `https://cameras.cetsp.com.br/cams/{pasta}/1.jpg`, keyless.
+- `available` is driven by the snapshot's `Last-Modified` age, never by HTTP 200
+  and never by `CamerasCentral.status` — three cameras are marked `INOPERANTE`
+  there while their images update fine.
+- Coordinates ship as a hand-verified `.data.ts` table (precedent:
+  `cities.data.ts`, `ports.data.ts`). Token-matching the 11 cameras against the
+  GeoServer's 615-row `CamerasCentral` resolved 9 cleanly and got 2 wrong on a
+  single shared token (`Ibirapuera / R Ipê` matched a Bandeirantes intersection).
+  For eleven cameras, verify once offline and commit the table.
+- **The adapter never contacts the GeoServer at runtime.** `cet-inf7242.cetsp.com.br:8080`
+  is an internal-looking host — no TLS, port 8080 — that happens to be reachable.
+  It is a build-time research tool here, not a production dependency.
+- `cameras.cetsp.com.br` is added to `lib/proxy/allowlist.ts`.
+
+### 3. `fix/youtube-channel-resolver`
+
+**This fixes a bug that is live in production.**
+`lib/console/widgets/satellites.detail.tsx:278` embeds
+`https://www.youtube.com/embed/live_stream?channel={id}`. YouTube has retired
+that endpoint: loaded in a real Chromium against the repo's own `NASA_CHANNEL`
+it renders **"Error 153 — Video player configuration error"**, and the page
+builds a link to `watch?v=live_stream`, i.e. it treats the literal string as a
+video id. The ISS "Live feed" panel is a dead player for every user today.
+
+The same file's sibling problem: `lib/console/news/providers.ts` pins 12 channels
+by **video** id, and `lib/console/help.ts:206` already documents the failure
+("broadcasters rotate those ids without notice and a rotated preset simply plays
+nothing"). Measured uptimes on seven live cams: 8h, 8h, 7d, 13d, 14d, 18d, 86d —
+**2 of 7 had restarted within 10 hours.**
+
+`lib/youtube/` resolves channel id → current live video id, server-side:
+
+- Holds last-known `videoId` per channel.
+- Each refresh batches every known id into one `videos.list` call — **1 quota
+  unit per 50 ids** — and keeps those still `live`.
+- Only a channel whose id went dead costs a `search.list?eventType=live`
+  (100 units).
+- At the measured ~29%/day rotation rate: ~1,900 units/day against a 10,000/day
+  free quota.
+- Dormant-safe: no `YOUTUBE_API_KEY` → empty list and an honest note. Never a
+  throw, never a 5xx, never a stale embed presented as live.
+
+`YOUTUBE_API_KEY` goes in `docs/API_KEYS.md` and `NEEDED-APIS.txt`.
+
+### 4. `feat/brazil-livecams-board`
+
+A Brazil live-cams board in the console, on the same pattern as the news presets,
+consuming the resolver from #3. Channels are the registered unit, not videos.
+
+**Explicitly not doing:** no map pins for the YouTube streams. YouTube returns no
+geotags — `location` was `None` on every stream checked — so pins would mean
+geocoding titles to city centroids, and a city-centroid pin sitting next to
+metre-accurate camera pins misrepresents what it is. This also keeps
+`lib/types.ts`'s existing separation intact: "Windy webcams are a DISTINCT layer
+from road CCTV … keeping the camera registry + counts uncontaminated."
+
+## Testing
+
+Per `CLAUDE.md`: `npx tsc --noEmit && npm test`, vitest in `tests/unit/`, node
+environment, pure normalisers tested against captured fixtures. One commit per
+PR, solo attribution.
+
+Live verification is not optional for a source adapter — every count in this
+document came from a real request, and the end-to-end check for #1 was
+`/api/webcams` on a dev server, not a unit test.

--- a/lib/sources/windy.ts
+++ b/lib/sources/windy.ts
@@ -120,8 +120,11 @@ export function normalizeWindy(json: WindyListResponse): Webcam[] {
 // --- Network ----------------------------------------------------------------
 
 const INCLUDE = "images,location,urls,categories";
-const LIMIT = 50; // free-tier hard cap
-const PAGES_PER_REGION = 2; // 2 × 50 = up to 100 webcams/region (offset 0,50)
+// Exported so tests derive the expected request count from the registry instead
+// of hard-coding "14 regions × 2" — a literal that silently rots the moment a
+// region is added or given a `pages` override.
+export const LIMIT = 50; // free-tier hard cap
+export const PAGES_PER_REGION = 2; // 2 × 50 = up to 100 webcams/region (offset 0,50)
 const REGION_CONCURRENCY = 6; // polite + bounded parallelism across page jobs
 const MAX_WEBCAMS = 2000; // safety cap on the merged global sample — disclosed via lib/signals/coverage.ts, not silent
 
@@ -131,6 +134,17 @@ const MAX_WEBCAMS = 2000; // safety cap on the merged global sample — disclose
 export interface WindyRegion {
   name: string;
   bbox: [number, number, number, number];
+  /**
+   * Pages to request for THIS region, overriding the module default. A page is
+   * `LIMIT` (50) webcams, so `pages` × 50 is the region's ceiling.
+   *
+   * Exists because the default of 2 is a global compromise that silently
+   * truncates dense regions: every region is capped at 100 regardless of how
+   * many webcams the bbox actually holds, and nothing reports the shortfall.
+   * Splitting a dense bbox into smaller boxes is the tempting fix and it is the
+   * wrong one — the split has to be re-tuned every time Windy's inventory moves.
+   */
+  pages?: number;
 }
 
 export const WINDY_REGIONS: WindyRegion[] = [
@@ -142,6 +156,20 @@ export const WINDY_REGIONS: WindyRegion[] = [
   { name: "na-west", bbox: [60, -100, 24, -130] },
   { name: "na-east", bbox: [50, -60, 24, -100] },
   { name: "latin-america", bbox: [25, -35, -56, -118] },
+  // Brazil, overlapping `latin-america` deliberately — the fan-out dedupes by
+  // webcamId, so an overlap costs requests, not correctness.
+  //
+  // Measured 2026-08-14 against api.windy.com: this bbox reports total=206, of
+  // which 135 carry location.country === "Brazil" (the rest are Chile 35,
+  // Argentina 23, Paraguay 9, Uruguay 2, Ecuador 1 — real webcams, kept). The
+  // `latin-america` box already spans this area but at the default 2 pages it
+  // ceilings at 100 for the whole continent, so Brazil was mostly invisible.
+  //
+  // 5 pages = 250 capacity against a measured 206, i.e. headroom rather than a
+  // number tuned to today's inventory. Re-measure before changing it:
+  //   curl -H "x-windy-api-key: $KEY" \
+  //     "https://api.windy.com/webcams/api/v3/webcams?bbox=5.3,-34.7,-33.8,-74.0&limit=1"
+  { name: "brazil", bbox: [5.3, -34.7, -33.8, -74.0], pages: 5 },
   { name: "africa", bbox: [37, 52, -35, -18] },
   { name: "middle-east", bbox: [42, 63, 12, 34] },
   { name: "s-asia", bbox: [37, 92, 5, 60] },
@@ -149,6 +177,37 @@ export const WINDY_REGIONS: WindyRegion[] = [
   { name: "se-asia", bbox: [23, 141, -11, 92] },
   { name: "oceania", bbox: [-9, 180, -48, 110] },
 ];
+
+/** One planned upstream request: which bbox, and which page of it. */
+export interface WindyPageJob {
+  region: string;
+  bbox: [number, number, number, number];
+  offset: number;
+}
+
+/**
+ * Expand the region list into the flat list of page requests to make.
+ *
+ * Pure so the paging arithmetic — the part that decides whether a region is
+ * silently truncated — is unit-testable without touching the network. Both
+ * fan-outs (this module's `fetchWebcams` and lib/webcams/fetch.ts's
+ * `fetchWebcamSample`) call this, so `WindyRegion.pages` cannot be honoured on
+ * one path and ignored on the other.
+ */
+export function planPageJobs(
+  regions: readonly WindyRegion[],
+  defaultPages: number,
+  limit: number,
+): WindyPageJob[] {
+  const jobs: WindyPageJob[] = [];
+  for (const region of regions) {
+    const pages = Math.max(0, Math.trunc(region.pages ?? defaultPages));
+    for (let p = 0; p < pages; p++) {
+      jobs.push({ region: region.name, bbox: region.bbox, offset: p * limit });
+    }
+  }
+  return jobs;
+}
 
 /** Tiny bounded-concurrency map — no deps; runs `fn` over items, `limit` at a time. */
 async function mapPool<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
@@ -205,10 +264,7 @@ export async function fetchWebcams(apiKey: string | undefined = process.env.WIND
     return [];
   }
 
-  const jobs: { bbox: [number, number, number, number]; offset: number }[] = [];
-  for (const region of WINDY_REGIONS) {
-    for (let p = 0; p < PAGES_PER_REGION; p++) jobs.push({ bbox: region.bbox, offset: p * LIMIT });
-  }
+  const jobs = planPageJobs(WINDY_REGIONS, PAGES_PER_REGION, LIMIT);
 
   const pages = await mapPool(jobs, REGION_CONCURRENCY, (job) =>
     fetchPage(apiKey, job.bbox, job.offset).catch(() => [] as WindyWebcam[]),

--- a/lib/webcams/fetch.ts
+++ b/lib/webcams/fetch.ts
@@ -1,5 +1,10 @@
 import type { Webcam } from "@/lib/types";
-import { WINDY_REGIONS, type WindyListResponse, type WindyWebcam } from "@/lib/sources/windy";
+import {
+  WINDY_REGIONS,
+  planPageJobs,
+  type WindyListResponse,
+  type WindyWebcam,
+} from "@/lib/sources/windy";
 import { toWebcams, MAX_WEBCAMS, type WebcamMapping } from "@/lib/webcams/normalize";
 import { coverageCountLabel, type SignalCoverage } from "@/lib/signals/coverage";
 
@@ -126,10 +131,10 @@ export async function fetchWebcamSample(
     return { webcams: [], dormant: true, pagesOk: 0, pagesFailed: 0, statuses: [], mapping: null };
   }
 
-  const jobs: { bbox: [number, number, number, number]; offset: number }[] = [];
-  for (const region of WINDY_REGIONS) {
-    for (let p = 0; p < PAGES_PER_REGION; p++) jobs.push({ bbox: region.bbox, offset: p * LIMIT });
-  }
+  // Shared with lib/sources/windy.ts's fan-out so a region's `pages` override
+  // cannot be honoured on one path and ignored on the other — this is the path
+  // /api/webcams actually runs.
+  const jobs = planPageJobs(WINDY_REGIONS, PAGES_PER_REGION, LIMIT);
 
   const pages = await mapPool(jobs, CONCURRENCY, (job) => fetchPage(key, job.bbox, job.offset));
 

--- a/tests/unit/honest-strings.test.ts
+++ b/tests/unit/honest-strings.test.ts
@@ -8,7 +8,14 @@
 //                                 brand, not the competitor's (already fixed pre-existing; guarded here)
 import { afterEach, expect, test } from "vitest";
 import { getCatalogSource } from "@/lib/sources/catalog";
-import { fetchWebcams, type WindyWebcam } from "@/lib/sources/windy";
+import {
+  fetchWebcams,
+  planPageJobs,
+  WINDY_REGIONS,
+  PAGES_PER_REGION,
+  LIMIT,
+  type WindyWebcam,
+} from "@/lib/sources/windy";
 import { readCoverage } from "@/lib/signals/coverage";
 import { exportFilename } from "@/lib/export";
 import { postWebhook, type AlertHit } from "@/lib/events/alerting";
@@ -50,9 +57,13 @@ function stubWindyFetch(rowsPerPage: number) {
   }) as unknown as typeof fetch;
 }
 
+// Derived from the registry, not hard-coded: regions carry per-region `pages`
+// overrides now, so "14 × 2" is no longer the request count and any literal here
+// would break every time a region is added rather than testing the disclosure.
+const REQUESTS = planPageJobs(WINDY_REGIONS, PAGES_PER_REGION, LIMIT).length;
+
 test("fetchWebcams discloses the cap when the merged sample exceeds it", async () => {
-  // 14 regions x 2 pages = 28 requests; 100/page = 2,800 unique candidates,
-  // comfortably over the 2,000 safety cap.
+  // 100 unique rows per request, which is comfortably over the 2,000 safety cap.
   stubWindyFetch(100);
   const result = await fetchWebcams("fake-test-key");
   expect(result.length).toBe(2000);
@@ -60,21 +71,21 @@ test("fetchWebcams discloses the cap when the merged sample exceeds it", async (
   const coverage = readCoverage(result);
   expect(coverage).toBeDefined();
   expect(coverage!.capped).toBe(true);
-  expect(coverage!.available).toBe(2800);
+  expect(coverage!.available).toBe(REQUESTS * 100);
   expect(coverage!.cap).toBe(2000);
   expect(coverage!.noun).toBe("webcams");
 });
 
 test("fetchWebcams does NOT claim a cap when the sample is under it", async () => {
-  // 28 requests x 1 row = 28 unique candidates, well under the cap.
+  // 1 row per request — well under the cap however many regions are registered.
   stubWindyFetch(1);
   const result = await fetchWebcams("fake-test-key");
-  expect(result.length).toBe(28);
+  expect(result.length).toBe(REQUESTS);
 
   const coverage = readCoverage(result);
   expect(coverage).toBeDefined();
   expect(coverage!.capped).toBe(false);
-  expect(coverage!.available).toBe(28);
+  expect(coverage!.available).toBe(REQUESTS);
 });
 
 test("fetchWebcams stays dormant-safe with no key configured (no network call)", async () => {

--- a/tests/unit/windy-paging.test.ts
+++ b/tests/unit/windy-paging.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import { WINDY_REGIONS, planPageJobs, type WindyRegion } from "@/lib/sources/windy";
+
+// The paging arithmetic is what decides whether a dense region is silently
+// truncated, so it is tested directly rather than through the network fan-out.
+
+const LIMIT = 50;
+const DEFAULT_PAGES = 2;
+
+test("defaults to the module page count when a region does not override it", () => {
+  const regions: WindyRegion[] = [{ name: "r", bbox: [1, 2, 3, 4] }];
+  const jobs = planPageJobs(regions, DEFAULT_PAGES, LIMIT);
+  expect(jobs).toEqual([
+    { region: "r", bbox: [1, 2, 3, 4], offset: 0 },
+    { region: "r", bbox: [1, 2, 3, 4], offset: 50 },
+  ]);
+});
+
+test("honours a per-region page override and steps offsets by the page limit", () => {
+  const regions: WindyRegion[] = [{ name: "dense", bbox: [1, 2, 3, 4], pages: 5 }];
+  const jobs = planPageJobs(regions, DEFAULT_PAGES, LIMIT);
+  expect(jobs.map((j) => j.offset)).toEqual([0, 50, 100, 150, 200]);
+  expect(jobs.every((j) => j.region === "dense")).toBe(true);
+});
+
+test("an override of 0 or a negative asks for no pages rather than looping", () => {
+  expect(planPageJobs([{ name: "off", bbox: [1, 2, 3, 4], pages: 0 }], DEFAULT_PAGES, LIMIT)).toEqual([]);
+  expect(planPageJobs([{ name: "neg", bbox: [1, 2, 3, 4], pages: -3 }], DEFAULT_PAGES, LIMIT)).toEqual([]);
+});
+
+test("Brazil is registered with enough pages to carry the measured inventory", () => {
+  const brazil = WINDY_REGIONS.find((r) => r.name === "brazil");
+  expect(brazil).toBeDefined();
+  // Measured 2026-08-14: bbox total=206, of which 135 are location.country "Brazil".
+  // The default 2 pages ceilings at 100 and would drop roughly half the box.
+  const capacity = (brazil!.pages ?? DEFAULT_PAGES) * LIMIT;
+  expect(capacity).toBeGreaterThanOrEqual(206);
+});
+
+test("every Brazil offset stays inside the free tier's offset<=1000 limit", () => {
+  const brazil = WINDY_REGIONS.find((r) => r.name === "brazil")!;
+  const jobs = planPageJobs([brazil], DEFAULT_PAGES, LIMIT);
+  expect(jobs.length).toBeGreaterThan(0);
+  for (const job of jobs) expect(job.offset).toBeLessThanOrEqual(1000);
+});
+
+test("region names are unique, so a duplicate bbox cannot be added unnoticed", () => {
+  const names = WINDY_REGIONS.map((r) => r.name);
+  expect(new Set(names).size).toBe(names.length);
+});


### PR DESCRIPTION
## What

`PAGES_PER_REGION = 2` ceilinged **every** region at 100 webcams and reported no shortfall. The `latin-america` bbox spans a continent, so its first 100 rows came back 49 Chile / 15 Argentina / 11 Mexico / **10 Brazil** — a country with 135 webcams in the feed was showing 10, and nothing said so.

- `WindyRegion` gains an optional `pages`.
- The paging arithmetic moves into a pure, unit-tested `planPageJobs()`.
- A `brazil` region at 5 pages (250 capacity against a measured 206).

## Why it is structured this way

`WINDY_REGIONS` is consumed by **two** separate fan-outs — `lib/sources/windy.ts` and `lib/webcams/fetch.ts`. An override that only one of them read would be a field that silently did nothing on the live path, so both now call the same pure function.

The Brazil bbox overlaps `latin-america` deliberately. The fan-out dedupes by `webcamId`, so the overlap costs requests, not correctness. Splitting the bbox instead was the tempting fix and it is the wrong one — a 3-way split still left one box at 109, and any split has to be re-tuned every time Windy's inventory moves.

## Test change worth a look

`honest-strings.test.ts` hard-coded `28` requests and `2800` candidates, derived from "14 regions × 2 pages". Those literals now derive from the registry, so adding a region cannot break a test that is really asserting *truncation disclosure*. `PAGES_PER_REGION` and `LIMIT` are exported for that.

## How it was verified

Not just unit tests — end to end against the live API on a dev server:

| | `/api/webcams` returns | of which BR |
|---|---|---|
| before | 1,300 | **10** |
| after | 1,358 | **136** |

Brazil is now the second-largest country in the layer after the US (160). Measured 2026-08-14; Windy's inventory drifts, so re-measure before quoting.

Full gate green: `npx tsc --noEmit` clean, `npm test` 1,738 tests / 230 files passing.