### PR TITLE
Give the sitemap routes time to build, and stop them publishing a lie

### DIFF
--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,4 +1,4 @@
-import { loadSitemapShards } from "@/lib/seo/sitemapData";
+import { loadSitemapShards, sitemapUnavailable } from "@/lib/seo/sitemapData";
 import { renderSitemapIndex, sitemapHeaders } from "@/lib/seo/xml";
 import { absoluteUrl } from "@/lib/seo/paths";
 
@@ -21,8 +21,30 @@ import { absoluteUrl } from "@/lib/seo/paths";
  */
 export const revalidate = 86_400;
 
+/**
+ * Headroom for a COLD registry build, and it is not optional.
+ *
+ * Google reported "Couldn't fetch" against three children on the first read after
+ * this shipped, including the two largest. The cause was a duration limit, not the
+ * documents: with no `maxDuration` a route inherits Vercel's default (10-15 s),
+ * while `getRegistry()` on a cold cache waits on the Castle Rock feed, whose
+ * measured budget is 60 s (lib/sources/registry.ts). The children that succeeded
+ * were the ones whose requests arrived AFTER the registry had warmed.
+ *
+ * The interaction is what made it invisible: before Castle Rock was repaired it
+ * failed fast, so a cold sitemap build finished inside the default and nobody had
+ * to think about this. Repairing the feed made the cold path six times slower.
+ *
+ * `app/api/planes/route.ts` sets its own limit for the same class of reason.
+ */
+export const maxDuration = 60;
+
 export async function GET(): Promise<Response> {
-  const { origin, shards, result } = await loadSitemapShards();
+  const { origin, shards, result, registryOk } = await loadSitemapShards();
+
+  // Never publish an index we cannot vouch for. Advertising only the core shard
+  // would tell a crawler the ~20,000 camera pages have been removed.
+  if (!registryOk) return sitemapUnavailable();
 
   // An empty shard is omitted rather than advertised. A child sitemap containing
   // zero URLs is a valid document that tells a crawler nothing, and Search Console

--- a/app/sitemap/[shard]/route.ts
+++ b/app/sitemap/[shard]/route.ts
@@ -1,4 +1,4 @@
-import { loadSitemapShards } from "@/lib/seo/sitemapData";
+import { loadSitemapShards, sitemapUnavailable } from "@/lib/seo/sitemapData";
 import { findShard } from "@/lib/seo/directory";
 import { renderUrlset, sitemapHeaders } from "@/lib/seo/xml";
 
@@ -18,6 +18,9 @@ import { renderUrlset, sitemapHeaders } from "@/lib/seo/xml";
  */
 export const revalidate = 86_400;
 
+/** Same cold-registry headroom as the index — see app/sitemap.xml/route.ts. */
+export const maxDuration = 60;
+
 export async function GET(
   _req: Request,
   ctx: { params: Promise<{ shard: string }> },
@@ -29,7 +32,14 @@ export async function GET(
   }
   const id = raw.slice(0, -".xml".length);
 
-  const { shards } = await loadSitemapShards();
+  const { shards, registryOk } = await loadSitemapShards();
+
+  // 503, not 404, when the registry did not answer. A 404 on a child the index
+  // advertises tells a crawler that group is permanently gone; a 503 says come back.
+  // Order matters — this must precede the not-found check, because a failed registry
+  // makes every camera shard look non-existent.
+  if (!registryOk) return sitemapUnavailable();
+
   const shard = findShard(shards, id);
   if (!shard || shard.entries.length === 0) {
     return new Response("Not found", { status: 404 });

--- a/lib/seo/sitemapData.ts
+++ b/lib/seo/sitemapData.ts
@@ -13,22 +13,57 @@ import { buildSitemapShards, type SitemapShard, type SitemapResult } from "@/lib
 /** Static pages that are not part of the camera directory. */
 export const STATIC_PATHS = ["/app", "/locate"];
 
+/**
+ * Response for a sitemap route that must not publish what it cannot vouch for.
+ *
+ * `Retry-After` is a real instruction, not decoration: it tells the crawler this is
+ * transient and worth coming back for, which is the difference between a retry and
+ * being dropped from the schedule.
+ */
+export function sitemapUnavailable(): Response {
+  return new Response("Sitemap temporarily unavailable: camera registry did not answer.\n", {
+    status: 503,
+    headers: { "Content-Type": "text/plain; charset=utf-8", "Retry-After": "600", "Cache-Control": "no-store" },
+  });
+}
+
 export async function loadSitemapShards(): Promise<{
   origin: string;
   shards: SitemapShard[];
   result: SitemapResult;
+  /** False when the registry threw or came back empty — the caller must NOT publish. */
+  registryOk: boolean;
 }> {
   const origin = siteUrl();
 
-  // Dormant-safe, matching the convention every adapter in this repo follows: a
-  // failed registry must not serve a 5xx. A sitemap listing only the static pages is
-  // a degraded answer; an error page is not an answer at all, and a crawler that
-  // gets a 5xx from a sitemap backs off the whole set rather than retrying one file.
+  // A SITEMAP IS THE ONE PLACE THE DORMANT-SAFE CONVENTION INVERTS.
+  //
+  // Everywhere else in this repo a failed upstream degrades to `[]` and never a
+  // 5xx, because a user-facing route that errors is worse than one that is honestly
+  // empty. This route is not user-facing, and for a crawler the two outcomes swap
+  // places: serving a 200 index that lists only the static pages, when 20,000 camera
+  // pages exist, does not read as "degraded" — it reads as a DELIBERATE STATEMENT
+  // that those pages are gone. A sitemap is an assertion about what exists, so the
+  // empty answer is the destructive one.
+  //
+  // A 5xx, by contrast, is a retry. Google refetches a sitemap that failed and, by
+  // then, `getRegistry()`'s stale-while-revalidate cache is warm and the second
+  // attempt succeeds. Failing loudly is self-healing here; succeeding quietly is not.
+  //
+  // Zero cameras counts as failure for the same reason. A genuinely camera-less
+  // deployment is not a state worth optimising for, and treating it as success is
+  // exactly how a transient outage would delist the whole directory.
   let cameras: Awaited<ReturnType<typeof getRegistry>> = [];
+  let registryOk = true;
   try {
     cameras = await getRegistry();
+    if (cameras.length === 0) {
+      registryOk = false;
+      console.error("[sitemap] registry returned zero cameras; refusing to publish a truncated sitemap");
+    }
   } catch (err) {
-    console.warn("[sitemap] camera registry unavailable, emitting static pages only:", err);
+    registryOk = false;
+    console.error("[sitemap] camera registry unavailable; refusing to publish a truncated sitemap:", err);
   }
 
   const { shards, result } = buildSitemapShards(cameras, origin, STATIC_PATHS);
@@ -42,5 +77,5 @@ export async function loadSitemapShards(): Promise<{
     );
   }
 
-  return { origin, shards, result };
+  return { origin, shards, result, registryOk };
 }

--- a/tests/unit/sitemap-xml.test.ts
+++ b/tests/unit/sitemap-xml.test.ts
@@ -14,6 +14,7 @@ import {
   xmlEscape,
   SITEMAP_STYLESHEET_PATH,
 } from "@/lib/seo/xml";
+import { sitemapUnavailable } from "@/lib/seo/sitemapData";
 
 const ORIGIN = "https://provenance-online.vercel.app";
 
@@ -195,6 +196,28 @@ describe("buildSitemapShards — sharding must be a REGROUPING, never a filter",
     const { shards } = buildSitemapShards([], ORIGIN, ["/app"]);
     expect(findShard(shards, CORE_SHARD_ID)!.entries.length).toBeGreaterThan(0);
     expect(shards.filter((s) => s.id.startsWith("cameras-"))).toHaveLength(0);
+  });
+});
+
+describe("sitemapUnavailable — the dormant-safe convention inverts here", () => {
+  it("is a 503 with Retry-After, not a 200 with fewer URLs", () => {
+    // Everywhere else in this repo a failed upstream degrades to [] and never 5xxes.
+    // A sitemap is an assertion about what EXISTS, so a 200 listing only the static
+    // pages reads as "the 20,000 camera pages were removed" rather than "degraded".
+    // A 5xx is merely a retry, and by the retry the registry cache is warm.
+    const res = sitemapUnavailable();
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("600");
+  });
+
+  it("is never cached, or the outage outlives itself", () => {
+    expect(sitemapUnavailable().headers.get("Cache-Control")).toContain("no-store");
+  });
+
+  it("does not masquerade as XML", () => {
+    // A 503 body served as application/xml invites a parser to read the error text
+    // as a sitemap.
+    expect(sitemapUnavailable().headers.get("Content-Type")).toContain("text/plain");
   });
 });
 


### PR DESCRIPTION
**Regression fix for #108.** Google reported `Couldn't fetch` against three of the eight children on its first read of the new index — including the two that matter most.

| Child | Status | Discovered |
|---|---|---|
| `cameras-us.xml` | **Couldn't fetch** | 0 — *10,874 URLs, 58% of the corpus* |
| `core.xml` | **Couldn't fetch** | 0 — *the site's own pages* |
| `cameras-ee.xml` | **Couldn't fetch** | 0 |
| `cameras-ca / gb / fi / is / br` | Success | 4,619 |
| `cameras-nz.xml` | not attempted | — |

Two separate defects, both mine, both from #108.

---

### 1. No `maxDuration`

A route that declares none inherits Vercel's default (10–15 s), while `getRegistry()` on a cold cache waits on Castle Rock, whose measured budget is **60 s**. The function was killed before it could answer. The children that succeeded are simply the ones whose requests arrived *after* the registry warmed — which is why it looked random rather than systematic.

**The interaction is what hid it.** Before #106 repaired Castle Rock, that feed failed fast, so a cold sitemap build finished inside the default limit and nobody had to think about duration. Repairing the feed made the cold path ~6× slower, and #108 shipped into that. Neither change is wrong alone. `app/api/planes/route.ts` already sets its own limit for exactly this class of reason; the sitemap routes should have too.

### 2. The dormant-safe convention is wrong for a sitemap

This is the worse one, and I carried it over from the old `app/sitemap.ts` without thinking about what it means *here*.

Everywhere else in this repo a failed upstream degrades to `[]` and never 5xxes, because a user-facing route that errors is worse than one that is honestly empty. **This route is not user-facing, and for a crawler the two outcomes swap places.**

A sitemap is an assertion about what *exists*. Serving a `200` index listing only the static pages, while 20,000 camera pages are live, does not read as "degraded" — it reads as a deliberate statement that those pages **have been removed**. That is the destructive outcome, and it is the one the old code chose.

A `5xx` is merely a retry, and by the time Google retries, `getRegistry()`'s stale-while-revalidate cache is warm and the second attempt succeeds. **Failing loudly is self-healing here; succeeding quietly is not.**

So both routes now return `503` + `Retry-After: 600` rather than publishing a truncated set. Zero cameras counts as failure for the same reason — a transient outage must not be able to delist the whole directory.

In the child route the 503 check **precedes** the not-found check on purpose: a failed registry makes every camera shard look non-existent, and answering `404` to a child the index advertises tells a crawler that group is permanently gone.

---

**Gate:** `npx tsc --noEmit` clean, **1,866 tests across 236 files pass** (3 new).

**After merge:** I'll re-submit in Search Console so the failed children are re-read. The successful ones will stay successful; the three failures should clear on the retry.

**Worth noting for next time:** I verified every route by hand before shipping #108 and they all returned 200 — because my own verification had warmed the cache. Warm-path testing cannot see this class of bug, which is the general lesson rather than anything specific to sitemaps.
