### PR TITLE
Build the 6.4 MB camera body once per registry refresh, not once per request

### DIFF
--- a/app/api/cameras/route.ts
+++ b/app/api/cameras/route.ts
@@ -1,82 +1,18 @@
-import type { Camera } from "@/lib/types";
 import { getRegistry } from "@/lib/sources/registry";
-import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { camerasBody, camerasCacheControl } from "@/lib/cameras/body";
 
 export const dynamic = "force-dynamic";
 
-/**
- * Shared-cache lifetime for the camera list. The registry itself is already
- * stale-while-revalidate server-side, so this is about not paying an invocation per
- * visitor, not about protecting the upstreams.
- *
- * 60 s is safe for this body specifically because every time it carries is ABSOLUTE
- * (`lastSampledAt`), so a cached copy cannot under-report a camera's age — the client
- * subtracts from its own clock. Positions and names move on the order of days.
- */
-const CAMERAS_TTL_MS = 60_000;
-
-/**
- * The serialised body, held until the registry replaces its array.
- *
- * WHY. This is the fattest thing the deployment serves: 18,948 cameras, 6.44 MB of
- * JSON measured on prod. Building it means allocating 18,948 fresh objects, calling
- * `isLiveStreamUrl` (a `new URL()` parse) once per camera, and running
- * `JSON.stringify` over the result — 24.3 ms of CPU per call on a developer laptop,
- * and a Fluid vCPU is slower. That was paid on EVERY edge-cache miss, and the answer
- * was byte-for-byte the same each time until the registry refreshed.
- *
- * WHY IDENTITY IS THE RIGHT KEY, AND WHY IT IS EXACT. `getRegistry()` hands back
- * `cache.cameras`, and that array is only ever REPLACED — `mergeResults` builds a new
- * one each round and `refresh()` assigns it — never mutated in place after it is
- * published. So `from === cams` is true exactly while the contents are unchanged, and
- * a refresh produces a new reference which recomputes. No TTL to keep in step with
- * the registry's own, and no way for the two to drift apart.
- *
- * This is a memo, not a cache: it holds one entry, and it is per-isolate, so a cold
- * start pays the build once and nothing else does. It also LOWERS peak memory rather
- * than raising it — one retained 6.44 MB string in place of 6.44 MB of garbage per
- * request.
- */
-let serialised: { from: Camera[]; body: string } | null = null;
-
-/**
- * The response body for a camera set. Exported for the test, which is the only way
- * to observe the memo: the string it returns is identical either way, so the
- * property worth asserting is that the WORK is not repeated.
- */
-export function camerasBody(cams: Camera[]): string {
-  if (serialised && serialised.from === cams) return serialised.body;
-  // source + live let the client pick the right camera icon (shape = feed,
-  // colour = region). `live` = has a stream our /api/hls proxy can play, so the
-  // video icon means genuinely-playable live video (not just any mediaType).
-  const cameras = cams.map((c) => ({
-    id: c.id, name: c.name, lat: c.lat, lon: c.lon, available: c.available,
-    source: c.source, country: c.country, live: isLiveStreamUrl(c.streamUrl),
-    // Enriched for the focus view (Camera fields the docked widget doesn't need).
-    // NOTE: deliberately NO imageUrl/streamUrl — snapshots go through /api/proxy?id=
-    // and /api/hls?id= (SSRF allowlist by id), never a raw upstream URL.
-    region: c.region, road: c.road, refreshSeconds: c.refreshSeconds,
-    attribution: c.attribution, license: c.license, lastSampledAt: c.lastSampledAt,
-  }));
-  const body = JSON.stringify({ count: cameras.length, cameras });
-  serialised = { from: cams, body };
-  return body;
-}
-
-/** Test seam, matching the house pattern in lib/webcams/search.ts. */
-export function __resetCamerasBody(): void {
-  serialised = null;
-}
+// A route module may export ONLY the fields Next recognises, so `camerasBody` and its
+// test seam live in lib/cameras/body.ts, where the reasoning for the memo is written up.
 
 export async function GET() {
-  const cams = await getRegistry();
-  // `Response.json` is not used here only because the body is already a string;
-  // it sets exactly this Content-Type, so the response is unchanged on the wire.
-  return new Response(camerasBody(cams), {
+  // `Response.json` is not used only because the body is already a string; it sets
+  // exactly this Content-Type, so the response is unchanged on the wire.
+  return new Response(camerasBody(await getRegistry()), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": edgeCacheControl(CAMERAS_TTL_MS, 300_000),
+      "Cache-Control": camerasCacheControl(),
     },
   });
 }

--- a/app/api/cameras/route.ts
+++ b/app/api/cameras/route.ts
@@ -1,3 +1,4 @@
+import type { Camera } from "@/lib/types";
 import { getRegistry } from "@/lib/sources/registry";
 import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
 import { edgeCacheControl } from "@/lib/http/cache";
@@ -15,8 +16,37 @@ export const dynamic = "force-dynamic";
  */
 const CAMERAS_TTL_MS = 60_000;
 
-export async function GET() {
-  const cams = await getRegistry();
+/**
+ * The serialised body, held until the registry replaces its array.
+ *
+ * WHY. This is the fattest thing the deployment serves: 18,948 cameras, 6.44 MB of
+ * JSON measured on prod. Building it means allocating 18,948 fresh objects, calling
+ * `isLiveStreamUrl` (a `new URL()` parse) once per camera, and running
+ * `JSON.stringify` over the result — 24.3 ms of CPU per call on a developer laptop,
+ * and a Fluid vCPU is slower. That was paid on EVERY edge-cache miss, and the answer
+ * was byte-for-byte the same each time until the registry refreshed.
+ *
+ * WHY IDENTITY IS THE RIGHT KEY, AND WHY IT IS EXACT. `getRegistry()` hands back
+ * `cache.cameras`, and that array is only ever REPLACED — `mergeResults` builds a new
+ * one each round and `refresh()` assigns it — never mutated in place after it is
+ * published. So `from === cams` is true exactly while the contents are unchanged, and
+ * a refresh produces a new reference which recomputes. No TTL to keep in step with
+ * the registry's own, and no way for the two to drift apart.
+ *
+ * This is a memo, not a cache: it holds one entry, and it is per-isolate, so a cold
+ * start pays the build once and nothing else does. It also LOWERS peak memory rather
+ * than raising it — one retained 6.44 MB string in place of 6.44 MB of garbage per
+ * request.
+ */
+let serialised: { from: Camera[]; body: string } | null = null;
+
+/**
+ * The response body for a camera set. Exported for the test, which is the only way
+ * to observe the memo: the string it returns is identical either way, so the
+ * property worth asserting is that the WORK is not repeated.
+ */
+export function camerasBody(cams: Camera[]): string {
+  if (serialised && serialised.from === cams) return serialised.body;
   // source + live let the client pick the right camera icon (shape = feed,
   // colour = region). `live` = has a stream our /api/hls proxy can play, so the
   // video icon means genuinely-playable live video (not just any mediaType).
@@ -29,8 +59,24 @@ export async function GET() {
     region: c.region, road: c.road, refreshSeconds: c.refreshSeconds,
     attribution: c.attribution, license: c.license, lastSampledAt: c.lastSampledAt,
   }));
-  return Response.json(
-    { count: cameras.length, cameras },
-    { headers: { "Cache-Control": edgeCacheControl(CAMERAS_TTL_MS, 300_000) } },
-  );
+  const body = JSON.stringify({ count: cameras.length, cameras });
+  serialised = { from: cams, body };
+  return body;
+}
+
+/** Test seam, matching the house pattern in lib/webcams/search.ts. */
+export function __resetCamerasBody(): void {
+  serialised = null;
+}
+
+export async function GET() {
+  const cams = await getRegistry();
+  // `Response.json` is not used here only because the body is already a string;
+  // it sets exactly this Content-Type, so the response is unchanged on the wire.
+  return new Response(camerasBody(cams), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": edgeCacheControl(CAMERAS_TTL_MS, 300_000),
+    },
+  });
 }

--- a/app/api/webcams/route.ts
+++ b/app/api/webcams/route.ts
@@ -1,130 +1,20 @@
 import { getWebcams } from "@/lib/webcams/registry";
-import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
-import { WINDY_SOURCE } from "@/lib/sources/windy";
-import { describeCoverage } from "@/lib/signals/coverage";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { webcamsBody, webcamsCacheControl } from "@/lib/webcams/body";
 
 export const dynamic = "force-dynamic";
 
-/**
- * Shared-cache lifetime, and the reasoning is NOT the registry's.
- *
- * lib/webcams/registry.ts holds its sample for 8 minutes, deliberately under Windy's
- * ~10-minute image-token expiry. That ceiling protects TOKENS, and there are none in
- * this response: the route ships thin markers and the dossier re-resolves a fresh
- * image per view through /api/webcam-image. So the token clock does not bind here.
- *
- * What does bind is honesty, and this body is the easy case — it carries no timestamp
- * at all, absolute or relative, so a cached copy cannot under-report anything's age.
- * Compare /api/planes, whose `staleness.ageMs` is relative and freezes under a cache;
- * that is why its TTL is 20 s and this one can be the same 60 s as /api/cameras. What
- * moves in this body is a webcam's position, title and `available` flag, on the order
- * of the 8-minute sample behind it.
- *
- * As with /api/cameras this is about not paying an invocation per visitor, not about
- * protecting the upstream — getWebcams() already shields Windy.
- */
-const WEBCAMS_TTL_MS = 60_000;
-
-/**
- * The serialised body, held until the registry publishes a new sample.
- *
- * WHY. 2,000 webcams, 425 KB of JSON measured on prod, rebuilt on every request
- * because this route had no cache header at all — so the edge never answered one and
- * every visitor cost an invocation AND a full re-serialisation. The answer was
- * byte-for-byte the same each time until the 8-minute sample rolled over.
- *
- * WHY IDENTITY IS THE RIGHT KEY. `getWebcams()` returns `cache.sample`, and
- * `refresh()` only ever REPLACES that object — including on the failure path, where it
- * rewrites the timestamp but re-uses the same sample rather than mutating it. So
- * `from === sample` is true exactly while the contents are unchanged, and a new sample
- * recomputes. Nothing in the body depends on the clock: `describeWebcamSample` and
- * `describeCoverage` are both pure over the sample, so there is no second expiry to
- * keep in step.
- *
- * Same shape as the memo in app/api/cameras/route.ts. One entry, per isolate, and it
- * lowers peak memory rather than raising it — one retained string instead of 425 KB of
- * garbage per request.
- */
-let serialised: { from: WebcamSample; body: string } | null = null;
-
-/**
- * GET /api/webcams — a global sample of Windy webcams as thin markers (the
- * x-windy-api-key is added server-side; it never reaches the client). Distinct
- * from /api/cameras: webcams are their own layer and never fold into the
- * road-camera count.
- *
- * Image URLs are intentionally omitted here — their tokens are short-lived, so
- * the dossier re-resolves a fresh image per view through /api/webcam-image.
- *
- * TRUNCATION HONESTY. The merged global sample is capped at MAX_WEBCAMS (2000);
- * before this the cap shipped with nothing disclosing it, so `count` was the
- * ceiling wearing the costume of a measurement — the exact defect the coverage
- * contract exists to prevent. `sample.coverage` (lib/signals/coverage.ts,
- * attached in lib/webcams/normalize.ts's toWebcams()) now carries the true
- * pre-cap total, so this can say "2,000 of N" instead of a bare 2,000.
- *
- * DESIGN DECISION — SIGNAL style ("N of M"), not the camera style. Cameras'
- * /api/coverage reports {feeds: {answered, total, stale}} because a camera total
- * is a SUM ACROSS ELEVEN INDEPENDENT NETWORKS, any of which can be down on a
- * given refresh — the denominator that matters there is "how many of our feeds
- * answered". Webcams have exactly ONE upstream (Windy) and no per-feed health
- * dimension to report; the only thing being hidden is a single render cap over
- * one merged pool of rows. That is precisely what lib/signals/coverage.ts's
- * applyCap/coverageCountLabel contract was built for (it already backs
- * /api/planes and /api/signals/<id> for the same reason), so reusing it costs
- * nothing, and inventing a "feeds" shape for a single source would just be
- * duplication with no real denominator to put in it.
- *
- * Returns {count, webcams[], dormant, note, attribution, coverage?}. `note` is a
- * plain sentence describing what actually happened upstream, so an empty layer
- * can always explain itself instead of silently looking like "no webcams exist".
- * `coverage` is present only when the sample declared one (i.e. not dormant) —
- * its absence means "not declared", never "nothing was truncated".
- */
-export function webcamsBody(sample: WebcamSample): string {
-  if (serialised && serialised.from === sample) return serialised.body;
-  // `city` and `categories` survive lib/webcams/normalize.ts but used to be dropped
-  // here. They are what lets a caller filter to squares, promenades and old towns
-  // instead of matching on title text — the difference between finding the
-  // pedestrian-zone cameras this layer is mostly useful for and guessing at them.
-  const thin = sample.webcams.map((w) => ({
-    id: w.id,
-    title: w.title,
-    lat: w.lat,
-    lon: w.lon,
-    country: w.country,
-    region: w.region,
-    city: w.city,
-    categories: w.categories,
-    available: w.available,
-    detailUrl: w.detailUrl,
-  }));
-  const body = JSON.stringify({
-    count: thin.length,
-    webcams: thin,
-    dormant: sample.dormant,
-    note: describeWebcamSample(sample),
-    attribution: WINDY_SOURCE.attribution,
-    ...(sample.coverage ? { coverage: describeCoverage(sample.coverage) } : {}),
-  });
-  serialised = { from: sample, body };
-  return body;
-}
-
-/** Test seam, matching the house pattern in lib/webcams/search.ts. */
-export function __resetWebcamsBody(): void {
-  serialised = null;
-}
+// A route module may export ONLY the fields Next recognises; `webcamsBody` and its
+// test seam therefore live in lib/webcams/body.ts, where the reasoning is written up.
+// That file also carries the route documentation - what this endpoint returns, why the
+// coverage record is shaped the way it is, and why no image URL ever leaves here.
 
 export async function GET() {
-  const sample = await getWebcams();
-  // `Response.json` is not used here only because the body is already a string;
-  // it sets exactly this Content-Type, so the response is unchanged on the wire.
-  return new Response(webcamsBody(sample), {
+  // `Response.json` is not used only because the body is already a string; it sets
+  // exactly this Content-Type, so the response is unchanged on the wire.
+  return new Response(webcamsBody(await getWebcams()), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": edgeCacheControl(WEBCAMS_TTL_MS, 300_000),
+      "Cache-Control": webcamsCacheControl(),
     },
   });
 }

--- a/lib/cameras/body.ts
+++ b/lib/cameras/body.ts
@@ -1,0 +1,82 @@
+import type { Camera } from "@/lib/types";
+import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
+import { edgeCacheControl } from "@/lib/http/cache";
+
+// The body of GET /api/cameras, and its edge-cache policy.
+//
+// WHY THIS IS NOT IN THE ROUTE FILE. A Next.js route module may export ONLY the names
+// Next recognises - the HTTP verbs plus dynamic, revalidate, runtime, dynamicParams,
+// fetchCache, preferredRegion, maxDuration and generateStaticParams. Anything else is a
+// HARD BUILD FAILURE ("... is not a valid Route export field"), and `npx tsc --noEmit`
+// plus the whole vitest suite pass anyway - the contract is checked only inside
+// `next build`, after tsc has already been satisfied. Helpers live here; the route
+// imports one function. tests/unit/route-export-contract.test.ts enforces it.
+
+/**
+ * Shared-cache lifetime for the camera list. The registry itself is already
+ * stale-while-revalidate server-side, so this is about not paying an invocation per
+ * visitor, not about protecting the upstreams.
+ *
+ * 60 s is safe for this body specifically because every time it carries is ABSOLUTE
+ * (`lastSampledAt`), so a cached copy cannot under-report a camera's age — the client
+ * subtracts from its own clock. Positions and names move on the order of days.
+ */
+const CAMERAS_TTL_MS = 60_000;
+
+/**
+ * The serialised body, held until the registry replaces its array.
+ *
+ * WHY. This is the fattest thing the deployment serves: 18,948 cameras, 6.44 MB of
+ * JSON measured on prod. Building it means allocating 18,948 fresh objects, calling
+ * `isLiveStreamUrl` (a `new URL()` parse) once per camera, and running
+ * `JSON.stringify` over the result — 24.3 ms of CPU per call on a developer laptop,
+ * and a Fluid vCPU is slower. That was paid on EVERY edge-cache miss, and the answer
+ * was byte-for-byte the same each time until the registry refreshed.
+ *
+ * WHY IDENTITY IS THE RIGHT KEY, AND WHY IT IS EXACT. `getRegistry()` hands back
+ * `cache.cameras`, and that array is only ever REPLACED — `mergeResults` builds a new
+ * one each round and `refresh()` assigns it — never mutated in place after it is
+ * published. So `from === cams` is true exactly while the contents are unchanged, and
+ * a refresh produces a new reference which recomputes. No TTL to keep in step with
+ * the registry's own, and no way for the two to drift apart.
+ *
+ * This is a memo, not a cache: it holds one entry, and it is per-isolate, so a cold
+ * start pays the build once and nothing else does. It also LOWERS peak memory rather
+ * than raising it — one retained 6.44 MB string in place of 6.44 MB of garbage per
+ * request.
+ */
+let serialised: { from: Camera[]; body: string } | null = null;
+
+/**
+ * The response body for a camera set. Exported for the test, which is the only way
+ * to observe the memo: the string it returns is identical either way, so the
+ * property worth asserting is that the WORK is not repeated.
+ */
+export function camerasBody(cams: Camera[]): string {
+  if (serialised && serialised.from === cams) return serialised.body;
+  // source + live let the client pick the right camera icon (shape = feed,
+  // colour = region). `live` = has a stream our /api/hls proxy can play, so the
+  // video icon means genuinely-playable live video (not just any mediaType).
+  const cameras = cams.map((c) => ({
+    id: c.id, name: c.name, lat: c.lat, lon: c.lon, available: c.available,
+    source: c.source, country: c.country, live: isLiveStreamUrl(c.streamUrl),
+    // Enriched for the focus view (Camera fields the docked widget doesn't need).
+    // NOTE: deliberately NO imageUrl/streamUrl — snapshots go through /api/proxy?id=
+    // and /api/hls?id= (SSRF allowlist by id), never a raw upstream URL.
+    region: c.region, road: c.road, refreshSeconds: c.refreshSeconds,
+    attribution: c.attribution, license: c.license, lastSampledAt: c.lastSampledAt,
+  }));
+  const body = JSON.stringify({ count: cameras.length, cameras });
+  serialised = { from: cams, body };
+  return body;
+}
+
+/** Test seam, matching the house pattern in lib/webcams/search.ts. */
+export function __resetCamerasBody(): void {
+  serialised = null;
+}
+
+/** The Cache-Control this route answers with. Lives beside the TTL it is derived from. */
+export function camerasCacheControl(): string {
+  return edgeCacheControl(CAMERAS_TTL_MS, 300_000);
+}

--- a/lib/webcams/body.ts
+++ b/lib/webcams/body.ts
@@ -1,0 +1,136 @@
+import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
+import { WINDY_SOURCE } from "@/lib/sources/windy";
+import { describeCoverage } from "@/lib/signals/coverage";
+import { edgeCacheControl } from "@/lib/http/cache";
+
+// The body of GET /api/webcams, and its edge-cache policy.
+//
+// WHY THIS IS NOT IN THE ROUTE FILE. A Next.js App Router route module may only export
+// the names Next recognises - the HTTP verbs plus dynamic, revalidate, runtime,
+// dynamicParams, fetchCache, preferredRegion, maxDuration and generateStaticParams.
+// Anything else is a HARD BUILD FAILURE:
+//
+//     Type error: Route "app/api/webcams/route.ts" does not match the required types
+//     of a Next.js Route. "webcamsBody" is not a valid Route export field.
+//
+// and - this is the part worth knowing - `npx tsc --noEmit` and the whole vitest suite
+// pass anyway. The route-export contract is checked only inside `next build`, during
+// "Linting and checking validity of types", AFTER tsc has already been satisfied. So a
+// helper exported from a route file for a test to import looks completely green locally
+// and fails the deployment. Helpers live here; the route imports one function.
+
+/**
+ * Shared-cache lifetime, and the reasoning is NOT the registry's.
+ *
+ * lib/webcams/registry.ts holds its sample for 8 minutes, deliberately under Windy's
+ * ~10-minute image-token expiry. That ceiling protects TOKENS, and there are none in
+ * this response: the route ships thin markers and the dossier re-resolves a fresh
+ * image per view through /api/webcam-image. So the token clock does not bind here.
+ *
+ * What does bind is honesty, and this body is the easy case — it carries no timestamp
+ * at all, absolute or relative, so a cached copy cannot under-report anything's age.
+ * Compare /api/planes, whose `staleness.ageMs` is relative and freezes under a cache;
+ * that is why its TTL is 20 s and this one can be the same 60 s as /api/cameras. What
+ * moves in this body is a webcam's position, title and `available` flag, on the order
+ * of the 8-minute sample behind it.
+ *
+ * As with /api/cameras this is about not paying an invocation per visitor, not about
+ * protecting the upstream — getWebcams() already shields Windy.
+ */
+const WEBCAMS_TTL_MS = 60_000;
+
+/**
+ * The serialised body, held until the registry publishes a new sample.
+ *
+ * WHY. 2,000 webcams, 425 KB of JSON measured on prod, rebuilt on every request
+ * because this route had no cache header at all — so the edge never answered one and
+ * every visitor cost an invocation AND a full re-serialisation. The answer was
+ * byte-for-byte the same each time until the 8-minute sample rolled over.
+ *
+ * WHY IDENTITY IS THE RIGHT KEY. `getWebcams()` returns `cache.sample`, and
+ * `refresh()` only ever REPLACES that object — including on the failure path, where it
+ * rewrites the timestamp but re-uses the same sample rather than mutating it. So
+ * `from === sample` is true exactly while the contents are unchanged, and a new sample
+ * recomputes. Nothing in the body depends on the clock: `describeWebcamSample` and
+ * `describeCoverage` are both pure over the sample, so there is no second expiry to
+ * keep in step.
+ *
+ * Same shape as the memo in app/api/cameras/route.ts. One entry, per isolate, and it
+ * lowers peak memory rather than raising it — one retained string instead of 425 KB of
+ * garbage per request.
+ */
+let serialised: { from: WebcamSample; body: string } | null = null;
+
+/**
+ * GET /api/webcams — a global sample of Windy webcams as thin markers (the
+ * x-windy-api-key is added server-side; it never reaches the client). Distinct
+ * from /api/cameras: webcams are their own layer and never fold into the
+ * road-camera count.
+ *
+ * Image URLs are intentionally omitted here — their tokens are short-lived, so
+ * the dossier re-resolves a fresh image per view through /api/webcam-image.
+ *
+ * TRUNCATION HONESTY. The merged global sample is capped at MAX_WEBCAMS (2000);
+ * before this the cap shipped with nothing disclosing it, so `count` was the
+ * ceiling wearing the costume of a measurement — the exact defect the coverage
+ * contract exists to prevent. `sample.coverage` (lib/signals/coverage.ts,
+ * attached in lib/webcams/normalize.ts's toWebcams()) now carries the true
+ * pre-cap total, so this can say "2,000 of N" instead of a bare 2,000.
+ *
+ * DESIGN DECISION — SIGNAL style ("N of M"), not the camera style. Cameras'
+ * /api/coverage reports {feeds: {answered, total, stale}} because a camera total
+ * is a SUM ACROSS ELEVEN INDEPENDENT NETWORKS, any of which can be down on a
+ * given refresh — the denominator that matters there is "how many of our feeds
+ * answered". Webcams have exactly ONE upstream (Windy) and no per-feed health
+ * dimension to report; the only thing being hidden is a single render cap over
+ * one merged pool of rows. That is precisely what lib/signals/coverage.ts's
+ * applyCap/coverageCountLabel contract was built for (it already backs
+ * /api/planes and /api/signals/<id> for the same reason), so reusing it costs
+ * nothing, and inventing a "feeds" shape for a single source would just be
+ * duplication with no real denominator to put in it.
+ *
+ * Returns {count, webcams[], dormant, note, attribution, coverage?}. `note` is a
+ * plain sentence describing what actually happened upstream, so an empty layer
+ * can always explain itself instead of silently looking like "no webcams exist".
+ * `coverage` is present only when the sample declared one (i.e. not dormant) —
+ * its absence means "not declared", never "nothing was truncated".
+ */
+export function webcamsBody(sample: WebcamSample): string {
+  if (serialised && serialised.from === sample) return serialised.body;
+  // `city` and `categories` survive lib/webcams/normalize.ts but used to be dropped
+  // here. They are what lets a caller filter to squares, promenades and old towns
+  // instead of matching on title text — the difference between finding the
+  // pedestrian-zone cameras this layer is mostly useful for and guessing at them.
+  const thin = sample.webcams.map((w) => ({
+    id: w.id,
+    title: w.title,
+    lat: w.lat,
+    lon: w.lon,
+    country: w.country,
+    region: w.region,
+    city: w.city,
+    categories: w.categories,
+    available: w.available,
+    detailUrl: w.detailUrl,
+  }));
+  const body = JSON.stringify({
+    count: thin.length,
+    webcams: thin,
+    dormant: sample.dormant,
+    note: describeWebcamSample(sample),
+    attribution: WINDY_SOURCE.attribution,
+    ...(sample.coverage ? { coverage: describeCoverage(sample.coverage) } : {}),
+  });
+  serialised = { from: sample, body };
+  return body;
+}
+
+/** Test seam, matching the house pattern in lib/webcams/search.ts. */
+export function __resetWebcamsBody(): void {
+  serialised = null;
+}
+
+/** The Cache-Control this route answers with. Lives beside the TTL it is derived from. */
+export function webcamsCacheControl(): string {
+  return edgeCacheControl(WEBCAMS_TTL_MS, 300_000);
+}

--- a/tests/unit/cameras-body-memo.test.ts
+++ b/tests/unit/cameras-body-memo.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Camera } from "@/lib/types";
+
+// /api/cameras is the fattest response the deployment serves — 18,948 cameras and
+// 6.44 MB of JSON on prod — and it was rebuilt from scratch on every edge-cache
+// miss even though the answer only changes when the registry refreshes.
+//
+// The memo cannot be observed from its return value: the string is identical either
+// way. So what gets asserted here is the WORK. `isLiveStreamUrl` runs exactly once
+// per camera per registry array, and a replaced array recomputes.
+
+const isLiveStreamUrl = vi.fn((url?: string) => Boolean(url));
+vi.mock("@/lib/proxy/hls-allowlist", () => ({
+  isLiveStreamUrl: (url?: string) => isLiveStreamUrl(url),
+}));
+
+const { camerasBody, __resetCamerasBody } = await import("@/app/api/cameras/route");
+
+const cam = (id: string, over: Partial<Camera> = {}): Camera =>
+  ({
+    id,
+    name: `Camera ${id}`,
+    lat: 51.5,
+    lon: -0.12,
+    available: true,
+    source: "tfl",
+    country: "GB",
+    mediaType: "jpeg",
+    refreshSeconds: 300,
+    license: "OGL",
+    attribution: "Powered by TfL Open Data",
+    ...over,
+  }) as Camera;
+
+beforeEach(() => {
+  __resetCamerasBody();
+  isLiveStreamUrl.mockClear();
+});
+
+describe("camerasBody", () => {
+  it("serialises once for a given registry array", () => {
+    const cams = [cam("a"), cam("b"), cam("c")];
+
+    const first = camerasBody(cams);
+    const second = camerasBody(cams);
+
+    expect(second).toBe(first);
+    // Three cameras, one pass — not two passes of three.
+    expect(isLiveStreamUrl).toHaveBeenCalledTimes(3);
+  });
+
+  it("rebuilds when the registry publishes a new array", () => {
+    const before = [cam("a")];
+    const after = [cam("a"), cam("b")];
+
+    const first = camerasBody(before);
+    isLiveStreamUrl.mockClear();
+    const second = camerasBody(after);
+
+    expect(JSON.parse(first).count).toBe(1);
+    expect(JSON.parse(second).count).toBe(2);
+    expect(isLiveStreamUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("keys on identity, so equal-looking arrays are not confused", () => {
+    // `refresh()` builds a fresh array every round. Two arrays with the same
+    // contents must still be treated as different publications, because the memo
+    // has no way to know the contents are equal without doing the work it exists
+    // to avoid.
+    const first = [cam("a")];
+    const second = [cam("a")];
+
+    camerasBody(first);
+    isLiveStreamUrl.mockClear();
+    camerasBody(second);
+
+    expect(isLiveStreamUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the shape the client reads, and no upstream URLs", () => {
+    const body = JSON.parse(
+      camerasBody([cam("a", { streamUrl: "https://wzmedia.dot.ca.gov/x.m3u8", region: "London", road: "A406" })]),
+    );
+
+    expect(body.count).toBe(1);
+    expect(body.cameras[0]).toMatchObject({
+      id: "a",
+      name: "Camera a",
+      source: "tfl",
+      country: "GB",
+      region: "London",
+      road: "A406",
+      live: true,
+    });
+    // The SSRF allowlist is by id; a raw upstream URL must never leave this route.
+    expect(body.cameras[0]).not.toHaveProperty("streamUrl");
+    expect(body.cameras[0]).not.toHaveProperty("imageUrl");
+  });
+});

--- a/tests/unit/cameras-body-memo.test.ts
+++ b/tests/unit/cameras-body-memo.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/proxy/hls-allowlist", () => ({
   isLiveStreamUrl: (url?: string) => isLiveStreamUrl(url),
 }));
 
-const { camerasBody, __resetCamerasBody } = await import("@/app/api/cameras/route");
+const { camerasBody, __resetCamerasBody } = await import("@/lib/cameras/body");
 
 const cam = (id: string, over: Partial<Camera> = {}): Camera =>
   ({

--- a/tests/unit/route-export-contract.test.ts
+++ b/tests/unit/route-export-contract.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { expect, test } from "vitest";
+
+/**
+ * A Next.js route or page module may export ONLY the names Next recognises. Anything
+ * else is a hard build failure:
+ *
+ *     Type error: Route "app/api/webcams/route.ts" does not match the required types
+ *     of a Next.js Route. "webcamsBody" is not a valid Route export field.
+ *
+ * WHY THIS TEST EXISTS RATHER THAN A CODE REVIEW NOTE. The house gate is
+ * `npx tsc --noEmit && npm test`, and BOTH PASS on a file that breaks this rule. The
+ * route-export contract is checked only inside `next build`, during "Linting and
+ * checking validity of types", after tsc has already been satisfied. So the failure
+ * mode is: green locally, green in the suite, dead on deploy - and it reached `main`
+ * exactly once that way, in the commit this test was added to fix.
+ *
+ * It is a tempting mistake because the motive is good. You write a helper in a route
+ * file, you want a unit test for it, so you export it. The fix is always the same:
+ * move the helper to `lib/` and have the route import it. That is better anyway - the
+ * helper becomes testable without pulling a route module into the test.
+ *
+ * The allowed list is Next's, not ours. If a future Next version adds a segment
+ * option, add it here with a link, do not widen the check.
+ */
+const ALLOWED = new Set([
+  // HTTP verbs a route handler may implement
+  "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+  // route segment config
+  "dynamic", "dynamicParams", "revalidate", "fetchCache", "runtime",
+  "preferredRegion", "maxDuration", "experimental_ppr",
+  // page/layout conventions
+  "default", "metadata", "generateMetadata", "generateStaticParams",
+  "generateViewport", "viewport", "generateImageMetadata", "alt", "size",
+  "contentType", "config",
+]);
+
+const APP = resolve(process.cwd(), "app");
+const MODULE_NAMES = /^(route|page|layout|template|default|error|loading|not-found|opengraph-image|twitter-image|icon|apple-icon|sitemap|robots|manifest)\.(ts|tsx|js|jsx)$/;
+
+function routeModules(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) routeModules(full, found);
+    else if (MODULE_NAMES.test(entry.name)) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Exported binding names, read off the source.
+ *
+ * Deliberately a parse of the text rather than an import: importing every route module
+ * would execute them, and several reach for adapters and environment at module scope.
+ * `export type` and `export interface` are skipped - they are erased at compile time
+ * and Next never sees them.
+ */
+function exportedNames(source: string): string[] {
+  const names: string[] = [];
+  const decl = /^export\s+(?!type\b|interface\b)(?:async\s+)?(?:function\*?|const|let|var|class)\s+([A-Za-z_$][\w$]*)/gm;
+  for (const m of source.matchAll(decl)) names.push(m[1]);
+  if (/^export\s+default\b/m.test(source)) names.push("default");
+  // `export { a, b as c }` - the exported (right-hand) name is the one Next reads.
+  for (const m of source.matchAll(/^export\s*\{([^}]*)\}/gm)) {
+    for (const part of m[1].split(",")) {
+      const piece = part.trim();
+      if (!piece || piece.startsWith("type ")) continue;
+      names.push((piece.split(/\s+as\s+/).pop() ?? piece).trim());
+    }
+  }
+  return names;
+}
+
+const MODULES = routeModules(APP).map((f) => relative(process.cwd(), f).replace(/\\/g, "/"));
+
+test("there are route modules to check", () => {
+  // A silent zero here would make every case below vacuously pass.
+  expect(MODULES.length).toBeGreaterThan(30);
+});
+
+test.each(MODULES)("%s exports only fields Next.js recognises", (file) => {
+  const offenders = exportedNames(readFileSync(file, "utf8")).filter((n) => !ALLOWED.has(n));
+
+  // Named so the failure tells you what to move and where, rather than just going red.
+  expect(
+    offenders,
+    `${file} exports ${offenders.join(", ")}, which Next rejects at build time. ` +
+      "Move the helper into lib/ and import it from the route.",
+  ).toEqual([]);
+});

--- a/tests/unit/webcams-body-memo.test.ts
+++ b/tests/unit/webcams-body-memo.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/webcams/fetch", async (importOriginal) => ({
   describeWebcamSample: () => describeWebcamSample(),
 }));
 
-const { webcamsBody, __resetWebcamsBody } = await import("@/app/api/webcams/route");
+const { webcamsBody, __resetWebcamsBody } = await import("@/lib/webcams/body");
 
 const webcam = (id: string, over: Record<string, unknown> = {}) => ({
   id,


### PR DESCRIPTION
> **Read this first — two things happened after the original description was written.**
>
> **1. The helpers moved out of the route file.** Vercel rejected this branch with
> `Type error: Route "app/api/cameras/route.ts" does not match the required types of a Next.js Route. "camerasBody" is not a valid Route export field.` A Next route module may export only the names Next recognises. `camerasBody` and `__resetCamerasBody` now live in `lib/cameras/body.ts`; the route exports `dynamic` and `GET` and nothing else, and the test imports the lib module. **The memo, its registry-array identity key and the edge TTL are all unchanged** — only where the symbols live.
>
> Worth knowing why it got this far: `npx tsc --noEmit` passes on the broken file, and so does the whole suite. That contract is checked only inside `next build`, after tsc has already been satisfied.
>
> **2. This branch carries #121.** The same defect reached `main` through #120, so `main` itself does not build, and anything cut from it inherits a red check. #121 fixes that and adds `tests/unit/route-export-contract.test.ts`, which parses every module under `app/` and asserts each exports only fields Next accepts. It is merged into this branch so this PR stands green on its own. Merging #121 first makes those commits a no-op here; either order is fine.

---

## The cost

`/api/cameras` is the fattest thing the deployment serves. Measured on prod:

```
18,948 cameras, 6,443,932 bytes, 1.3s warm
```

Producing it means allocating 18,948 fresh objects, calling `isLiveStreamUrl` (a `new URL()` parse) once per camera, and running `JSON.stringify` over the result. Profiled against the real payload:

| step | CPU |
|---|---|
| `.map()` + `isLiveStreamUrl` x18,948 | 5.5 ms |
| `JSON.stringify` (6.4 MB) | 23.4 ms |
| **total per invocation** | **24.3 ms** |

That is a developer laptop; a Fluid vCPU is slower. It was paid on **every edge-cache miss**, and the answer was byte-for-byte the same each time until the registry refreshed.

## The change

Memoise the serialised body against the registry **array identity**.

`getRegistry()` hands back `cache.cameras`. That array is only ever *replaced* - `mergeResults` builds a new one each round and `refresh()` assigns it - never mutated in place after publication. So `from === cams` is true exactly while the contents are unchanged, and a refresh produces a new reference which recomputes.

That is why identity and not a TTL: there is no second expiry to keep in step with the registry's own 5-minute one, and no way for the two to drift apart.

One entry, per isolate. A cold start pays the build once and nothing else does. It **lowers** peak memory rather than raising it - one retained 6.44 MB string in place of 6.44 MB of garbage per request.

## Is the response identical?

Yes, and I checked rather than assuming. `Response.json` is dropped only because the body is already a string:

```
Response.json(obj).text().length  = 6395441
JSON.stringify(obj).length        = 6395441
identical bytes                   = true
Response.json content-type        = application/json   (the same header set here)
```

Projection code, field order, `Cache-Control` and `stale-while-revalidate` are untouched. Nothing about freshness changes: the memo is invalidated by the same event that changes the data.

## Test

The memo cannot be observed from its return value - the string is identical either way - so the test asserts the *work*: `isLiveStreamUrl` runs once per camera per array, a replaced array recomputes, and two equal-looking arrays are correctly treated as separate publications. It also pins that no raw upstream `streamUrl`/`imageUrl` leaves the route, since that is the SSRF property the projection exists to hold.

Follows the `__resetXCache()` test-seam pattern already in `lib/webcams/search.ts`.

## Scope

One file plus its test. Does not touch `lib/sources/*` (no conflict with the Serbia adapter work) and does not overlap #114.

## Also considered and deliberately deferred

`/api/webcams` has the same shape - 425 KB of JSON, 2,000 rows mapped and stringified per request, `force-dynamic` with no cache header. Its body carries **no timestamp at all**, so unlike `/api/planes` (whose `staleness.ageMs` is relative and would freeze under a cache) a TTL there cannot make any freshness indicator lie. Named here rather than left unsaid.

The rest of the uncached read routes are a smaller prize than they look: `/api/news`, `/api/markets`, `/api/brief`, `/api/advisory`, `/api/markets/ath` and `/api/markets/chart` all already hold their own in-process cache keyed on `Date.now()`, so a warm invocation is a cache hit plus a small `JSON.stringify`. An edge TTL there saves the invocation, not much CPU - and Fluid bills active CPU.

```
npx tsc --noEmit  ->  exit 0
Test Files  253 passed (253)
     Tests  2135 passed (2135)
```
Re-measured after merging `origin/main` at 8986349 - i.e. with #113, #114, #116, #117, #118, #119 and #120 all landed. Baseline on that main is **252 / 2131**, so this adds one file and four cases. (252 is derived: `git ls-tree origin/main tests/unit/cameras-body-memo.test.ts` is empty, so my one file is the only difference, and 2135 - 4 = 2131 reconciles exactly with the 2131 measured independently on main.) Any earlier figure in this PR's history is against a `main` that no longer exists.




