### PR TITLE
Make the crawlable pages actually honour the revalidate they declare

### DIFF
--- a/app/camera/[id]/page.tsx
+++ b/app/camera/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getCameraById, nearestTo } from "@/lib/sources/registry";
+import { getCameraPage } from "@/lib/seo/registrySnapshot";
 import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
 import { CameraImage } from "@/components/CameraImage";
 import { CameraVideo } from "@/components/CameraVideo";
@@ -29,7 +29,7 @@ import {
 export const revalidate = 3_600;
 
 async function load(idParam: string) {
-  return getCameraById(decodeURIComponent(idParam));
+  return getCameraPage(decodeURIComponent(idParam));
 }
 
 export async function generateMetadata({
@@ -38,9 +38,10 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
-  const cam = await load(id);
-  if (!cam) return { title: "Camera not found" };
+  const hit = await load(id);
+  if (!hit) return { title: "Camera not found" };
 
+  const cam = hit.camera;
   const title = cameraTitle(cam);
   const description = cameraDescription(cam);
 
@@ -57,12 +58,10 @@ export async function generateMetadata({
 
 export default async function CameraPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const cam = await load(id);
-  if (!cam) notFound();
+  const hit = await load(id);
+  if (!hit) notFound();
 
-  const nearby = (await nearestTo(cam.lat, cam.lon, 8))
-    .filter((n) => n.camera.id !== cam.id)
-    .slice(0, 6);
+  const { camera: cam, nearby } = hit;
   const live = isLiveStreamUrl(cam.streamUrl);
   const country = countryName(cam.country);
 
@@ -136,9 +135,9 @@ export default async function CameraPage({ params }: { params: Promise<{ id: str
         <h2>Nearby cameras</h2>
         <ul>
           {nearby.map((n) => (
-            <li key={n.camera.id}>
-              <Link href={cameraPath(n.camera.id)}>
-                {n.camera.name} &middot; {n.km.toFixed(2)} km
+            <li key={n.id}>
+              <Link href={cameraPath(n.id)}>
+                {n.name} &middot; {n.km.toFixed(2)} km
               </Link>
             </li>
           ))}

--- a/app/camera/[id]/page.tsx
+++ b/app/camera/[id]/page.tsx
@@ -28,6 +28,35 @@ import {
  */
 export const revalidate = 3_600;
 
+/**
+ * Returns NO paths, and that empty array is the entire point.
+ *
+ * From the Next.js docs on on-demand static generation: "To statically render all
+ * paths the first time they're visited, return an empty array from
+ * generateStaticParams... It is important to note that you must return an array from
+ * generateStaticParams, even if it's empty. Otherwise, THE ROUTE WILL BE DYNAMICALLY
+ * RENDERED instead of statically."
+ *
+ * That is the second half of why this page never honoured its `revalidate`, and it is
+ * separate from the uncached-fetch problem `lib/seo/registrySnapshot.ts` solves.
+ * Measured across two builds of this tree: caching the data alone moved `/cameras`
+ * from dynamic to static, but left `/camera/[id]` on `f (Dynamic)` - because a route
+ * with a dynamic segment and no `generateStaticParams` at all is dynamic regardless of
+ * how well its data is cached. Both were needed.
+ *
+ * Deliberately empty rather than the full id list: there are 18,766 crawlable camera
+ * URLs, and prerendering them would trade a runtime problem for a build-time one on a
+ * build we pay for. `dynamicParams` defaults to true, so each page is rendered the
+ * first time it is asked for and then served from the cache for `revalidate`.
+ *
+ * Do NOT reach for `dynamic = "force-static"` as a shortcut here. It flips
+ * `dynamicParams` to false, which would 404 every camera page that had not already
+ * been generated.
+ */
+export async function generateStaticParams() {
+  return [];
+}
+
 async function load(idParam: string) {
   return getCameraPage(decodeURIComponent(idParam));
 }

--- a/app/cameras/[country]/[region]/[[...paging]]/page.tsx
+++ b/app/cameras/[country]/[region]/[[...paging]]/page.tsx
@@ -38,6 +38,18 @@ function parsePage(paging: string[] | undefined): number | null {
   return Number(raw);
 }
 
+/**
+ * Returns NO paths, for the same reason as `/camera/[id]` - see the long note there.
+ * Next's docs: "you must return an array from generateStaticParams, even if it's
+ * empty. Otherwise, the route will be dynamically rendered instead of statically."
+ *
+ * Empty rather than the ~60 region/page combinations, so a region that appears when a
+ * feed is added is cached on first visit with no build edit and no build cost.
+ */
+export async function generateStaticParams() {
+  return [];
+}
+
 export async function generateMetadata({
   params,
 }: {

--- a/app/cameras/[country]/[region]/[[...paging]]/page.tsx
+++ b/app/cameras/[country]/[region]/[[...paging]]/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
-import { getRegistry } from "@/lib/sources/registry";
-import { camerasInRegion, pageSlice } from "@/lib/seo/directory";
+import { getRegionPage } from "@/lib/seo/registrySnapshot";
 import {
   CAMERAS_ROOT,
   REGION_PAGE_SIZE,
@@ -39,11 +38,6 @@ function parsePage(paging: string[] | undefined): number | null {
   return Number(raw);
 }
 
-async function load(country: string, region: string) {
-  const cameras = await getRegistry().catch(() => []);
-  return camerasInRegion(cameras, country, region);
-}
-
 export async function generateMetadata({
   params,
 }: {
@@ -51,11 +45,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { country, region, paging } = await params;
   const page = parsePage(paging);
-  const hit = await load(country, region);
-  if (!hit || page === null) return { title: "Region not found" };
+  if (page === null) return { title: "Region not found" };
+  const hit = await getRegionPage(country, region, page);
+  if (!hit) return { title: "Region not found" };
 
-  const pages = regionPageCount(hit.cameras.length);
-  const title = regionTitle(country, hit.region, hit.cameras.length, page);
+  const pages = regionPageCount(hit.total);
+  const title = regionTitle(country, hit.region, hit.total, page);
   const where = `${hit.region}, ${countryName(country)}`;
 
   return {
@@ -63,7 +58,7 @@ export async function generateMetadata({
     description:
       page > 1
         ? `Page ${page} of ${pages}: more public road cameras in ${where}, each with a live image and its operator named.`
-        : `Every public road camera in ${where}: ${formatCount(hit.cameras.length)} live feeds, each with its own page showing the current image, the operator and how often it refreshes.`,
+        : `Every public road camera in ${where}: ${formatCount(hit.total)} live feeds, each with its own page showing the current image, the operator and how often it refreshes.`,
     alternates: { canonical: regionPath(country, hit.region, page) },
     // Deep pages of a long list are real, useful and crawlable, but they are not
     // what should surface for "cameras in Florida" - page 1 is. Following the links
@@ -82,13 +77,13 @@ export default async function RegionPage({ params }: { params: Promise<RoutePara
   // canonical one permanently rather than serving identical content at two URLs.
   if (paging && paging.length === 1 && page === 1) permanentRedirect(regionPath(country, region));
 
-  const hit = await load(country, region);
+  const hit = await getRegionPage(country, region, page);
   if (!hit) notFound();
 
-  const pages = regionPageCount(hit.cameras.length);
+  const pages = regionPageCount(hit.total);
   if (page > pages) notFound();
 
-  const slice = pageSlice(hit.cameras, page, REGION_PAGE_SIZE);
+  const slice = hit.cameras;
   const first = (page - 1) * REGION_PAGE_SIZE + 1;
   const last = first + slice.length - 1;
   const countryLabel = countryName(country);
@@ -107,7 +102,7 @@ export default async function RegionPage({ params }: { params: Promise<RoutePara
       </h1>
 
       <p className="tn-dir-lede">
-        {formatCount(hit.cameras.length)} public road cameras.{" "}
+        {formatCount(hit.total)} public road cameras.{" "}
         {pages > 1 && (
           <>
             Showing {formatCount(first)}&ndash;{formatCount(last)}, page {page} of {pages}.

--- a/app/cameras/[country]/page.tsx
+++ b/app/cameras/[country]/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getRegistry } from "@/lib/sources/registry";
-import { groupByCountry } from "@/lib/seo/directory";
+import { getDirectory } from "@/lib/seo/registrySnapshot";
 import {
   CAMERAS_ROOT,
   countryName,
@@ -20,14 +19,13 @@ export const revalidate = 86_400;
  * being warm when a crawler first arrives.
  */
 export async function generateStaticParams() {
-  const cameras = await getRegistry().catch(() => []);
-  return groupByCountry(cameras).map((g) => ({ country: g.iso2.toLowerCase() }));
+  const { groups } = await getDirectory();
+  return groups.map((g) => ({ country: g.iso2.toLowerCase() }));
 }
 
 async function load(countryParam: string) {
-  const cameras = await getRegistry().catch(() => []);
-  const group = groupByCountry(cameras).find((g) => g.iso2.toLowerCase() === countryParam.toLowerCase());
-  return group ?? null;
+  const { groups } = await getDirectory();
+  return groups.find((g) => g.iso2.toLowerCase() === countryParam.toLowerCase()) ?? null;
 }
 
 export async function generateMetadata({

--- a/app/cameras/page.tsx
+++ b/app/cameras/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getRegistry } from "@/lib/sources/registry";
-import { groupByCountry } from "@/lib/seo/directory";
+import { getDirectory } from "@/lib/seo/registrySnapshot";
 import { CAMERAS_ROOT, countryPath, formatCount, regionPath } from "@/lib/seo/paths";
 import { BRAND } from "@/lib/brand";
 
@@ -15,10 +14,7 @@ export const metadata: Metadata = {
 };
 
 export default async function CamerasIndex() {
-  const cameras = await getRegistry().catch(() => []);
-  const groups = groupByCountry(cameras);
-  const available = cameras.filter((c) => c.available).length;
-  const regionCount = groups.reduce((n, g) => n + g.regions.length, 0);
+  const { groups, total, available, regionCount } = await getDirectory();
 
   return (
     <main className="tn-dir">
@@ -29,7 +25,7 @@ export default async function CamerasIndex() {
       <h1>Live traffic cameras by country</h1>
 
       <p className="tn-dir-lede">
-        {formatCount(cameras.length)} public road cameras from {groups.length} countries and{" "}
+        {formatCount(total)} public road cameras from {groups.length} countries and{" "}
         {formatCount(regionCount)} regions, read directly from the transport authorities that
         operate them. {formatCount(available)} were answering at the last check.
       </p>

--- a/lib/seo/registrySnapshot.ts
+++ b/lib/seo/registrySnapshot.ts
@@ -1,0 +1,180 @@
+// Cached, page-shaped reads of the camera registry for the SEO pages.
+//
+// WHY THIS FILE EXISTS — it is not a speed optimisation, it is a caching BUG FIX.
+//
+// `/camera/[id]` declares `revalidate = 3600` and the region pages declare
+// `revalidate = 86400`, and neither declaration was taking effect. Measured against
+// production on 2026-08-18, four consecutive requests for the same camera page:
+//
+//     X-Vercel-Cache: MISS  (x4),  Age: 0  (x4)
+//     Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
+//     and no X-Nextjs-Prerender header at all
+//
+// The build agrees: neither route appears in `.next/prerender-manifest.json`, under
+// `routes` or under `dynamicRoutes`. They are fully dynamic. Every request renders
+// from scratch, and the sitemap advertises 18,766 URLs to every crawler that asks.
+//
+// THE MECHANISM. From the Next.js caching docs: "if a route has a fetch request that
+// is not cached, this will opt the route out of the Full Route Cache", and "during
+// rendering, if a Dynamic API or a fetch option of { cache: 'no-store' } is
+// discovered, Next.js will switch to dynamically rendering the whole route". Next 15
+// changed the `fetch` default from `force-cache` to `no-store`, and none of the 23
+// fetch call sites in `lib/sources/*` opt back in. So any render that reaches a live
+// upstream call is dynamic, and `getRegistry()` reaches one whenever its 5-minute
+// module cache is cold — which, on a fresh serverless isolate, is always.
+//
+// WHY SOME PAGES ESCAPED, AND WHY THAT IS NOT LUCK YOU CAN RELY ON. `/cameras/[country]`
+// survives because its `generateStaticParams` calls `getRegistry()` during "collecting
+// page data", so the module cache is already warm by the time the page renders and no
+// fetch happens. That makes the static/dynamic decision a RACE on build ordering, not
+// a property of the code — and the race is visibly non-deterministic: `/cameras` is
+// prerendered on the production deployment (X-Nextjs-Prerender: 1, Age 76902) and came
+// out dynamic in the local build of the same commit.
+//
+// THE FIX. `unstable_cache` runs its callback in a swapped work-unit store, so an
+// uncached fetch inside it cannot mark the surrounding render dynamic — which is
+// exactly what the docs mean by "enabling pages to be prerendered during next build".
+// Reading the registry through here removes the race: the pages are static-eligible
+// whether or not anything warmed the module cache first.
+//
+// TWO RULES FOR ANYTHING ADDED BELOW.
+//
+//   1. KEEP ENTRIES SMALL. These are stored in the same incremental cache that backs
+//      ISR, and Vercel caps a Data Cache entry at 2 MB. The whole registry is ~6.4 MB
+//      of JSON, so it must never be cached whole; every reader here returns only the
+//      rows its page renders. The region reader is keyed by page number for this
+//      reason — US/Florida alone is 4,838 cameras, and REGION_PAGE_SIZE bounds a
+//      cached slice at 500 rows.
+//   2. NEVER CALL A DYNAMIC API IN A CALLBACK. `headers()`, `cookies()` and friends
+//      throw inside `unstable_cache`. That is the same property that makes this work.
+//
+// The `revalidate` on each reader matches the `revalidate` its page declares, so the
+// data and the rendered HTML expire together rather than the page pinning an older
+// snapshot than it claims.
+
+import { unstable_cache } from "next/cache";
+import type { Camera } from "@/lib/types";
+import { getRegistry } from "@/lib/sources/registry";
+import { findById, nearest } from "@/lib/sources/select";
+import { camerasInRegion, groupByCountry, pageSlice, type CountryGroup } from "@/lib/seo/directory";
+import { REGION_PAGE_SIZE } from "@/lib/seo/paths";
+
+/** Matches `revalidate` on app/cameras/**. The directory moves at the speed of a feed being added. */
+const DIRECTORY_TTL_SECONDS = 86_400;
+
+/** Matches `revalidate` on app/camera/[id]/page.tsx. */
+const CAMERA_TTL_SECONDS = 3_600;
+
+/**
+ * Everything `/cameras` and `/cameras/[country]` render, in one small object.
+ *
+ * Counts are computed here rather than in the pages so the whole 19k array stays on
+ * this side of the cache boundary — the pages receive ~40 country/region rows.
+ */
+export interface DirectorySnapshot {
+  groups: CountryGroup[];
+  /** Every camera in the registry, including the ones not currently answering. */
+  total: number;
+  /** How many were answering at the last refresh. */
+  available: number;
+  /** Regions summed across all countries. */
+  regionCount: number;
+}
+
+export const getDirectory = unstable_cache(
+  async (): Promise<DirectorySnapshot> => {
+    const cameras = await getRegistry().catch(() => []);
+    const groups = groupByCountry(cameras);
+    return {
+      groups,
+      total: cameras.length,
+      available: cameras.filter((c) => c.available).length,
+      regionCount: groups.reduce((n, g) => n + g.regions.length, 0),
+    };
+  },
+  ["seo", "directory"],
+  { revalidate: DIRECTORY_TTL_SECONDS },
+);
+
+/** One row of a region listing — only the four fields the page actually prints. */
+export interface RegionCameraRow {
+  id: string;
+  name: string;
+  road?: string;
+  available: boolean;
+}
+
+export interface RegionPageSnapshot {
+  /** The upstream's own wording for the region, not the slug. */
+  region: string;
+  /** Cameras in the whole region, which is what the pager and the lede count. */
+  total: number;
+  /** Just this page's slice. */
+  cameras: RegionCameraRow[];
+}
+
+/**
+ * One page of one region.
+ *
+ * `unstable_cache` folds a cached function's ARGUMENTS into its cache key, so the
+ * three parameters below shard the entries; the key parts only namespace them.
+ * Returns null for a slug that matches no camera, which the route turns into a 404 —
+ * the same contract `camerasInRegion` already has.
+ */
+export const getRegionPage = unstable_cache(
+  async (country: string, regionSlug: string, page: number): Promise<RegionPageSnapshot | null> => {
+    const cameras = await getRegistry().catch(() => []);
+    const hit = camerasInRegion(cameras, country, regionSlug);
+    if (!hit) return null;
+    return {
+      region: hit.region,
+      total: hit.cameras.length,
+      cameras: pageSlice(hit.cameras, page, REGION_PAGE_SIZE).map((c) => ({
+        id: c.id,
+        name: c.name,
+        road: c.road,
+        available: c.available,
+      })),
+    };
+  },
+  ["seo", "region"],
+  { revalidate: DIRECTORY_TTL_SECONDS },
+);
+
+/** A neighbour link on a camera page: the two fields it prints, and the distance. */
+export interface NearbyCamera {
+  id: string;
+  name: string;
+  km: number;
+}
+
+export interface CameraPageSnapshot {
+  camera: Camera;
+  nearby: NearbyCamera[];
+}
+
+/**
+ * One camera plus its six nearest neighbours.
+ *
+ * Deliberately NOT wrapped in a `.catch(() => [])`. `getRegistry()` throws only when
+ * the registry is cold AND every feed failed, and the page's existing behaviour for
+ * that case is to surface the error rather than claim the camera does not exist —
+ * a 404 would tell a crawler to drop a page that is fine.
+ *
+ * `generateMetadata` and the page body both read through here, so the pair now costs
+ * one cache entry between them instead of resolving the camera twice.
+ */
+export const getCameraPage = unstable_cache(
+  async (id: string): Promise<CameraPageSnapshot | null> => {
+    const cameras = await getRegistry();
+    const camera = findById(cameras, id);
+    if (!camera) return null;
+    const nearby = nearest(cameras, camera.lat, camera.lon, 8)
+      .filter((n) => n.camera.id !== camera.id)
+      .slice(0, 6)
+      .map((n) => ({ id: n.camera.id, name: n.camera.name, km: n.km }));
+    return { camera, nearby };
+  },
+  ["seo", "camera"],
+  { revalidate: CAMERA_TTL_SECONDS },
+);

--- a/tests/unit/seo-page-caching.test.ts
+++ b/tests/unit/seo-page-caching.test.ts
@@ -68,3 +68,33 @@ test("the snapshot never caches the whole registry", () => {
   expect(text).toContain("pageSlice(");
   expect(text).not.toMatch(/return\s+await\s+getRegistry\(\)/);
 });
+
+/**
+ * The second half of the same fix, and the half that is easiest to delete by accident
+ * because an empty array looks like dead code.
+ *
+ * Next's docs, on on-demand static generation: "you must return an array from
+ * generateStaticParams, even if it's empty. Otherwise, the route will be dynamically
+ * rendered instead of statically." Measured across two builds of this tree: caching
+ * the data alone moved /cameras from dynamic to static but left /camera/[id] and the
+ * region route on `f (Dynamic)`. A route with a dynamic segment and no
+ * generateStaticParams is dynamic no matter how well its data is cached.
+ */
+const PARAMETERISED_PAGES = [
+  "app/cameras/[country]/page.tsx",
+  "app/cameras/[country]/[region]/[[...paging]]/page.tsx",
+  "app/camera/[id]/page.tsx",
+];
+
+test.each(PARAMETERISED_PAGES)("%s exports generateStaticParams", (page) => {
+  expect(source(page)).toMatch(/export async function generateStaticParams\(/);
+});
+
+test.each(PARAMETERISED_PAGES)("%s does not force-static its way out of it", (page) => {
+  // `dynamic = "force-static"` flips dynamicParams to false, which would 404 every
+  // camera page that had not already been generated - a far worse failure than the
+  // caching one, and a tempting-looking shortcut.
+  // Anchored on `export const` so the warning ABOUT force-static in the page's own
+  // comment does not trip it.
+  expect(source(page)).not.toMatch(/export\s+const\s+dynamic\s*=\s*["']force-static["']/);
+});

--- a/tests/unit/seo-page-caching.test.ts
+++ b/tests/unit/seo-page-caching.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "vitest";
+
+/**
+ * Guards the cache boundary in front of the crawlable pages.
+ *
+ * WHY A SOURCE-SHAPE TEST RATHER THAN A BEHAVIOURAL ONE. What this protects is a
+ * Next.js render-mode decision, and that decision is invisible from inside the
+ * process: calling the page function returns the same markup whether the route was
+ * prerendered or rendered from scratch. The difference only shows up in a built
+ * `.next/prerender-manifest.json`, or as an `X-Vercel-Cache: MISS` on a deployment.
+ * Neither is reachable from a unit test, so the thing worth pinning is the property
+ * that CAUSES the mode: whether a page can reach a live upstream fetch.
+ *
+ * The failure being prevented is silent. Per Next's caching docs, "if a route has a
+ * fetch request that is not cached, this will opt the route out of the Full Route
+ * Cache", and Next 15 makes every `fetch` uncached by default. `getRegistry()`
+ * fetches whenever its 5-minute module cache is cold. So a page importing it
+ * directly renders correctly, passes every test, deploys green, and quietly costs a
+ * full server render on every one of the ~19k crawlable URLs.
+ *
+ * Reading through `lib/seo/registrySnapshot` instead puts an `unstable_cache`
+ * boundary in the way, and its callback runs in a swapped work-unit store so the
+ * fetch inside it cannot mark the surrounding render dynamic.
+ *
+ * If you are here because this test failed: you have not broken the page, you have
+ * broken its caching. Add what you need to `lib/seo/registrySnapshot.ts` and read it
+ * from there. API routes under `app/api/**` are exempt by design - they are
+ * `force-dynamic` already and have nothing to lose.
+ */
+const CRAWLABLE_PAGES = [
+  "app/cameras/page.tsx",
+  "app/cameras/[country]/page.tsx",
+  "app/cameras/[country]/[region]/[[...paging]]/page.tsx",
+  "app/camera/[id]/page.tsx",
+];
+
+function source(relative: string): string {
+  return readFileSync(resolve(process.cwd(), relative), "utf8");
+}
+
+test.each(CRAWLABLE_PAGES)("%s reads the registry through the cached snapshot", (page) => {
+  const text = source(page);
+  expect(text).toContain('from "@/lib/seo/registrySnapshot"');
+});
+
+test.each(CRAWLABLE_PAGES)("%s does not import the live registry directly", (page) => {
+  expect(source(page)).not.toContain('from "@/lib/sources/registry"');
+});
+
+test("every cached reader declares a revalidate window", () => {
+  const text = source("lib/seo/registrySnapshot.ts");
+  const readers = text.match(/unstable_cache\(/g) ?? [];
+  const windows = text.match(/\{ revalidate: [A-Z_]+ \}/g) ?? [];
+  expect(readers.length).toBeGreaterThan(0);
+  // A reader with no revalidate is cached for a year by default, which would pin a
+  // camera page to a snapshot long after the feed that produced it changed.
+  expect(windows).toHaveLength(readers.length);
+});
+
+test("the snapshot never caches the whole registry", () => {
+  // A Vercel Data Cache entry is capped at 2 MB and the full camera array is ~6.4 MB
+  // of JSON, so a reader that returns `cameras` wholesale would fail to store - and
+  // fail SILENTLY, falling back to recomputing on every request, which is the exact
+  // cost this module exists to remove.
+  const text = source("lib/seo/registrySnapshot.ts");
+  expect(text).toContain("pageSlice(");
+  expect(text).not.toMatch(/return\s+await\s+getRegistry\(\)/);
+});


### PR DESCRIPTION
## What this fixes

`/camera/[id]` declares `revalidate = 3600`. The region pages declare `revalidate = 86400`. **Neither declaration was taking effect.** Both routes were server-rendered from scratch on every request, and `robots.txt` plus a **20,061-URL sitemap** invite every crawler to walk them.

Measured on production, four consecutive requests for the same camera page:

```
X-Vercel-Cache: MISS  (x4)
Age: 0                (x4)
Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
(no X-Nextjs-Prerender header)
```

## Two causes, and I only found the second one by building

**Cause 1 - an uncached fetch in the render path.** From the Next.js caching docs: *"if a route has a `fetch` request that is not cached, this will opt the route out of the Full Route Cache."* Next 15 changed the `fetch` default from `force-cache` to `no-store`, and none of the 23 fetch call sites in `lib/sources/*` opt back in. `getRegistry()` therefore performs an uncached fetch whenever its 5-minute module cache is cold, which on a fresh isolate is always.

`lib/seo/registrySnapshot.ts` puts an `unstable_cache` boundary in front of the registry. Its callback runs in a swapped work-unit store, so the fetch inside it cannot dynamise the surrounding render.

**Cause 2 - no `generateStaticParams` at all.** From the same docs: *"you must return an array from `generateStaticParams`, even if it's empty. Otherwise, the route will be dynamically rendered instead of statically."* A route with a dynamic segment and no `generateStaticParams` is dynamic **however well its data is cached**. That is the difference between `/cameras/[country]`, which has one and is SSG, and these two, which had none.

I would have shipped cause 1 alone believing it fixed this. The build is what caught it.

## Evidence: three builds, one variable at a time

Same artefact each time (`.next/prerender-manifest.json`), same base tree.

| route | before | cause 1 only | both |
|---|---|---|---|
| `/cameras` | absent (dynamic) | **routes (static)** | routes (static) |
| `/cameras/[country]` | dynamicRoutes | dynamicRoutes | dynamicRoutes |
| `/camera/[id]` | absent (dynamic) | absent (dynamic) | **dynamicRoutes, `fallback: null`** |
| `/cameras/[country]/[region]/[[...paging]]` | absent (dynamic) | absent (dynamic) | **dynamicRoutes, `fallback: null`** |

Absent from both `routes` and `dynamicRoutes` means fully dynamic. `fallback: null` is the App Router's *blocking* form - render on first request, then serve from cache - not `fallback: false`, which would 404 an ungenerated page. That was the specific way this could have gone wrong, and it did not.

**The build is confirmatory, not the argument.** The argument is mechanical and documented: the two rules quoted above. The manifest is evidence that the mechanism fired. It does not prove determinism - and that matters here, because the middle column shows `/cameras` moving between two builds of the same commit, which is a real build-ordering race in how `generateStaticParams` warms the registry's module cache.

## What changes for a visitor

**Rendered output: nothing.** Same markup, same counts, same ordering.

| | before | after |
|---|---|---|
| camera page server text (name, place, operator, cadence, neighbours) | live per request | up to 1h old, as `revalidate = 3600` says |
| region/country/index listings | live per request | up to 24h old, as `revalidate = 86400` says |
| **camera live frame** | client-fetched on its own interval | **unchanged** |

The live image is a client component hitting `/api/proxy` on its own refresh interval, so the thing people actually watch is untouched. Pages get *faster* for visitors, since they can now be served from cache.

**@Sampo, this one is your call:** caching the camera page's server-rendered text for an hour is what the file already asks for - the comment above `revalidate = 3_600` argues for exactly this - but it is a real change in freshness and you should agree to it rather than discover it. Two constants in `lib/seo/registrySnapshot.ts` plus the matching `revalidate` exports if you want it tighter; the mechanism is unaffected.

## Design notes

- **Entries stay small.** These share the incremental cache that backs ISR, and a Vercel Data Cache entry is capped at 2 MB while the camera array is ~6.4 MB of JSON. Every reader returns only the rows its page renders - the directory snapshot measures 1,663 bytes, and the region reader is keyed by page number because US/Florida alone is 4,838 cameras with `REGION_PAGE_SIZE` bounding a slice at 500 rows.
- **`generateStaticParams` returns `[]` deliberately.** Prerendering 20,061 camera pages would trade a runtime bill for a build-time one. `dynamicParams` defaults to true, so pages generate on first request and cache after.
- **Not `dynamic = "force-static"`.** It flips `dynamicParams` to false and would 404 every camera page not already generated. A guard test asserts nobody adds it later.
- `generateMetadata` and the page body now share one cache entry instead of resolving the camera twice.

## Tests

`tests/unit/seo-page-caching.test.ts` pins both halves. The failure it guards is silent - a page that reads `getRegistry()` directly, or loses its empty `generateStaticParams` (it looks like dead code), still renders correctly, passes every test and deploys green while quietly costing a full server render on each of ~20k URLs. Proved it can fail: reverting `app/camera/[id]/page.tsx` to `origin/main` fails 2 of its cases.

```
npx tsc --noEmit  ->  exit 0
Test Files  247 passed (247)
     Tests  2053 passed (2053)
```
Baseline on `main` is 246 / 2037.

Not verified against a deployment: the preview answers `302` to Vercel SSO on every request, so it cannot be measured anonymously. After merge the check is one command, and it should print `X-Nextjs-Prerender: 1` and go `MISS` then `HIT`:

```
curl -sI "https://provenance-online.vercel.app/camera/tfl:JamCams_00002.00865" \
  | grep -iE "x-vercel-cache|x-nextjs-prerender|cache-control"
```
