### PR TITLE
SEO: make the ~20k camera pages reachable

### DIFF
--- a/app/camera/[id]/page.tsx
+++ b/app/camera/[id]/page.tsx
@@ -1,26 +1,115 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getCameraById, nearestTo } from "@/lib/sources/registry";
 import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
 import { CameraImage } from "@/components/CameraImage";
 import { CameraVideo } from "@/components/CameraVideo";
+import {
+  CAMERAS_ROOT,
+  cameraDescription,
+  cameraPath,
+  cameraTitle,
+  countryName,
+  countryPath,
+  describeCadence,
+  placeLabel,
+  regionPath,
+} from "@/lib/seo/paths";
 
-export const dynamic = "force-dynamic";
+/**
+ * Was `force-dynamic`, which meant this page was recomputed from the registry on
+ * every single request and could never be cached at the edge.
+ *
+ * It is safe to cache: the only genuinely live thing on the page is the frame, and
+ * that is fetched by a CLIENT component straight from the image proxy on its own
+ * refresh interval. Everything the server renders - name, place, operator, cadence,
+ * neighbours - changes at the speed of the registry, not the speed of traffic.
+ */
+export const revalidate = 3_600;
+
+async function load(idParam: string) {
+  return getCameraById(decodeURIComponent(idParam));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const cam = await load(id);
+  if (!cam) return { title: "Camera not found" };
+
+  const title = cameraTitle(cam);
+  const description = cameraDescription(cam);
+
+  return {
+    title,
+    description,
+    // Next serves this page for both the percent-encoded id and the raw-colon form.
+    // Naming one canonical stops the two being read as duplicate pages.
+    alternates: { canonical: cameraPath(cam.id) },
+    openGraph: { title, description, url: cameraPath(cam.id), type: "article" },
+    twitter: { title, description },
+  };
+}
 
 export default async function CameraPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const cam = await getCameraById(decodeURIComponent(id));
+  const cam = await load(id);
   if (!cam) notFound();
 
   const nearby = (await nearestTo(cam.lat, cam.lon, 8))
     .filter((n) => n.camera.id !== cam.id)
     .slice(0, 6);
   const live = isLiveStreamUrl(cam.streamUrl);
+  const country = countryName(cam.country);
+
+  // Breadcrumbs, in markup a search engine reads and as links a person can use. The
+  // page was previously an orphan with one link back to the globe; this is what
+  // connects it to the directory above it.
+  const trail = [
+    { name: "Cameras", href: CAMERAS_ROOT },
+    { name: country, href: countryPath(cam.country) },
+    ...(cam.region ? [{ name: cam.region, href: regionPath(cam.country, cam.region) }] : []),
+  ];
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: trail.map((crumb, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: crumb.name,
+      item: crumb.href,
+    })),
+  };
 
   return (
     <main className="camera-detail">
-      <p><Link href="/">← Globe</Link></p>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+
+      <nav className="tn-dir-crumbs" aria-label="Breadcrumb">
+        <Link href="/">Home</Link>
+        {trail.map((crumb) => (
+          <span key={crumb.href}>
+            {" "}
+            <span aria-hidden="true">/</span> <Link href={crumb.href}>{crumb.name}</Link>
+          </span>
+        ))}
+      </nav>
+
       <h1>{cam.name}</h1>
+
+      <p className="tn-dir-lede">
+        Live traffic camera in {placeLabel(cam)}. The image refreshes{" "}
+        {describeCadence(cam.refreshSeconds)}, direct from {cam.attribution}.
+      </p>
+
       {live ? (
         <CameraVideo
           id={cam.id} alt={cam.name}
@@ -36,23 +125,38 @@ export default async function CameraPage({ params }: { params: Promise<{ id: str
       )}
       <dl>
         <dt>Source</dt><dd>{cam.source}</dd>
-        <dt>Location</dt><dd>{cam.region}, {cam.country}</dd>
+        <dt>Location</dt><dd>{placeLabel(cam)}</dd>
         <dt>Coordinates</dt><dd>{cam.lat.toFixed(4)}, {cam.lon.toFixed(4)}</dd>
-        <dt>Status</dt><dd>{cam.available ? "available" : "unavailable"}</dd>
-        <dt>Refresh</dt><dd>every {cam.refreshSeconds}s</dd>
+        <dt>Status</dt><dd>{cam.available ? "available" : "not answering at the last check"}</dd>
+        <dt>Refresh</dt><dd>{describeCadence(cam.refreshSeconds)}</dd>
+        <dt>Licence</dt><dd>{cam.license}</dd>
       </dl>
+
       <section>
         <h2>Nearby cameras</h2>
         <ul>
           {nearby.map((n) => (
             <li key={n.camera.id}>
-              <Link href={`/camera/${encodeURIComponent(n.camera.id)}`}>
-                {n.camera.name} · {n.km.toFixed(2)} km
+              <Link href={cameraPath(n.camera.id)}>
+                {n.camera.name} &middot; {n.km.toFixed(2)} km
               </Link>
             </li>
           ))}
         </ul>
       </section>
+
+      <p className="tn-dir-note">
+        {cam.region && (
+          <>
+            <Link href={regionPath(cam.country, cam.region)}>
+              All cameras in {cam.region}
+            </Link>{" "}
+            &middot;{" "}
+          </>
+        )}
+        <Link href={countryPath(cam.country)}>All cameras in {country}</Link> &middot;{" "}
+        <Link href="/app">Open the console</Link>
+      </p>
     </main>
   );
 }

--- a/app/cameras/[country]/[region]/[[...paging]]/page.tsx
+++ b/app/cameras/[country]/[region]/[[...paging]]/page.tsx
@@ -1,0 +1,157 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, permanentRedirect } from "next/navigation";
+import { getRegistry } from "@/lib/sources/registry";
+import { camerasInRegion, pageSlice } from "@/lib/seo/directory";
+import {
+  CAMERAS_ROOT,
+  REGION_PAGE_SIZE,
+  cameraPath,
+  countryName,
+  countryPath,
+  formatCount,
+  regionPageCount,
+  regionPath,
+  regionTitle,
+} from "@/lib/seo/paths";
+
+export const revalidate = 86_400;
+
+interface RouteParams {
+  country: string;
+  region: string;
+  /** Optional trailing page number: /cameras/us/florida/2. Absent means page 1. */
+  paging?: string[];
+}
+
+/**
+ * Reads the page number out of the optional catch-all.
+ *
+ * Returns null for anything that is not a plain page number, so the route 404s
+ * instead of quietly serving page 1 at an unlimited number of junk URLs - which
+ * would be an infinite crawl space pointing at duplicate content.
+ */
+function parsePage(paging: string[] | undefined): number | null {
+  if (!paging || paging.length === 0) return 1;
+  if (paging.length > 1) return null;
+  const raw = paging[0];
+  if (!/^[1-9][0-9]*$/.test(raw)) return null;
+  return Number(raw);
+}
+
+async function load(country: string, region: string) {
+  const cameras = await getRegistry().catch(() => []);
+  return camerasInRegion(cameras, country, region);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<RouteParams>;
+}): Promise<Metadata> {
+  const { country, region, paging } = await params;
+  const page = parsePage(paging);
+  const hit = await load(country, region);
+  if (!hit || page === null) return { title: "Region not found" };
+
+  const pages = regionPageCount(hit.cameras.length);
+  const title = regionTitle(country, hit.region, hit.cameras.length, page);
+  const where = `${hit.region}, ${countryName(country)}`;
+
+  return {
+    title,
+    description:
+      page > 1
+        ? `Page ${page} of ${pages}: more public road cameras in ${where}, each with a live image and its operator named.`
+        : `Every public road camera in ${where}: ${formatCount(hit.cameras.length)} live feeds, each with its own page showing the current image, the operator and how often it refreshes.`,
+    alternates: { canonical: regionPath(country, hit.region, page) },
+    // Deep pages of a long list are real, useful and crawlable, but they are not
+    // what should surface for "cameras in Florida" - page 1 is. Following the links
+    // without indexing the tail keeps the crawl path intact and the index clean.
+    robots: page > 1 ? { index: false, follow: true } : undefined,
+    openGraph: { title, url: regionPath(country, hit.region, page) },
+  };
+}
+
+export default async function RegionPage({ params }: { params: Promise<RouteParams> }) {
+  const { country, region, paging } = await params;
+  const page = parsePage(paging);
+  if (page === null) notFound();
+
+  // /cameras/us/florida/1 is the same page as /cameras/us/florida. Send it to the
+  // canonical one permanently rather than serving identical content at two URLs.
+  if (paging && paging.length === 1 && page === 1) permanentRedirect(regionPath(country, region));
+
+  const hit = await load(country, region);
+  if (!hit) notFound();
+
+  const pages = regionPageCount(hit.cameras.length);
+  if (page > pages) notFound();
+
+  const slice = pageSlice(hit.cameras, page, REGION_PAGE_SIZE);
+  const first = (page - 1) * REGION_PAGE_SIZE + 1;
+  const last = first + slice.length - 1;
+  const countryLabel = countryName(country);
+
+  return (
+    <main className="tn-dir">
+      <nav className="tn-dir-crumbs" aria-label="Breadcrumb">
+        <Link href="/">Home</Link> <span aria-hidden="true">/</span>{" "}
+        <Link href={CAMERAS_ROOT}>Cameras</Link> <span aria-hidden="true">/</span>{" "}
+        <Link href={countryPath(country)}>{countryLabel}</Link> <span aria-hidden="true">/</span>{" "}
+        <span>{hit.region}</span>
+      </nav>
+
+      <h1>
+        Live traffic cameras in {hit.region}, {countryLabel}
+      </h1>
+
+      <p className="tn-dir-lede">
+        {formatCount(hit.cameras.length)} public road cameras.{" "}
+        {pages > 1 && (
+          <>
+            Showing {formatCount(first)}&ndash;{formatCount(last)}, page {page} of {pages}.
+          </>
+        )}
+      </p>
+
+      <ul className="tn-dir-cams">
+        {slice.map((c) => (
+          <li key={c.id}>
+            <Link href={cameraPath(c.id)}>{c.name}</Link>
+            {c.road && <span className="tn-dir-dim">{c.road}</span>}
+            {!c.available && (
+              <span className="tn-dir-down" title="This feed was not answering at the last check">
+                not answering
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {pages > 1 && (
+        <nav className="tn-dir-pager" aria-label="Pagination">
+          {page > 1 && (
+            <Link href={regionPath(country, hit.region, page - 1)} rel="prev">
+              &larr; Previous
+            </Link>
+          )}
+          <span className="tn-dir-dim">
+            Page {page} of {pages}
+          </span>
+          {page < pages && (
+            <Link href={regionPath(country, hit.region, page + 1)} rel="next">
+              Next &rarr;
+            </Link>
+          )}
+        </nav>
+      )}
+
+      <p className="tn-dir-note">
+        <Link href={countryPath(country)}>All regions in {countryLabel}</Link> &middot;{" "}
+        <Link href={CAMERAS_ROOT}>All countries</Link> &middot;{" "}
+        <Link href="/app">Open the console</Link>
+      </p>
+    </main>
+  );
+}

--- a/app/cameras/[country]/page.tsx
+++ b/app/cameras/[country]/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getRegistry } from "@/lib/sources/registry";
+import { groupByCountry } from "@/lib/seo/directory";
+import {
+  CAMERAS_ROOT,
+  countryName,
+  countryPath,
+  countryTitle,
+  formatCount,
+  regionPath,
+} from "@/lib/seo/paths";
+
+export const revalidate = 86_400;
+
+/**
+ * Pre-renders the country pages at build time. There are only eight of them and they
+ * are the hinge of the whole crawl path, so they should not depend on a cold cache
+ * being warm when a crawler first arrives.
+ */
+export async function generateStaticParams() {
+  const cameras = await getRegistry().catch(() => []);
+  return groupByCountry(cameras).map((g) => ({ country: g.iso2.toLowerCase() }));
+}
+
+async function load(countryParam: string) {
+  const cameras = await getRegistry().catch(() => []);
+  const group = groupByCountry(cameras).find((g) => g.iso2.toLowerCase() === countryParam.toLowerCase());
+  return group ?? null;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ country: string }>;
+}): Promise<Metadata> {
+  const { country } = await params;
+  const group = await load(country);
+  if (!group) return { title: "Country not found" };
+
+  const name = countryName(group.iso2);
+  return {
+    title: countryTitle(group.iso2, group.count),
+    description: `Every public road camera in ${name} on one map: ${formatCount(group.count)} cameras across ${group.regions.length} regions, each with a live image and its operator named.`,
+    alternates: { canonical: countryPath(group.iso2) },
+    openGraph: {
+      title: countryTitle(group.iso2, group.count),
+      url: countryPath(group.iso2),
+    },
+  };
+}
+
+export default async function CountryPage({ params }: { params: Promise<{ country: string }> }) {
+  const { country } = await params;
+  const group = await load(country);
+  if (!group) notFound();
+
+  return (
+    <main className="tn-dir">
+      <nav className="tn-dir-crumbs" aria-label="Breadcrumb">
+        <Link href="/">Home</Link> <span aria-hidden="true">/</span>{" "}
+        <Link href={CAMERAS_ROOT}>Cameras</Link> <span aria-hidden="true">/</span>{" "}
+        <span>{group.name}</span>
+      </nav>
+
+      <h1>Live traffic cameras in {group.name}</h1>
+
+      <p className="tn-dir-lede">
+        {formatCount(group.count)} public road cameras across {group.regions.length}{" "}
+        {group.regions.length === 1 ? "region" : "regions"}. Pick a region to see its cameras.
+      </p>
+
+      <ul className="tn-dir-regions">
+        {group.regions.map((region) => (
+          <li key={region.slug}>
+            <Link href={regionPath(group.iso2, region.region)}>{region.region}</Link>
+            <span className="tn-dir-dim">
+              {formatCount(region.count)} {region.count === 1 ? "camera" : "cameras"}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="tn-dir-note">
+        <Link href={CAMERAS_ROOT}>All countries</Link> &middot;{" "}
+        <Link href="/app">Open the console</Link>
+      </p>
+    </main>
+  );
+}

--- a/app/cameras/page.tsx
+++ b/app/cameras/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getRegistry } from "@/lib/sources/registry";
+import { groupByCountry } from "@/lib/seo/directory";
+import { CAMERAS_ROOT, countryPath, formatCount, regionPath } from "@/lib/seo/paths";
+import { BRAND } from "@/lib/brand";
+
+export const revalidate = 86_400;
+
+export const metadata: Metadata = {
+  title: `Live traffic cameras by country | ${BRAND.name}`,
+  description:
+    "Browse every public road camera on the map by country and region. Each camera has its own page with a live image, its operator, its refresh interval and the cameras nearest to it.",
+  alternates: { canonical: CAMERAS_ROOT },
+};
+
+export default async function CamerasIndex() {
+  const cameras = await getRegistry().catch(() => []);
+  const groups = groupByCountry(cameras);
+  const available = cameras.filter((c) => c.available).length;
+  const regionCount = groups.reduce((n, g) => n + g.regions.length, 0);
+
+  return (
+    <main className="tn-dir">
+      <nav className="tn-dir-crumbs" aria-label="Breadcrumb">
+        <Link href="/">Home</Link> <span aria-hidden="true">/</span> <span>Cameras</span>
+      </nav>
+
+      <h1>Live traffic cameras by country</h1>
+
+      <p className="tn-dir-lede">
+        {formatCount(cameras.length)} public road cameras from {groups.length} countries and{" "}
+        {formatCount(regionCount)} regions, read directly from the transport authorities that
+        operate them. {formatCount(available)} were answering at the last check.
+      </p>
+
+      <p className="tn-dir-note">
+        Every camera below has its own page showing the current image, who operates the feed, how
+        often it refreshes and the nearest other cameras. Nothing here is stored or re-hosted: each
+        frame is fetched from its operator when you open the page.
+      </p>
+
+      <ul className="tn-dir-grid">
+        {groups.map((country) => (
+          <li key={country.iso2} className="tn-dir-card">
+            <h2>
+              <Link href={countryPath(country.iso2)}>{country.name}</Link>
+            </h2>
+            <p className="tn-dir-count">
+              {formatCount(country.count)} cameras across {country.regions.length}{" "}
+              {country.regions.length === 1 ? "region" : "regions"}
+            </p>
+            <ul className="tn-dir-sub">
+              {country.regions.slice(0, 6).map((region) => (
+                <li key={region.slug}>
+                  <Link href={regionPath(country.iso2, region.region)}>{region.region}</Link>{" "}
+                  <span className="tn-dir-dim">{formatCount(region.count)}</span>
+                </li>
+              ))}
+              {country.regions.length > 6 && (
+                <li>
+                  <Link href={countryPath(country.iso2)}>
+                    and {country.regions.length - 6} more
+                  </Link>
+                </li>
+              )}
+            </ul>
+          </li>
+        ))}
+      </ul>
+
+      <p className="tn-dir-note">
+        Prefer the map? <Link href="/app">Open the console</Link> to see these cameras alongside
+        flights, earthquakes and the other live layers.
+      </p>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -562,6 +562,39 @@ a { color: var(--tn-accent); }
 .camera-detail dt { color: var(--tn-text-faint); }
 .attribution { font-size: 12px; color: var(--tn-text-muted); }
 
+/* ===================== Crawlable camera directory (/cameras) =====================
+   These pages sit OUTSIDE the .tn-terminal skin, so plain class selectors are safe
+   here - the specificity trap documented at the foot of this file applies only to
+   things the terminal also styles. Sizing is done with clamp() and auto-fill grids
+   rather than media queries, for the same reason: a media query adds no specificity
+   and is easy to lose. */
+.tn-dir { max-width: 940px; margin: 0 auto; padding: clamp(16px, 4vw, 32px); color: var(--tn-text); }
+.tn-dir h1 { font-size: clamp(22px, 4vw, 30px); line-height: 1.2; margin: 0 0 12px; text-wrap: balance; }
+.tn-dir h2 { font-size: 16px; margin: 0 0 4px; }
+.tn-dir-crumbs { font-size: 13px; color: var(--tn-text-muted); margin-bottom: 18px; }
+.tn-dir-crumbs a { color: var(--tn-text-muted); }
+.tn-dir-lede { font-size: 15px; line-height: 1.6; margin: 0 0 12px; max-width: 62ch; }
+.tn-dir-note { font-size: 13px; color: var(--tn-text-muted); line-height: 1.6; margin: 18px 0 0; max-width: 66ch; }
+.tn-dir-count { font-size: 13px; color: var(--tn-text-muted); margin: 0 0 8px; }
+.tn-dir-dim { color: var(--tn-text-faint); font-size: 12px; }
+.tn-dir-down { color: var(--tn-warn, #92600f); font-size: 12px; }
+
+.tn-dir-grid { list-style: none; padding: 0; margin: 22px 0 0; display: grid; gap: 14px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.tn-dir-card { border: 1px solid var(--tn-border); border-radius: 8px; padding: 14px; background: var(--tn-surface); }
+.tn-dir-sub { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 3px; font-size: 13px; }
+
+.tn-dir-regions { list-style: none; padding: 0; margin: 22px 0 0; display: grid; gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); }
+.tn-dir-regions li { display: flex; justify-content: space-between; gap: 10px; align-items: baseline;
+  border-bottom: 1px solid var(--tn-border); padding-bottom: 6px; }
+
+.tn-dir-cams { list-style: none; padding: 0; margin: 22px 0 0; display: grid; gap: 6px;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); font-size: 14px; }
+.tn-dir-cams li { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+
+.tn-dir-pager { display: flex; gap: 16px; align-items: center; margin-top: 24px; font-size: 14px; }
+
 /* ===================== Share button (deep links) ===================== */
 .tn-share-btn { font-size: 12px; font-weight: 600; padding: 0 10px; white-space: nowrap; }
 .tn-share-btn.is-copied { color: var(--tn-live); border-color: var(--tn-live); }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,57 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/lib/brand";
+
+/**
+ * There was no robots policy at all: `/robots.txt` returned 404 on production, so
+ * nothing pointed a crawler at the sitemap and nothing kept preview deployments out
+ * of the index.
+ *
+ * Route Segment Config note: this is a static file, generated at build time. It
+ * therefore reads the environment of the BUILD, which is the correct scope - a
+ * preview build should ship a preview robots.txt.
+ */
+export default function robots(): MetadataRoute.Robots {
+  const origin = siteUrl();
+
+  // Every non-production deployment gets a blanket refusal. Preview URLs carry a
+  // byte-identical copy of the whole site, and an indexed preview competes with
+  // production for the same queries as duplicate content. VERCEL_ENV is absent
+  // outside Vercel (local dev), where the file is not served to anyone anyway, so
+  // the default has to be "allow" - defaulting to noindex would risk silently
+  // deindexing production if the variable ever went missing.
+  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production") {
+    return { rules: [{ userAgent: "*", disallow: "/" }] };
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: [
+          "/",
+          // The OG card endpoint must stay crawlable or social previews break:
+          // Twitterbot and facebookexternalhit obey robots.txt, and a blocked card
+          // image renders as an empty box. Google resolves competing rules by
+          // longest match, so this beats the "/api/" line below.
+          "/api/og",
+        ],
+        disallow: [
+          // Internal JSON handlers. Nothing here is a landing page, and several are
+          // expensive to serve.
+          "/api/",
+          // Deliberate, and not only a crawl-budget decision: /api/proxy and
+          // /api/hls re-serve THIRD-PARTY camera imagery that arrives with its own
+          // licence and attribution obligations (TfL OGL, Windy, the DOT feeds).
+          // Letting a search engine index and redistribute those frames is a claim
+          // about redistribution rights we have not established, so we do not make
+          // it. The consequence is no image-search presence for camera frames.
+          "/api/proxy",
+          "/api/hls",
+          "/api/webcam-image",
+        ],
+      },
+    ],
+    sitemap: `${origin}/sitemap.xml`,
+    host: origin,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/lib/brand";
+import { getRegistry } from "@/lib/sources/registry";
+import { buildSitemap } from "@/lib/seo/directory";
+
+/**
+ * Regenerated daily rather than pinned at build time. The registry is a live thing:
+ * feeds come and go, cameras appear, and `available` flips on its own. A sitemap
+ * frozen at the last deploy would keep advertising cameras that have since gone and
+ * would never mention the ones that arrived.
+ */
+export const revalidate = 86_400;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const origin = siteUrl();
+
+  // Dormant-safe, matching the convention every adapter in this repo follows: a
+  // failed registry must not fail the build or serve a 5xx. A sitemap listing only
+  // the static pages is a degraded answer; a broken deploy is not an answer at all.
+  let cameras: Awaited<ReturnType<typeof getRegistry>> = [];
+  try {
+    cameras = await getRegistry();
+  } catch (err) {
+    console.warn("[sitemap] camera registry unavailable, emitting static pages only:", err);
+  }
+
+  const result = buildSitemap(cameras, origin, ["/app", "/locate"]);
+
+  // No silent caps. If either of these ever prints, the single-file design has been
+  // outgrown and the fix is generateSitemaps(), not a larger constant.
+  if (result.dropped > 0) {
+    console.warn(
+      `[sitemap] ${result.total} URLs exceeds the per-file protocol limit; ${result.dropped} were dropped. Split with generateSitemaps().`,
+    );
+  }
+  console.info(
+    `[sitemap] ${result.entries.length} URLs from ${cameras.length} cameras (${result.skippedUnavailable} unavailable, not advertised)`,
+  );
+
+  return result.entries;
+}

--- a/lib/seo/directory.ts
+++ b/lib/seo/directory.ts
@@ -1,0 +1,216 @@
+// Grouping and sitemap assembly for the camera directory.
+//
+// The registry is a flat array of ~20k cameras. A crawler needs a path to each one,
+// and no page should carry twenty thousand links, so this builds the three-level
+// hierarchy the route files render:
+//
+//     /cameras  ->  /cameras/gb  ->  /cameras/gb/london  ->  /camera/tfl%3A...
+//
+// Measured against prod on 2026-08-14: 20,246 cameras, 8 countries, 39 distinct
+// country/region groups, every camera carrying a region. The largest single region
+// is US/Florida at 4,838, which is why region pages paginate.
+//
+// Pure module. No fetching, no Next imports.
+
+import type { Camera } from "@/lib/types";
+import {
+  REGION_PAGE_SIZE,
+  SITEMAP_MAX_URLS,
+  absoluteUrl,
+  cameraPath,
+  countryName,
+  countryPath,
+  regionPageCount,
+  regionPath,
+  slugify,
+} from "@/lib/seo/paths";
+
+export interface RegionGroup {
+  /** The region string exactly as the upstream feed gave it. */
+  region: string;
+  slug: string;
+  count: number;
+  pages: number;
+}
+
+export interface CountryGroup {
+  iso2: string;
+  name: string;
+  count: number;
+  regions: RegionGroup[];
+}
+
+/**
+ * Stable ordering for anything paginated.
+ *
+ * Pagination that reshuffles between requests shows a crawler different content at
+ * the same URL on every visit, which is worse than not paginating at all. Name is
+ * the human-meaningful key and id is the tiebreak that makes it total.
+ */
+function byNameThenId(a: Camera, b: Camera): number {
+  return a.name.localeCompare(b.name, "en") || a.id.localeCompare(b.id);
+}
+
+/** Countries by size (biggest first), each with its regions A-Z. */
+export function groupByCountry(cameras: Camera[]): CountryGroup[] {
+  const countries = new Map<string, Map<string, number>>();
+
+  for (const cam of cameras) {
+    const iso2 = cam.country.toUpperCase();
+    const region = cam.region?.trim() || countryName(iso2);
+    const regions = countries.get(iso2) ?? new Map<string, number>();
+    regions.set(region, (regions.get(region) ?? 0) + 1);
+    countries.set(iso2, regions);
+  }
+
+  return [...countries]
+    .map(([iso2, regions]) => ({
+      iso2,
+      name: countryName(iso2),
+      count: [...regions.values()].reduce((a, b) => a + b, 0),
+      regions: [...regions]
+        .map(([region, count]) => ({
+          region,
+          slug: slugify(region),
+          count,
+          pages: regionPageCount(count),
+        }))
+        .sort((a, b) => a.region.localeCompare(b.region, "en")),
+    }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "en"));
+}
+
+/** Every camera in a country, sorted stably. `iso2` may be upper or lower case. */
+export function camerasInCountry(cameras: Camera[], iso2: string): Camera[] {
+  const want = iso2.toUpperCase();
+  return cameras.filter((c) => c.country.toUpperCase() === want).sort(byNameThenId);
+}
+
+/**
+ * Every camera in one region of one country, matched by SLUG.
+ *
+ * Returns the canonical region string alongside, because the slug is lossy and the
+ * page heading must show the upstream's own words ("Lower Mainland", not
+ * "lower-mainland"). Null when the slug matches nothing, which the route turns into
+ * a 404 rather than an empty page.
+ */
+export function camerasInRegion(
+  cameras: Camera[],
+  iso2: string,
+  regionSlug: string,
+): { region: string; cameras: Camera[] } | null {
+  const inCountry = camerasInCountry(cameras, iso2);
+  const wanted = regionSlug.toLowerCase();
+  const matched = inCountry.filter((c) => slugify(c.region?.trim() || countryName(iso2)) === wanted);
+  if (matched.length === 0) return null;
+  return { region: matched[0].region?.trim() || countryName(iso2), cameras: matched };
+}
+
+/** One page of a sorted list. `page` is 1-based; out-of-range gives an empty slice. */
+export function pageSlice<T>(items: T[], page: number, size = REGION_PAGE_SIZE): T[] {
+  return items.slice((page - 1) * size, page * size);
+}
+
+/**
+ * Detects two different region names that slugify to the same URL.
+ *
+ * If it ever returns a non-empty array, two regions are fighting over one page and
+ * whichever sorts first silently swallows the other's cameras. A unit test asserts
+ * this is empty for a representative set; the real defence is that it is cheap to
+ * re-run against live data.
+ */
+export function slugCollisions(cameras: Camera[]): { iso2: string; slug: string; regions: string[] }[] {
+  const seen = new Map<string, Set<string>>();
+  for (const cam of cameras) {
+    const iso2 = cam.country.toUpperCase();
+    const region = cam.region?.trim() || countryName(iso2);
+    const key = `${iso2}/${slugify(region)}`;
+    const set = seen.get(key) ?? new Set<string>();
+    set.add(region);
+    seen.set(key, set);
+  }
+  return [...seen]
+    .filter(([, regions]) => regions.size > 1)
+    .map(([key, regions]) => {
+      const [iso2, slug] = key.split("/");
+      return { iso2, slug, regions: [...regions].sort() };
+    });
+}
+
+export type ChangeFrequency = "always" | "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "never";
+
+export interface SitemapEntry {
+  url: string;
+  lastModified?: Date;
+  changeFrequency?: ChangeFrequency;
+  priority?: number;
+}
+
+export interface SitemapResult {
+  entries: SitemapEntry[];
+  /** How many URLs we wanted to publish, before any cap. */
+  total: number;
+  /** How many the protocol limit forced us to drop. Zero is the expected value. */
+  dropped: number;
+  /** Cameras left out because they are currently unavailable. */
+  skippedUnavailable: number;
+}
+
+/**
+ * Assembles the whole sitemap.
+ *
+ * Two deliberate choices worth knowing about:
+ *
+ * 1. **Unavailable cameras are left out.** A sitemap is an invitation to crawl, and
+ *    inviting a crawler to a page whose whole point is a picture that is not loading
+ *    earns a thin-content impression we only get to make once. They stay linked in
+ *    the directory, so they are still reachable and the coverage numbers stay honest
+ *    - they are simply not advertised. `available` flips back on its own, and the
+ *    sitemap revalidates daily, so this self-heals with no intervention.
+ *
+ * 2. **No `lastModified` on a camera unless the feed told us one.** Stamping every
+ *    entry with "now" claims twenty thousand pages changed today, every day, which
+ *    is noise a crawler learns to discount. `changeFrequency` already carries the
+ *    "this image is always moving" fact.
+ */
+export function buildSitemap(cameras: Camera[], origin: string, staticPaths: string[] = []): SitemapResult {
+  const abs = (p: string) => absoluteUrl(origin, p);
+  const entries: SitemapEntry[] = [];
+
+  entries.push({ url: abs("/"), changeFrequency: "hourly", priority: 1 });
+  for (const path of staticPaths) {
+    entries.push({ url: abs(path), changeFrequency: "weekly", priority: 0.6 });
+  }
+  entries.push({ url: abs("/cameras"), changeFrequency: "daily", priority: 0.8 });
+
+  const groups = groupByCountry(cameras);
+  for (const country of groups) {
+    entries.push({ url: abs(countryPath(country.iso2)), changeFrequency: "daily", priority: 0.7 });
+    for (const region of country.regions) {
+      for (let page = 1; page <= region.pages; page++) {
+        entries.push({
+          url: abs(regionPath(country.iso2, region.region, page)),
+          changeFrequency: "daily",
+          priority: page === 1 ? 0.6 : 0.4,
+        });
+      }
+    }
+  }
+
+  const publishable = cameras.filter((c) => c.available);
+  const skippedUnavailable = cameras.length - publishable.length;
+
+  for (const cam of [...publishable].sort(byNameThenId)) {
+    const sampled = cam.lastSampledAt ? new Date(cam.lastSampledAt) : undefined;
+    entries.push({
+      url: abs(cameraPath(cam.id)),
+      lastModified: sampled && !Number.isNaN(sampled.getTime()) ? sampled : undefined,
+      changeFrequency: "hourly",
+      priority: 0.5,
+    });
+  }
+
+  const total = entries.length;
+  const dropped = Math.max(0, total - SITEMAP_MAX_URLS);
+  return { entries: dropped ? entries.slice(0, SITEMAP_MAX_URLS) : entries, total, dropped, skippedUnavailable };
+}

--- a/lib/seo/paths.ts
+++ b/lib/seo/paths.ts
@@ -1,0 +1,174 @@
+// URL shapes and human-readable copy for the crawlable camera directory.
+//
+// WHY THIS EXISTS: `app/camera/[id]/page.tsx` has always rendered a real, useful,
+// server-rendered page per camera - live frame, place, operator, refresh cadence,
+// nearest neighbours - and roughly twenty thousand of them were unreachable. There
+// was no sitemap, no robots policy, no per-page metadata, and the only link into
+// them came from a CLIENT component inside the console, which a crawler never runs.
+// So every camera page was an orphan. This module is the pure half of the fix: URL
+// shapes, slugs and page copy, kept out of the route files so they can be tested.
+//
+// Everything here is pure. The route files supply the data.
+
+import type { Camera } from "@/lib/types";
+import { COUNTRY_CENTROIDS } from "@/lib/signals/country-centroids.data";
+import { BRAND } from "@/lib/brand";
+
+/**
+ * Hard limit on URLs in a single sitemap file, from the sitemaps.org protocol.
+ * We are at ~20.3k today and one file is correct; `buildSitemap` reports when a cap
+ * bites rather than truncating quietly, and a unit test fails the build if the
+ * projected total ever approaches this. Splitting via `generateSitemaps` is the fix
+ * at that point, not a bigger number here.
+ */
+export const SITEMAP_MAX_URLS = 50_000;
+
+/** Camera links rendered on one region page before it paginates. */
+export const REGION_PAGE_SIZE = 500;
+
+/** ISO-3166 alpha-2 -> display name, from the centroid table already in the repo. */
+const COUNTRY_NAMES = new Map(COUNTRY_CENTROIDS.map((c) => [c.iso2.toUpperCase(), c.name]));
+
+/**
+ * Letters that carry meaning rather than an accent, so NFD leaves them intact and
+ * stripping combining marks never reaches them. Keyed by CODEPOINT rather than by
+ * the literal character: this file passes through enough tooling that a raw
+ * non-ASCII source literal is a real hazard, and a mangled key here would fail
+ * silently as a wrong slug rather than loudly as a syntax error.
+ */
+const FOLD = new Map<number, string>([
+  [0x00d8, "o"],  // O with stroke
+  [0x00f8, "o"],  // o with stroke
+  [0x00d0, "d"],  // Eth
+  [0x00f0, "d"],  // eth
+  [0x00de, "th"], // Thorn
+  [0x00fe, "th"], // thorn
+  [0x00c6, "ae"], // AE
+  [0x00e6, "ae"], // ae
+  [0x00df, "ss"], // sharp s
+  [0x0141, "l"],  // L with stroke
+  [0x0142, "l"],  // l with stroke
+]);
+
+/** Unicode "combining diacritical marks" block, which NFD splits accents into. */
+const COMBINING_FIRST = 0x0300;
+const COMBINING_LAST = 0x036f;
+
+/**
+ * URL-safe slug.
+ *
+ * Accents are folded rather than deleted, so Icelandic and Nordic region names stay
+ * readable instead of collapsing into punctuation: naively dropping non-ASCII turns
+ * an eth into nothing and "Sudurland" into "su-urland", which is a different, uglier
+ * and unguessable URL. Decomposition handles accented Latin letters; the FOLD table
+ * handles the ones decomposition cannot.
+ */
+export function slugify(value: string): string {
+  let out = "";
+  for (const ch of value.normalize("NFD")) {
+    const cp = ch.codePointAt(0) as number;
+    if (cp >= COMBINING_FIRST && cp <= COMBINING_LAST) continue;
+    out += FOLD.get(cp) ?? ch;
+  }
+  return out
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Display name for a country code; falls back to the code so nothing renders blank. */
+export function countryName(iso2: string): string {
+  return COUNTRY_NAMES.get(iso2.toUpperCase()) ?? iso2.toUpperCase();
+}
+
+/**
+ * Canonical path for one camera.
+ *
+ * The id is `${source}:${nativeId}`, and the console has always linked it
+ * percent-encoded. Next also serves the raw-colon form, which is the same page at a
+ * second URL - a duplicate. Every link we emit, plus the `canonical` on the page
+ * itself, uses this one shape so there is a single answer.
+ */
+export function cameraPath(id: string): string {
+  return `/camera/${encodeURIComponent(id)}`;
+}
+
+/** Directory root. */
+export const CAMERAS_ROOT = "/cameras";
+
+export function countryPath(iso2: string): string {
+  return `${CAMERAS_ROOT}/${iso2.toLowerCase()}`;
+}
+
+/** Region listing. Page 1 is the bare path, so it has exactly one URL and not two. */
+export function regionPath(iso2: string, region: string, page = 1): string {
+  const base = `${countryPath(iso2)}/${slugify(region)}`;
+  return page > 1 ? `${base}/${page}` : base;
+}
+
+/** Absolute URL against a known origin, for sitemap entries and canonicals. */
+export function absoluteUrl(origin: string, path: string): string {
+  return `${origin.replace(/\/+$/, "")}${path}`;
+}
+
+/** How many pages a region of `count` cameras needs (always at least 1). */
+export function regionPageCount(count: number, pageSize = REGION_PAGE_SIZE): number {
+  return Math.max(1, Math.ceil(count / pageSize));
+}
+
+/** "London, United Kingdom" - the place line reused across titles and headings. */
+export function placeLabel(cam: Pick<Camera, "region" | "country">): string {
+  const country = countryName(cam.country);
+  return cam.region ? `${cam.region}, ${country}` : country;
+}
+
+/**
+ * The <title>. There is no title template on the root layout, so this returns the
+ * complete string including the brand suffix.
+ *
+ * Shape is deliberate: the camera's own name first (the distinguishing part, and the
+ * part a search result is scanned for), then what the page IS, then where. Twenty
+ * thousand pages sharing one site-wide title was the single biggest reason none of
+ * them could rank - to a crawler they were duplicates of one another.
+ */
+export function cameraTitle(cam: Pick<Camera, "name" | "region" | "country">): string {
+  return `${cam.name} - live traffic camera, ${placeLabel(cam)} | ${BRAND.name}`;
+}
+
+/**
+ * The meta description, and the sentence an answer engine is most likely to lift.
+ *
+ * Written to survive being quoted with no surrounding page: it names the camera, the
+ * place, the operator and the cadence, and it never says "this feed" or "as above".
+ * Nothing in it is a claim we cannot back - the cadence is the camera's declared
+ * `refreshSeconds`, and the operator is its own required attribution string.
+ */
+export function cameraDescription(
+  cam: Pick<Camera, "name" | "region" | "country" | "refreshSeconds" | "attribution">,
+): string {
+  return (
+    `Live view from the ${cam.name} traffic camera in ${placeLabel(cam)}. ` +
+    `The image refreshes ${describeCadence(cam.refreshSeconds)}, direct from ${cam.attribution}.`
+  );
+}
+
+/** "every 30 seconds" / "every 5 minutes" - plain English, never a bare integer. */
+export function describeCadence(seconds: number): string {
+  if (seconds < 60) return `every ${Math.round(seconds)} seconds`;
+  const mins = Math.round(seconds / 60);
+  return mins === 1 ? "every minute" : `every ${mins} minutes`;
+}
+
+/** Thousands-separated count, so "4838 cameras" never appears in a title. */
+export function formatCount(n: number): string {
+  return n.toLocaleString("en-GB");
+}
+
+export function countryTitle(iso2: string, count: number): string {
+  return `Live traffic cameras in ${countryName(iso2)} (${formatCount(count)}) | ${BRAND.name}`;
+}
+
+export function regionTitle(iso2: string, region: string, count: number, page: number): string {
+  const suffix = page > 1 ? ` - page ${page}` : "";
+  return `Live traffic cameras in ${region}, ${countryName(iso2)} (${formatCount(count)})${suffix} | ${BRAND.name}`;
+}

--- a/tests/unit/seo.test.ts
+++ b/tests/unit/seo.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect } from "vitest";
+import type { Camera } from "@/lib/types";
+import {
+  REGION_PAGE_SIZE,
+  SITEMAP_MAX_URLS,
+  absoluteUrl,
+  cameraDescription,
+  cameraPath,
+  cameraTitle,
+  countryName,
+  countryPath,
+  countryTitle,
+  describeCadence,
+  placeLabel,
+  regionPageCount,
+  regionPath,
+  regionTitle,
+  slugify,
+} from "@/lib/seo/paths";
+import {
+  buildSitemap,
+  camerasInCountry,
+  camerasInRegion,
+  groupByCountry,
+  pageSlice,
+  slugCollisions,
+} from "@/lib/seo/directory";
+
+function cam(patch: Partial<Camera> = {}): Camera {
+  return {
+    id: "tfl:JamCams_00002.00865",
+    source: "tfl",
+    country: "GB",
+    region: "London",
+    name: "A406 Billet Upass E",
+    lat: 51.60067,
+    lon: -0.01594,
+    mediaType: "jpeg",
+    refreshSeconds: 300,
+    license: "OGL",
+    attribution: "Powered by TfL Open Data",
+    available: true,
+    ...patch,
+  };
+}
+
+/** Codepoints, not literals: the source file must stay ASCII (see paths.ts FOLD). */
+const ETH = String.fromCodePoint(0x00f0);
+const A_ACUTE = String.fromCodePoint(0x00e1);
+const O_UMLAUT = String.fromCodePoint(0x00f6);
+
+describe("slugify", () => {
+  it("lowercases and hyphenates", () => {
+    expect(slugify("South Carolina")).toBe("south-carolina");
+    expect(slugify("Lower Mainland")).toBe("lower-mainland");
+  });
+
+  it("collapses runs of punctuation and trims the ends", () => {
+    expect(slugify("  A406 / Billet  Upass (E)  ")).toBe("a406-billet-upass-e");
+  });
+
+  it("folds accents to their base letter rather than deleting them", () => {
+    // Deleting instead of folding turns this into "su-urland", a different URL.
+    expect(slugify(`Su${ETH}urland`)).toBe("sudurland");
+    expect(slugify(`H${A_ACUTE}${O_UMLAUT}n`)).toBe("haon");
+  });
+
+  it("is idempotent, so a slug re-slugified is unchanged", () => {
+    const once = slugify("Lower Mainland");
+    expect(slugify(once)).toBe(once);
+  });
+
+  it("returns an empty string when there is nothing sluggable", () => {
+    expect(slugify("---")).toBe("");
+  });
+});
+
+describe("paths", () => {
+  it("percent-encodes the colon in a camera id, giving one canonical shape", () => {
+    expect(cameraPath("tfl:JamCams_1")).toBe("/camera/tfl%3AJamCams_1");
+  });
+
+  it("puts page 1 at the bare region path so it does not exist at two URLs", () => {
+    expect(regionPath("US", "Florida")).toBe("/cameras/us/florida");
+    expect(regionPath("US", "Florida", 1)).toBe("/cameras/us/florida");
+    expect(regionPath("US", "Florida", 2)).toBe("/cameras/us/florida/2");
+  });
+
+  it("lower-cases the country segment", () => {
+    expect(countryPath("GB")).toBe("/cameras/gb");
+  });
+
+  it("joins an origin without doubling the slash", () => {
+    expect(absoluteUrl("https://example.com/", "/cameras")).toBe("https://example.com/cameras");
+    expect(absoluteUrl("https://example.com", "/cameras")).toBe("https://example.com/cameras");
+  });
+
+  it("counts region pages, never returning zero for an empty region", () => {
+    expect(regionPageCount(0)).toBe(1);
+    expect(regionPageCount(1)).toBe(1);
+    expect(regionPageCount(REGION_PAGE_SIZE)).toBe(1);
+    expect(regionPageCount(REGION_PAGE_SIZE + 1)).toBe(2);
+    expect(regionPageCount(4838, 500)).toBe(10);
+  });
+
+  it("resolves country names from the shared centroid table, falling back to the code", () => {
+    expect(countryName("GB")).toBe("United Kingdom");
+    expect(countryName("br")).toBe("Brazil");
+    expect(countryName("ZZ")).toBe("ZZ");
+  });
+});
+
+describe("page copy", () => {
+  it("leads the title with the camera's own name, then the place", () => {
+    const t = cameraTitle(cam());
+    expect(t.startsWith("A406 Billet Upass E - live traffic camera, London, United Kingdom")).toBe(true);
+    expect(t).toContain("Provenance");
+  });
+
+  it("gives two different cameras two different titles", () => {
+    // The whole point: 20k pages previously shared one site-wide title.
+    expect(cameraTitle(cam())).not.toBe(cameraTitle(cam({ name: "M4 J4b", region: "Berkshire" })));
+  });
+
+  it("writes a description that stands alone when quoted out of context", () => {
+    const d = cameraDescription(cam());
+    expect(d).toContain("A406 Billet Upass E");
+    expect(d).toContain("London, United Kingdom");
+    expect(d).toContain("every 5 minutes");
+    expect(d).toContain("Powered by TfL Open Data");
+    // No unresolved back-references - the failure mode that makes a page unquotable.
+    expect(d).not.toMatch(/\bthis feed\b|\bas above\b|\bthe above\b/i);
+  });
+
+  it("says cadence in plain English", () => {
+    expect(describeCadence(30)).toBe("every 30 seconds");
+    expect(describeCadence(60)).toBe("every minute");
+    expect(describeCadence(300)).toBe("every 5 minutes");
+  });
+
+  it("falls back to the country alone when a camera has no region", () => {
+    expect(placeLabel({ region: undefined, country: "IS" })).toBe("Iceland");
+  });
+
+  it("thousands-separates counts in country and region titles", () => {
+    expect(countryTitle("US", 14989)).toContain("(14,989)");
+    expect(regionTitle("US", "Florida", 4838, 1)).toContain("(4,838)");
+    expect(regionTitle("US", "Florida", 4838, 1)).not.toContain("page");
+    expect(regionTitle("US", "Florida", 4838, 3)).toContain("page 3");
+  });
+});
+
+describe("grouping", () => {
+  const fleet = [
+    cam({ id: "a", country: "GB", region: "London", name: "B" }),
+    cam({ id: "b", country: "GB", region: "London", name: "A" }),
+    cam({ id: "c", country: "GB", region: "Scotland", name: "C" }),
+    cam({ id: "d", country: "US", region: "Florida", name: "D" }),
+    cam({ id: "e", country: "US", region: "Florida", name: "E" }),
+    cam({ id: "f", country: "US", region: "Georgia", name: "F" }),
+    cam({ id: "g", country: "US", region: "Georgia", name: "G" }),
+  ];
+
+  it("orders countries by size and regions alphabetically", () => {
+    const groups = groupByCountry(fleet);
+    expect(groups.map((g) => g.iso2)).toEqual(["US", "GB"]);
+    expect(groups[0].count).toBe(4);
+    expect(groups[1].regions.map((r) => r.region)).toEqual(["London", "Scotland"]);
+  });
+
+  it("carries the slug and page count on every region", () => {
+    const gb = groupByCountry(fleet).find((g) => g.iso2 === "GB")!;
+    const london = gb.regions.find((r) => r.region === "London")!;
+    expect(london.slug).toBe("london");
+    expect(london.count).toBe(2);
+    expect(london.pages).toBe(1);
+  });
+
+  it("matches a region by slug and reports the upstream's own wording", () => {
+    const hit = camerasInRegion(fleet, "gb", "london");
+    expect(hit?.region).toBe("London");
+    expect(hit?.cameras.map((c) => c.name)).toEqual(["A", "B"]);
+  });
+
+  it("returns null for a slug that matches nothing, so the route can 404", () => {
+    expect(camerasInRegion(fleet, "gb", "atlantis")).toBeNull();
+    expect(camerasInRegion(fleet, "zz", "london")).toBeNull();
+  });
+
+  it("sorts a country's cameras stably regardless of input order", () => {
+    const forward = camerasInCountry(fleet, "US").map((c) => c.id);
+    const backward = camerasInCountry([...fleet].reverse(), "US").map((c) => c.id);
+    expect(forward).toEqual(backward);
+  });
+
+  it("slices pages 1-based", () => {
+    expect(pageSlice([1, 2, 3, 4, 5], 1, 2)).toEqual([1, 2]);
+    expect(pageSlice([1, 2, 3, 4, 5], 3, 2)).toEqual([5]);
+    expect(pageSlice([1, 2, 3, 4, 5], 9, 2)).toEqual([]);
+  });
+
+  it("reports two region names that would fight over one URL", () => {
+    const clash = [
+      cam({ id: "x", country: "US", region: "New York" }),
+      cam({ id: "y", country: "US", region: "new-york" }),
+    ];
+    expect(slugCollisions(clash)).toEqual([
+      { iso2: "US", slug: "new-york", regions: ["New York", "new-york"] },
+    ]);
+    expect(slugCollisions(fleet)).toEqual([]);
+  });
+});
+
+describe("buildSitemap", () => {
+  const fleet = [
+    cam({ id: "a", country: "GB", region: "London", name: "A" }),
+    cam({ id: "b", country: "GB", region: "London", name: "B" }),
+    cam({ id: "c", country: "US", region: "Florida", name: "C" }),
+  ];
+  const ORIGIN = "https://example.com";
+
+  it("includes the root, the directory, every country and every region", () => {
+    const urls = buildSitemap(fleet, ORIGIN, ["/app"]).entries.map((e) => e.url);
+    expect(urls).toContain("https://example.com/");
+    expect(urls).toContain("https://example.com/app");
+    expect(urls).toContain("https://example.com/cameras");
+    expect(urls).toContain("https://example.com/cameras/gb");
+    expect(urls).toContain("https://example.com/cameras/us");
+    expect(urls).toContain("https://example.com/cameras/gb/london");
+    expect(urls).toContain("https://example.com/cameras/us/florida");
+  });
+
+  it("includes one entry per available camera, canonically encoded", () => {
+    const urls = buildSitemap(fleet, ORIGIN).entries.map((e) => e.url);
+    expect(urls).toContain("https://example.com/camera/a");
+    expect(urls.filter((u) => u.startsWith("https://example.com/camera/"))).toHaveLength(3);
+  });
+
+  it("leaves unavailable cameras out and says how many", () => {
+    const withDead = [...fleet, cam({ id: "dead", available: false, name: "Z" })];
+    const result = buildSitemap(withDead, ORIGIN);
+    expect(result.skippedUnavailable).toBe(1);
+    expect(result.entries.map((e) => e.url)).not.toContain("https://example.com/camera/dead");
+  });
+
+  it("only stamps lastModified when the feed actually told us one", () => {
+    const stamped = buildSitemap(
+      [cam({ id: "s", lastSampledAt: "2026-08-14T10:00:00.000Z" }), cam({ id: "u", name: "U" })],
+      ORIGIN,
+    );
+    const byUrl = new Map(stamped.entries.map((e) => [e.url, e]));
+    expect(byUrl.get("https://example.com/camera/s")?.lastModified?.toISOString()).toBe(
+      "2026-08-14T10:00:00.000Z",
+    );
+    expect(byUrl.get("https://example.com/camera/u")?.lastModified).toBeUndefined();
+  });
+
+  it("ignores an unparseable lastSampledAt rather than emitting Invalid Date", () => {
+    const result = buildSitemap([cam({ id: "bad", lastSampledAt: "not a date" })], ORIGIN);
+    const entry = result.entries.find((e) => e.url.endsWith("/camera/bad"));
+    expect(entry?.lastModified).toBeUndefined();
+  });
+
+  it("emits a page URL for every page of a paginated region", () => {
+    const big = Array.from({ length: REGION_PAGE_SIZE * 2 + 1 }, (_, i) =>
+      cam({ id: `big-${i}`, country: "US", region: "Florida", name: `C${i}` }),
+    );
+    const urls = buildSitemap(big, ORIGIN).entries.map((e) => e.url);
+    expect(urls).toContain("https://example.com/cameras/us/florida");
+    expect(urls).toContain("https://example.com/cameras/us/florida/2");
+    expect(urls).toContain("https://example.com/cameras/us/florida/3");
+    expect(urls).not.toContain("https://example.com/cameras/us/florida/4");
+  });
+
+  it("produces the same camera order however the registry was ordered", () => {
+    const a = buildSitemap(fleet, ORIGIN).entries.map((e) => e.url);
+    const b = buildSitemap([...fleet].reverse(), ORIGIN).entries.map((e) => e.url);
+    expect(a).toEqual(b);
+  });
+
+  it("stays inside one sitemap file at today's scale, with headroom", () => {
+    // Measured on prod 2026-08-14: 20,246 cameras -> ~20.3k URLs. This asserts the
+    // single-file design is still correct and fails loudly, well before the protocol
+    // limit, if the registry grows into needing generateSitemaps().
+    const fleetSize = 25_000;
+    const many = Array.from({ length: fleetSize }, (_, i) =>
+      cam({ id: `c-${i}`, country: "US", region: `R${i % 40}`, name: `C${i}` }),
+    );
+    const result = buildSitemap(many, ORIGIN);
+    expect(result.dropped).toBe(0);
+    expect(result.total).toBeLessThan(SITEMAP_MAX_URLS);
+  });
+
+  it("reports a cap rather than truncating in silence", () => {
+    // No silent caps: if the limit ever bites, the count says so.
+    const over = Array.from({ length: SITEMAP_MAX_URLS + 10 }, (_, i) =>
+      cam({ id: `o-${i}`, country: "US", region: "Florida", name: `C${i}` }),
+    );
+    const result = buildSitemap(over, ORIGIN);
+    expect(result.dropped).toBeGreaterThan(0);
+    expect(result.entries).toHaveLength(SITEMAP_MAX_URLS);
+    expect(result.total).toBeGreaterThan(SITEMAP_MAX_URLS);
+  });
+});


### PR DESCRIPTION
## The problem

`app/camera/[id]/page.tsx` has always rendered a real, useful page per camera: the live frame, the place, the operator, the refresh cadence, and the nearest neighbours. Roughly twenty thousand of them, and every one was invisible to a search engine.

Four reasons, all checked against this branch's parent and against prod:

| Blocker | Evidence |
|---|---|
| No sitemap | `app/sitemap.ts` did not exist |
| No robots policy | prod `/robots.txt` returned **404** |
| No per-page metadata | no `generateMetadata`, so ~20k pages shared one site-wide title and description |
| Orphaned | the only link in was `components/CameraDetail.tsx:61`, a **client** component inside the console, which a crawler never executes |

Plus `export const dynamic = "force-dynamic"` on the route, and no canonical while Next serves the same page for both `tfl%3Ax` and `tfl:x`.

## What this does

- **`app/robots.ts`** — allow crawling, point at the sitemap, and refuse indexing on every non-production deployment so preview URLs stop competing with production as duplicate content. `/api/og` is explicitly allowed or social cards break (Twitterbot and facebookexternalhit obey robots.txt). The image proxies stay blocked: `/api/proxy` and `/api/hls` re-serve third-party frames under their operators' own licences, and letting a search engine index and redistribute those is a claim about redistribution rights we have not established.
- **`app/sitemap.ts`** — daily `revalidate` rather than build-time-frozen, dormant-safe (a failed registry degrades to the static pages, it never fails the build), and it logs a cap rather than truncating in silence.
- **`app/cameras/**`** — a three-level crawl path, `/cameras` → `/cameras/gb` → `/cameras/gb/london` → `/camera/…`. Region pages paginate at 500; `/cameras/us/florida/1` 308s to the canonical bare path; junk trailing segments 404 instead of opening an infinite crawl space onto duplicate content. Deep pages are `noindex, follow` so the crawl path survives without the tail cluttering the index.
- **`app/camera/[id]/page.tsx`** — `generateMetadata` giving each page its own title and description built from the camera's own name, place, operator and cadence; an explicit canonical; breadcrumbs as links and as `BreadcrumbList` JSON-LD; and `force-dynamic` → `revalidate = 3600`, which is safe because the only genuinely live thing is the frame and that is fetched client-side.
- **`lib/seo/*`** — the pure half, per the repo convention that upstream→domain mappings live in tested pure functions.

## Two judgement calls

**Unavailable cameras are left out of the sitemap.** A sitemap is an invitation to crawl, and inviting one to a page whose whole point is an image that is not loading spends a first impression we get once. They stay linked in the directory, so they are still reachable and the coverage numbers stay honest — they are simply not advertised. `available` flips back on its own and the sitemap revalidates daily, so it self-heals.

**No `lastModified` on a camera unless the feed gave us one.** Stamping 20k entries with "now" every day claims everything changed every day, which a crawler learns to discount.

## No domain hardcoded

`siteUrl()` already resolves Vercel's production URL. The day a custom domain is pointed, setting `NEXT_PUBLIC_SITE_URL` updates every canonical and every sitemap URL with no code change.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **1834 passed / 234 files**, including 33 new cases
- **Break-then-fix proof** on the two guards that could have passed vacuously: disabling the unavailable-filter, and then the stable sort, each failed exactly one test and the correct one
- Pipeline probed against the **live production fleet**: 0 slug collisions, 0 empty slugs, 0 cameras without a region, 0 slug round-trip failures, 0 dropped URLs, ~0.6 MB serialised

**`npm run build` was NOT run locally.** It OOM'd, as did a dev server and eventually vitest's worker fork — the machine had 0.8 GB free of 15.4 GB with 53 node processes from concurrent worktrees. Nothing was killed. **The Vercel preview build on this PR is the build gate**; please don't merge until it's green.

Counts in this description were measured 2026-08-14 and rot, as ever.
