### PR TITLE
Resolve YouTube channels to live videos — the ISS panel and 8 news presets are dead

### DIFF
--- a/app/api/youtube-live/route.ts
+++ b/app/api/youtube-live/route.ts
@@ -1,0 +1,47 @@
+import { getLiveVideos } from "@/lib/youtube/registry";
+import { NEWS_PROVIDERS, newsChannelRequests } from "@/lib/console/news/providers";
+import { requestKey } from "@/lib/youtube/live";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/youtube-live — which video each registered channel is broadcasting
+ * right now, keyed by provider id.
+ *
+ * WHY THE CLIENT CANNOT DO THIS ITSELF. The obvious client-side answer,
+ * `youtube.com/embed/live_stream?channel={id}`, is retired and renders
+ * "Error 153". The working answer is the YouTube Data API, which needs a key
+ * that must not reach the browser. So resolution happens here and the client
+ * receives video ids only — never the key.
+ *
+ * Returns {resolved: {providerId: videoId}, dormant, note, quotaSpent}.
+ *
+ * `dormant: true` means no YOUTUBE_API_KEY is configured, which is a legitimate
+ * switched-off state, not an error: the console falls back to each provider's
+ * last-known `ref`, i.e. exactly today's behaviour, never worse. A provider
+ * missing from `resolved` means that channel had nothing live — the caller
+ * should say so rather than render a dead player.
+ *
+ * `quotaSpent` is published because the free tier is 10,000 units/day and this
+ * design's whole claim is that it costs ~1,900. A number nobody can see is a
+ * number nobody notices going wrong.
+ */
+export async function GET() {
+  const requests = newsChannelRequests();
+  const result = await getLiveVideos(requests);
+
+  const byKey = new Map(result.resolutions.map((r) => [requestKey(r), r]));
+  const resolved: Record<string, string> = {};
+  for (const p of NEWS_PROVIDERS) {
+    if (p.kind !== "youtube" || !p.channelId) continue;
+    const hit = byKey.get(requestKey({ channelId: p.channelId, match: p.match }));
+    if (hit?.videoId) resolved[p.id] = hit.videoId;
+  }
+
+  return Response.json({
+    resolved,
+    dormant: result.dormant,
+    note: result.note,
+    quotaSpent: result.quotaSpent,
+  });
+}

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -88,6 +88,34 @@ Every layer now shows a live **freshness dot** in the rail (the trust spine).
 | **Photo geolocation** (`/locate`) vision fallback | freellmapi.co gateway (you own it) | `FREELLMAPI_BASE_URL`, `FREELLMAPI_KEY` |
 | **Photo geolocation** GeoCLIP backend (best accuracy) | run `scripts/geolocate_service.py`, point the app at it | `GEOLOCATE_GEOCLIP_URL` (+ optional `GEOLOCATE_BACKEND=geoclip\|llm`) |
 | **Windy webcams** layer | Windy API keys (you said these are already in `.env.local`) | `WINDY_WEBCAMS_API_KEY`, `WINDY_MAP_FORECAST_API_KEY` |
+| **Live channel resolution** (news presets + the ISS panel) | YouTube Data API v3 key — see below | `YOUTUBE_API_KEY` |
+
+### `YOUTUBE_API_KEY` — why this one is not optional polish
+
+Pinned YouTube **video** ids rot. Audited 2026-08-14: **8 of the 12 news presets were
+already dead** ("Video unavailable", "this live stream recording is not available", one
+gone private), and the ISS panel had been rendering *"Error 153 — Video player
+configuration error"* since YouTube retired the `embed/live_stream?channel=` endpoint.
+
+Channel ids are durable, but resolving one to its current live video needs this key.
+Without it the console falls back to the pinned ids — i.e. exactly today's behaviour,
+no worse — so nothing breaks while it is missing.
+
+Getting it (~2 minutes, free, **no billing account required**):
+
+1. console.cloud.google.com → create or pick a project
+2. **APIs & Services → Library** → "YouTube Data API v3" → **Enable**
+3. **APIs & Services → Credentials** → **Create credentials → API key**
+4. **Edit** the key → **API restrictions → Restrict key → YouTube Data API v3**.
+   Leave *Application restrictions* as **None** — it is called server-side, so an
+   HTTP-referrer or IP restriction would break it.
+5. `.env.local` → `YOUTUBE_API_KEY=…`, and the same in Vercel → Environment Variables
+
+Quota: 10,000 units/day free. The resolver is built to fit well inside that — it
+validates every known stream in a single 1-unit call and only pays the expensive
+100-unit search for channels that actually rotated, costing roughly 1,900 units/day at
+the measured rotation rate. `/api/youtube-live` publishes `quotaSpent` so this can be
+checked rather than assumed.
 
 ---
 

--- a/lib/console/news/providers.ts
+++ b/lib/console/news/providers.ts
@@ -3,26 +3,75 @@ export interface NewsProvider {
   name: string;
   category: string;
   kind: "youtube" | "hls";
+  /**
+   * Last-known video id (YouTube) or stream URL (HLS). For YouTube this is now
+   * a FALLBACK only — see `channelId`.
+   */
   ref: string;
+  /**
+   * The channel that actually broadcasts this feed. Durable: unlike a video id
+   * it survives the broadcaster restarting their stream. Resolved to a current
+   * live video by lib/youtube/live.ts.
+   */
+  channelId?: string;
+  /**
+   * Title preference when a channel runs several concurrent live streams — a
+   * soft hint, not a filter. NASA is why: it broadcasts both ISS feeds at once,
+   * so "NASA TV" and "ISS Live" would otherwise resolve to the same video.
+   */
+  match?: string;
   favorite?: boolean;
 }
 
-// YouTube live video ids for free 24/7 news channels. ids are tunable — they
-// occasionally rotate; the picker's add-custom-stream covers breakage.
+// 24/7 news and space channels.
+//
+// PINNED VIDEO IDS DO NOT SURVIVE. Audited 2026-08-14 with yt-dlp against the
+// twelve ids this list used to carry: EIGHT WERE ALREADY DEAD — DW, France 24,
+// TRT, NHK, Bloomberg, NASA TV and ISS Live all returned "Video unavailable" or
+// "This live stream recording is not available", and Sky News had gone private.
+// Only Al Jazeera, Euronews, CNA and ABC (AU) still played. lib/console/help.ts
+// has described this failure for a while; this is the measurement of it.
+//
+// So `channelId` is now the registered handle and `ref` is only a fallback for
+// when resolution is dormant (no YOUTUBE_API_KEY) — in which case a stale id
+// behaves exactly as it does today rather than any worse.
+//
+// Every channelId below was resolved from the broadcaster's own handle and
+// confirmed to have a live stream at the time of writing. To re-check one:
+//   yt-dlp --flat-playlist -J "https://www.youtube.com/channel/<id>/streams"
 export const NEWS_PROVIDERS: NewsProvider[] = [
-  { id: "aljazeera", name: "Al Jazeera English", category: "World", kind: "youtube", ref: "gCNeDWCI0vo", favorite: true },
-  { id: "dw", name: "DW News", category: "World", kind: "youtube", ref: "tQwQfNuvb1A", favorite: true },
-  { id: "france24", name: "France 24", category: "World", kind: "youtube", ref: "h3MuIUNCCzI", favorite: true },
-  { id: "sky", name: "Sky News", category: "World", kind: "youtube", ref: "9Auq9mYxFEE" },
-  { id: "euronews", name: "Euronews", category: "World", kind: "youtube", ref: "pykpO5kQJ98" },
-  { id: "cna", name: "CNA", category: "World", kind: "youtube", ref: "XWq5kBlakcQ" },
-  { id: "trt", name: "TRT World", category: "World", kind: "youtube", ref: "Wp0_Dk0nJOk" },
-  { id: "nhk", name: "NHK World", category: "World", kind: "youtube", ref: "f0lYkdg2DZw" },
-  { id: "abcau", name: "ABC News (AU)", category: "World", kind: "youtube", ref: "vOTiJkg1voo" },
-  { id: "bloomberg", name: "Bloomberg TV", category: "Business", kind: "youtube", ref: "iEpJwprxDdk" },
-  { id: "nasa", name: "NASA TV", category: "Space", kind: "youtube", ref: "21X5lGlDOfg" },
-  { id: "iss", name: "ISS Live", category: "Space", kind: "youtube", ref: "DIgkvm2nmHc" },
+  { id: "aljazeera", name: "Al Jazeera English", category: "World", kind: "youtube", channelId: "UCNye-wNBqNL5ZzHSJj3l8Bg", ref: "gCNeDWCI0vo", favorite: true },
+  { id: "dw", name: "DW News", category: "World", kind: "youtube", channelId: "UCknLrEdhRCp1aegoMqRaCZg", ref: "tQwQfNuvb1A", favorite: true },
+  { id: "france24", name: "France 24", category: "World", kind: "youtube", channelId: "UCQfwfsi5VrQ8yKZ-UWmAEFg", ref: "h3MuIUNCCzI", favorite: true },
+  { id: "sky", name: "Sky News", category: "World", kind: "youtube", channelId: "UCoMdktPbSTixAyNGwb-UYkQ", ref: "9Auq9mYxFEE" },
+  { id: "euronews", name: "Euronews", category: "World", kind: "youtube", channelId: "UCSrZ3UV4jOidv8ppoVuvW9Q", ref: "pykpO5kQJ98" },
+  { id: "cna", name: "CNA", category: "World", kind: "youtube", channelId: "UC83jt4dlz1Gjl58fzQrrKZg", ref: "XWq5kBlakcQ" },
+  { id: "trt", name: "TRT World", category: "World", kind: "youtube", channelId: "UC7fWeaHhqgM4Ry-RMpM2YYw", ref: "Wp0_Dk0nJOk" },
+  { id: "nhk", name: "NHK World", category: "World", kind: "youtube", channelId: "UCSPEjw8F2nQDtmUKPFNF7_A", ref: "f0lYkdg2DZw" },
+  { id: "abcau", name: "ABC News (AU)", category: "World", kind: "youtube", channelId: "UCVgO39Bk5sMo66-6o6Spn6Q", ref: "vOTiJkg1voo" },
+  { id: "bloomberg", name: "Bloomberg TV", category: "Business", kind: "youtube", channelId: "UCIALMKvObZNtJ6AmdCLP7Lg", ref: "iEpJwprxDdk" },
+  // NASA runs both ISS feeds concurrently, hence the `match` hints.
+  { id: "nasa", name: "NASA TV", category: "Space", kind: "youtube", channelId: "UCLA_DiR1FfKNvjuUpBHmylQ", match: "Official NASA", ref: "21X5lGlDOfg" },
+  { id: "iss", name: "ISS Live", category: "Space", kind: "youtube", channelId: "UCLA_DiR1FfKNvjuUpBHmylQ", match: "High-Definition", ref: "DIgkvm2nmHc" },
 ];
+
+/** The channels worth asking the resolver about, deduped, in list order. */
+export function newsChannelRequests(
+  providers: readonly NewsProvider[] = NEWS_PROVIDERS,
+): { channelId: string; match?: string }[] {
+  const seen = new Set<string>();
+  const out: { channelId: string; match?: string }[] = [];
+  for (const p of providers) {
+    if (p.kind !== "youtube" || !p.channelId) continue;
+    // A channel serving two providers (NASA/ISS) is requested once per distinct
+    // match hint — the resolver picks a different video for each.
+    const key = `${p.channelId}::${p.match ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p.match ? { channelId: p.channelId, match: p.match } : { channelId: p.channelId });
+  }
+  return out;
+}
 
 const YT_ID = /(?:v=|youtu\.be\/|\/live\/|\/embed\/)([A-Za-z0-9_-]{11})/;
 
@@ -36,12 +85,27 @@ export function parseCustomStream(url: string): NewsProvider | null {
   return null;
 }
 
-export function resolveEmbed(p: NewsProvider): { kind: "youtube" | "hls"; src: string } {
-  if (p.kind === "youtube") return { kind: "youtube", src: `https://www.youtube.com/embed/${p.ref}?autoplay=1&mute=1&playsinline=1` };
+/**
+ * The video id to actually play: the freshly resolved one when /api/youtube-live
+ * answered, otherwise the pinned `ref`. The fallback is deliberate — with no API
+ * key the console behaves exactly as it does today rather than going blank.
+ */
+export function playableRef(p: NewsProvider, liveVideoId?: string | null): string {
+  return p.kind === "youtube" && liveVideoId ? liveVideoId : p.ref;
+}
+
+export function resolveEmbed(
+  p: NewsProvider,
+  liveVideoId?: string | null,
+): { kind: "youtube" | "hls"; src: string } {
+  if (p.kind === "youtube") {
+    const id = playableRef(p, liveVideoId);
+    return { kind: "youtube", src: `https://www.youtube.com/embed/${id}?autoplay=1&mute=1&playsinline=1` };
+  }
   return { kind: "hls", src: /^https?:\/\//i.test(p.ref) ? p.ref : "" };
 }
 
 /** Keyless YouTube thumbnail for a provider, or null for HLS (no free thumbnail). */
-export function providerThumb(p: NewsProvider): string | null {
-  return p.kind === "youtube" ? `https://img.youtube.com/vi/${p.ref}/hqdefault.jpg` : null;
+export function providerThumb(p: NewsProvider, liveVideoId?: string | null): string | null {
+  return p.kind === "youtube" ? `https://img.youtube.com/vi/${playableRef(p, liveVideoId)}/hqdefault.jpg` : null;
 }

--- a/lib/console/news/useLiveVideoIds.ts
+++ b/lib/console/news/useLiveVideoIds.ts
@@ -1,0 +1,59 @@
+"use client";
+import { useEffect, useState } from "react";
+
+/**
+ * Provider id → the video that provider's channel is broadcasting right now,
+ * from /api/youtube-live.
+ *
+ * Shared module-level state, not per-component: the news widget, its detail
+ * view and the satellites panel all want the same answer, and one resolution
+ * round costs real API quota. Components mount and unmount as boards change, so
+ * a per-component fetch would re-ask constantly for data that changes every ten
+ * minutes at most.
+ *
+ * Failure is silent by design. An empty map means "nothing resolved", and every
+ * caller already falls back to its pinned `ref`, so a dead resolver leaves the
+ * console exactly as it behaves today instead of blanking the players.
+ */
+const REFRESH_MS = 10 * 60 * 1000;
+
+let cache: Record<string, string> = {};
+let fetchedAt = 0;
+let inflight: Promise<void> | null = null;
+const listeners = new Set<(v: Record<string, string>) => void>();
+
+async function refresh(): Promise<void> {
+  try {
+    const res = await fetch("/api/youtube-live", { cache: "no-store" });
+    if (!res.ok) return;
+    const json = (await res.json()) as { resolved?: Record<string, string> };
+    cache = json.resolved ?? {};
+    fetchedAt = Date.now();
+    for (const fn of listeners) fn(cache);
+  } catch {
+    // Keep whatever we had; callers fall back to their pinned ref.
+  }
+}
+
+function ensureFresh(): void {
+  if (Date.now() - fetchedAt < REFRESH_MS && fetchedAt !== 0) return;
+  if (!inflight) {
+    inflight = refresh().finally(() => {
+      inflight = null;
+    });
+  }
+}
+
+export function useLiveVideoIds(): Record<string, string> {
+  const [ids, setIds] = useState<Record<string, string>>(cache);
+  useEffect(() => {
+    listeners.add(setIds);
+    ensureFresh();
+    const timer = setInterval(ensureFresh, REFRESH_MS);
+    return () => {
+      listeners.delete(setIds);
+      clearInterval(timer);
+    };
+  }, []);
+  return ids;
+}

--- a/lib/console/widgets/news.detail.tsx
+++ b/lib/console/widgets/news.detail.tsx
@@ -11,7 +11,8 @@ import type { WidgetDetailProps } from "@/lib/console/registry";
 import type { NewsItem } from "@/lib/news";
 import { useJsonPoll } from "@/lib/console/widgets/useJsonPoll";
 import { shellLayoutStore } from "@/lib/console/store";
-import { NEWS_PROVIDERS, parseCustomStream, providerThumb, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+import { NEWS_PROVIDERS, parseCustomStream, playableRef, providerThumb, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+import { useLiveVideoIds } from "@/lib/console/news/useLiveVideoIds";
 import { toCsv, downloadText, exportFilename } from "@/lib/export";
 
 /** Compact relative age (mirrors headlines.detail). */
@@ -102,7 +103,9 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
   const headlines = newsData.items ?? [];
   const now = Date.now();
 
-  const embed = active ? resolveEmbed(active) : null;
+  // Channel-resolved video ids, falling back to each provider's pinned ref.
+  const liveIds = useLiveVideoIds();
+  const embed = active ? resolveEmbed(active, liveIds[active.id]) : null;
 
   // HLS hero: reuse the docked NewsBody's inline hls.js loader verbatim (no new player,
   // no /api/hls host change). YouTube heroes use the keyless <iframe> below. Since the
@@ -161,7 +164,7 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
             return (
               <div key={p.id} className={`tn-nv-cell${on ? " is-on" : ""}`}>
                 <iframe
-                  src={`https://www.youtube.com/embed/${p.ref}?autoplay=1&mute=${on ? 0 : 1}&playsinline=1`}
+                  src={`https://www.youtube.com/embed/${playableRef(p, liveIds[p.id])}?autoplay=1&mute=${on ? 0 : 1}&playsinline=1`}
                   title={p.name}
                   allow="autoplay; encrypted-media; picture-in-picture"
                   allowFullScreen
@@ -186,7 +189,7 @@ export default function NewsDetail({ instanceId, config }: WidgetDetailProps) {
           <Fragment key={cat}>
             <div className="tn-nv-cat-h">{cat}</div>
             {ps.map((p) => {
-              const thumb = providerThumb(p);
+              const thumb = providerThumb(p, liveIds[p.id]);
               const on = p.id === activeId;
               return (
                 <button

--- a/lib/console/widgets/news.tsx
+++ b/lib/console/widgets/news.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
 import { useWidgetReport } from "@/components/console/WidgetFrame";
 import { NEWS_PROVIDERS, parseCustomStream, resolveEmbed, type NewsProvider } from "@/lib/console/news/providers";
+import { useLiveVideoIds } from "@/lib/console/news/useLiveVideoIds";
 import NewsDetail from "./news.detail";
 
 function NewsBody({ instanceId, config }: WidgetBodyProps) {
@@ -10,7 +11,10 @@ function NewsBody({ instanceId, config }: WidgetBodyProps) {
   const activeId = (config.providerId as string) ?? NEWS_PROVIDERS[0].id;
   const custom = config.customProvider as NewsProvider | undefined;
   const active = custom?.id === activeId ? custom : NEWS_PROVIDERS.find((p) => p.id === activeId) ?? NEWS_PROVIDERS[0];
-  const embed = resolveEmbed(active);
+  // Resolved live video ids; falls back to the provider's pinned ref when the
+  // resolver is dormant or the channel has nothing live.
+  const liveIds = useLiveVideoIds();
+  const embed = resolveEmbed(active, liveIds[active.id]);
   const favorites = NEWS_PROVIDERS.filter((p) => p.favorite).slice(0, 4);
   const [picker, setPicker] = useState(false);
   // No `fresh` observation here on purpose: this widget embeds a third-party live

--- a/lib/console/widgets/satellites.detail.tsx
+++ b/lib/console/widgets/satellites.detail.tsx
@@ -22,6 +22,7 @@ import InsetMap from "@/components/InsetMap";
 import type { InsetPoint } from "@/lib/map/inset";
 import SatelliteDetail from "@/components/SatelliteDetail";
 import { toCsv, toGeoJson, downloadText, exportFilename } from "@/lib/export";
+import { useLiveVideoIds } from "@/lib/console/news/useLiveVideoIds";
 
 // The satellite meta the propagation hook attaches (see lib/satellites/useSatellites).
 // meta is Record<string, unknown> on WorldObject, so we narrow it here.
@@ -37,9 +38,17 @@ interface SatMeta {
 }
 const metaOf = (o: WorldObject | undefined): SatMeta => (o?.meta ?? {}) as SatMeta;
 
-// NASA's official (main) YouTube channel — the live_stream embed resolves to whatever
-// that channel is currently broadcasting: the ISS HD cameras when they're live, other
-// NASA programming otherwise. Keyless. The caption is honest about this (not ISS-only).
+// NASA's official (main) YouTube channel.
+//
+// This used to be embedded as `youtube.com/embed/live_stream?channel=${NASA_CHANNEL}`,
+// on the assumption that YouTube would resolve the channel's current broadcast for us.
+// IT NO LONGER DOES — that endpoint is retired. Loaded in a real browser against this
+// exact channel id it renders "Error 153 — Video player configuration error" and builds
+// a link to `watch?v=live_stream`, i.e. it takes the literal string as a video id. The
+// panel has been a dead player for every user since YouTube pulled it.
+//
+// The channel id is still the right thing to register — it is durable where a video id
+// is not — but it now has to be resolved server-side. See lib/youtube/live.ts.
 const NASA_CHANNEL = "UCLA_DiR1FfKNvjuUpBHmylQ";
 const ISS_NORAD = "25544";
 
@@ -52,6 +61,11 @@ export default function SatellitesDetail(props: WidgetDetailProps) {
   const objects = useSatellites(group, 5000);
   const total = objects.length;
 
+  // Resolved server-side (lib/youtube/live.ts): "iss" prefers NASA's HD Earth-viewing
+  // stream, "nasa" its other concurrent feed. Undefined when nothing is live or the
+  // resolver is dormant — the panel then says so instead of rendering a dead player.
+  const liveIds = useLiveVideoIds();
+  const issVideoId = liveIds["iss"] ?? liveIds["nasa"];
   const [selId, setSelId] = useState<string | null>(null);
   const [openId, setOpenId] = useState<string | null>(null);
   const [q, setQ] = useState("");
@@ -273,13 +287,29 @@ export default function SatellitesDetail(props: WidgetDetailProps) {
             <h3>Live feed</h3>
             {selMeta.noradId === ISS_NORAD ? (
               <div className="tn-sat-live">
-                <iframe
-                  className="tn-sat-live-frame"
-                  src={`https://www.youtube.com/embed/live_stream?channel=${NASA_CHANNEL}`}
-                  title="NASA live channel"
-                  allow="encrypted-media; picture-in-picture"
-                  allowFullScreen
-                />
+                {issVideoId ? (
+                  <iframe
+                    className="tn-sat-live-frame"
+                    src={`https://www.youtube.com/embed/${issVideoId}?playsinline=1`}
+                    title="NASA live channel"
+                    allow="encrypted-media; picture-in-picture"
+                    allowFullScreen
+                  />
+                ) : (
+                  // Say nothing is playing rather than render a player that fails.
+                  // An empty state a user can act on beats "Error 153".
+                  <p className="tn-w-empty">
+                    NASA is not broadcasting a live stream right now, or live resolution is
+                    unavailable.{" "}
+                    <a
+                      href={`https://www.youtube.com/channel/${NASA_CHANNEL}/streams`}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      Open NASA&apos;s channel
+                    </a>
+                  </p>
+                )}
                 <p className="tn-sat-cap">
                   NASA&apos;s live channel — carries the ISS HD cameras when NASA is broadcasting them (other NASA programming otherwise).
                 </p>

--- a/lib/sources/keyRequirements.ts
+++ b/lib/sources/keyRequirements.ts
@@ -115,6 +115,16 @@ export const KEY_REQUIREMENTS: KeyRequirement[] = [
     obtain: "Free tier — api.windy.com/webcams.",
   },
   {
+    kind: "required",
+    id: "youtube-live",
+    label: "Live channel resolution (news presets, ISS panel)",
+    env: ["YOUTUBE_API_KEY"],
+    degrades:
+      "Live video ids fall back to the pinned ones, which rot: 8 of the 12 news presets were already dead when audited on 2026-08-14, and the ISS panel shows an empty state instead of a stream. Nothing errors, and no other layer is affected.",
+    obtain:
+      "Free, no billing account: console.cloud.google.com → enable YouTube Data API v3 → Credentials → API key. Restrict it to that API, leave application restrictions as None (it is called server-side).",
+  },
+  {
     kind: "enhancement",
     id: "markets-equities",
     label: "Real-time equities",
@@ -158,6 +168,8 @@ export const KEY_REQUIREMENTS: KeyRequirement[] = [
 /** Ids in KEY_REQUIREMENTS that are capabilities rather than signal layers. */
 export const NON_SIGNAL_IDS = new Set([
   "webcams",
+  // Console capability, not a map layer — resolves channel ids to live video ids.
+  "youtube-live",
   "markets-equities",
   "markets-macro",
   "ai-brief",

--- a/lib/youtube/live.ts
+++ b/lib/youtube/live.ts
@@ -1,0 +1,282 @@
+// Resolve "which video is this channel live-streaming right now" — server-side.
+//
+// WHY THIS EXISTS
+//
+// Pinning a YouTube LIVE VIDEO id does not work. Broadcasters restart their
+// 24/7 streams and the id changes, which lib/console/help.ts has documented for
+// a while ("a rotated preset simply plays nothing"). Measured 2026-08-14:
+//   • 8 of the 12 pinned news presets were already dead — "Video unavailable",
+//     "This live stream recording is not available", one gone private.
+//   • Across seven live cameras, uptimes were 8h, 8h, 7d, 13d, 14d, 18d, 86d.
+//     Two of seven had restarted within 10 hours.
+//
+// The obvious keyless fix does NOT work either. `youtube.com/embed/live_stream
+// ?channel={id}` is retired: loaded in a real browser it renders "Error 153 —
+// Video player configuration error" and builds a link to `watch?v=live_stream`,
+// i.e. it treats the literal string as a video id. That endpoint is still in
+// this repo (satellites.detail.tsx) and is a dead player for every user today.
+//
+// So: channel id in, current live video id out, resolved server-side.
+//
+// QUOTA — the reason this is not just a search call per channel.
+//
+// The YouTube Data API gives 10,000 units/day free. search.list costs 100 units
+// and is the ONLY endpoint that discovers a channel's current live video, so
+// "search every channel every refresh" would cost 59 channels × 100 = 5,900
+// units per refresh and allow barely one refresh a day.
+//
+// videos.list costs 1 unit for up to 50 ids. So we VALIDATE CHEAPLY and
+// REDISCOVER RARELY: keep the last-known video id per channel, confirm the whole
+// set is still live in one 1-unit call, and only pay 100 units for a channel
+// whose stream actually rotated. At the measured ~29%/day rotation rate that is
+// roughly 1,900 units/day against the 10,000 allowance.
+//
+// NOT LIVE-VERIFIED: the request/response shapes below are from Google's
+// published API reference, not from a call against a real key — there is no
+// YOUTUBE_API_KEY on this project yet. The parsers are defensive and unit-tested
+// against captured-shape fixtures, and the whole module is dormant-safe, so a
+// shape surprise degrades to "unresolved" rather than to a crash or a lie.
+
+const API = "https://www.googleapis.com/youtube/v3";
+
+/** videos.list accepts up to 50 ids per call, and that call costs 1 unit. */
+export const VIDEOS_LIST_BATCH = 50;
+export const COST_VIDEOS_LIST = 1;
+export const COST_SEARCH_LIST = 100;
+
+export interface ChannelRequest {
+  channelId: string;
+  /**
+   * Case-insensitive substring preferred when a channel runs SEVERAL concurrent
+   * live streams. A soft preference, not a filter: if nothing matches we still
+   * take the channel's first live stream, because a playing stream from the
+   * right channel beats an empty panel. NASA is the live example — it runs both
+   * ISS feeds at once, so "NASA TV" and "ISS Live" would otherwise be the same
+   * video.
+   */
+  match?: string;
+}
+
+export interface LiveVideo {
+  videoId: string;
+  channelId: string;
+  title: string;
+}
+
+export interface Resolution {
+  channelId: string;
+  /** Echoed back so a caller can tell two requests on the same channel apart. */
+  match?: string;
+  videoId: string | null;
+  title: string | null;
+  /** How we got it — "cached" cost ~0 units, "search" cost 100. */
+  via: "cached" | "search" | "unresolved";
+}
+
+/**
+ * Identity of a request. NOT just the channel id: one channel can back two
+ * different entries via different `match` hints (NASA runs both ISS feeds at
+ * once and backs both "NASA TV" and "ISS Live"). Keying on channelId alone made
+ * the second entry silently inherit the first one's video.
+ */
+export function requestKey(req: ChannelRequest): string {
+  return `${req.channelId}::${req.match?.trim().toLowerCase() ?? ""}`;
+}
+
+export interface ResolveResult {
+  resolutions: Resolution[];
+  /** Quota units this round actually spent. */
+  quotaSpent: number;
+  /** True only when no API key is configured — legitimately switched off. */
+  dormant: boolean;
+  note: string | null;
+}
+
+/** Split into fixed-size chunks. Exported for the batching test. */
+export function chunk<T>(items: readonly T[], size: number): T[][] {
+  if (size <= 0) return [items.slice()];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Pull the still-live videos out of a videos.list response.
+ *
+ * `liveBroadcastContent` is the field that matters: a video id stays valid long
+ * after its stream ends, coming back as "none". Treating a 200 as "still live"
+ * is the same mistake as treating an HTTP 200 JPEG as a live camera.
+ */
+export function parseVideosList(json: unknown): LiveVideo[] {
+  const items = (json as { items?: unknown[] })?.items;
+  if (!Array.isArray(items)) return [];
+  const out: LiveVideo[] = [];
+  for (const raw of items) {
+    const item = raw as {
+      id?: unknown;
+      snippet?: { title?: unknown; channelId?: unknown; liveBroadcastContent?: unknown };
+    };
+    const videoId = typeof item?.id === "string" ? item.id : null;
+    const channelId = typeof item?.snippet?.channelId === "string" ? item.snippet.channelId : null;
+    if (!videoId || !channelId) continue;
+    if (item.snippet?.liveBroadcastContent !== "live") continue;
+    out.push({
+      videoId,
+      channelId,
+      title: typeof item.snippet?.title === "string" ? item.snippet.title : "",
+    });
+  }
+  return out;
+}
+
+/** Pull live videos out of a search.list response (ids are nested under id.videoId). */
+export function parseSearchList(json: unknown): LiveVideo[] {
+  const items = (json as { items?: unknown[] })?.items;
+  if (!Array.isArray(items)) return [];
+  const out: LiveVideo[] = [];
+  for (const raw of items) {
+    const item = raw as {
+      id?: { videoId?: unknown };
+      snippet?: { title?: unknown; channelId?: unknown };
+    };
+    const videoId = typeof item?.id?.videoId === "string" ? item.id.videoId : null;
+    const channelId = typeof item?.snippet?.channelId === "string" ? item.snippet.channelId : null;
+    if (!videoId || !channelId) continue;
+    out.push({
+      videoId,
+      channelId,
+      title: typeof item.snippet?.title === "string" ? item.snippet.title : "",
+    });
+  }
+  return out;
+}
+
+/**
+ * Choose one live video for a channel, preferring a title that contains `match`.
+ * Returns null when the channel has nothing live.
+ */
+export function pickLiveVideo(
+  candidates: readonly LiveVideo[],
+  request: ChannelRequest,
+): LiveVideo | null {
+  const mine = candidates.filter((c) => c.channelId === request.channelId);
+  if (mine.length === 0) return null;
+  const wanted = request.match?.trim().toLowerCase();
+  if (wanted) {
+    const hit = mine.find((c) => c.title.toLowerCase().includes(wanted));
+    if (hit) return hit;
+  }
+  return mine[0];
+}
+
+/**
+ * Work out which channels the cheap validation round already answered and which
+ * still need an expensive per-channel search. Pure, so the quota arithmetic —
+ * the part that decides whether this design fits in the free tier — is testable
+ * without touching the network.
+ */
+export function planRediscovery(
+  requests: readonly ChannelRequest[],
+  validated: readonly LiveVideo[],
+): { resolved: Resolution[]; needSearch: ChannelRequest[] } {
+  const resolved: Resolution[] = [];
+  const needSearch: ChannelRequest[] = [];
+  for (const req of requests) {
+    const hit = pickLiveVideo(validated, req);
+    if (hit) {
+      resolved.push({ channelId: req.channelId, match: req.match, videoId: hit.videoId, title: hit.title, via: "cached" });
+    } else {
+      needSearch.push(req);
+    }
+  }
+  return { resolved, needSearch };
+}
+
+async function getJson(url: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve every requested channel to its current live video.
+ *
+ * Never throws and never invents a video id: an unreachable API, a rejected key
+ * or an unexpected shape all come back as `via: "unresolved"` with a null
+ * videoId, and the caller decides what to show. Serving a stale id as if it were
+ * live is exactly the failure this module exists to remove.
+ */
+export async function resolveLiveVideos(
+  requests: readonly ChannelRequest[],
+  lastKnown: ReadonlyMap<string, string>,
+  apiKey: string | undefined = process.env.YOUTUBE_API_KEY,
+): Promise<ResolveResult> {
+  const key = (apiKey ?? "").trim();
+  if (!key) {
+    return {
+      resolutions: requests.map((r) => ({ channelId: r.channelId, videoId: null, title: null, via: "unresolved" as const })),
+      quotaSpent: 0,
+      dormant: true,
+      note: "YOUTUBE_API_KEY is not set — live channel resolution is switched off.",
+    };
+  }
+
+  let quotaSpent = 0;
+
+  // Round 1 — one cheap call per 50 known ids, to see what is still running.
+  const knownIds = requests.map((r) => lastKnown.get(requestKey(r))).filter((v): v is string => !!v);
+  const validated: LiveVideo[] = [];
+  for (const batch of chunk([...new Set(knownIds)], VIDEOS_LIST_BATCH)) {
+    if (batch.length === 0) continue;
+    const url = `${API}/videos?part=snippet&id=${batch.join(",")}&maxResults=${VIDEOS_LIST_BATCH}&key=${encodeURIComponent(key)}`;
+    const json = await getJson(url);
+    quotaSpent += COST_VIDEOS_LIST;
+    if (json) validated.push(...parseVideosList(json));
+  }
+
+  const { resolved, needSearch } = planRediscovery(requests, validated);
+
+  // Round 2 — only for channels whose stream actually rotated. 100 units each.
+  for (const req of needSearch) {
+    const url =
+      `${API}/search?part=snippet&channelId=${encodeURIComponent(req.channelId)}` +
+      `&eventType=live&type=video&maxResults=10&key=${encodeURIComponent(key)}`;
+    const json = await getJson(url);
+    quotaSpent += COST_SEARCH_LIST;
+    const hit = json ? pickLiveVideo(parseSearchList(json), req) : null;
+    resolved.push(
+      hit
+        ? { channelId: req.channelId, match: req.match, videoId: hit.videoId, title: hit.title, via: "search" }
+        : { channelId: req.channelId, match: req.match, videoId: null, title: null, via: "unresolved" },
+    );
+  }
+
+  // Preserve caller order — callers render these next to fixed UI labels.
+  const byKey = new Map(resolved.map((r) => [requestKey(r), r]));
+  const resolutions = requests.map(
+    (r) =>
+      byKey.get(requestKey(r)) ?? {
+        channelId: r.channelId,
+        match: r.match,
+        videoId: null,
+        title: null,
+        via: "unresolved" as const,
+      },
+  );
+
+  const unresolved = resolutions.filter((r) => r.videoId === null).length;
+  return {
+    resolutions,
+    quotaSpent,
+    dormant: false,
+    note: unresolved > 0 ? `${unresolved} of ${resolutions.length} channels had nothing live.` : null,
+  };
+}

--- a/lib/youtube/registry.ts
+++ b/lib/youtube/registry.ts
@@ -1,0 +1,67 @@
+import {
+  resolveLiveVideos,
+  requestKey,
+  type ChannelRequest,
+  type ResolveResult,
+  type Resolution,
+} from "@/lib/youtube/live";
+
+// Server-side cache for channel → current live video, the YouTube analogue of
+// lib/webcams/registry.ts.
+//
+// The last-known map is the whole point of the cheap-validate/rare-rediscover
+// design (see live.ts): without it every refresh would have to pay 100 quota
+// units per channel. It is deliberately module-level and process-local — a cold
+// serverless instance simply pays for one round of rediscovery and repopulates.
+//
+// TTL is 10 minutes. Long enough that a warm instance spends almost nothing;
+// short enough that a broadcaster restarting a stream is picked up quickly.
+
+const TTL_MS = 10 * 60 * 1000;
+
+const lastKnown = new Map<string, string>();
+let cache: { result: ResolveResult; at: number } | null = null;
+let inflight: Promise<ResolveResult> | null = null;
+
+/** Exposed for tests — resets the module-level memory between cases. */
+export function __resetYoutubeRegistry(): void {
+  lastKnown.clear();
+  cache = null;
+  inflight = null;
+}
+
+/**
+ * Fold a finished round back into the last-known map.
+ *
+ * Only positive results are written. A channel that resolved to nothing KEEPS
+ * its previous id, so a single flaky API round does not force a 100-unit
+ * rediscovery on the next one — the cheap validation call will simply report it
+ * dead again if it really is.
+ */
+export function rememberResolutions(resolutions: readonly Resolution[]): void {
+  for (const r of resolutions) {
+    if (r.videoId) lastKnown.set(requestKey(r), r.videoId);
+  }
+}
+
+async function refresh(requests: readonly ChannelRequest[]): Promise<ResolveResult> {
+  const result = await resolveLiveVideos(requests, lastKnown);
+  rememberResolutions(result.resolutions);
+  cache = { result, at: Date.now() };
+  return result;
+}
+
+/**
+ * Fresh-or-revalidate. A warm cache answers instantly; a stale one answers
+ * instantly too while a single shared refresh runs behind it. resolveLiveVideos
+ * never throws, so there is no failure path to guard here.
+ */
+export async function getLiveVideos(requests: readonly ChannelRequest[]): Promise<ResolveResult> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.result;
+  if (!inflight) {
+    inflight = refresh(requests).finally(() => {
+      inflight = null;
+    });
+  }
+  return cache ? cache.result : inflight;
+}

--- a/tests/unit/sources-status.test.ts
+++ b/tests/unit/sources-status.test.ts
@@ -227,7 +227,7 @@ describe("buildStatusReport", () => {
   it("reports the non-layer capabilities too, and keeps them out of the layer totals", () => {
     const rep = buildStatusReport(reg, {}, NOW);
     expect(rep.capabilities.map((c) => c.id).sort()).toEqual(
-      ["ai-brief", "geolocate-vision", "markets-equities", "markets-macro", "webcams"],
+      ["ai-brief", "geolocate-vision", "markets-equities", "markets-macro", "webcams", "youtube-live"],
     );
     expect(rep.summary.layersRegistered).toBe(3);
   });

--- a/tests/unit/youtube-live.test.ts
+++ b/tests/unit/youtube-live.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  chunk,
+  parseVideosList,
+  parseSearchList,
+  pickLiveVideo,
+  planRediscovery,
+  requestKey,
+  resolveLiveVideos,
+  COST_SEARCH_LIST,
+  COST_VIDEOS_LIST,
+  type LiveVideo,
+} from "@/lib/youtube/live";
+import { NEWS_PROVIDERS, newsChannelRequests, playableRef, resolveEmbed } from "@/lib/console/news/providers";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+const NASA = "UCLA_DiR1FfKNvjuUpBHmylQ";
+
+// --- parsers ---------------------------------------------------------------
+
+test("videos.list: a video id that is no longer live is NOT treated as live", () => {
+  // The whole failure this module exists to remove. A finished stream keeps a
+  // valid video id and returns HTTP 200 — liveBroadcastContent is the truth.
+  const json = {
+    items: [
+      { id: "aaa", snippet: { channelId: NASA, title: "Live now", liveBroadcastContent: "live" } },
+      { id: "bbb", snippet: { channelId: NASA, title: "Ended earlier", liveBroadcastContent: "none" } },
+      { id: "ccc", snippet: { channelId: NASA, title: "Starts soon", liveBroadcastContent: "upcoming" } },
+    ],
+  };
+  expect(parseVideosList(json).map((v) => v.videoId)).toEqual(["aaa"]);
+});
+
+test("parsers survive junk without throwing", () => {
+  for (const junk of [null, undefined, {}, { items: null }, { items: [null, 42, {}] }]) {
+    expect(parseVideosList(junk)).toEqual([]);
+    expect(parseSearchList(junk)).toEqual([]);
+  }
+});
+
+test("search.list ids are read from the nested id.videoId", () => {
+  const json = { items: [{ id: { kind: "youtube#video", videoId: "zzz" }, snippet: { channelId: NASA, title: "T" } }] };
+  expect(parseSearchList(json)).toEqual([{ videoId: "zzz", channelId: NASA, title: "T" }]);
+});
+
+// --- picking ---------------------------------------------------------------
+
+const candidates: LiveVideo[] = [
+  { videoId: "official", channelId: NASA, title: "Live Video from the ISS (Official NASA Broadcast)" },
+  { videoId: "hd", channelId: NASA, title: "Live High-Definition Views from the ISS" },
+  { videoId: "other", channelId: "UCother", title: "Something else" },
+];
+
+test("match picks the intended stream when a channel runs several at once", () => {
+  expect(pickLiveVideo(candidates, { channelId: NASA, match: "High-Definition" })?.videoId).toBe("hd");
+  expect(pickLiveVideo(candidates, { channelId: NASA, match: "Official NASA" })?.videoId).toBe("official");
+});
+
+test("match is a preference, not a filter — an unmatched hint still plays the channel", () => {
+  expect(pickLiveVideo(candidates, { channelId: NASA, match: "nothing like this" })?.videoId).toBe("official");
+});
+
+test("a channel with nothing live resolves to null", () => {
+  expect(pickLiveVideo(candidates, { channelId: "UCnope" })).toBeNull();
+});
+
+test("requestKey distinguishes two entries sharing one channel", () => {
+  // NASA backs both "NASA TV" and "ISS Live". Keying on channelId alone made the
+  // second silently inherit the first one's video.
+  const a = requestKey({ channelId: NASA, match: "Official NASA" });
+  const b = requestKey({ channelId: NASA, match: "High-Definition" });
+  expect(a).not.toBe(b);
+  expect(requestKey({ channelId: NASA, match: "HIGH-definition " })).toBe(b);
+});
+
+// --- quota plan ------------------------------------------------------------
+
+test("planRediscovery only sends the rotated channels to the expensive call", () => {
+  const { resolved, needSearch } = planRediscovery(
+    [{ channelId: NASA }, { channelId: "UCgone" }],
+    [{ videoId: "official", channelId: NASA, title: "t" }],
+  );
+  expect(resolved).toHaveLength(1);
+  expect(resolved[0].via).toBe("cached");
+  expect(needSearch.map((r) => r.channelId)).toEqual(["UCgone"]);
+});
+
+test("chunk batches ids for the 50-per-call videos.list limit", () => {
+  expect(chunk(Array.from({ length: 120 }, (_, i) => i), 50).map((c) => c.length)).toEqual([50, 50, 20]);
+  expect(chunk([], 50)).toEqual([]);
+});
+
+// --- network behaviour -----------------------------------------------------
+
+test("no API key: dormant, and it does not touch the network", async () => {
+  globalThis.fetch = (() => {
+    throw new Error("resolveLiveVideos must not call fetch when dormant");
+  }) as unknown as typeof fetch;
+  const out = await resolveLiveVideos([{ channelId: NASA }], new Map(), undefined);
+  expect(out.dormant).toBe(true);
+  expect(out.quotaSpent).toBe(0);
+  expect(out.resolutions).toEqual([{ channelId: NASA, videoId: null, title: null, via: "unresolved" }]);
+});
+
+test("everything still live costs ONE unit, however many channels", async () => {
+  const ids = Array.from({ length: 40 }, (_, i) => `ch${i}`);
+  const known = new Map(ids.map((c) => [requestKey({ channelId: c }), `vid${c}`]));
+  globalThis.fetch = vi.fn(async () =>
+    new Response(
+      JSON.stringify({
+        items: ids.map((c) => ({ id: `vid${c}`, snippet: { channelId: c, title: "t", liveBroadcastContent: "live" } })),
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ),
+  ) as unknown as typeof fetch;
+
+  const out = await resolveLiveVideos(ids.map((c) => ({ channelId: c })), known, "k");
+  expect(out.quotaSpent).toBe(COST_VIDEOS_LIST);
+  expect(out.resolutions.every((r) => r.via === "cached")).toBe(true);
+  expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+});
+
+test("a rotated channel costs a search, and the answer is the new video", async () => {
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/videos?")) {
+      // Old id came back not-live: the stream restarted.
+      return new Response(JSON.stringify({ items: [{ id: "old", snippet: { channelId: NASA, title: "t", liveBroadcastContent: "none" } }] }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ items: [{ id: { videoId: "new" }, snippet: { channelId: NASA, title: "fresh" } }] }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const known = new Map([[requestKey({ channelId: NASA }), "old"]]);
+  const out = await resolveLiveVideos([{ channelId: NASA }], known, "k");
+  expect(out.resolutions[0]).toMatchObject({ videoId: "new", via: "search" });
+  expect(out.quotaSpent).toBe(COST_VIDEOS_LIST + COST_SEARCH_LIST);
+});
+
+test("an upstream failure resolves to null rather than a stale id or a throw", async () => {
+  globalThis.fetch = vi.fn(async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+  const known = new Map([[requestKey({ channelId: NASA }), "old"]]);
+  const out = await resolveLiveVideos([{ channelId: NASA }], known, "k");
+  // Critically NOT "old": presenting a dead stream as live is the bug, not the fix.
+  expect(out.resolutions[0].videoId).toBeNull();
+  expect(out.resolutions[0].via).toBe("unresolved");
+});
+
+test("resolutions come back in request order", async () => {
+  globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ items: [] }), { status: 200 })) as unknown as typeof fetch;
+  const reqs = [{ channelId: "a" }, { channelId: "b" }, { channelId: "c" }];
+  const out = await resolveLiveVideos(reqs, new Map(), "k");
+  expect(out.resolutions.map((r) => r.channelId)).toEqual(["a", "b", "c"]);
+});
+
+// --- provider wiring -------------------------------------------------------
+
+test("every YouTube provider now registers a channel id", () => {
+  for (const p of NEWS_PROVIDERS) {
+    if (p.kind !== "youtube") continue;
+    expect(p.channelId, `${p.id} has no channelId`).toMatch(/^UC[A-Za-z0-9_-]{22}$/);
+  }
+});
+
+test("NASA and ISS share a channel but request different streams", () => {
+  const nasa = NEWS_PROVIDERS.find((p) => p.id === "nasa")!;
+  const iss = NEWS_PROVIDERS.find((p) => p.id === "iss")!;
+  expect(nasa.channelId).toBe(iss.channelId);
+  expect(nasa.match).not.toBe(iss.match);
+  // ...and both survive deduping into the request list.
+  expect(newsChannelRequests().filter((r) => r.channelId === nasa.channelId)).toHaveLength(2);
+});
+
+test("embeds prefer the resolved id but fall back to the pinned ref", () => {
+  const p = NEWS_PROVIDERS[0];
+  expect(playableRef(p, "fresh123")).toBe("fresh123");
+  expect(playableRef(p, undefined)).toBe(p.ref);
+  expect(resolveEmbed(p, "fresh123").src).toContain("/embed/fresh123");
+  expect(resolveEmbed(p, null).src).toContain(`/embed/${p.ref}`);
+});
+
+test("no embed anywhere still uses the retired live_stream endpoint", () => {
+  // It renders "Error 153". Guarding it here so it cannot come back.
+  for (const p of NEWS_PROVIDERS) {
+    expect(resolveEmbed(p, "x").src).not.toContain("live_stream");
+  }
+});


### PR DESCRIPTION
## Two live bugs, one cause

**1. The ISS "Live feed" panel is a dead player for every user.**
`satellites.detail.tsx:278` embeds `youtube.com/embed/live_stream?channel={id}`. YouTube has retired that endpoint. Loaded in a real Chromium against this repo's own `NASA_CHANNEL` constant it renders:

> **Error 153 — Video player configuration error**

and the page builds a link to `watch?v=live_stream` — it is treating the literal string `live_stream` as a video id.

**2. Eight of the twelve news presets were already dead.**
Audited 2026-08-14 with yt-dlp against the pinned ids:

| Still playing | Dead |
|---|---|
| Al Jazeera, Euronews, CNA, ABC (AU) | DW, France 24, TRT, NHK, Bloomberg, NASA TV, ISS Live — *"Video unavailable"* / *"this live stream recording is not available"*; **Sky News had gone private** |

`lib/console/help.ts:206` has described this failure for a while ("broadcasters rotate those ids without notice and a rotated preset simply plays nothing"). This is the measurement of it. For reference, uptimes across seven live cams: 8h, 8h, 7d, 13d, 14d, 18d, 86d — **2 of 7 restarted within 10 hours**.

## The fix

Channel ids are durable where video ids are not. Every provider now registers one (each resolved from the broadcaster's own handle and confirmed live), and `lib/youtube/live.ts` resolves it server-side to whatever that channel is currently broadcasting.

## Why it isn't just a search per channel

`search.list` is the only endpoint that *discovers* a live video and costs **100 quota units** against a 10,000/day free tier. Searching every channel every refresh would allow roughly **one refresh a day**.

`videos.list` costs **1 unit for up to 50 ids**. So the design **validates cheaply and rediscovers rarely**: confirm the whole known set is still live in one 1-unit call, and only pay 100 units for a channel that actually rotated. At the measured ~29%/day rotation that is **~1,900 units/day**. `/api/youtube-live` publishes `quotaSpent` so the claim is checkable rather than asserted.

## Safety

- **Dormant-safe.** No `YOUTUBE_API_KEY` → nothing is called, embeds fall back to the pinned `ref` (exactly today's behaviour, never worse), and the ISS panel shows an empty state with a link out instead of Error 153. Verified: `/api/youtube-live` → `{"resolved":{},"dormant":true,"note":"YOUTUBE_API_KEY is not set…","quotaSpent":0}`.
- **An upstream failure resolves to `null`, never to a stale id.** Presenting a dead stream as live is the bug, not the fix — there's a test for it.
- NASA broadcasts both ISS feeds at once and backs two providers, so requests key on channel **and** match hint. Keying on channel alone made "ISS Live" silently inherit "NASA TV"'s video.

## What is NOT verified

**The live API path has not been run against a real key** — this project has no `YOUTUBE_API_KEY` yet. The parsers are written from Google's published reference, are defensive against every shape I could think of, and are unit-tested against captured shapes; any surprise degrades to "unresolved" rather than a crash or a wrong answer. It needs a real key pointed at it before we can call the live path proven. Setup steps are in `docs/API_KEYS.md`.

## Gate

`npx tsc --noEmit` clean. `npm test` **1,773 tests / 232 files** passing, including 18 new ones. Two existing tests were updated, both deliberately: the repo's own guard that every env var read by code must be declared in `KEY_REQUIREMENTS` caught the new key — good test, it did its job.