### PR TITLE
Upstream-terms compliance, and prove the site to Search Console

### DIFF
--- a/app/api/advisory/route.ts
+++ b/app/api/advisory/route.ts
@@ -25,7 +25,7 @@ interface Cached {
 }
 const cache = new Map<string, Cached>();
 const TTL_MS = 6 * 60 * 60 * 1000; // the FCDO updates continuously but not by the minute
-const UA = "OpenData/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 
 export async function GET(req: Request) {
   const iso2 = (new URL(req.url).searchParams.get("iso2") ?? "").trim().toUpperCase();

--- a/app/api/planes/route.ts
+++ b/app/api/planes/route.ts
@@ -28,10 +28,17 @@ const PLANES_TTL_MS = 20_000;
 export const maxDuration = 30;
 
 /**
- * GET /api/planes — live aircraft worldwide (keyless, from OpenSky's global
- * `/states/all` snapshot) as classified WorldObjects. fetchAircraftSnapshot serves a
- * shared, stored snapshot (Next Data Cache) and handles failure (last-good / empty),
- * so this route never throws and users never trigger their own upstream pull.
+ * GET /api/planes — live aircraft (keyless, from a bounded adsb.lol grid sweep) as
+ * classified WorldObjects. fetchAircraftSnapshot serves a shared, stored snapshot
+ * (Next Data Cache) and handles failure (last-good / empty), so this route never
+ * throws and users never trigger their own upstream pull.
+ *
+ * NOT WORLDWIDE, and do not describe it as such. OpenSky's global `/states/all` was
+ * the source until it was removed on licensing grounds (lib/sources/opensky.ts,
+ * `fetchAircraftOnce`). The sweep that replaced it is dense over North America and
+ * Europe and thin elsewhere. Production had already been served entirely by the
+ * sweep for months, so the coverage did not change here — only the code's claim
+ * about it did.
  *
  * TRUNCATION HONESTY. The served set is capped at MAX_PLANES (3,000) out of a global
  * snapshot measured at 11,705 positioned aircraft, so `count` alone was the cap
@@ -52,12 +59,15 @@ export const maxDuration = 30;
  *   - too old, or never fetched → `planes: []`; `staleness: {reason, ageMs?}` when
  *     there's a reason to give (never served as if the layer were simply quiet).
  *
- * PROVENANCE. `source` names which upstream actually produced these positions:
- * `"opensky"` (worldwide, one global snapshot) or `"adsb.lol"` (a bounded grid
- * sweep of a community receiver network, dense over North America and Europe and
- * thin elsewhere). The two are NOT interchangeable in coverage, so a consumer that
- * prints a count without reading this cannot describe it correctly. Absent means no
- * snapshot was served, never "either is fine".
+ * PROVENANCE. `source` names which upstream actually produced these positions.
+ * Everything minted now is `"adsb.lol"` (a bounded grid sweep of a community
+ * receiver network, dense over North America and Europe and thin elsewhere).
+ * `"opensky"` (worldwide, one global snapshot) can still appear on a snapshot the
+ * Data Cache kept across the deploy that removed it; that is a correctly-labelled
+ * stale snapshot, not a live source, and it ages out on its own. The two are NOT
+ * interchangeable in coverage, so a consumer that prints a count without reading
+ * this cannot describe it correctly. Absent means no snapshot was served, never
+ * "either is fine".
  *
  * Response: { count, source?, coverage?, staleness?, planes }
  */

--- a/app/api/recon/bgp/route.ts
+++ b/app/api/recon/bgp/route.ts
@@ -25,7 +25,7 @@ import {
 export const revalidate = 300; // 5-minute edge cache per target
 
 const RIPESTAT = "https://stat.ripe.net/data";
-const UA = "OpenData/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 const TIMEOUT_MS = 8_000;
 
 function empty(kind: "ip" | "asn", reason: string, target: string) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,13 @@ export const metadata: Metadata = {
   title: DEFAULT_TITLE,
   description: BRAND.description,
   applicationName: BRAND.name,
+  // Google Search Console ownership proof for the URL-prefix property
+  // https://provenance-online.vercel.app/. A *domain* property is not available to
+  // us: it needs a DNS TXT record and `vercel.app` is on the Public Suffix List, so
+  // we cannot prove ownership of the zone. Removing this tag un-verifies the
+  // property and silently drops all indexing telemetry, so leave it in place even
+  // after verification succeeds.
+  verification: { google: "dzW30K7NcjXkOgxgdARj9YQ6bgR6oIIrMlfUgTu_y1s" },
   // app/manifest.ts is auto-linked by Next; this is the explicit reference.
   manifest: "/manifest.webmanifest",
   appleWebApp: { capable: true, title: BRAND.name, statusBarStyle: "default" },

--- a/components/SignalDetail.tsx
+++ b/components/SignalDetail.tsx
@@ -172,6 +172,40 @@ export default function SignalDetail({ object }: { object: WorldObject }) {
                 {s.scope === "record" ? `View record · ${s.label}` : s.label} ↗
               </a>
             ))}
+            {/*
+              Licence chips. CC BY 4.0 requires a link to the LICENCE, not just credit
+              to the provider, so a source whose terms demand it renders its deed URL
+              here. Deduped by licence URL: a layer can resolve both a record link and
+              a provider link from the same upstream, and one obligation is one chip.
+              Muted on purpose — this is a legal notice sitting beside the sources, not
+              a third place to click through to the data.
+            */}
+            {Array.from(
+              new Map(
+                sources
+                  .filter((s) => s.licence)
+                  .map((s) => [s.licence!.url, s.licence!] as const),
+              ).values(),
+            ).map((lic) => (
+              <a
+                key={lic.url}
+                href={lic.url}
+                target="_blank"
+                rel="noreferrer noopener license"
+                style={{
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: "var(--tn-text-muted)",
+                  textDecoration: "none",
+                  border: "1px dashed var(--tn-border)",
+                  borderRadius: 999,
+                  padding: "3px 10px",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {lic.label} ↗
+              </a>
+            ))}
           </div>
         </div>
       )}

--- a/lib/signals/cloud-status.ts
+++ b/lib/signals/cloud-status.ts
@@ -16,7 +16,7 @@ import type { SignalFeature, SignalSource } from "@/lib/signals/types";
 // layer can exist on a map, and the layer explainer says exactly that. We do NOT
 // invent a region or draw an outage footprint.
 
-const UA = "OpenData/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 const TIMEOUT_MS = 8_000;
 
 export const CLOUD_STATUS_ATTRIBUTION = "Service status © each vendor's own Atlassian Statuspage";

--- a/lib/signals/faa.ts
+++ b/lib/signals/faa.ts
@@ -20,7 +20,7 @@ import { parseAirportsCsv } from "@/lib/signals/airports";
 
 const ENDPOINT = "https://nasstatus.faa.gov/api/airport-status-information";
 const AIRPORTS_CSV = "https://davidmegginson.github.io/ourairports-data/airports.csv";
-const UA = "OpenData/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
+const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 const REFRESH_MS = 5 * 60_000;
 const COORD_TTL_MS = 24 * 60 * 60 * 1000;
 

--- a/lib/signals/sourceLink.ts
+++ b/lib/signals/sourceLink.ts
@@ -17,6 +17,34 @@
 
 export type SourceScope = "record" | "provider";
 
+/**
+ * A licence that obliges us to LINK it, not merely to name the provider.
+ *
+ * CC BY 4.0 asks for three things: appropriate credit, a link to the licence, and an
+ * indication of whether changes were made. Naming the provider satisfies the first
+ * only. Open-Meteo publishes its API data under CC BY 4.0 ("API data are offered
+ * under Attribution 4.0 International"), so a bare "Open-Meteo" chip left us
+ * nearly-conformant rather than conformant.
+ *
+ * Only declare this where the upstream's own terms ask for a licence link. Most of
+ * the table does not: USGS and NOAA are US-government public domain, GDELT asks for
+ * a citation plus a link to gdeltproject.org (which the provider chip already is),
+ * and OGL v3 sources are covered by the site-wide OGL notice on the landing page.
+ * Adding it everywhere would be noise, and noise is how a real obligation gets
+ * missed.
+ */
+export interface SourceLicence {
+  /** Short licence name shown on the chip, e.g. "CC BY 4.0". */
+  label: string;
+  /** Canonical licence deed URL — this is the link the licence actually requires. */
+  url: string;
+}
+
+export const CC_BY_4_0: SourceLicence = {
+  label: "CC BY 4.0",
+  url: "https://creativecommons.org/licenses/by/4.0/",
+};
+
 export interface ResolvedSource {
   /** Absolute https URL to open in a new tab. */
   href: string;
@@ -24,11 +52,14 @@ export interface ResolvedSource {
   label: string;
   /** "record" = deep permalink to THIS event; "provider" = the dataset / home page. */
   scope: SourceScope;
+  /** Present only when the upstream's terms require the licence itself to be linked. */
+  licence?: SourceLicence;
 }
 
 interface Provider {
   label: string;
   url: string;
+  licence?: SourceLicence;
 }
 
 /**
@@ -62,8 +93,12 @@ export const SIGNAL_PROVIDER_URLS: Record<string, Provider> = {
   conflict: { label: "GDELT", url: "https://www.gdeltproject.org/" },
   protests: { label: "GDELT", url: "https://www.gdeltproject.org/" },
   acled: { label: "ACLED", url: "https://acleddata.com/" },
-  weather: { label: "Open-Meteo", url: "https://open-meteo.com/" },
-  airquality: { label: "Open-Meteo", url: "https://open-meteo.com/en/docs/air-quality-api" },
+  weather: { label: "Open-Meteo", url: "https://open-meteo.com/", licence: CC_BY_4_0 },
+  airquality: {
+    label: "Open-Meteo",
+    url: "https://open-meteo.com/en/docs/air-quality-api",
+    licence: CC_BY_4_0,
+  },
   "air-quality-stations": { label: "OpenAQ", url: "https://openaq.org/" },
   crime: { label: "data.police.uk", url: "https://data.police.uk/" },
   "cyber-c2": { label: "abuse.ch", url: "https://feodotracker.abuse.ch/" },
@@ -147,9 +182,13 @@ export function resolveSignalSources(input: {
       : SIGNAL_PROVIDER_URLS[id]);
 
   // 1. Deep record permalink (preferred) — the exact upstream page for THIS event.
+  // It carries the provider's licence too: the obligation attaches to the data, and
+  // a record link can be the ONLY chip shown (step 2 suppresses a provider chip on
+  // the same host), so hanging the licence off the provider entry alone would drop
+  // it exactly when the deep link works.
   if (isHttpUrl(input.link)) {
     const label = provider?.label ?? hostLabel(input.link);
-    push({ href: input.link, label, scope: "record" });
+    push({ href: input.link, label, scope: "record", licence: provider?.licence });
   }
 
   // 2. Provider dataset / home page(s). A composite shows all contributors; a plain
@@ -157,9 +196,10 @@ export function resolveSignalSources(input: {
   //    the same host (that would just duplicate it).
   const recordHosts = new Set(out.map((s) => hostOf(s.href)));
   if (composite) {
-    for (const p of composite) push({ href: p.url, label: p.label, scope: "provider" });
+    for (const p of composite)
+      push({ href: p.url, label: p.label, scope: "provider", licence: p.licence });
   } else if (provider && !recordHosts.has(hostOf(provider.url))) {
-    push({ href: provider.url, label: provider.label, scope: "provider" });
+    push({ href: provider.url, label: provider.label, scope: "provider", licence: provider.licence });
   }
 
   return out;

--- a/lib/sources/opensky.ts
+++ b/lib/sources/opensky.ts
@@ -1,38 +1,42 @@
 /**
- * The aircraft layer. OpenSky Network is the PRIMARY source — live aircraft
- * worldwide from ONE global snapshot — with a bounded adsb.lol grid sweep
- * (lib/sources/adsb.ts) as the fallback when OpenSky refuses. See
- * `fetchAircraftOnce` for why the fallback exists and what it costs in coverage.
- * Everything below this line describes the OpenSky path specifically.
+ * The aircraft layer. The sole source is a bounded adsb.lol grid sweep
+ * (lib/sources/adsb.ts). See `fetchAircraftOnce` for why OpenSky was removed —
+ * the reason is its licence, not its reliability — and what the change costs in
+ * coverage (in practice: nothing, because the sweep was already serving prod alone).
  *
- * WHY GLOBAL, NOT A SWEEP: adsb.lol/adsb.fi are point+radius only (max 250 nm, no
- * global query), so worldwide coverage there means sweeping ~50 cells and stitching
- * them together in server state. On Vercel serverless that state is per-instance and
- * never accumulates across the cold, independent lambdas that handle each cache
- * revalidation — so the stitched union collapses to whichever handful of (rate-limit-
- * surviving, North-America-first) cells landed last. OpenSky's `/states/all` returns
- * EVERY tracked aircraft on Earth in a single request, so coverage is worldwide by
- * construction — no grid, no rolling store, no rate-limit-order bias.
+ * FILENAME. This module is still called `opensky.ts` even though it no longer
+ * contacts OpenSky, because renaming it touches eight importers and would bury a
+ * licensing fix inside a rename diff. That rename is a named follow-up, not an
+ * oversight.
  *
- * TRADE-OFF: OpenSky's anonymous tier is credit-capped (~400 credits/day, a global
- * call costs ~4), so we DON'T poll it per-visitor. The fetch is wrapped in Next's
- * Data Cache (`unstable_cache`, revalidate = REVALIDATE_S) so upstream is hit at most
- * once per window for the ENTIRE deployment (stale-while-revalidate) and REVALIDATE_S
- * is set so a fully-saturated day still stays under the daily cap. On any failure
- * (429 / 5xx / null states / timeout) fetchGlobalOnce THROWS rather than swallowing
- * the failure, so the Data Cache keeps serving whatever it last cached successfully
- * — a persisted last-good snapshot, not a module variable a fresh serverless
- * instance would reset to empty (see fetchGlobalOnce below for why that distinction
- * is the whole fix). Because that snapshot is GLOBAL, even a stale serve is still
- * worldwide, never regional. A staleness gate (decideStaleness/gateSnapshot) then
- * refuses to serve anything older than STALE_CEILING_MS — aircraft move, so an old
- * enough "live" snapshot would be a fabrication, not just a late one.
+ * WHY A SWEEP IS AWKWARD, retained because it still shapes the code below:
+ * adsb.lol is point+radius only (max 250 nm, no global query), so worldwide coverage
+ * means sweeping ~50 cells and stitching them. On Vercel serverless that stitching
+ * cannot accumulate across the cold, independent lambdas that handle each cache
+ * revalidation, so the union is whatever one sweep collects inside its own budget —
+ * dense over North America and Europe, thin elsewhere. That limit is real and is
+ * declared through the coverage record rather than hidden. OpenSky's `/states/all`
+ * did not have it, which is why it was preferred until the terms were read.
  *
- * OpenSky omits type-code + registration (unlike adsb.lol); the dossier fetches those
- * on demand from /api/flight by callsign+hex, both of which OpenSky provides. squawk
- * IS present (index 14), so the emergency-squawk (7500/7600/7700) alerts stay live.
+ * CADENCE: the sweep is wrapped in Next's Data Cache (`unstable_cache`,
+ * revalidate = REVALIDATE_S), so upstream is hit at most once per window for the
+ * ENTIRE deployment (stale-while-revalidate) rather than per visitor. On failure
+ * `fetchAircraftOnce` THROWS rather than returning empty, so the Data Cache keeps
+ * serving whatever it last cached successfully — a persisted last-good snapshot, not
+ * a module variable a fresh serverless instance would reset to empty. That
+ * distinction is load-bearing: `unstable_cache` commits whatever it is handed, so a
+ * swallowed failure overwrites a good snapshot with an empty one. A staleness gate
+ * (decideStaleness/gateSnapshot) then refuses to serve anything older than
+ * STALE_CEILING_MS — aircraft move, so an old enough "live" snapshot would be a
+ * fabrication, not just a late one.
  *
- * Docs: https://openskynetwork.github.io/opensky-api/rest.html#all-state-vectors
+ * RETAINED, NOT DEAD: `parseStates` / `planeToWorldObject` / the `Plane` interface
+ * parse OpenSky's positional state-vector format and are no longer on any live path.
+ * They stay because `lib/sources/adsb.ts` shapes its `meta` to match
+ * `planeToWorldObject` exactly, so this is the written contract for that shape, and
+ * because their squawk handling (index 14 → 7500/7600/7700) is what the
+ * emergency-squawk alerts in `lib/console/widgets/aviation.tsx` are specified
+ * against. Deleting them is a separate mechanical change with its own test churn.
  */
 
 import type { WorldObject } from "@/lib/world";
@@ -255,10 +259,18 @@ export interface AircraftSnapshot {
    */
   staleness?: { stale: true; ageMs: number } | { reason: "too-old"; ageMs: number };
   /**
-   * Which upstream actually produced these positions. The two providers have
-   * materially different coverage — OpenSky is worldwide, the adsb.lol sweep sees
-   * only where volunteers run receivers — so a consumer that prints a count without
-   * knowing the provider cannot describe it correctly. Undefined only for a
+   * Which upstream actually produced these positions. Everything minted now is
+   * `"adsb.lol"` — OpenSky was removed on licensing grounds (see `fetchAircraftOnce`).
+   *
+   * `"opensky"` REMAINS IN THIS UNION ON PURPOSE. The Data Cache persists across
+   * deploys, so a snapshot stamped by the previous code can still be rehydrated and
+   * served after this change ships; narrowing the type would make that a parse
+   * failure rather than a correctly-labelled stale snapshot. It will age out on its
+   * own. Do not remove it in the same PR as the fetch change.
+   *
+   * The providers had materially different coverage — OpenSky was worldwide, the
+   * sweep sees only where volunteers run receivers — so a consumer that prints a
+   * count without reading this cannot describe it correctly. Undefined only for a
    * snapshot that predates this field or carries no aircraft.
    */
   source?: "opensky" | "adsb.lol";
@@ -271,95 +283,60 @@ export function toAircraftSnapshot(planes: WorldObject[]): AircraftSnapshot {
 }
 
 // ---------------------------------------------------------------------------
-// Global fetch — one worldwide snapshot, cached deployment-wide, dormant-safe
+// Snapshot fetch — one adsb.lol sweep, cached deployment-wide, dormant-safe
 // ---------------------------------------------------------------------------
 
-// No bbox → every tracked aircraft on Earth in one response.
-const GLOBAL_URL = "https://opensky-network.org/api/states/all";
-const FETCH_TIMEOUT_MS = 12_000;
-// Deployment-wide revalidate. OpenSky anonymous is ~400 credits/day and a global
-// call costs ~4 (≈100 calls/day). 240 s ⇒ ≤360 upstream calls even on a fully
-// saturated day, so it never exhausts the daily budget and freezes. (A registered
-// OpenSky account lifts the cap ~10×; this could then drop to ~60–90 s.)
+// Deployment-wide revalidate, unchanged at 240 s. This used to be sized against
+// OpenSky's ~400-credits/day anonymous budget; adsb.lol publishes no such cap, so
+// the number now exists only to bound how often the 14 s sweep runs.
 const REVALIDATE_S = 240;
 
-interface OpenSkyResponse {
-  time: number;
-  states: unknown[][] | null;
-}
-
 /**
- * Fetch one global snapshot and map it to capped WorldObjects, stamped with the
- * moment it was fetched.
+ * One aircraft snapshot, from a bounded adsb.lol grid sweep (lib/sources/adsb.ts).
  *
- * THROWS — deliberately — on any failure: a 429 (rate-limit), non-2xx, null
- * `states` (degraded upstream), a zero-aircraft parse, a timeout, or a parse
- * error. This used to swallow every one of those into a "last-good" fallback
- * held in a MODULE-LEVEL variable, which does not survive between serverless
- * invocations: Vercel starts each cold lambda with fresh module state, so on a
- * fresh instance that fallback was always `{planes: []}`. Once OpenSky's
- * anonymous credit cap was hit on the deployment's IP, EVERY poll failed there —
- * so `{planes: []}` is what got returned, and because fetchAircraftSnapshot's
- * unstable_cache wrapper commits whatever this function returns, that empty
- * result is what got WRITTEN into the Data Cache, overwriting any earlier good
- * snapshot. That is the exact bug this fixes: one throttled poll from a fresh
- * instance emptied the whole layer for the rest of the revalidate window —
- * indefinitely, on an IP whose cap never lifts.
+ * WHY OPENSKY IS GONE, AND WHY THIS IS NOT A REGRESSION.
  *
- * Throwing instead means unstable_cache never commits a new value on failure —
- * the PREVIOUS cached snapshot (in the Data Cache, which persists across
- * invocations, unlike module state) keeps being served. That persisted snapshot
- * is what fetchAircraftSnapshot's staleness gate then decides whether to serve,
- * serve-with-disclosed-age, or withhold as too old — see `decideStaleness`.
- */
-async function fetchGlobalOnce(): Promise<AircraftSnapshot> {
-  const res = await fetch(GLOBAL_URL, {
-    headers: { Accept: "application/json" },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
-  if (!res.ok) throw new Error(`OpenSky /states/all answered ${res.status}`);
-  const data = (await res.json()) as OpenSkyResponse;
-  if (!data.states) throw new Error("OpenSky /states/all returned degraded (null) states");
-  const objects = capPlanes(parseStates(data.states).map(planeToWorldObject), MAX_PLANES);
-  if (!objects.length) throw new Error("OpenSky /states/all parsed to zero positioned aircraft");
-  return { ...toAircraftSnapshot(objects), fetchedAt: Date.now() };
-}
-
-/**
- * One aircraft snapshot from the best provider that answers.
+ * OpenSky used to be the primary here, with this sweep as its fallback. It has been
+ * removed outright — not demoted — because of its licence, not its reliability.
+ * OpenSky's Terms of Use require a WRITTEN LICENCE for "use of the REST API in any
+ * operational ... integration into a live product, service, or automated system",
+ * and state that this applies "REGARDLESS OF THE ENTITY'S NON-PROFIT STATUS". The
+ * free grant covers non-profit research and education only. Provenance is a live,
+ * publicly reachable product, so calling that endpoint from it is the licensed act
+ * whether or not the response is ever served onward, and whether or not this project
+ * is free and open-source. We hold no such licence, so we do not make the call.
  *
- * OpenSky stays PRIMARY because `/states/all` is genuinely worldwide in one call.
- * But its anonymous tier is credit-capped per IP, and on the production
- * deployment's IP that cap is permanently exhausted — measured 2026-08-13, prod
- * `/api/planes` served `{count: 0}` while the same endpoint answered 200 with
- * ~1.7 MB in 0.58 s from a home IP. With OpenSky as the only provider,
- * `fetchGlobalOnce` throws on every poll, `unstable_cache` never commits, and the
- * layer sits in `never-fetched` forever. A staleness gate cannot rescue that: there
- * has never been a good snapshot to go stale.
+ * Note the shape of that clause: it binds the CALL, not the data. Demoting OpenSky
+ * to a fallback would not have helped — a fallback still calls it. Neither would
+ * adding credentials, which is what CLAUDE.md previously prescribed for the empty
+ * layer: that turns an anonymous failing request into an authenticated, working,
+ * attributable one, which is more squarely the licensed act, not less.
  *
- * So on an OpenSky failure we fall back to a bounded adsb.lol grid sweep
- * (lib/sources/adsb.ts), which answers fine from a datacentre IP — the sibling
- * `military-air` layer has been serving from it in prod all along, which is the
- * evidence that the block is OpenSky-specific and not general egress.
+ * NOTHING IS LOST OPERATIONALLY. The OpenSky call had already been failing from the
+ * deployment for months, and this sweep has been carrying the layer alone: prod
+ * `/api/planes` measured 3,000 aircraft with `source: "adsb.lol"` on 2026-08-14. The
+ * coverage difference is real and is still declared — OpenSky was worldwide in one
+ * call, the sweep sees only where volunteers run receivers, dense over North America
+ * and Europe and thin elsewhere — but that difference was already what production
+ * was serving. This change makes the code match it.
  *
- * The two providers do NOT have equal coverage, and the snapshot says which one
- * served so that difference is never silent: OpenSky is worldwide, the sweep sees
- * only where volunteers run receivers. Each attaches its own coverage record.
+ * adsb.lol carries no equivalent restriction: its feeders waive rights under CC0 and
+ * no term on its site restricts API use, commercial use or redistribution. Verified
+ * against content/en/privacy-license/index.md in the adsblol/website repo, 2026-08-14.
+ * That is "no restriction exists", which is a slightly weaker claim than "a licence
+ * expressly grants this" — worth knowing before anyone builds a paid product on it.
  *
- * If BOTH fail we rethrow OpenSky's error rather than returning an empty snapshot —
- * `unstable_cache` must not commit a success on a total failure, or an empty result
- * poisons the cache for the whole revalidate window. That is the same bug the
- * `fetchGlobalOnce` docstring describes; it applies to the fallback path too.
+ * THROWS on a sweep that returns nothing, deliberately. `unstable_cache` commits
+ * whatever this returns, so returning an empty snapshot on failure would overwrite a
+ * good cached one and empty the layer for the rest of the revalidate window. Throwing
+ * leaves the previous Data Cache entry in place for the staleness gate to judge —
+ * see `decideStaleness`.
  */
 async function fetchAircraftOnce(): Promise<AircraftSnapshot> {
-  try {
-    return { ...(await fetchGlobalOnce()), source: "opensky" };
-  } catch (openSkyError) {
-    const sweep = await fetchAdsbSweep();
-    if (!sweep.objects.length) throw openSkyError;
-    const objects = sweepToObjects(sweep, MAX_PLANES);
-    return { ...toAircraftSnapshot(objects), fetchedAt: Date.now(), source: "adsb.lol" };
-  }
+  const sweep = await fetchAdsbSweep();
+  if (!sweep.objects.length) throw new Error("adsb.lol sweep returned zero positioned aircraft");
+  const objects = sweepToObjects(sweep, MAX_PLANES);
+  return { ...toAircraftSnapshot(objects), fetchedAt: Date.now(), source: "adsb.lol" };
 }
 
 /** Re-attach the coverage field to the array after a Data Cache (JSON) round trip. */

--- a/tests/unit/signals-sourceLink.test.ts
+++ b/tests/unit/signals-sourceLink.test.ts
@@ -7,6 +7,7 @@ import {
   isCompositeSignal,
   SIGNAL_PROVIDER_URLS,
   SIGNAL_COMPOSITE_SOURCES,
+  CC_BY_4_0,
 } from "@/lib/signals/sourceLink";
 
 describe("resolveSignalSources — the clickable-source guarantee", () => {
@@ -78,5 +79,45 @@ describe("resolveSignalSources — the clickable-source guarantee", () => {
       if (SIGNAL_COMPOSITE_SOURCES[s.id]) continue;
       expect(SIGNAL_PROVIDER_URLS[s.id], `missing provider url for ${s.id}`).toBeTruthy();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Licence linking — CC BY 4.0 asks for a link to the LICENCE, not just credit.
+// Naming the provider satisfies "appropriate credit" only, which left the two
+// Open-Meteo layers nearly-conformant rather than conformant.
+// ---------------------------------------------------------------------------
+describe("resolveSignalSources — licence obligations", () => {
+  test("Open-Meteo layers carry the CC BY 4.0 deed link", () => {
+    for (const id of ["weather", "airquality"]) {
+      const sources = resolveSignalSources({ signalId: id });
+      const licensed = sources.filter((s) => s.licence);
+      expect(licensed.length, `${id} lost its licence link`).toBeGreaterThanOrEqual(1);
+      expect(licensed[0].licence).toEqual(CC_BY_4_0);
+    }
+  });
+
+  test("the licence survives when a deep record link is the only chip", () => {
+    // A record link on the provider's own host suppresses the provider chip, so a
+    // licence hung only off the provider entry would vanish exactly when the deep
+    // link works. It must ride on the record entry too.
+    const sources = resolveSignalSources({
+      signalId: "weather",
+      link: "https://open-meteo.com/en/docs#some-record",
+    });
+    expect(sources.some((s) => s.licence?.url === CC_BY_4_0.url)).toBe(true);
+  });
+
+  test("the deed URL is the canonical creativecommons.org link", () => {
+    // The obligation is specifically to link the licence. A link to Open-Meteo's own
+    // terms page would name it without discharging it.
+    expect(CC_BY_4_0.url).toBe("https://creativecommons.org/licenses/by/4.0/");
+  });
+
+  test("licences are declared, never inferred — most sources carry none", () => {
+    // Public-domain (USGS, NOAA) and OGL sources must NOT sprout a licence chip:
+    // an unnecessary legal notice on every layer is how a real one gets ignored.
+    expect(resolveSignalSources({ signalId: "earthquakes" }).every((s) => !s.licence)).toBe(true);
+    expect(resolveSignalSources({ signalId: "crime" }).every((s) => !s.licence)).toBe(true);
   });
 });


### PR DESCRIPTION
Four small changes from the Velocity competitive review. Two are upstream-terms
compliance, one unblocks indexing telemetry, one is tidying. Each is its own commit.

Gate: `npx tsc --noEmit` clean, **1,838 tests across 234 files pass** (1,834 on
`main` plus 4 new). `npm run build` deliberately not run — it OOMs on this machine,
which is what CI is for and is a separate finding.

---

### 1. Stop calling OpenSky — we do not hold the licence its terms require

The important one. OpenSky's Terms of Use require a **written licence** for "use of
the REST API in any operational ... integration into a live product, service, or
automated system", and state this applies **"REGARDLESS OF THE ENTITY'S NON-PROFIT
STATUS"**. The free grant covers non-profit research and education only.

The clause binds **the call, not the data**. Three things follow that are easy to
get backwards:

- Demoting OpenSky to a fallback would not help — a fallback still calls it.
- Being free, open-source and non-commercial is not a defence; the clause rules it out.
- Adding credentials, which `CLAUDE.md` currently prescribes for the empty aircraft
  layer, would make it **worse** — an anonymous failing request becomes an
  authenticated, working, attributable one.

**Nothing is lost operationally.** The call had already been failing from the
deployment for months and `adsb.lol` has been carrying the layer alone — prod
`/api/planes` measured **3,000 aircraft with `source: "adsb.lol"`** on 2026-08-14.
This makes the code match what production already serves, and stops the route
calling itself worldwide when the sweep is thin outside North America and Europe.

`adsb.lol` is clean: feeders waive rights under CC0 and no term restricts API use,
commercial use or redistribution. Read from `content/en/privacy-license/index.md` in
`adsblol/website`. Stated precisely, that is *no restriction exists* — a weaker claim
than *a licence expressly grants this*, and worth knowing before anyone builds a paid
product on it.

### 2. Link the CC BY licence Open-Meteo asks for

CC BY 4.0 wants credit **and a link to the licence**. We gave credit; a grep for
`creativecommons.org` across `app/`, `components/` and `lib/` returned zero hits.
Nearly-conformant is not conformant.

Declared per-source, never inferred — USGS and NOAA are public domain, GDELT's
citation is already the provider chip, OGL is covered site-wide. A test asserts those
stay bare, because a legal notice on every layer is how the one that matters gets
ignored. Also verified: Open-Meteo's own grant is CC BY, **not** CC BY-SA, so no
share-alike reaches us.

### 3. Prove the site to Google Search Console

Search Console holds **one property, `turingdna.com`, and nothing for
`provenance-online.vercel.app`**. The ~6,400 crawlable camera pages #105 shipped have
no telemetry behind them — there is no way to know whether Google has fetched one.

A *domain* property is impossible here: it needs a DNS TXT record and `vercel.app` is
on the Public Suffix List. Hence a URL-prefix property and a meta tag.

**After merge + deploy, the token must be live before I can click Verify** and submit
the sitemap.

### 4. Present one identity to upstreams

Four adapters said `OpenData/2.0` while 53 said `TrafficNerd/2.0`. Aligned on the
majority string rather than on "Provenance" **on purpose**: `lib/brand.ts:4` records
that the UA is deliberately not derived from `BRAND.name`, because upstreams may have
allowlisted against it and it should not churn on a rename.

---

### Follow-ups this deliberately does not do

- **Hoist the UA to one constant.** It is hand-typed in 57 places. Mechanical, and it
  touches `lib/sources/castlerock.ts`, which #106 is editing right now.
- **Rename `lib/sources/opensky.ts`.** It no longer contacts OpenSky. Eight importers;
  it does not belong inside a licensing fix.
- **Delete the OpenSky state-vector parsers.** Retained for now: `adsb.ts` matches
  `planeToWorldObject`'s shape, and their squawk handling is what the emergency-squawk
  alerts are specified against.
- **`CLAUDE.md` is stale** on the product name, the domain, layers (35 vs 37), tests
  (1,414 vs 1,834) and the aircraft layer, and it prescribes the OpenSky credentials
  fix this PR argues against. Left alone to keep this diff reviewable.
