### PR TITLE
Add CET São Paulo — the first South American camera feed

### DIFF
--- a/lib/proxy/allowlist.ts
+++ b/lib/proxy/allowlist.ts
@@ -29,6 +29,8 @@ const RULES: { host: string; prefix: string; suffix?: string }[] = [
   // Scotland Traffic Scotland — the "image" is the camerahtml page; the proxy
   // fetches it and extracts the embedded base64 JPEG (not a direct .jpg).
   { host: "www.traffic.gov.scot", prefix: "/tsis/camerahtml" },
+  // CET São Paulo — snapshots at /cams/{pasta}/1.jpg.
+  { host: "cameras.cetsp.com.br", prefix: "/cams/", suffix: ".jpg" },
   // Windy.com webcams — image CDN. URLs look like
   // /_/<size>/plain/<current|daylight>/<webcamId>/original.jpg (the Webcams layer,
   // a DISTINCT layer from road CCTV; resolved fresh by /api/webcam-image).

--- a/lib/sources/cetsp.data.ts
+++ b/lib/sources/cetsp.data.ts
@@ -1,0 +1,56 @@
+/**
+ * CET São Paulo — the 11 cameras the city publishes to the public web viewer.
+ *
+ * Hand-verified 2026-08-14. The list itself is the `gCams` array inlined in
+ * https://cameras.cetsp.com.br/View/Cam.aspx (fields: pasta, titulo, subTitulo,
+ * detalhe). CET publishes NO coordinates there, so `lat`/`lon` were resolved
+ * offline against the `sqlProducao:CamerasCentral` layer (615 rows, EPSG:4326)
+ * on CET's GeoServer and committed here.
+ *
+ * WHY A COMMITTED TABLE RATHER THAN A RUNTIME LOOKUP:
+ *
+ *   1. That GeoServer is `cet-inf7242.cetsp.com.br:8080` — no TLS, port 8080, an
+ *      internal-looking hostname that merely happens to be reachable. It is not a
+ *      published open-data product and this adapter must not depend on it in
+ *      production. It was a research tool, used once.
+ *   2. Matching camera titles to intersection strings is not reliable enough to
+ *      do unattended. Token-matching resolved 9 of these 11 cleanly and got two
+ *      WRONG on a single shared token — `Ibirapuera × R Ipê` matched a
+ *      Bandeirantes intersection, and `Paulista × Av Brig Luiz Antônio` matched
+ *      something in Tucuruvi, 12 km north. Both were then resolved by hand and
+ *      cross-checked against the `vwCamerasWeb` layer where it carried geometry.
+ *
+ * `local` records the CamerasCentral row each coordinate came from, so a future
+ * re-verification can check the provenance rather than re-deriving it.
+ *
+ * To re-verify a row:
+ *   curl -sI https://cameras.cetsp.com.br/cams/{pasta}/1.jpg   # Last-Modified
+ */
+export interface CetspCamera {
+  /** CET's own folder id — the only stable key, and the image path segment. */
+  pasta: number;
+  lat: number;
+  lon: number;
+  /** Human label, assembled from gCams titulo/subTitulo/detalhe. */
+  name: string;
+  /** The CamerasCentral intersection this coordinate was taken from. */
+  local: string;
+}
+
+export const CETSP_CAMERAS: CetspCamera[] = [
+  // pasta 22 has been serving the same JPEG since 25 Feb 2026 (169 days old at
+  // verification). It is kept because CET still registers it: the freshness check
+  // in cetsp.ts marks it unavailable rather than this file deleting it, so the
+  // coverage denominator stays honest instead of quietly shrinking.
+  { pasta: 22, lat: -23.55804, lon: -46.66004, name: "Paulista x Metrô Consolação (R Augusta)", local: "PAULISTA, AV x AUGUSTA, R" },
+  { pasta: 23, lat: -23.56767, lon: -46.64921, name: "Paulista x Av Brigadeiro Luiz Antônio", local: "PAULISTA, AV x LUIS ANTONIO, AV BRIG x MANUEL DA NOBREGA" },
+  { pasta: 180, lat: -23.54767, lon: -46.64894, name: "Consolação x R Caio Prado", local: "CONSOLACAO, R DA x CAIO PRADO, R" },
+  { pasta: 184, lat: -23.57919, lon: -46.66156, name: "Brasil x Av Brig Luis Antônio (Pr Armando S Oliveira)", local: "LUIS ANTONIO, AV BRIG x BRASIL, AV" },
+  { pasta: 195, lat: -23.56432, lon: -46.67785, name: "Brasil x Av Henrique Schaumann (Av Rebouças)", local: "REBOUCAS, AV x BRASIL, AV x HENRIQUE SCHAUMANN, AV" },
+  { pasta: 200, lat: -23.58222, lon: -46.68373, name: "Iguatemi x Av Brig Faria Lima (R Jerônimo da Veiga)", local: "FARIA LIMA, AV BRIG x IGUATEMI, R x JERÔNIMO DA VEIGA, R" },
+  { pasta: 210, lat: -23.56859, lon: -46.64974, name: "Brig Luis Antônio x Al Santos", local: "LUIS ANTONIO, AV BRIG x SANTOS, AL" },
+  { pasta: 220, lat: -23.58028, lon: -46.6833, name: "Cidade Jardim x Av Nove de Julho (Túnel Máx Feffer)", local: "NOVE DE JULHO, AV x CIDADE JARDIM, AV" },
+  { pasta: 222, lat: -23.59738, lon: -46.66788, name: "Hélio Pellegrino x R Diogo Jácome", local: "HÉLIO PELLEGRINO, AV x DIOGO JACOME, R" },
+  { pasta: 224, lat: -23.59365, lon: -46.65257, name: "Ibirapuera x R Ipê", local: "IBIRAPUERA, AV x IPÊ, R" },
+  { pasta: 225, lat: -23.59765, lon: -46.65113, name: "Ascendino Reis x R Pedro de Toledo", local: "ASCENDINO REIS, AV PROF x PEDRO DE TOLEDO, R" },
+];

--- a/lib/sources/cetsp.ts
+++ b/lib/sources/cetsp.ts
@@ -1,0 +1,125 @@
+import { Camera, CameraArray, Source } from "@/lib/types";
+import { CETSP_CAMERAS, type CetspCamera } from "@/lib/sources/cetsp.data";
+
+// São Paulo — CET (Companhia de Engenharia de Tráfego), the city's traffic
+// authority. Keyless JPEG snapshots of major corridors (Paulista, Faria Lima,
+// Nove de Julho, Ibirapuera, Rebouças, Consolação) at
+// https://cameras.cetsp.com.br/cams/{pasta}/1.jpg.
+//
+// THE GOTCHA THAT DEFINES THIS ADAPTER: 205 of the /cams/{id}/ folders on that
+// host return HTTP 200 with a valid JPEG, and only ~10 of them are live. The
+// rest are abandoned stills whose Last-Modified dates run from 2017 to 2025 —
+// the server never stopped serving them, it just stopped updating them. Counting
+// HTTP 200s would report "205 São Paulo cameras" and be wrong by ~195.
+//
+// So availability here is decided by the snapshot's AGE, never by its status
+// code, and never by CamerasCentral's own `status` column either — that layer
+// marks three of the live cameras INOPERANTE while their images update fine.
+//
+// The camera list and coordinates are a committed, hand-verified table
+// (./cetsp.data.ts) rather than a runtime scrape; see that file for why.
+
+const IMAGE_ORIGIN = "https://cameras.cetsp.com.br/cams";
+
+/**
+ * How old a snapshot may be and still count as a live camera.
+ *
+ * The live cameras were all under a minute old across repeated checks, and the
+ * dead ones are months to years stale, so anything in this range separates them
+ * cleanly. 60 minutes is deliberately loose: it tolerates a CET-side pause or a
+ * slow overnight cycle without flapping the whole layer to unavailable, while
+ * still being four orders of magnitude below the staleness it exists to catch.
+ */
+export const MAX_SNAPSHOT_AGE_MS = 60 * 60 * 1000;
+
+export const CETSP_SOURCE: Source = {
+  id: "cetsp",
+  name: "CET — Companhia de Engenharia de Tráfego (São Paulo)",
+  license: "CET/Prefeitura de São Paulo — public traffic-camera viewer",
+  attribution: "Live traffic images © CET — Companhia de Engenharia de Tráfego, Prefeitura de São Paulo",
+  refreshSeconds: 120,
+  needsKey: false,
+};
+
+/** What one freshness probe learned about a camera's snapshot. */
+export interface SnapshotProbe {
+  pasta: number;
+  /** Last-Modified as epoch ms, or null when the probe failed or sent no header. */
+  lastModifiedMs: number | null;
+}
+
+export function snapshotUrl(pasta: number): string {
+  return `${IMAGE_ORIGIN}/${pasta}/1.jpg`;
+}
+
+/**
+ * Build the camera list from the static table plus this round's freshness probes.
+ *
+ * Pure, so the availability rule — the whole point of this adapter — is testable
+ * without the network. A camera with no usable probe is reported UNAVAILABLE
+ * rather than dropped: the registry's coverage denominator should say "11 known,
+ * 10 online", not silently shrink to 10 and present that as the whole truth.
+ */
+export function normalizeCetsp(
+  probes: readonly SnapshotProbe[],
+  now: number,
+  cameras: readonly CetspCamera[] = CETSP_CAMERAS,
+  maxAgeMs: number = MAX_SNAPSHOT_AGE_MS,
+): Camera[] {
+  const byPasta = new Map(probes.map((p) => [p.pasta, p]));
+  const out: Camera[] = [];
+  for (const cam of cameras) {
+    const lm = byPasta.get(cam.pasta)?.lastModifiedMs ?? null;
+    // A future-dated header is a clock disagreement, not freshness — clamp the
+    // age at 0 so it reads as fresh rather than as a huge negative.
+    const ageMs = lm === null ? null : Math.max(0, now - lm);
+    const fresh = ageMs !== null && ageMs <= maxAgeMs;
+    out.push({
+      id: `cetsp:${cam.pasta}`,
+      source: "cetsp",
+      country: "BR",
+      region: "São Paulo",
+      name: cam.name,
+      lat: cam.lat,
+      lon: cam.lon,
+      imageUrl: snapshotUrl(cam.pasta),
+      mediaType: "jpeg",
+      refreshSeconds: CETSP_SOURCE.refreshSeconds,
+      license: CETSP_SOURCE.license,
+      attribution: CETSP_SOURCE.attribution,
+      available: fresh,
+      ...(lm !== null ? { lastSampledAt: new Date(lm).toISOString() } : {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * HEAD each snapshot for its Last-Modified. HEAD rather than GET so a refresh
+ * costs headers, not ~11 × 25 KB of JPEG we would immediately discard — the
+ * images themselves are fetched by the client through /api/proxy.
+ *
+ * One camera failing must not fail the round, so every probe resolves.
+ */
+async function probeSnapshot(pasta: number): Promise<SnapshotProbe> {
+  try {
+    const res = await fetch(snapshotUrl(pasta), {
+      method: "HEAD",
+      headers: { "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)" },
+      signal: AbortSignal.timeout(8_000),
+      cache: "no-store",
+    });
+    if (!res.ok) return { pasta, lastModifiedMs: null };
+    const header = res.headers.get("last-modified");
+    if (!header) return { pasta, lastModifiedMs: null };
+    const parsed = Date.parse(header);
+    return { pasta, lastModifiedMs: Number.isFinite(parsed) ? parsed : null };
+  } catch {
+    return { pasta, lastModifiedMs: null };
+  }
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  const probes = await Promise.all(CETSP_CAMERAS.map((c) => probeSnapshot(c.pasta)));
+  return CameraArray.parse(normalizeCetsp(probes, Date.now()));
+}

--- a/lib/sources/registry.ts
+++ b/lib/sources/registry.ts
@@ -10,6 +10,7 @@ import { fetchRegistry as fetchNzta } from "@/lib/sources/nzta";
 import { fetchRegistry as fetchIceland } from "@/lib/sources/iceland";
 import { fetchRegistry as fetchEstonia } from "@/lib/sources/estonia";
 import { fetchRegistry as fetchTrafficScotland } from "@/lib/sources/trafficscotland";
+import { fetchRegistry as fetchCetsp } from "@/lib/sources/cetsp";
 import { findById, nearest } from "@/lib/sources/select";
 
 const TTL_MS = 5 * 60 * 1000;
@@ -76,6 +77,10 @@ const SOURCES: CameraFeed[] = [
   { key: "iceland", fetch: fetchIceland },
   { key: "estonia", fetch: fetchEstonia },
   { key: "trafficscotland", fetch: fetchTrafficScotland },
+  // First South American feed. Small (11 cameras) and deliberately so — see
+  // lib/sources/cetsp.ts for why the other ~195 snapshot folders on that host
+  // are not cameras.
+  { key: "cetsp", fetch: fetchCetsp },
 ];
 
 export const CAMERA_FEED_COUNT = SOURCES.length;

--- a/tests/unit/cetsp.test.ts
+++ b/tests/unit/cetsp.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "vitest";
+import {
+  normalizeCetsp,
+  snapshotUrl,
+  MAX_SNAPSHOT_AGE_MS,
+  CETSP_SOURCE,
+  type SnapshotProbe,
+} from "@/lib/sources/cetsp";
+import { CETSP_CAMERAS } from "@/lib/sources/cetsp.data";
+import { CameraArray } from "@/lib/types";
+import { isAllowed } from "@/lib/proxy/allowlist";
+
+const NOW = Date.UTC(2026, 7, 14, 0, 0, 0);
+const fresh = (pasta: number, minsAgo = 1): SnapshotProbe => ({
+  pasta,
+  lastModifiedMs: NOW - minsAgo * 60_000,
+});
+
+test("normalizes into schema-valid Cameras", () => {
+  const cams = normalizeCetsp(CETSP_CAMERAS.map((c) => fresh(c.pasta)), NOW);
+  expect(cams.length).toBe(CETSP_CAMERAS.length);
+  expect(() => CameraArray.parse(cams)).not.toThrow();
+});
+
+test("maps id, country, coords and image url", () => {
+  const cams = normalizeCetsp([fresh(225)], NOW, [
+    CETSP_CAMERAS.find((c) => c.pasta === 225)!,
+  ]);
+  const [cam] = cams;
+  expect(cam.id).toBe("cetsp:225");
+  expect(cam.source).toBe("cetsp");
+  expect(cam.country).toBe("BR");
+  expect(cam.region).toBe("São Paulo");
+  expect(cam.lat).toBeCloseTo(-23.59765, 5);
+  expect(cam.lon).toBeCloseTo(-46.65113, 5);
+  expect(cam.imageUrl).toBe("https://cameras.cetsp.com.br/cams/225/1.jpg");
+  expect(cam.mediaType).toBe("jpeg");
+  expect(cam.attribution).toBe(CETSP_SOURCE.attribution);
+});
+
+// The reason this adapter exists. ~195 folders on that host serve HTTP 200 JPEGs
+// that were last written between 2017 and 2025; pasta 22 has been static since
+// 25 Feb 2026. Availability must come from the snapshot's age, not its status.
+test("a stale snapshot is unavailable, however happily it serves HTTP 200", () => {
+  const staleByADay = [{ pasta: 22, lastModifiedMs: NOW - 169 * 24 * 60 * 60_000 }];
+  const [cam] = normalizeCetsp(staleByADay, NOW, [CETSP_CAMERAS.find((c) => c.pasta === 22)!]);
+  expect(cam.available).toBe(false);
+  expect(cam.lastSampledAt).toBe(new Date(NOW - 169 * 24 * 60 * 60_000).toISOString());
+});
+
+test("a fresh snapshot is available", () => {
+  const [cam] = normalizeCetsp([fresh(180)], NOW, [CETSP_CAMERAS.find((c) => c.pasta === 180)!]);
+  expect(cam.available).toBe(true);
+});
+
+test("the freshness boundary is inclusive on the fresh side", () => {
+  const one = [CETSP_CAMERAS[0]];
+  const atLimit = normalizeCetsp([{ pasta: one[0].pasta, lastModifiedMs: NOW - MAX_SNAPSHOT_AGE_MS }], NOW, one);
+  const pastLimit = normalizeCetsp([{ pasta: one[0].pasta, lastModifiedMs: NOW - MAX_SNAPSHOT_AGE_MS - 1 }], NOW, one);
+  expect(atLimit[0].available).toBe(true);
+  expect(pastLimit[0].available).toBe(false);
+});
+
+test("a failed probe reports the camera unavailable, and does not drop it", () => {
+  const cams = normalizeCetsp([{ pasta: 195, lastModifiedMs: null }], NOW, [
+    CETSP_CAMERAS.find((c) => c.pasta === 195)!,
+  ]);
+  // Kept, so the coverage denominator stays "known" rather than quietly shrinking.
+  expect(cams).toHaveLength(1);
+  expect(cams[0].available).toBe(false);
+  expect(cams[0].lastSampledAt).toBeUndefined();
+});
+
+test("a camera with no probe at all is unavailable rather than missing", () => {
+  const cams = normalizeCetsp([], NOW, CETSP_CAMERAS);
+  expect(cams).toHaveLength(CETSP_CAMERAS.length);
+  expect(cams.every((c) => c.available === false)).toBe(true);
+});
+
+test("a future-dated Last-Modified reads as fresh, not as a huge negative age", () => {
+  const one = [CETSP_CAMERAS[0]];
+  const [cam] = normalizeCetsp([{ pasta: one[0].pasta, lastModifiedMs: NOW + 10 * 60_000 }], NOW, one);
+  expect(cam.available).toBe(true);
+});
+
+test("every committed camera has plausible São Paulo coordinates", () => {
+  // Guards the failure mode that produced two wrong rows during research: a bad
+  // intersection match silently placing a camera in another part of the city.
+  for (const cam of CETSP_CAMERAS) {
+    expect(cam.lat).toBeGreaterThan(-24.1);
+    expect(cam.lat).toBeLessThan(-23.3);
+    expect(cam.lon).toBeGreaterThan(-46.9);
+    expect(cam.lon).toBeLessThan(-46.3);
+  }
+});
+
+test("pasta ids are unique", () => {
+  const ids = CETSP_CAMERAS.map((c) => c.pasta);
+  expect(new Set(ids).size).toBe(ids.length);
+});
+
+test("snapshot urls pass the media proxy allowlist", () => {
+  for (const cam of CETSP_CAMERAS) {
+    expect(isAllowed(new URL(snapshotUrl(cam.pasta)))).toBe(true);
+  }
+  // And the rule stays tight — not the whole host.
+  expect(isAllowed(new URL("https://cameras.cetsp.com.br/View/Cam.aspx"))).toBe(false);
+});


### PR DESCRIPTION
## What

A 12th camera adapter: **CET São Paulo**, covering the city's main corridors — Paulista, Faria Lima, Nove de Julho, Ibirapuera, Rebouças, Consolação. Keyless JPEG snapshots. 11 cameras, 10 of them live.

Brazil had no cameras in this product at all before this.

## The thing this adapter is actually about

**205** of the `/cams/{id}/` folders on that host return HTTP 200 with a perfectly valid JPEG. **~10 are live.** The rest are abandoned stills whose `Last-Modified` dates run from 2017 to 2025 — the server never stopped serving them, it just stopped updating them.

The clearest case is folder `22`. Fetched through our own proxy at **01:40 São Paulo time**, alongside a live camera fetched in the same second:

| `cetsp:220` — live | `cetsp:22` — HTTP 200, last written 25 Feb 2026 |
|---|---|
| night, moving traffic | **Avenida Paulista in broad daylight** |

Both are 200s. Both are plausible traffic scenes. One is six months old. Counting status codes would have reported *"205 São Paulo cameras"* and been wrong by ~195.

So `available` is decided by the snapshot's **age**. Not by its status code — and not by `CamerasCentral.status` either, which marks three of the *live* cameras `INOPERANTE` while their images update fine.

A stale or unprobeable camera is `available: false` and **kept**, so coverage reads "11 known, 10 online" rather than silently shrinking to 10 and presenting that as the whole truth.

## Why coordinates are a committed table

CET publishes none. They can be derived from a `CamerasCentral` layer on CET's GeoServer, but:

1. That host is `cet-inf7242.cetsp.com.br:8080` — no TLS, port 8080, an internal-looking name that merely happens to be reachable. It is not a published open-data product and this adapter must not depend on it in production. It was used once, offline.
2. Deriving them unattended is not safe. Token-matching resolved 9 of 11 cleanly and put **two cameras in the wrong part of the city** on a single shared token — `Ibirapuera × R Ipê` matched a Bandeirantes intersection, and `Paulista × Av Brig Luiz Antônio` matched somewhere in Tucuruvi, 12 km north. Both were resolved by hand and cross-checked against `vwCamerasWeb` where it carried geometry.

Each row records the `CamerasCentral` intersection its coordinate came from, so a re-verification can check provenance rather than re-derive it. A test also asserts every camera sits inside a São Paulo bounding box — a direct guard against that failure mode.

## How it was verified

- `/api/coverage` → `{"source":"cetsp","total":11,"online":10}`
- `/api/proxy?id=cetsp:220` → `200 image/jpeg`, 30 KB, visually confirmed as live night traffic
- `npx tsc --noEmit` clean; `npm test` **1,749 tests / 231 files** passing