### PR TITLE
Brazil live cams board — 32 channels, resolved on demand

### DIFF
--- a/app/api/youtube-live/route.ts
+++ b/app/api/youtube-live/route.ts
@@ -1,4 +1,4 @@
-import { getLiveVideos } from "@/lib/youtube/registry";
+import { getLiveVideos, getChannelLive } from "@/lib/youtube/registry";
 import { NEWS_PROVIDERS, newsChannelRequests } from "@/lib/console/news/providers";
 import { requestKey } from "@/lib/youtube/live";
 
@@ -26,7 +26,25 @@ export const dynamic = "force-dynamic";
  * design's whole claim is that it costs ~1,900. A number nobody can see is a
  * number nobody notices going wrong.
  */
-export async function GET() {
+export async function GET(req: Request) {
+  // ?channel=UC… — everything ONE channel is running right now, for the live-cams
+  // board. Demand-driven on purpose: this costs a 100-unit search, so it is paid
+  // for the channel a user opened, never for a whole list up front.
+  const channelId = new URL(req.url).searchParams.get("channel");
+  if (channelId) {
+    if (!/^UC[A-Za-z0-9_-]{22}$/.test(channelId)) {
+      return Response.json({ error: "bad channel id" }, { status: 400 });
+    }
+    const live = await getChannelLive(channelId);
+    return Response.json({
+      channelId: live.channelId,
+      videos: live.videos.map((v) => ({ videoId: v.videoId, title: v.title })),
+      dormant: live.dormant,
+      note: live.note,
+      quotaSpent: live.quotaSpent,
+    });
+  }
+
   const requests = newsChannelRequests();
   const result = await getLiveVideos(requests);
 

--- a/lib/console/help.ts
+++ b/lib/console/help.ts
@@ -203,9 +203,31 @@ const WIDGET_EXPLAINERS: WidgetExplainer[] = [
     limitations: [
       "This is a television channel, not a data layer. Nothing in it is plotted, searchable, alertable or checked by us in any way.",
       "The header word \"live stream\" names the medium, not a freshness we can observe. We cannot tell whether the player is actually playing, so a dead or geo-blocked stream still says it.",
-      "Channels are pinned by YouTube video id. Broadcasters rotate those ids without notice and a rotated preset simply plays nothing until someone updates the id.",
+      "Channels are registered by YouTube CHANNEL id and resolved to whatever that channel is streaming now, so a broadcaster restarting a stream no longer breaks the preset. Without a YOUTUBE_API_KEY that resolution is switched off and the panel falls back to a pinned video id, which does rot — 8 of the 12 pinned ids were already dead when audited on 2026-08-14.",
       "Several of these are state-funded broadcasters. The panel presents every channel identically and makes no editorial distinction between them.",
       "Playback depends on YouTube, so regional blocking, ads and platform outages all apply and none of them surface as an error here.",
+    ],
+  },
+
+  {
+    id: "livecams-brazil",
+    whatItShows:
+      "Live cameras across Brazil — beaches, city centres, the BR-101, ports and airports — streamed 24/7 on YouTube by local broadcasters, embedded in the panel.",
+    method:
+      "Nothing is derived or measured. We register a broadcaster's CHANNEL id and ask YouTube which video that channel is streaming right now, then embed it. Stream titles are the broadcaster's own words, shown verbatim.",
+    // NOT "official". The news panel earns that word because broadcasters are
+    // institutions; these are private individuals and small local media. What was
+    // actually checked is the channel list, by hand — which is "reported".
+    confidence: "reported",
+    coverage:
+      "32 independent Brazilian channels, carrying 100 live streams between them when the list was captured on 2026-08-14. Both numbers move: broadcasters start and stop cameras without notice.",
+    limitations: [
+      "These are private individuals and local media, NOT government camera feeds. Nobody guarantees a camera stays up, points the same way, or is where its title says.",
+      "No coordinates. YouTube attaches none, so nothing here is plotted on the map, and the panel deliberately asserts no city or category of its own — deriving those from titles was tried and got a Cubatão train labelled Natal.",
+      "The header word \"live stream\" names the medium, not a freshness we can observe. We cannot tell whether the player is actually playing.",
+      "The channel list was assembled by searching YouTube in Portuguese and reading the results. It is a sample of what exists, not an inventory of it.",
+      "Without a YOUTUBE_API_KEY the panel falls back to a last-known stream that may have ended, and says so rather than presenting it as current.",
+      "Playback depends on YouTube, so ads, regional blocking and platform outages all apply and none surface as an error here.",
     ],
   },
 

--- a/lib/console/livecams/brazil.data.ts
+++ b/lib/console/livecams/brazil.data.ts
@@ -1,0 +1,82 @@
+/**
+ * Brazilian live-camera channels on YouTube.
+ *
+ * WHY CHANNELS AND NOT STREAMS. A video id is not a durable handle — see
+ * lib/youtube/live.ts for the measurements. A channel id is. These 32 channels
+ * were carrying 100 live Brazilian streams between them when this file was
+ * written (2026-08-14); the board resolves a channel's CURRENT streams at view
+ * time rather than pinning any of them.
+ *
+ * WHY THERE IS NO place / city / category FIELD HERE. There was, and it was
+ * wrong often enough to delete. Deriving location and category from stream
+ * titles produced: a Cubatão train labelled "Natal" (1,800 km out), an
+ * "Av. Curitiba" in Goioerê read as the city of Curitiba, a Chapecó airport
+ * filed under Roads, and "Balneário Camboriú - CÂMERA do tempo" mangled into
+ * "do tempo". Rather than ship ~100 machine-written labels at that error rate,
+ * the board shows each broadcaster's OWN title, verbatim. Their words are always
+ * accurate about their own camera; mine were not.
+ *
+ * HOW THIS LIST WAS CURATED. Discovered with yt-dlp (20 Portuguese-language
+ * searches, then every candidate channel's /streams tab enumerated), filtered to
+ * Brazilian place names, then read by hand. Five channels were removed at that
+ * last step and they are the reason the hand step is not optional:
+ *
+ *   Wolkam IT       — Vitoria-GASTEIZ, SPAIN. Matched the Brazilian "Vitória"
+ *                     on the name alone.
+ *   Gutti Show      — IRL phone stream, not a fixed camera
+ *   Olhar Urbano    — IRL phone stream, dated title, gone tomorrow
+ *   Biel Turismo    — IRL phone stream, dated title
+ *   Edson IRL Brasil— IRL phone stream
+ *
+ * `seedVideoId` is a last-known live video, used only when resolution is dormant
+ * (no YOUTUBE_API_KEY). It WILL rot — that is the entire premise of this
+ * feature — so it is a fallback, never the source of truth.
+ *
+ * To re-verify a channel:
+ *   yt-dlp --flat-playlist -J "https://www.youtube.com/channel/<channelId>/streams"
+ */
+export interface BrazilCamChannel {
+  id: string;
+  /** The broadcaster's own channel name — not a label we invented. */
+  name: string;
+  channelId: string;
+  /** Last-known live video, for the dormant fallback only. Expected to rot. */
+  seedVideoId: string;
+  /** Live streams this channel was carrying when the list was captured. */
+  knownStreams: number;
+}
+
+export const BRAZIL_CAM_CHANNELS: BrazilCamChannel[] = [
+  { id: "br-t5yt3goz", name: "Barra da Lagoa Online", channelId: "UCt5YT3gOz4HXJcPTC_tce-A", seedVideoId: "1k0c7CxKU5g", knownStreams: 1 },
+  { id: "br-qnrfonvl", name: "BNU.tv", channelId: "UCQnRFONVlt96xf5lYVr4Tzg", seedVideoId: "0nJHcJ8ELrM", knownStreams: 2 },
+  { id: "br-fgipvn1d", name: "Camera Aeroporto Porto Alegre BrAmigos", channelId: "UCFGIPvN1dMn4Bdo8B8WWPDw", seedVideoId: "IdAvz5TD6Wc", knownStreams: 2 },
+  { id: "br-zki8jovv", name: "chumbinho.aviacao.nasnuvens", channelId: "UCzki8JOvVr95qFXmY-pbOqw", seedVideoId: "wf2Eiq6e80M", knownStreams: 1 },
+  { id: "br-i1vqx48j", name: "CLIMA BC Brazil", channelId: "UCi1vQx48j_nfrMg6XH5PItQ", seedVideoId: "TjI12t1uU6M", knownStreams: 6 },
+  { id: "br-37r9r29m", name: "ConexãoDCTV - Oficial", channelId: "UC37R9R29MAwvrOBafYoBtow", seedVideoId: "1UtQUMxH6oc", knownStreams: 6 },
+  { id: "br-qi8nu3-d", name: "Câmeras ao Vivo RS - Pôr do Sol Guaíba", channelId: "UCqI8nU3-dstxAS3YCXhKuPg", seedVideoId: "D5VLbXaqZfg", knownStreams: 2 },
+  { id: "br-lt4xisai", name: "Farol Da Bahia", channelId: "UCLt4xIsAiZuLnVdZgcpxPAw", seedVideoId: "vjuviTl7zkA", knownStreams: 1 },
+  { id: "br-0t38ezzt", name: "Filipe Serena", channelId: "UC0T38EzZthvvGk8cf98GaXA", seedVideoId: "slsKpIYENGg", knownStreams: 1 },
+  { id: "br-tnycgipu", name: "FVF Drone 2", channelId: "UCTnYcgIpurN_1Wy-NGARTbg", seedVideoId: "2rc0k9ghgOQ", knownStreams: 6 },
+  { id: "br-nrkceezy", name: "FVF DRONE LIVES 24H", channelId: "UCNrkCeEzYg79oHO2_5VRDMw", seedVideoId: "8quWDK9i-v0", knownStreams: 7 },
+  { id: "br-4roe4sbv", name: "Guia Turístico de Praia Grande", channelId: "UC4roE4SbVIvcQGCYXlnijGQ", seedVideoId: "wNXOI0pmz7I", knownStreams: 5 },
+  { id: "br-hwgykk0i", name: "Homes in Rio", channelId: "UChWGYkK0I8U83C0FxAxWy4w", seedVideoId: "14QUwx-ZRd0", knownStreams: 2 },
+  { id: "br-fmoswhx9", name: "Live Rio", channelId: "UCfMOswhx9NN_laZ8Ukcm4-Q", seedVideoId: "vXgKLmbzSgU", knownStreams: 6 },
+  { id: "br-trwk-doz", name: "Maaxcam Ao Vivo", channelId: "UCtrwK-DOZGcQo9p1VwIkDZw", seedVideoId: "Kr34rd9VWHE", knownStreams: 8 },
+  { id: "br-8yaup2vi", name: "Marcelo Praia Grande e Região", channelId: "UC8YAup2viRbegzrqjAyEXYA", seedVideoId: "_kgpVicqJOo", knownStreams: 2 },
+  { id: "br-hhtdcqzw", name: "Olhar 013", channelId: "UCHhtdcqzwyPYY0qBlEPh0QQ", seedVideoId: "gmc9ryoJ-vs", knownStreams: 1 },
+  { id: "br--erixslt", name: "Ouro Verde FM Easy", channelId: "UC-ErIXslTvIsRHxmMcc9itg", seedVideoId: "lTPWpnic8ow", knownStreams: 1 },
+  { id: "br-dz_kbzu8", name: "Papa Charlie Golf TV", channelId: "UCdz_Kbzu83ZE86LVcGFN0JA", seedVideoId: "Ae08ZGn4OcA", knownStreams: 2 },
+  { id: "br-htfpxxmi", name: "Pernambuco Fishing", channelId: "UChtFpXxMI8UpJ1P33sw_W_w", seedVideoId: "1bSc965aq70", knownStreams: 1 },
+  { id: "br-blhvdpcp", name: "Point do Forte", channelId: "UCBLHvdpCPy8J1acuXWu82tA", seedVideoId: "WULBz__uPzg", knownStreams: 2 },
+  { id: "br-6hcr5rrz", name: "Pontal NeTv e Internet", channelId: "UC6hcr5RRZvTtSfsNJ2MLj2Q", seedVideoId: "9uccePeQQK4", knownStreams: 1 },
+  { id: "br-zwtw6vgc", name: "Portal Chapecó", channelId: "UCzwTW6vgC7RcmxssUrGZnwA", seedVideoId: "i2KUyICHyOY", knownStreams: 3 },
+  { id: "br-yunmstqx", name: "Porto Alegre Skyline - Câmera no Centro Histórico", channelId: "UCYUNMStQx5hZTi7oIRXtHGw", seedVideoId: "ig7mClmrsL4", knownStreams: 1 },
+  { id: "br--5cvlxn0", name: "Praticagem de São Paulo - Canal Oficial", channelId: "UC-5CVLXN0tBhGsqv-DMcHuw", seedVideoId: "ZvTdzjwPGA0", knownStreams: 2 },
+  { id: "br-nzckdhav", name: "SBGR LIVE", channelId: "UCNZCKDhAVtbh7sddChTxI7w", seedVideoId: "ixxHcBHvDaU", knownStreams: 1 },
+  { id: "br-yp308hb2", name: "SE-CONNECT", channelId: "UCyP308hB27ZZsRbvnDLpWbw", seedVideoId: "vWXTuYO48QA", knownStreams: 8 },
+  { id: "br-gjaquevw", name: "Surfistafotografo", channelId: "UCGJaqUeVWMrxawXUhCK2wPw", seedVideoId: "xtTSysda5fc", knownStreams: 6 },
+  { id: "br-eo1c8wzu", name: "TARTADRONE", channelId: "UCeo1c8wZUrwt4L7E1Q9yxdQ", seedVideoId: "t2Sbj4Cd2SI", knownStreams: 2 },
+  { id: "br-2ll1rrh9", name: "TRAIN CAM", channelId: "UC2LL1Rrh9mXbaII5mT-nN0g", seedVideoId: "6HF6sqHk_Fg", knownStreams: 2 },
+  { id: "br-ak21edmz", name: "TRANSMISSÃO AO VIVO CIDADE", channelId: "UCak21Edmz9LDZ_3-bl3TNyA", seedVideoId: "zKsgtmgGHt4", knownStreams: 1 },
+  { id: "br-vqg1pbkr", name: "UBACAM", channelId: "UCVQG1pBkRM4xlRrBmV65kUw", seedVideoId: "ye7wWfbktQw", knownStreams: 8 },
+];

--- a/lib/console/widgets/index.ts
+++ b/lib/console/widgets/index.ts
@@ -3,6 +3,7 @@ import "@/lib/console/widgets/aviation";
 import "@/lib/console/widgets/events";
 import "@/lib/console/widgets/cameras";
 import "@/lib/console/widgets/news";
+import "@/lib/console/widgets/livecams";
 import "@/lib/console/widgets/satellites";
 import "@/lib/console/widgets/markets";
 import "@/lib/console/widgets/headlines";

--- a/lib/console/widgets/livecams.tsx
+++ b/lib/console/widgets/livecams.tsx
@@ -1,0 +1,152 @@
+"use client";
+import { useEffect, useState } from "react";
+import { registerWidget, type WidgetBodyProps } from "@/lib/console/registry";
+import { useWidgetReport } from "@/components/console/WidgetFrame";
+import { BRAZIL_CAM_CHANNELS } from "@/lib/console/livecams/brazil.data";
+
+// Brazil live cams — YouTube channels, resolved to their CURRENT streams.
+//
+// Brazil is a thin country for road CCTV: the toll-road concessionaires hard-403
+// a real browser, Motiva/AutoBAn withdrew their public cameras, and Rio publishes
+// no camera dataset at all. What Brazil does have is a large community of
+// broadcasters running fixed cameras 24/7 on YouTube, which is why this is a
+// console board and not a map layer — YouTube attaches no coordinates, and a
+// city-centroid pin sitting beside metre-accurate camera pins would misrepresent
+// what it is.
+//
+// Titles shown here are the BROADCASTER'S OWN, verbatim. See brazil.data.ts for
+// why nothing about location or category is derived.
+
+interface LiveStream {
+  videoId: string;
+  title: string;
+}
+
+interface ChannelResponse {
+  videos?: LiveStream[];
+  dormant?: boolean;
+  note?: string | null;
+}
+
+function LiveCamsBody({ instanceId, config }: WidgetBodyProps) {
+  const report = useWidgetReport();
+  const channelId = (config.channelId as string) ?? BRAZIL_CAM_CHANNELS[0].channelId;
+  const channel =
+    BRAZIL_CAM_CHANNELS.find((c) => c.channelId === channelId) ?? BRAZIL_CAM_CHANNELS[0];
+
+  const [streams, setStreams] = useState<LiveStream[]>([]);
+  const [note, setNote] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [picked, setPicked] = useState(0);
+  const [picker, setPicker] = useState(false);
+
+  // Same honesty rule as the news widget: "live stream" names the MEDIUM. We
+  // cannot observe whether a third-party player is actually playing, so we do
+  // not claim a freshness we have not measured.
+  useEffect(() => {
+    report({ alerts: [], freshLabel: "live stream" });
+  }, [report]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setPicked(0);
+    fetch(`/api/youtube-live?channel=${encodeURIComponent(channel.channelId)}`, { cache: "no-store" })
+      .then((r) => (r.ok ? (r.json() as Promise<ChannelResponse>) : null))
+      .then((json) => {
+        if (cancelled) return;
+        setStreams(json?.videos ?? []);
+        setNote(json?.note ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStreams([]);
+          setNote("Could not reach live resolution.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [channel.channelId]);
+
+  // Dormant or unresolved → the last-known stream, labelled as such. It is
+  // expected to rot; saying so is better than presenting it as current.
+  const resolved = streams[picked];
+  const videoId = resolved?.videoId ?? channel.seedVideoId;
+  const usingSeed = !resolved;
+
+  const choose = (id: string) => {
+    import("@/lib/console/store").then((m) => m.shellLayoutStore.configure(instanceId, { channelId: id }));
+    setPicker(false);
+  };
+
+  return (
+    <div className="tn-newsw">
+      <div className="tn-newsw-screen">
+        <iframe
+          className="tn-newsw-video"
+          src={`https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1&playsinline=1`}
+          title={resolved?.title ?? channel.name}
+          allow="autoplay; encrypted-media; picture-in-picture"
+          allowFullScreen
+        />
+        <span className="tn-newsw-ch">{resolved?.title ?? channel.name}</span>
+      </div>
+
+      <div className="tn-newsw-tabs">
+        {streams.slice(0, 4).map((s, i) => (
+          <button key={s.videoId} className={i === picked ? "is-on" : ""} onClick={() => setPicked(i)}>
+            {s.title.slice(0, 18)}
+          </button>
+        ))}
+        <button className="tn-newsw-more" onClick={() => setPicker((o) => !o)}>
+          {channel.name.slice(0, 16)}&hellip;
+        </button>
+      </div>
+
+      {(usingSeed || note) && (
+        <p className="tn-w-empty">
+          {loading
+            ? "Checking what this channel is streaming…"
+            : usingSeed
+              ? `Showing ${channel.name}'s last-known stream — it may have ended. ${note ?? ""}`
+              : note}
+        </p>
+      )}
+
+      {picker && (
+        <div className="tn-newsw-picker">
+          {BRAZIL_CAM_CHANNELS.map((c) => (
+            <button
+              key={c.id}
+              className={c.channelId === channel.channelId ? "is-on" : ""}
+              onClick={() => choose(c.channelId)}
+            >
+              {c.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const LIVECAMS_WIDGET = {
+  id: "livecams-brazil",
+  title: "Brazil Live Cams",
+  icon: "🇧🇷",
+  category: "Cameras",
+  defaultHeight: 240,
+  defaultConfig: { channelId: BRAZIL_CAM_CHANNELS[0].channelId },
+  component: LiveCamsBody,
+  help: {
+    what: "Live cameras across Brazil — beaches, city centres, BR-101, ports and airports — streamed 24/7 on YouTube by local broadcasters. Titles are theirs, not ours. Channels are resolved to whatever they are streaming right now, so a broadcaster restarting a stream does not break the tile.",
+    source: "Independent Brazilian YouTube channels (32 registered)",
+    caveat:
+      "These are third-party streams, not government camera feeds, and they carry no coordinates — which is why they are a board and not map pins. Availability, ads and outages are the broadcaster's and YouTube's. Without a YOUTUBE_API_KEY the tile falls back to a last-known stream that may have ended.",
+  },
+};
+registerWidget(LIVECAMS_WIDGET);

--- a/lib/youtube/live.ts
+++ b/lib/youtube/live.ts
@@ -192,6 +192,51 @@ export function planRediscovery(
   return { resolved, needSearch };
 }
 
+export interface ChannelLive {
+  channelId: string;
+  videos: LiveVideo[];
+  dormant: boolean;
+  quotaSpent: number;
+  note: string | null;
+}
+
+/**
+ * Every stream a single channel is running right now, not just one.
+ *
+ * Used by the live-cams board, where one broadcaster commonly runs many cameras
+ * at once (UBACAM 8, CLIMA BC 6). Costs a full search.list — 100 units — so it
+ * is called ON DEMAND for the channel a user actually opened, never eagerly for
+ * a whole list. Resolving all 32 registered Brazilian channels up front would
+ * cost 3,200 units of a 10,000/day budget on a single cold start.
+ */
+export async function listChannelLive(
+  channelId: string,
+  apiKey: string | undefined = process.env.YOUTUBE_API_KEY,
+): Promise<ChannelLive> {
+  const key = (apiKey ?? "").trim();
+  if (!key) {
+    return {
+      channelId,
+      videos: [],
+      dormant: true,
+      quotaSpent: 0,
+      note: "YOUTUBE_API_KEY is not set — showing the last-known stream instead of the current one.",
+    };
+  }
+  const url =
+    `${API}/search?part=snippet&channelId=${encodeURIComponent(channelId)}` +
+    `&eventType=live&type=video&order=date&maxResults=25&key=${encodeURIComponent(key)}`;
+  const json = await getJson(url);
+  const videos = json ? parseSearchList(json).filter((v) => v.channelId === channelId) : [];
+  return {
+    channelId,
+    videos,
+    dormant: false,
+    quotaSpent: COST_SEARCH_LIST,
+    note: videos.length === 0 ? "This channel has nothing live right now." : null,
+  };
+}
+
 async function getJson(url: string): Promise<unknown | null> {
   try {
     const res = await fetch(url, {

--- a/lib/youtube/registry.ts
+++ b/lib/youtube/registry.ts
@@ -1,9 +1,11 @@
 import {
   resolveLiveVideos,
+  listChannelLive,
   requestKey,
   type ChannelRequest,
   type ResolveResult,
   type Resolution,
+  type ChannelLive,
 } from "@/lib/youtube/live";
 
 // Server-side cache for channel → current live video, the YouTube analogue of
@@ -28,6 +30,8 @@ export function __resetYoutubeRegistry(): void {
   lastKnown.clear();
   cache = null;
   inflight = null;
+  channelCache.clear();
+  channelInflight.clear();
 }
 
 /**
@@ -42,6 +46,33 @@ export function rememberResolutions(resolutions: readonly Resolution[]): void {
   for (const r of resolutions) {
     if (r.videoId) lastKnown.set(requestKey(r), r.videoId);
   }
+}
+
+// Per-channel cache for the live-cams board. Separate from the resolution cache
+// above because it answers a different question ("everything this channel is
+// running") and is populated ON DEMAND, one channel at a time — see
+// listChannelLive for why eager resolution would be unaffordable.
+const channelCache = new Map<string, { value: ChannelLive; at: number }>();
+const channelInflight = new Map<string, Promise<ChannelLive>>();
+
+export async function getChannelLive(channelId: string): Promise<ChannelLive> {
+  const hit = channelCache.get(channelId);
+  if (hit && Date.now() - hit.at < TTL_MS) return hit.value;
+
+  let pending = channelInflight.get(channelId);
+  if (!pending) {
+    pending = listChannelLive(channelId)
+      .then((value) => {
+        // Only cache a positive answer. Caching "nothing live" for ten minutes
+        // would hide a stream that started thirty seconds later, and costs the
+        // user the thing they clicked on.
+        if (value.videos.length > 0 || value.dormant) channelCache.set(channelId, { value, at: Date.now() });
+        return value;
+      })
+      .finally(() => channelInflight.delete(channelId));
+    channelInflight.set(channelId, pending);
+  }
+  return pending;
 }
 
 async function refresh(requests: readonly ChannelRequest[]): Promise<ResolveResult> {

--- a/tests/unit/livecams-brazil.test.ts
+++ b/tests/unit/livecams-brazil.test.ts
@@ -1,0 +1,84 @@
+import { expect, test, vi, afterEach } from "vitest";
+import { BRAZIL_CAM_CHANNELS } from "@/lib/console/livecams/brazil.data";
+import { listChannelLive, COST_SEARCH_LIST } from "@/lib/youtube/live";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+test("every registered channel has a well-formed id and a seed", () => {
+  expect(BRAZIL_CAM_CHANNELS.length).toBeGreaterThan(0);
+  for (const c of BRAZIL_CAM_CHANNELS) {
+    expect(c.channelId, c.name).toMatch(/^UC[A-Za-z0-9_-]{22}$/);
+    expect(c.seedVideoId, c.name).toMatch(/^[A-Za-z0-9_-]{11}$/);
+    expect(c.name.trim()).toBe(c.name);
+    expect(c.knownStreams).toBeGreaterThan(0);
+  }
+});
+
+test("channel ids and widget ids are unique", () => {
+  const chans = BRAZIL_CAM_CHANNELS.map((c) => c.channelId);
+  const ids = BRAZIL_CAM_CHANNELS.map((c) => c.id);
+  expect(new Set(chans).size).toBe(chans.length);
+  expect(new Set(ids).size).toBe(ids.length);
+});
+
+test("the channels excluded during curation stay excluded", () => {
+  // Wolkam IT is Vitoria-GASTEIZ, Spain — it matched the Brazilian "Vitória" on
+  // name alone. The others are IRL phone streams, not fixed cameras. All five
+  // were removed by hand; this guards the removal against a regenerated list.
+  const banned = ["UCd8Jm6IpuRLTGrGkPMKX_Yw", "Wolkam", "Gutti", "Olhar Urbano", "Biel Turismo", "Edson IRL"];
+  for (const b of banned) {
+    expect(BRAZIL_CAM_CHANNELS.some((c) => c.name.includes(b) || c.channelId === b)).toBe(false);
+  }
+});
+
+test("no location or category is asserted about a stream", () => {
+  // Deriving them from titles put a Cubatão train in Natal and read an
+  // "Av. Curitiba" in Goioerê as the city of Curitiba. The board shows the
+  // broadcaster's own words instead, so these fields must not come back.
+  for (const c of BRAZIL_CAM_CHANNELS) {
+    expect(Object.keys(c).sort()).toEqual(["channelId", "id", "knownStreams", "name", "seedVideoId"]);
+  }
+});
+
+test("listChannelLive is dormant-safe and does not call the network without a key", async () => {
+  globalThis.fetch = (() => {
+    throw new Error("listChannelLive must not call fetch when dormant");
+  }) as unknown as typeof fetch;
+  const out = await listChannelLive(BRAZIL_CAM_CHANNELS[0].channelId, undefined);
+  expect(out.dormant).toBe(true);
+  expect(out.videos).toEqual([]);
+  expect(out.quotaSpent).toBe(0);
+  expect(out.note).toContain("last-known");
+});
+
+test("listChannelLive returns every live stream a channel is running", async () => {
+  const ch = BRAZIL_CAM_CHANNELS[0].channelId;
+  globalThis.fetch = vi.fn(async () =>
+    new Response(
+      JSON.stringify({
+        items: [
+          { id: { videoId: "aaaaaaaaaaa" }, snippet: { channelId: ch, title: "Praia 1" } },
+          { id: { videoId: "bbbbbbbbbbb" }, snippet: { channelId: ch, title: "Praia 2" } },
+          // A collaborator's video that search sometimes returns — not this channel's.
+          { id: { videoId: "ccccccccccc" }, snippet: { channelId: "UCsomeoneelse00000000000", title: "Other" } },
+        ],
+      }),
+      { status: 200 },
+    ),
+  ) as unknown as typeof fetch;
+
+  const out = await listChannelLive(ch, "k");
+  expect(out.videos.map((v) => v.videoId)).toEqual(["aaaaaaaaaaa", "bbbbbbbbbbb"]);
+  expect(out.quotaSpent).toBe(COST_SEARCH_LIST);
+});
+
+test("an upstream failure yields no streams and an honest note, not a throw", async () => {
+  globalThis.fetch = vi.fn(async () => new Response("nope", { status: 403 })) as unknown as typeof fetch;
+  const out = await listChannelLive(BRAZIL_CAM_CHANNELS[0].channelId, "k");
+  expect(out.videos).toEqual([]);
+  expect(out.note).toContain("nothing live");
+});


### PR DESCRIPTION
## What

A console board carrying **32 Brazilian YouTube channels**, which were running **100 live Brazilian streams** between them when the list was captured (2026-08-14) — beaches, city centres, the BR-101, ports and airports.

This is the only route left to Brazilian road cameras. The concessionaires (Ecovias, Arteris, Rota das Bandeiras) hard-403 a real Chromium, Motiva/AutoBAn deleted their public camera page, and Rio publishes no camera dataset at all.

## A board, not map pins

YouTube attaches no coordinates — `location` was `null` on every stream checked. Pins would mean geocoding titles to city centroids, and a centroid pin sitting next to metre-accurate camera pins misrepresents what it is. This also preserves the separation `lib/types.ts` already draws between road CCTV and everything else.

## Resolution is demand-driven — a quota decision, not a style one

Listing every stream a channel runs costs a **100-unit `search.list`**. Resolving all 32 channels eagerly would burn **3,200 units of a 10,000/day budget on a single cold start**. So a channel is resolved when a user actually opens it, and cached for 10 minutes.

A *negative* answer is deliberately **not** cached — caching "nothing live" for ten minutes would hide a stream that started a minute later, and cost the user the exact thing they clicked.

## The interesting part: what this deliberately does NOT claim

I built location and category derivation first, then deleted it. From stream titles it produced:

| Derived | Reality |
|---|---|
| "Natal" | a **Cubatão** train, 1,800 km away |
| "Curitiba" | an **Av. Curitiba** in Goioerê — a street, not the city |
| Category: Roads | Chapecó **airport** (matched "tráfego") |
| "Balneário Camboriú - do tempo" | mangled from "CÂMERA do tempo" |

Rather than ship ~100 machine-written labels at that error rate, the board shows **each broadcaster's own title, verbatim**. Their words are accurate about their own camera; mine were not. There's a test asserting those fields cannot come back.

## The hand-curation step is not optional

The automated pass had accepted **Wolkam IT — a webcam in Vitoria-*Gasteiz*, SPAIN**, matched against the Brazilian "Vitória" on the name alone. Plus four IRL phone streams with dated titles, which are people with phones, not fixed cameras. All five excluded, guarded by a test.

## Safety

Dormant-safe: with no `YOUTUBE_API_KEY` the tile plays a last-known stream **and says so**, rather than presenting a possibly-dead stream as current. Verified: `/api/youtube-live?channel=UC…` → `{"videos":[],"dormant":true,"note":"…showing the last-known stream instead of the current one.","quotaSpent":0}`, and a malformed channel id → 400.

## Gate

`npx tsc --noEmit` clean, `npm test` **1,780 tests / 233 files**. The repo's own trust-card guard caught the new widget and now has an entry documenting exactly what it is and is not.

**Not captured:** a Playwright screenshot of the tile on a board. The widget registers correctly (the explainer test enumerates registered widgets and passes) and the endpoint is verified, but I have not put eyes on it rendered in the console.