### PR TITLE
Turn webcams on for the Brief board

### DIFF
--- a/lib/console/presetLayers.ts
+++ b/lib/console/presetLayers.ts
@@ -32,7 +32,11 @@ export interface PersonaLayers {
  * base layer (borders + click target) always stays ON. Works for custom presets too
  * since it reads the ShellLayout, not the preset spec.
  */
-export function layersForLayout(layout: ShellLayout, extraSignals: readonly string[] = []): PersonaLayers {
+export function layersForLayout(
+  layout: ShellLayout,
+  extraSignals: readonly string[] = [],
+  extraCore: readonly LayerKey[] = [],
+): PersonaLayers {
   const core: LayerState = {
     ...DEFAULT_STATE,
     cameras: false,
@@ -59,5 +63,10 @@ export function layersForLayout(layout: ShellLayout, extraSignals: readonly stri
   // I can read is on the map I can see". The cards are the captions; this is the
   // picture they caption.
   for (const id of extraSignals) signals[id] = true;
+  // The same escape hatch for CORE layers. Webcams is the case that needs it:
+  // there is no webcams widget, so WIDGET_TO_CORE can never imply it, and the
+  // reset above forces it off — which means no board could show webcams however
+  // it was composed. Applied after the widget pass so an explicit request wins.
+  for (const key of extraCore) core[key] = true;
   return { core, signals };
 }

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -4,7 +4,7 @@ import { addWidget, applyItems, setStage } from "@/lib/console/reducers";
 import { arrangeHouse, DEFAULT_BOARD_ROWS, RAIL_CAPACITY } from "@/lib/terminal/layoutGrid";
 import { visibleRows } from "@/lib/terminal/rowBudget";
 import { shellLayoutStore } from "@/lib/console/store";
-import { layersStore } from "@/lib/layers";
+import { layersStore, type LayerKey } from "@/lib/layers";
 import { signalsStore } from "@/lib/signals/store";
 import { layersForLayout } from "@/lib/console/presetLayers";
 import { activePresetStore } from "@/lib/console/activePreset";
@@ -24,6 +24,11 @@ export interface ConsolePreset {
    *  For boards whose cards are merged lists rather than one card per source —
    *  without it the Brief board's map would show nothing but camera pins. */
   mapSignals?: string[];
+  /** Core layers this board lights ON THE MAP without spending a card on each —
+   *  the `mapSignals` idea applied to cameras/planes/satellites/webcams. Needed
+   *  because a core layer is otherwise only ever implied by a widget, and webcams
+   *  has no widget to imply it. */
+  mapCore?: LayerKey[];
   /** `rows` is the board's height budget — see the note on WEIGHTS below. Defaults
    *  to DEFAULT_BOARD_ROWS so tests and any off-DOM caller still get a real board. */
   build(rows?: number): ShellLayout;
@@ -104,8 +109,17 @@ export const BUILTIN_PRESETS: ConsolePreset[] = [
   // own board and the photo-geolocation tool moved to Recon, which is where the
   // other query-and-answer surfaces live — it had been holding a 250px card on
   // the landing board every day to show an empty dropzone.
+  // Webcams is ON here and nowhere else. The Brief board is the one a fresh
+  // visitor lands on, and its job is "what changed since you last looked" — a
+  // ground-level view of somewhere is exactly that, and the webcam layer is the
+  // only one that covers the places our government camera feeds do not (Brazil,
+  // Belgium, most of the southern hemisphere). It stays opt-in on every other
+  // board and in lib/layers.ts's defaults; this is a per-board choice, not a
+  // change to what the layer does by default.
   { id: "overview", title: "Brief", icon: "🌐", blurb: "what changed since you last looked",
-    mapSignals: ["gdacs", "earthquakes", "conflict", "wildfires"], build: (rows = DEFAULT_BOARD_ROWS) => compose("map2d", rows, [
+    mapSignals: ["gdacs", "earthquakes", "conflict", "wildfires"],
+    mapCore: ["webcams"],
+    build: (rows = DEFAULT_BOARD_ROWS) => compose("map2d", rows, [
       { type: "anomaly", weight: 3 },
       { type: "events", weight: 3 },
       { type: "headlines", weight: 2 },
@@ -281,7 +295,7 @@ export function applyPreset(presetId: string, opts: { reset?: boolean } = {}): v
   // Drive the globe to match the board: the persona's widgets decide which core +
   // signal layers are lit, so switching persona actually re-skins the map (not just
   // the side rail). See lib/console/presetLayers.ts.
-  const { core, signals } = layersForLayout(layout, built?.mapSignals ?? []);
+  const { core, signals } = layersForLayout(layout, built?.mapSignals ?? [], built?.mapCore ?? []);
   layersStore.applyExact(core);
   signalsStore.applyExact(signals);
 }

--- a/tests/unit/preset-layers.test.ts
+++ b/tests/unit/preset-layers.test.ts
@@ -82,3 +82,37 @@ test("every built-in persona lights up at least one data layer (no blank-map boa
     ).toBeGreaterThan(0);
   }
 });
+
+// --- core-layer escape hatch (mapCore) --------------------------------------
+
+test("a board can light a core layer that no widget implies", () => {
+  // Webcams is the case this exists for: there is no webcams widget, so
+  // WIDGET_TO_CORE can never imply it and the reset forces it off — meaning
+  // before `extraCore` no board could show webcams however it was composed.
+  const bare = createDefaultLayout();
+  expect(layersForLayout(bare).core.webcams).toBe(false);
+  expect(layersForLayout(bare, [], ["webcams"]).core.webcams).toBe(true);
+});
+
+test("an explicit core request wins over the reset, and leaves the others alone", () => {
+  const { core } = layersForLayout(createDefaultLayout(), [], ["webcams"]);
+  expect(core.webcams).toBe(true);
+  expect(core.cameras).toBe(false);
+  expect(core.planes).toBe(false);
+  expect(core.satellites).toBe(false);
+});
+
+test("the Brief board turns webcams on", () => {
+  const brief = BUILTIN_PRESETS.find((p) => p.id === "overview")!;
+  expect(brief.mapCore).toContain("webcams");
+  const { core } = layersForLayout(brief.build(), brief.mapSignals ?? [], brief.mapCore ?? []);
+  expect(core.webcams).toBe(true);
+});
+
+test("no OTHER board turns webcams on — it stays opt-in everywhere else", () => {
+  for (const p of BUILTIN_PRESETS) {
+    if (p.id === "overview") continue;
+    const { core } = layersForLayout(p.build(), p.mapSignals ?? [], p.mapCore ?? []);
+    expect(core.webcams, `${p.id} unexpectedly lights webcams`).toBe(false);
+  }
+});


### PR DESCRIPTION
## What

Webcams are now ON by default on **Brief**, the board a fresh visitor lands on.

## Why it needed a mechanism change rather than a flag

`layersForLayout` resets all four core layers to `false`, then re-enables only those a **widget** implies via `WIDGET_TO_CORE`. There is no webcams widget — so no board could light that layer, however it was composed. It wasn't switched off for Brief; it was unreachable for every board.

So this adds `mapCore` to `ConsolePreset` — exactly the escape hatch `mapSignals` already provides for signal layers, applied to core layers — and sets `mapCore: ["webcams"]` on Brief. The comment on `mapSignals` already explains the same reasoning ("the cards are the captions; this is the picture they caption").

## Deliberately scoped

- `lib/layers.ts` still defaults `webcams: false`. This is a per-board choice, not a change to what the layer does by default.
- A test asserts **no other board** lights webcams, so it can't spread by accident.
- The explicit request is applied after the widget pass, so it wins over the reset without touching the other three layers.

## Why this board specifically

Webcams are the only layer covering the places our government camera feeds don't reach. Brazil, Belgium and most of the southern hemisphere have no road-CCTV adapter at all — on Brief they were rendering nothing.

## How it was verified

In a browser on a clean profile: loading `/app` with **no `layers` param** rewrites the URL to `layers=cameras,webcams`, the legend lists both CAMERAS and WEBCAMS, and the status bar reads `CAMERAS 6,294 · 6,110 ONLINE · PLANES OFF · SATELLITES OFF · WEBCAMS 1,583`.

`npx tsc --noEmit` clean, `npm test` **1,786 tests / 233 files** passing, including 4 new ones.