### PR TITLE
The 10s feed ceiling was deleting Castle Rock, not bounding it

### DIFF
--- a/lib/sources/registry.ts
+++ b/lib/sources/registry.ts
@@ -16,20 +16,40 @@ import { findById, nearest } from "@/lib/sources/select";
 const TTL_MS = 5 * 60 * 1000;
 
 /**
- * How long one upstream feed gets before its round is treated as a timeout.
- * `refresh()` used to await every feed with no ceiling, so the single slowest
- * source set the whole registry rebuild's latency — Castle Rock's ~100-request
- * pagination (see lib/sources/castlerock.ts) has been observed taking ~40s cold.
- * Every refresh() now has a hard ceiling of this value instead of "however long
- * the slowest feed takes." A feed that blows the budget is treated exactly like
- * any other failure by mergeResults: it keeps its last-good cameras and never
- * silently empties its region (see mergeResults above). This only stops US
- * WAITING on the feed — the underlying request has no AbortSignal wired through
- * `CameraFeed.fetch()`, so it keeps running server-side until it settles on its
- * own; that's a follow-up (threading an AbortSignal into each adapter), not
- * something fixable from this file alone.
+ * How long a feed gets before its round is treated as a timeout, unless it
+ * declares its own `budgetMs`. `refresh()` used to await every feed with no
+ * ceiling, so the single slowest source set the whole registry rebuild's
+ * latency; this bounds that.
+ *
+ * WHY THIS IS A DEFAULT AND NO LONGER A UNIFORM RULE. Applied to every feed
+ * alike, 10s did not bound Castle Rock — it DELETED it. That adapter pages ~143
+ * requests across nine 511 systems (see lib/sources/castlerock.ts) and its own
+ * measurements are ~18.5s warm and ~40s cold, so it lost this race on every
+ * refresh and was absent from production entirely. Not intermittently:
+ * structurally, and for as long as the ceiling was uniform.
+ *
+ * The symptom read like a network problem and was recorded as one — running the
+ * adapter DIRECTLY succeeded in 18.5s, so the deployment's egress looked
+ * refused. It was not. The ceiling lives here, in `refresh()`, not in the
+ * adapter, so a direct call never meets it. The 511 upstreams answer 200 in
+ * ~1s and refuse nobody.
+ *
+ * What the ceiling was protecting is already protected elsewhere: `getRegistry()`
+ * is stale-while-revalidate, so a warm caller gets the cached answer INSTANTLY
+ * while one shared refresh runs behind it. Only a cold call with no cache waits.
+ * So a feed that needs longer costs a slower cold start, not slower requests —
+ * and paying for it with two thirds of the camera catalogue was the worse trade.
+ *
+ * A feed that blows its budget is still treated exactly like any other failure
+ * by mergeResults: it keeps its last-good cameras and never silently empties its
+ * region. This only stops US WAITING on the feed — the underlying request has no
+ * AbortSignal wired through `CameraFeed.fetch()`, so it keeps running
+ * server-side until it settles on its own. On serverless that is ~143 abandoned
+ * requests still executing per refresh, and it is billed; threading an
+ * AbortSignal into each adapter is the fix and is a follow-up, not something
+ * this file can do alone.
  */
-const UPSTREAM_TIMEOUT_MS = 10_000;
+export const DEFAULT_UPSTREAM_TIMEOUT_MS = 10_000;
 
 /**
  * Race `promise` against a `ms` timer, rejecting with a labelled timeout error
@@ -63,6 +83,17 @@ export interface CameraFeed {
   /** Stable id, used only for last-good bookkeeping and the coverage denominator. */
   key: string;
   fetch: () => Promise<Camera[]>;
+  /**
+   * This feed's own timeout, for the rare source whose honest cost exceeds
+   * DEFAULT_UPSTREAM_TIMEOUT_MS. Omit it unless the number is MEASURED — the
+   * point of the default is that it still bounds everything else.
+   */
+  budgetMs?: number;
+}
+
+/** The budget one feed gets this round. Pure. */
+export function feedBudgetMs(feed: Pick<CameraFeed, "budgetMs">): number {
+  return feed.budgetMs ?? DEFAULT_UPSTREAM_TIMEOUT_MS;
 }
 
 const SOURCES: CameraFeed[] = [
@@ -70,7 +101,13 @@ const SOURCES: CameraFeed[] = [
   { key: "caltrans", fetch: fetchCaltrans },
   { key: "scdot", fetch: fetchScdot },
   { key: "digitraffic", fetch: fetchDigitraffic },
-  { key: "castlerock", fetch: fetchCastlerock },
+  // The one feed that needs longer than the default, and the reason the default
+  // exists rather than a uniform rule. ~143 paginated requests across nine 511
+  // systems; measured at ~18.5s warm and ~40s cold. 60s is that worst case plus
+  // headroom — not a guess, and not "big enough to be safe". See
+  // DEFAULT_UPSTREAM_TIMEOUT_MS above for why this costs a cold start and
+  // nothing else.
+  { key: "castlerock", fetch: fetchCastlerock, budgetMs: 60_000 },
   { key: "tripcheck", fetch: fetchTripcheck },
   { key: "drivebc", fetch: fetchDriveBc },
   { key: "nzta", fetch: fetchNzta },
@@ -84,6 +121,9 @@ const SOURCES: CameraFeed[] = [
 ];
 
 export const CAMERA_FEED_COUNT = SOURCES.length;
+
+/** The feed table itself, so a test can assert on the budgets we actually ship. */
+export const CAMERA_FEEDS: readonly CameraFeed[] = SOURCES;
 
 /** How the last refresh went, per feed. Published by /api/coverage. */
 export interface FeedHealth {
@@ -139,7 +179,7 @@ export function mergeResults(
 
 async function refresh(): Promise<Camera[]> {
   const results = await Promise.allSettled(
-    SOURCES.map((f) => withTimeout(f.fetch(), UPSTREAM_TIMEOUT_MS, f.key)),
+    SOURCES.map((f) => withTimeout(f.fetch(), feedBudgetMs(f), f.key)),
   );
   const merged = mergeResults(results, lastGood);
   if (merged.cameras.length === 0) {

--- a/tests/unit/cameras-feed-budget.test.ts
+++ b/tests/unit/cameras-feed-budget.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  CAMERA_FEEDS,
+  DEFAULT_UPSTREAM_TIMEOUT_MS,
+  feedBudgetMs,
+} from "@/lib/sources/registry";
+
+// Castle Rock's own docblock in lib/sources/registry.ts records it taking ~40s
+// cold, and README.md records 18.5s for a full run. A uniform 10s ceiling meant
+// it lost that race on EVERY refresh and was absent from production entirely —
+// not intermittently, structurally. These tests pin the per-feed budget so the
+// ceiling can never silently go back to killing the one feed that needs longer.
+
+describe("feedBudgetMs", () => {
+  it("gives a feed with no declared budget the shared default", () => {
+    expect(feedBudgetMs({})).toBe(DEFAULT_UPSTREAM_TIMEOUT_MS);
+  });
+
+  it("honours a feed's own budget when it declares one", () => {
+    expect(feedBudgetMs({ budgetMs: 45_000 })).toBe(45_000);
+  });
+});
+
+describe("the real feed table", () => {
+  it("gives castlerock more than its documented ~40s cold cost", () => {
+    const castlerock = CAMERA_FEEDS.find((f) => f.key === "castlerock");
+    expect(castlerock).toBeDefined();
+    expect(feedBudgetMs(castlerock!)).toBeGreaterThan(40_000);
+  });
+
+  it("leaves every other feed on the default — the ceiling still bounds them", () => {
+    const others = CAMERA_FEEDS.filter((f) => f.key !== "castlerock");
+    expect(others.length).toBeGreaterThan(0);
+    for (const feed of others) {
+      expect(feedBudgetMs(feed)).toBe(DEFAULT_UPSTREAM_TIMEOUT_MS);
+    }
+  });
+});


### PR DESCRIPTION
## What

`refresh()` gave every camera feed the same 10s budget. Castle Rock cannot finish in 10s and never could, so it has been absent from production entirely. Budget is now **per-feed**, the 10s default is unchanged for the other eleven feeds, and Castle Rock declares 60s.

## Why the recorded cause was wrong

`README.md` records this as "the deployment's egress being refused". It is not. Measured live, sending exactly the POST the adapter sends:

| Site | Result |
|---|---|
| `fl511.com` | 200 in 1.07s, recordsTotal 4838 |
| `511on.ca` | 200 in 1.01s, recordsTotal 948 |
| `511ny.org` | 500 in 3.03s (the adapter's own comment already anticipates NY's intermittent 500) |

The upstreams are healthy, fast, and refusing nobody.

The real cause was already in the repo, in two places that were never put side by side:

- the docblock **directly above** `UPSTREAM_TIMEOUT_MS` says Castle Rock "has been observed taking ~40s cold"
- `README.md` says the adapter fetched 10,859 cameras in 18.5s

Both are far outside a 10s ceiling. Castle Rock pages ~143 requests across nine 511 systems, so it lost that race on every refresh - not intermittently, structurally.

**Why it looked like a network problem:** the ceiling lives in `refresh()`, not in the adapter. Call the adapter directly and it succeeds in 18.5s; call it through the registry and it is abandoned at 10s. The difference was never the IP address, it was which code path the test went through. A true observation with a false explanation.

## Why raising it is safe

The ceiling's stated purpose was stopping the slowest feed from setting the whole rebuild's latency. `getRegistry()` already does that, and does it better: it is stale-while-revalidate, so a warm caller gets the cached answer **instantly** while one shared refresh runs behind it. Only a cold call with no cache waits.

So the ceiling was never protecting warm-path latency - SWR was. It only bounded the cold start, and it paid for that by permanently killing the single largest feed. A longer budget costs a slower cold start and nothing else.

## Impact

Castle Rock is roughly two thirds of the catalogue (13,436 of 20,048 when it answers). Because `sitemap.xml` is generated from whatever answered, this also cost about two thirds of the indexable camera pages - the sitemap currently carries 6,367 camera URLs and zero Castle Rock ones. So this is an SEO fix as much as a data one.

## How verified

- `npx tsc --noEmit` - clean
- `npm test` - 1,838 tests across 235 files, all passing
- New `tests/unit/cameras-feed-budget.test.ts` pins the behaviour, including a regression guard asserting Castle Rock's shipped budget exceeds its documented ~40s cold cost while every other feed stays on the default. That is the test that stops the ceiling silently going back to killing it.
- Upstream timings above measured live from a VPN'd connection, so they are an upper bound on latency, not a lower one.

## Deliberately not in this diff

`CameraFeed.fetch()` still takes no `AbortSignal`, so a feed that blows its budget keeps running server-side after nobody is listening. On serverless that is ~143 abandoned requests per refresh and **it is billed**. Threading a signal through all twelve adapters is its own change and would make this diff unreviewable.

## Note for whoever updates the docs

`README.md:32` describes this as an undiagnosed egress problem. That paragraph is now wrong and wants rewriting - I have left it alone rather than widen this PR.