### PR TITLE
Register Belgium — it was rendering 0 of its 114 webcams

### DIFF
--- a/lib/sources/windy.ts
+++ b/lib/sources/windy.ts
@@ -170,6 +170,26 @@ export const WINDY_REGIONS: WindyRegion[] = [
   //   curl -H "x-windy-api-key: $KEY" \
   //     "https://api.windy.com/webcams/api/v3/webcams?bbox=5.3,-34.7,-33.8,-74.0&limit=1"
   { name: "brazil", bbox: [5.3, -34.7, -33.8, -74.0], pages: 5 },
+  // Belgium (with its border strip into NL/LU/DE/FR), for the same reason as
+  // Brazil, only starker.
+  //
+  // Measured 2026-08-14: `w-europe` is the ONLY region whose bbox contains
+  // Brussels, that bbox holds 19,204 webcams, and at the default 2 pages it
+  // fetches 100 of them — 0.5%. Which 100 is not chosen, it is whatever the API
+  // returns first, and on the day of measurement that was Italy 60 / France 18 /
+  // Switzerland 8 / Czechia 5 / Germany 4 / Spain 2 and **zero Belgium**. So a
+  // country with 114 webcams in the feed was rendering none at all.
+  //
+  // This bbox holds 225 (114 of them Belgian), so 5 pages = 250 capacity covers
+  // it with headroom. Re-measure before changing:
+  //   curl -H "x-windy-api-key: $KEY" \
+  //     "https://api.windy.com/webcams/api/v3/webcams?bbox=51.55,6.45,49.45,2.5&limit=1"
+  //
+  // NOT A GENERAL FIX. The Netherlands and Luxembourg are starved by the same
+  // 100-row ceiling, and so is everywhere else in w-europe that is not Italy.
+  // Adding a region per country does not scale — the real fix is to stop
+  // sampling a 19k-webcam box with 100 rows. Tracked, not solved here.
+  { name: "belgium", bbox: [51.55, 6.45, 49.45, 2.5], pages: 5 },
   { name: "africa", bbox: [37, 52, -35, -18] },
   { name: "middle-east", bbox: [42, 63, 12, 34] },
   { name: "s-asia", bbox: [37, 92, 5, 60] },

--- a/tests/unit/windy-paging.test.ts
+++ b/tests/unit/windy-paging.test.ts
@@ -44,6 +44,27 @@ test("every Brazil offset stays inside the free tier's offset<=1000 limit", () =
   for (const job of jobs) expect(job.offset).toBeLessThanOrEqual(1000);
 });
 
+test("Belgium is registered with enough pages to carry the measured inventory", () => {
+  const belgium = WINDY_REGIONS.find((r) => r.name === "belgium");
+  expect(belgium).toBeDefined();
+  // Measured 2026-08-14: bbox total=225, of which 114 are Belgian. Under the
+  // default 2 pages the only region containing Brussels (w-europe) returned
+  // ZERO Belgian webcams — its 100 rows went to Italy, France and Switzerland.
+  const capacity = (belgium!.pages ?? DEFAULT_PAGES) * LIMIT;
+  expect(capacity).toBeGreaterThanOrEqual(225);
+});
+
+test("Belgium's bbox actually contains Brussels", () => {
+  // Guards the transcription slip that would make this whole region pointless:
+  // WindyRegion bbox order is [north, east, south, west], NOT a lat/lon pair.
+  const [north, east, south, west] = WINDY_REGIONS.find((r) => r.name === "belgium")!.bbox;
+  const [lat, lon] = [50.85, 4.35];
+  expect(south).toBeLessThanOrEqual(lat);
+  expect(north).toBeGreaterThanOrEqual(lat);
+  expect(west).toBeLessThanOrEqual(lon);
+  expect(east).toBeGreaterThanOrEqual(lon);
+});
+
 test("region names are unique, so a duplicate bbox cannot be added unnoticed", () => {
   const names = WINDY_REGIONS.map((r) => r.name);
   expect(new Set(names).size).toBe(names.length);


### PR DESCRIPTION
## The bug

`w-europe` is the **only** region whose bbox contains Brussels. That bbox holds **19,204 webcams**, and at the default 2 pages it fetches **100** of them — 0.5%.

Which 100 is not chosen. It is whatever the API returns first, and on the day of measurement that was:

| Italy | France | Switzerland | Czechia | Germany | Spain | **Belgium** |
|---|---|---|---|---|---|---|
| 60 | 18 | 8 | 5 | 4 | 2 | **0** |

So a country with **114 webcams sitting in the feed** was rendering none at all, and nothing anywhere reported the shortfall. Same defect the Brazil region fixed, one step worse — Brazil was showing 10 of 135; Belgium was showing 0 of 114.

## The change

One region entry. Its bbox holds 225 webcams (114 Belgian, the rest border cams in NL/LU/DE/FR), so 5 pages = 250 capacity covers it with headroom rather than being tuned to today's count.

## How it was verified

End to end on a dev server, not just in unit tests:

| | `/api/webcams` returns | of which BE |
|---|---|---|
| before | 1,358 | **0** |
| after | 1,583 | **114** |

Belgium is now the third-largest country in the layer, behind the US (160) and Brazil (136). Antwerp, Ghent, Zeebrugge, Knokke-Heist, Blankenberge, De Panne, Grand-Place and Place De Brouckère all render.

Two tests: capacity against the measured inventory, and an assertion that the bbox actually **contains Brussels** — `WindyRegion` bbox order is `[north, east, south, west]`, and a transcription slip there would leave the region silently pointing at open sea while every other test still passed.

## This is not a general fix, and the comment in the code says so

The Netherlands and Luxembourg are starved by the same ceiling, as is everywhere in `w-europe` that isn't Italy. Adding a region per country does not scale. The real fix is to stop sampling a 19,204-webcam box with 100 rows — worth doing properly, but it is a different change from this one.

## Gate

`npx tsc --noEmit` clean, `npm test` **1,782 tests / 233 files** passing.