### PR TITLE
Serbia: 62 cameras, read from the two operators that publish them

### DIFF
--- a/lib/icons/svg.ts
+++ b/lib/icons/svg.ts
@@ -265,6 +265,11 @@ export const CAMERA_REGIONS: RegionMeta[] = [
   { source: "iceland", label: "Iceland", color: "#2dd4bf", view: { lat: 64.9, lng: -18.6, altitude: 0.7 } },
   { source: "estonia", label: "Estonia", color: "#6ee7b7", view: { lat: 58.7, lng: 25.5, altitude: 0.55 } },
   { source: "trafficscotland", label: "Scotland", color: "#22d3ee", view: { lat: 56.5, lng: -4, altitude: 0.55 } },
+  // Serbia arrives as two operators rather than one region, so both get a view
+  // framing the whole country: the border crossings ring its edge and the toll
+  // plazas run down the motorway spine, and neither is legible zoomed to itself.
+  { source: "mup-rs", label: "Serbia (borders)", color: "#7dd3fc", view: { lat: 44.1, lng: 20.9, altitude: 0.6 } },
+  { source: "putevi-rs", label: "Serbia (motorways)", color: "#99f6e4", view: { lat: 44.1, lng: 20.9, altitude: 0.6 } },
 ];
 
 export const CAMERA_DEFAULT_REGION: RegionMeta = {

--- a/lib/proxy/allowlist.ts
+++ b/lib/proxy/allowlist.ts
@@ -31,6 +31,14 @@ const RULES: { host: string; prefix: string; suffix?: string }[] = [
   { host: "www.traffic.gov.scot", prefix: "/tsis/camerahtml" },
   // CET São Paulo — snapshots at /cams/{pasta}/1.jpg.
   { host: "cameras.cetsp.com.br", prefix: "/cams/", suffix: ".jpg" },
+  // JP Putevi Srbije toll plazas — one poster JPEG per camera, always at
+  // /{camera-slug}/index.jpg, so the suffix pins the filename and not just the
+  // extension. TWO hosts because the operator splits them: the front-plaza
+  // cameras post to cam, the side-plaza cameras to jpps. Both also serve the
+  // HLS, which is a separate rule in hls-allowlist.ts and needs a Referer; the
+  // JPEG does not.
+  { host: "cam.bitinfo.co.rs", prefix: "/", suffix: "/index.jpg" },
+  { host: "jpps.bitinfo.co.rs", prefix: "/", suffix: "/index.jpg" },
   // Windy.com webcams — image CDN. URLs look like
   // /_/<size>/plain/<current|daylight>/<webcamId>/original.jpg (the Webcams layer,
   // a DISTINCT layer from road CCTV; resolved fresh by /api/webcam-image).

--- a/lib/proxy/hls-allowlist.ts
+++ b/lib/proxy/hls-allowlist.ts
@@ -1,10 +1,26 @@
 // Streaming hosts are separate from the still-image allowlist: each rule also
 // carries the Referer to inject (Caltrans' wzmedia is hotlink-protected).
-type HlsRule = { match: (host: string) => boolean; prefix: string; referer: string };
+// `referer` is optional because not every host is hotlink-protected: MUP serves
+// its playlists and segments to a bare request, and sending an empty Referer
+// where none is wanted is a claim we do not need to make.
+type HlsRule = { match: (host: string) => boolean; prefix: string; referer?: string };
 
 const RULES: HlsRule[] = [
   { match: (h) => h === "wzmedia.dot.ca.gov", prefix: "/", referer: "https://cwwp2.dot.ca.gov/" },
   { match: (h) => h.endsWith(".us-east-1.skyvdn.com"), prefix: "/rtplive/", referer: "https://www.511sc.org/" },
+  // Serbia — MUP border crossings. Playlists carry ABSOLUTE segment URLs on the
+  // same host, and no Referer is required (measured).
+  { match: (h) => h === "kamere.mup.gov.rs", prefix: "/" },
+  // Serbia — JP Putevi Srbije toll plazas. 403s without a Referer, and the
+  // TRAILING SLASH matters: "https://kamere.toll4all.com" alone is refused.
+  // Segment URIs are relative, so rewritePlaylist resolves them onto the same
+  // host and they come back through this rule. Two subdomains because the
+  // operator splits front-plaza and side-plaza cameras across them.
+  {
+    match: (h) => h === "cam.bitinfo.co.rs" || h === "jpps.bitinfo.co.rs",
+    prefix: "/",
+    referer: "https://kamere.toll4all.com/",
+  },
 ];
 
 export function isHlsAllowed(url: URL): { ok: boolean; referer?: string } {

--- a/lib/sources/catalog.ts
+++ b/lib/sources/catalog.ts
@@ -25,7 +25,7 @@ export const CORE_IDS = ["cameras", "planes", "satellites", "webcams"] as const;
 // Core-layer descriptors. refreshMs mirrors lib/freshness.ts seed(); groups use the
 // roll-up vocabulary (a group with one source still yields a valid 1-source roll-up).
 const CORE_SOURCES: CatalogSource[] = [
-  { id: "cameras",    kind: "core", label: "Cameras",    group: "Cameras",  color: "#0e7d97", attribution: "TfL · Caltrans · SCDOT · Digitraffic · 511 · DriveBC", refreshMs: 300_000 },
+  { id: "cameras",    kind: "core", label: "Cameras",    group: "Cameras",  color: "#0e7d97", attribution: "TfL · Caltrans · SCDOT · Digitraffic · 511 · DriveBC · MUP Srbije · Putevi Srbije", refreshMs: 300_000 },
   { id: "webcams",    kind: "core", label: "Webcams",    group: "Cameras",  color: "#ec4899", attribution: "Windy.com — global webcams", refreshMs: 600_000 },
   // OpenSky, not adsb.lol: app/api/planes → lib/sources/opensky.ts pulls the global
   // /states/all snapshot. adsb.lol backs only the separate military-air SIGNAL layer

--- a/lib/sources/registry.ts
+++ b/lib/sources/registry.ts
@@ -11,6 +11,8 @@ import { fetchRegistry as fetchIceland } from "@/lib/sources/iceland";
 import { fetchRegistry as fetchEstonia } from "@/lib/sources/estonia";
 import { fetchRegistry as fetchTrafficScotland } from "@/lib/sources/trafficscotland";
 import { fetchRegistry as fetchCetsp } from "@/lib/sources/cetsp";
+import { fetchRegistry as fetchSerbiaBorders } from "@/lib/sources/serbia-borders";
+import { fetchRegistry as fetchSerbiaTolls } from "@/lib/sources/serbia-tolls";
 import { findById, nearest } from "@/lib/sources/select";
 
 const TTL_MS = 5 * 60 * 1000;
@@ -118,6 +120,14 @@ const SOURCES: CameraFeed[] = [
   // lib/sources/cetsp.ts for why the other ~195 snapshot folders on that host
   // are not cameras.
   { key: "cetsp", fetch: fetchCetsp },
+  // First Balkan feeds, and two rather than one on purpose: they are separate
+  // operators (the interior ministry and the roads company) with separate
+  // outages, and mergeResults keeps last-good PER FEED. Folded into a single
+  // "serbia" key, a bad round at either portal would mark the other's cameras
+  // stale too. Neither declares a budgetMs — both were measured well inside the
+  // 10s default (see each adapter's fetchRegistry).
+  { key: "mup-rs", fetch: fetchSerbiaBorders },
+  { key: "putevi-rs", fetch: fetchSerbiaTolls },
 ];
 
 export const CAMERA_FEED_COUNT = SOURCES.length;

--- a/lib/sources/serbia-borders.ts
+++ b/lib/sources/serbia-borders.ts
@@ -1,0 +1,176 @@
+import { Camera, CameraArray, Source } from "@/lib/types";
+import {
+  SERBIA_BORDER_SITES,
+  decodeHtmlEntities,
+  isBareIpHost,
+} from "@/lib/sources/serbia.data";
+
+// Serbia — MUP (Ministarstvo unutrašnjih poslova) border-crossing cameras. 32
+// live HLS streams at 16 crossings, two per crossing, published by the ministry
+// on its own portal. Keyless.
+//
+// WHY WE READ THE PORTAL AND NOT AN AGGREGATOR. This feed was suggested via
+// kameresrbije.rs, a third-party directory that lists ~203 Serbian cameras. That
+// site's own privacy page states it "only relays publicly available video
+// streams from external sources" and that it does "not hold the rights to these
+// streams" — so it cannot grant a redistribution right it says it does not have.
+// It is a good POINTER and a bad SOURCE OF RECORD, so every camera here is read
+// from the operator that actually publishes it. Same reason the Camera rows
+// below are attributed to MUP and not to the directory.
+//
+// THE URL, AND THE SCRIPT IT DECIDES. The portal is WebSphere Portal, and the
+// link you get by clicking through carries an `!ut/p/z1/...` navigational state
+// token that is not stable. The bare path below returns the same 16 crossings
+// and the same 32 streams without one, so that is what we request.
+//
+// It also decides the ALPHABET, which is worth knowing before you read a name
+// here and think something is broken. The state-token URL renders Latin
+// ("Granični prelaz Horgoš"); the bare path renders Cyrillic ("Гранични прелаз
+// Хоргош"), which is Serbia's official script and the ministry's own default.
+// There is no stable way to ask for Latin — `?locale=sr-Latn-RS`, `?lang=lat`
+// and a `/sr-lat/` path were all tried and all still answer Cyrillic — so we
+// take the operator's wording as published, the way every other adapter does.
+// Nothing else varies with it: the crossing key, the camera number and the
+// coordinate all come from the URL and the gazetteer, never from the label.
+//
+// WHY THE CAMERAS ARE NUMBERED AND NOT LABELLED. Each crossing exposes two
+// streams and the portal labels NEITHER — it has one link per crossing that
+// toggles both. The obvious guess is entry/exit, and the page order does not
+// support it: Đala lists `djala2` first and Kotroman lists `kotroman2` first,
+// so position does not encode direction. The number therefore comes from the
+// operator's own filename and claims nothing more than that.
+//
+// NO STILL IMAGE. MUP publishes HLS only, so these are `mediaType: "video"`
+// with no `imageUrl`. The camera wall already handles that: `live` cameras get
+// the ▶ Live button and the HLS player instead of a refreshing <img>.
+//
+// To re-check the portal by hand:
+//   curl -s "https://www.mup.gov.rs/wps/portal/sr/kamer%D0%B5/kamer%D0%B5GP" | grep -o 'toggleCamera([^)]*)'
+
+const PORTAL_URL = "https://www.mup.gov.rs/wps/portal/sr/kamer%D0%B5/kamer%D0%B5GP";
+/** The only host this adapter will emit a stream for. */
+const STREAM_HOST = "kamere.mup.gov.rs";
+
+export const SERBIA_BORDERS_SOURCE: Source = {
+  id: "mup-rs",
+  name: "MUP Republike Srbije — border-crossing cameras",
+  // No open-data licence is published for this portal. Saying so is more useful
+  // than inventing a licence name, and matches how cetsp records the same gap.
+  license: "MUP Republike Srbije — public border-crossing camera viewer (no stated licence)",
+  attribution:
+    "Live border-crossing cameras © Ministarstvo unutrašnjih poslova Republike Srbije (MUP)",
+  // Live HLS. 60s mirrors the other live-stream feeds (caltrans, scdot) — it is
+  // the still-frame cadence the UI assumes, not a claim about the stream.
+  refreshSeconds: 60,
+  needsKey: false,
+};
+
+/** One stream lifted off the portal, before it is joined to a coordinate. */
+export interface MupPortalStream {
+  /** Path segment identifying the crossing, e.g. `MaliZvornik`. */
+  key: string;
+  /** The crossing's name exactly as the portal prints it. */
+  name: string;
+  /** 1 or 2, taken from the operator's own filename. */
+  index: number;
+  streamUrl: string;
+}
+
+/** Accept only an https .m3u8 on the ministry's own streaming host. */
+function usableStream(raw: string): URL | null {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (isBareIpHost(raw)) return null;
+  if (u.protocol !== "https:") return null;
+  if (u.hostname !== STREAM_HOST) return null;
+  if (!u.pathname.toLowerCase().endsWith(".m3u8")) return null;
+  return u;
+}
+
+/**
+ * Pull every `toggleCamera('<uuid>','<url1>', '<url2>')` off the portal.
+ *
+ * Pure, so the parse is unit-testable against a captured page without network.
+ * The crossing key and the camera number both come from the STREAM URL rather
+ * than from the markup order, because the order is not meaningful (see header).
+ */
+export function parseMupPortal(html: string): MupPortalStream[] {
+  const out: MupPortalStream[] = [];
+  const seen = new Set<string>();
+  const re = /toggleCamera\('[^']*',\s*'([^']+)'\s*,\s*'([^']+)'\)[^>]*>\s*([^<]+)/g;
+  for (const m of html.matchAll(re)) {
+    const name = decodeHtmlEntities(m[3]).replace(/\s+/g, " ").trim();
+    if (!name) continue;
+    for (const raw of [m[1], m[2]]) {
+      const u = usableStream(raw);
+      if (!u) continue;
+      const parts = u.pathname.split("/").filter(Boolean);
+      const key = parts.at(-2);
+      const file = parts.at(-1) ?? "";
+      if (!key) continue;
+      const digits = file.replace(/\.m3u8$/i, "").match(/(\d+)$/);
+      const index = digits ? Number(digits[1]) : 0;
+      if (!index) continue;
+      const id = `${key}-${index}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push({ key, name, index, streamUrl: u.toString() });
+    }
+  }
+  return out;
+}
+
+/**
+ * Join parsed streams to the verified gazetteer. A crossing with no row in
+ * SERBIA_BORDER_SITES is DROPPED, not placed at a guessed point — if MUP adds a
+ * seventeenth crossing it stays off the map until somebody geolocates it.
+ */
+export function normalizeSerbiaBorders(streams: MupPortalStream[]): Camera[] {
+  const sites = new Map(SERBIA_BORDER_SITES.map((s) => [s.key.toLowerCase(), s]));
+  const cams: Camera[] = [];
+  for (const s of streams) {
+    const site = sites.get(s.key.toLowerCase());
+    if (!site) continue;
+    cams.push({
+      id: `mup-rs:${s.key.toLowerCase()}-${s.index}`,
+      source: "mup-rs",
+      country: "RS",
+      region: "Border crossings",
+      name: `${s.name} (kamera ${s.index})`,
+      lat: site.lat,
+      lon: site.lon,
+      streamUrl: s.streamUrl,
+      mediaType: "video",
+      refreshSeconds: SERBIA_BORDERS_SOURCE.refreshSeconds,
+      license: SERBIA_BORDERS_SOURCE.license,
+      attribution: SERBIA_BORDERS_SOURCE.attribution,
+      available: true,
+    });
+  }
+  return cams;
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  // 15s is the house default for a page fetch. Measured over five runs the
+  // portal answers in 0.78-1.25s for ~104 KB, so this is headroom and not a
+  // budget the feed is expected to use. No per-feed budgetMs in registry.ts for
+  // the same reason: the 10s default already clears it by ~8x.
+  const res = await fetch(PORTAL_URL, {
+    headers: {
+      Accept: "text/html",
+      "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)",
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`MUP border cameras: ${res.status}`);
+  const cams = normalizeSerbiaBorders(parseMupPortal(await res.text()));
+  // A 200 that parses to nothing means the portal's markup moved. Throwing lets
+  // registry.ts keep this feed's last-good cameras instead of silently emptying
+  // Serbia's border layer.
+  if (cams.length === 0) throw new Error("MUP border cameras: portal returned no parseable streams");
+  return CameraArray.parse(cams);
+}

--- a/lib/sources/serbia-tolls.ts
+++ b/lib/sources/serbia-tolls.ts
@@ -1,0 +1,184 @@
+import { Camera, CameraArray, Source } from "@/lib/types";
+import {
+  SERBIA_TOLL_PLAZAS,
+  decodeHtmlEntities,
+  isBareIpHost,
+} from "@/lib/sources/serbia.data";
+
+// Serbia — JP Putevi Srbije motorway toll-plaza cameras. The viewer at
+// kamere.toll4all.com is the roads company's own: it is titled "Kamere | JP
+// Putevi Srbije" and carries their logo, and OSM independently records the same
+// plazas with `operator=ЈП „Путеви Србије“`. Keyless.
+//
+// 38 cameras across 19 plazas, entry and exit at each. We ship 30 of them: four
+// plazas are dropped because their coordinate could not be established, and the
+// reasoning for each is written down in serbia.data.ts rather than here.
+//
+// EVERY CAMERA HAS BOTH A STILL AND A STREAM, which is why these are
+// `mediaType: "both"` while the MUP border cameras are video-only. The markup
+// carries `poster` (a JPEG regenerated continuously — measured Last-Modified 7s
+// behind the request) and `src` (HLS).
+//
+// THE HOTLINK GOTCHA. bitinfo serves the poster JPEG to anyone, but
+// answers 403 on the .m3u8 unless a Referer is sent, and it is picky about the
+// exact value: "https://kamere.toll4all.com/" works and "https://kamere.toll4all.com"
+// (no trailing slash) does not. That Referer lives in lib/proxy/hls-allowlist.ts
+// with the Caltrans wzmedia rule that has the same shape. The playlist's segment
+// URIs are RELATIVE ("501.ts"), which rewritePlaylist already resolves against
+// the upstream URL before proxying.
+//
+// To re-check the viewer by hand:
+//   curl -s https://kamere.toll4all.com/ | grep -o 'class="cam-item"[^>]*'
+
+const VIEWER_URL = "https://kamere.toll4all.com/";
+
+/**
+ * The operator's media hosts. TWO of them, and the split is not cosmetic: the
+ * 24 `front_pan_cam*` posters sit on cam.bitinfo.co.rs while all 14
+ * `side_pan_cam*` posters sit on jpps.bitinfo.co.rs, even though every one of
+ * the 38 STREAMS is on cam.bitinfo.co.rs. Pinning this adapter to one host
+ * looked right against the camera list that pointed us here and would have
+ * dropped Niš, Novi Sad, Smederevo, Požarevac, Pakovraće and Leskovac without
+ * saying so. Both hosts were checked directly: jpps serves the same JPEGs, and
+ * the same HLS, under the same Referer rule.
+ */
+const MEDIA_HOSTS = new Set(["cam.bitinfo.co.rs", "jpps.bitinfo.co.rs"]);
+
+export const SERBIA_TOLLS_SOURCE: Source = {
+  id: "putevi-rs",
+  name: "JP Putevi Srbije — motorway toll-plaza cameras",
+  license: "JP Putevi Srbije — public toll-plaza camera viewer (no stated licence)",
+  attribution: "Live toll-plaza cameras © JP Putevi Srbije",
+  // The poster is regenerated continuously upstream, so this is OUR ceiling on
+  // how often we ask for one, not a claim about the operator's cadence. 60s
+  // matches the other live-stream feeds and bounds /api/proxy's Cache-Control.
+  refreshSeconds: 60,
+  needsKey: false,
+};
+
+/** One tile lifted off the viewer, before it is joined to a coordinate. */
+export interface TollViewerCamera {
+  /** Path segment identifying the camera, e.g. `front_pan_cam1`. */
+  slug: string;
+  /** The tile's label exactly as the viewer prints it, e.g. `Stara Pazova Izlaz`. */
+  label: string;
+  /** The label with the direction word removed — the gazetteer join key. */
+  station: string;
+  /** The operator's own direction word: `Ulaz` (entry) or `Izlaz` (exit). */
+  direction?: string;
+  imageUrl: string;
+  streamUrl: string;
+}
+
+/** Accept only an https URL on one of the operator's media hosts with the wanted suffix. */
+function usableMedia(raw: string, suffix: string): URL | null {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (isBareIpHost(raw)) return null;
+  if (u.protocol !== "https:") return null;
+  if (!MEDIA_HOSTS.has(u.hostname)) return null;
+  if (!u.pathname.toLowerCase().endsWith(suffix)) return null;
+  return u;
+}
+
+/** The `front_pan_cam1` in `https://host/front_pan_cam1/index.jpg`. */
+function cameraSlug(u: URL): string | undefined {
+  return u.pathname.split("/").filter(Boolean).at(-2);
+}
+
+/**
+ * Pull every `<div class="cam-item" poster=… src=…><span>Name</span>` off the
+ * viewer. Pure, so it is unit-testable against a captured page without network.
+ *
+ * A tile is kept only when its poster and its stream agree on the same camera
+ * SLUG — deliberately not on the same host, since the operator splits those
+ * (see MEDIA_HOSTS). The page also carries one loose `cam1.m3u8` outside any
+ * tile, with no name and no place; requiring the pair keeps it out without a
+ * special case.
+ */
+export function parseTollViewer(html: string): TollViewerCamera[] {
+  const out: TollViewerCamera[] = [];
+  const seen = new Set<string>();
+  const re =
+    /<div class="cam-item"\s+poster="([^"]+)"\s+src="([^"]+)"\s*>\s*<span>([^<]+)<\/span>/g;
+  for (const m of html.matchAll(re)) {
+    const image = usableMedia(m[1], ".jpg");
+    const stream = usableMedia(m[2], ".m3u8");
+    if (!image || !stream) continue;
+    const slug = cameraSlug(image);
+    if (!slug || slug !== cameraSlug(stream)) continue;
+    if (seen.has(slug)) continue;
+    const label = decodeHtmlEntities(m[3]).replace(/\s+/g, " ").trim();
+    if (!label) continue;
+    const dir = label.match(/\s(Ulaz|Izlaz)$/i);
+    seen.add(slug);
+    out.push({
+      slug,
+      label,
+      station: dir ? label.slice(0, dir.index).trim() : label,
+      direction: dir ? dir[1] : undefined,
+      imageUrl: image.toString(),
+      streamUrl: stream.toString(),
+    });
+  }
+  return out;
+}
+
+/**
+ * Join parsed tiles to the verified gazetteer. A plaza with no row in
+ * SERBIA_TOLL_PLAZAS is DROPPED rather than placed at a guessed point — that is
+ * what removes Leskovac, Ruma, Vrba and Vrčin, and it is also what will happen
+ * to any plaza the operator adds before somebody geolocates it.
+ */
+export function normalizeSerbiaTolls(tiles: TollViewerCamera[]): Camera[] {
+  const plazas = new Map(SERBIA_TOLL_PLAZAS.map((p) => [p.station.toLowerCase(), p]));
+  const cams: Camera[] = [];
+  for (const t of tiles) {
+    const plaza = plazas.get(t.station.toLowerCase());
+    if (!plaza) continue;
+    cams.push({
+      id: `putevi-rs:${t.slug}`,
+      source: "putevi-rs",
+      country: "RS",
+      region: "Motorway tolls",
+      name: t.label,
+      lat: plaza.lat,
+      lon: plaza.lon,
+      direction: t.direction,
+      imageUrl: t.imageUrl,
+      streamUrl: t.streamUrl,
+      mediaType: "both",
+      refreshSeconds: SERBIA_TOLLS_SOURCE.refreshSeconds,
+      license: SERBIA_TOLLS_SOURCE.license,
+      attribution: SERBIA_TOLLS_SOURCE.attribution,
+      available: true,
+    });
+  }
+  return cams;
+}
+
+export async function fetchRegistry(): Promise<Camera[]> {
+  // Measured over five runs: 0.30-0.62s for ~16 KB. 15s is headroom, and the
+  // 10s default in registry.ts clears it by more than an order of magnitude, so
+  // this feed declares no budgetMs.
+  const res = await fetch(VIEWER_URL, {
+    headers: {
+      Accept: "text/html",
+      "User-Agent": "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)",
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`Putevi Srbije toll cameras: ${res.status}`);
+  const cams = normalizeSerbiaTolls(parseTollViewer(await res.text()));
+  // A 200 that parses to nothing means the viewer's markup moved. Throwing lets
+  // registry.ts keep this feed's last-good cameras rather than silently emptying
+  // the motorway layer.
+  if (cams.length === 0) {
+    throw new Error("Putevi Srbije toll cameras: viewer returned no parseable tiles");
+  }
+  return CameraArray.parse(cams);
+}

--- a/lib/sources/serbia.data.ts
+++ b/lib/sources/serbia.data.ts
@@ -1,0 +1,185 @@
+/**
+ * Serbia — the gazetteer half of the two Serbian camera adapters.
+ *
+ * WHY THIS FILE EXISTS. Neither Serbian operator publishes a coordinate. The MUP
+ * portal is a list of `toggleCamera(uuid, url1, url2)` calls behind a crossing
+ * name; kamere.toll4all.com is a list of `<div class="cam-item" poster= src=>`
+ * behind a station name. Both give us a NAME and a STREAM and nothing else, so
+ * the pin has to come from somewhere, and that somewhere has to be checkable.
+ *
+ * WHERE THE COORDINATES CAME FROM. OpenStreetMap, via Overpass: every
+ * `barrier=border_control` and `barrier=toll_booth` element inside Serbia's
+ * bounding box, then matched to the operator's name BY HAND. Each row carries
+ * the OSM element it was read from, so the number can be re-checked without
+ * repeating the search. Data (c) OpenStreetMap contributors, ODbL.
+ *
+ * WHY BY HAND, AND WHY FOUR STATIONS ARE MISSING. The first pass matched names
+ * automatically and it was wrong in exactly the way
+ * lib/console/livecams/brazil.data.ts warns about: a lossy fold of "Djala" to
+ * "ala" matched the crossing at BACKA PALANKA, 105 km away on a different
+ * border. So every row below was read individually and cross-checked against
+ * the neighbouring country the operator files it under, and anything that could
+ * not be pinned to a NAMED OSM element was dropped rather than guessed:
+ *
+ *   Leskovac - OSM has TWO plazas, "Leskovac centar" and "Leskovac jug", 15 km
+ *              apart. toll4all says only "Leskovac". A coin flip, so neither.
+ *   Vrcin    - no toll plaza of that name in OSM. The nearest is "Beograd" on
+ *              the A1, which is plausibly the same plaza under another name,
+ *              and "plausibly" is not the same claim.
+ *   Ruma     - an UNNAMED pair of toll booths sits where the A3 passes south of
+ *              Ruma. Almost certainly it. Almost is not a coordinate.
+ *   Vrba     - same shape: an unnamed booth 1.7 km from the village.
+ *
+ * That costs 8 of the 38 toll cameras. A pin in the wrong place is a worse
+ * product than a missing pin, and this is a map.
+ *
+ * WHAT IS DELIBERATELY NOT HERE: `road`. The motorway ref is derivable from the
+ * OSM parent way, but the query to establish all 31 of them would not return
+ * inside a sane timeout, and `Camera.road` is optional. An unverified "A1" would
+ * be the same class of mistake as an unverified pin.
+ *
+ * To re-verify one row (Overpass QL):
+ *   [out:json];node(<osm id>);out center tags;
+ */
+
+/** A border crossing the MUP portal carries cameras for. */
+export interface SerbiaBorderSite {
+  /**
+   * The path segment inside the MUP stream URL, e.g. `MaliZvornik` in
+   * `https://kamere.mup.gov.rs:4443/MaliZvornik/malizvornik1.m3u8`. This is the
+   * join key, NOT the display name: the name is read from the portal at fetch
+   * time so it stays the operator's own wording.
+   */
+  key: string;
+  /** ISO-3166 alpha-2 of the country on the far side. A cross-check, not output. */
+  neighbour: string;
+  lat: number;
+  lon: number;
+  /** OSM element the coordinate was read from. */
+  osm: string;
+}
+
+/**
+ * The 16 crossings on the MUP portal, every one verified to sit on the SERBIAN
+ * side. Horgos is the row that needed real work: the only OSM element carrying
+ * that name is the disused "Horgos 2 / Roszke 2" crossing on a primary road,
+ * while the cameras are on the motorway crossing 600 m west. The row below is
+ * the border-control node on way/693685273, tagged `ref=A1` — the Serbian
+ * motorway — and not the Hungarian `ref=M5` node facing it.
+ */
+export const SERBIA_BORDER_SITES: SerbiaBorderSite[] = [
+  // to Hungary
+  { key: "Horgos", neighbour: "HU", lat: 46.1733, lon: 19.97584, osm: "node/951312138" },
+  { key: "Kelebija", neighbour: "HU", lat: 46.16701, lon: 19.56142, osm: "node/974126073 +3" },
+  { key: "Djala", neighbour: "HU", lat: 46.15743, lon: 20.11424, osm: "node/1614974595" },
+  // to Montenegro
+  { key: "Gostun", neighbour: "ME", lat: 43.18574, lon: 19.76036, osm: "node/289875181 +4" },
+  { key: "Jabuka", neighbour: "ME", lat: 43.33753, lon: 19.47772, osm: "node/292103237 +1" },
+  { key: "Spiljani", neighbour: "ME", lat: 42.91046, lon: 20.34124, osm: "node/295259158 +1" },
+  // to Croatia
+  { key: "Batrovci", neighbour: "HR", lat: 45.04726, lon: 19.1066, osm: "node/293933070 +4" },
+  { key: "Sid", neighbour: "HR", lat: 45.1548, lon: 19.17521, osm: "node/3993798980 +1" },
+  // to Romania
+  { key: "Vatin", neighbour: "RO", lat: 45.22914, lon: 21.27667, osm: "node/1395848797 +2" },
+  // to Bosnia and Herzegovina
+  { key: "Kotroman", neighbour: "BA", lat: 43.76266, lon: 19.47016, osm: "node/2395001508 +2" },
+  { key: "MaliZvornik", neighbour: "BA", lat: 44.40363, lon: 19.12604, osm: "node/1091326565" },
+  { key: "SremskaRaca", neighbour: "BA", lat: 44.91655, lon: 19.30386, osm: "node/1909037501 +1" },
+  { key: "Trbusnica", neighbour: "BA", lat: 44.54074, lon: 19.18475, osm: "node/426042899 +1" },
+  // to Bulgaria
+  { key: "Gradina", neighbour: "BG", lat: 42.99858, lon: 22.8313, osm: "node/1027943649 +3" },
+  { key: "VrskaCuka", neighbour: "BG", lat: 43.85028, lon: 22.37892, osm: "node/1643958767 +2" },
+  // to North Macedonia
+  { key: "Presevo", neighbour: "MK", lat: 42.23979, lon: 21.70243, osm: "way/697622826" },
+];
+
+/** A motorway toll plaza kamere.toll4all.com carries cameras for. */
+export interface SerbiaTollPlaza {
+  /**
+   * The station name exactly as the operator prints it, with the direction word
+   * (`Ulaz` = entry, `Izlaz` = exit) removed. This is the join key.
+   */
+  station: string;
+  lat: number;
+  lon: number;
+  /** OSM element the coordinate was read from. */
+  osm: string;
+}
+
+/**
+ * 15 of the 19 plazas on kamere.toll4all.com. See the header for the four that
+ * are missing and why. Every row here matched a NAMED OSM toll_booth element.
+ */
+export const SERBIA_TOLL_PLAZAS: SerbiaTollPlaza[] = [
+  { station: "Dimitrovgrad", lat: 43.02192, lon: 22.73643, osm: "node/4422069471" },
+  { station: "Niš Jug", lat: 43.32757, lon: 21.81582, osm: "node/1637060629" },
+  { station: "Niš Sever", lat: 43.34961, lon: 21.85813, osm: "node/1542578669" },
+  { station: "Novi Sad Jug", lat: 45.28786, lon: 19.89044, osm: "node/2321341081" },
+  { station: "Obrenovac", lat: 44.57129, lon: 20.19029, osm: "node/6738774623" },
+  { station: "Pakovraće", lat: 43.90299, lon: 20.26156, osm: "node/7834692260" },
+  { station: "Požarevac", lat: 44.58001, lon: 20.98246, osm: "node/6769000141" },
+  { station: "Preševo", lat: 42.30264, lon: 21.70968, osm: "node/5521636563" },
+  { station: "Prilipac", lat: 43.8205, lon: 20.09095, osm: "node/12957447628" },
+  { station: "Smederevo", lat: 44.58996, lon: 20.95723, osm: "node/6638460804" },
+  { station: "Stara Pazova", lat: 45.00648, lon: 20.20132, osm: "node/4138894601" },
+  { station: "Subotica", lat: 46.02106, lon: 19.734, osm: "node/5265308125" },
+  { station: "Šabac", lat: 44.80839, lon: 19.71923, osm: "node/11257279967" },
+  { station: "Šid", lat: 45.04832, lon: 19.19241, osm: "node/611035828" },
+  { station: "Šimanovci", lat: 44.88212, lon: 20.11373, osm: "node/32403710" },
+];
+
+/**
+ * Decode the HTML entities the two Serbian portals actually emit, so a name
+ * reaches the map the way the operator wrote it.
+ *
+ * The two portals escape DIFFERENTLY, which is why this handles both forms.
+ * MUP uses named entities and only for its s-caron (`Horgo&scaron;`,
+ * `&Scaron;id`) while leaving the c-caron in `Rača` and the d-stroke in `Đala`
+ * as literal UTF-8. toll4all uses numeric entities and for every diacritic it
+ * has: `Ni&#353;`, `Pakovra&#263;e`, `Po&#382;arevac`. So this covers the named
+ * pair, both numeric forms, and the five entities any HTML can carry, and
+ * deliberately stops there rather than pulling in a parser for two pages whose
+ * escaping we have measured.
+ */
+export function decodeHtmlEntities(s: string): string {
+  const NAMED: Record<string, string> = {
+    scaron: "š",
+    Scaron: "Š",
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    nbsp: " ",
+  };
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)))
+    .replace(/&([a-zA-Z]+);/g, (m, name) => NAMED[name] ?? m);
+}
+
+/**
+ * Reject a URL whose host is a bare IP literal rather than a resolvable name.
+ *
+ * This is a RULE, not a hand-written exclusion list, because the thing it guards
+ * against recurs. The directory that pointed at these operators
+ * (kameresrbije.rs) also lists a handful of MJPEG boxes on bare `IP:port`
+ * addresses — an unsecured camera that has leaked, not a feed anyone published.
+ * Indexing those into a searchable map is a different product from showing
+ * public road infrastructure, and the difference belongs in code so it survives
+ * the next time a source list grows.
+ *
+ * Both adapters run every URL through this before emitting a camera, so a
+ * future edit that pastes in a raw-IP stream drops it instead of shipping it.
+ */
+export function isBareIpHost(rawUrl: string): boolean {
+  let host: string;
+  try {
+    host = new URL(rawUrl).hostname;
+  } catch {
+    return true; // unparseable is not a domain we can stand behind either
+  }
+  // URL() wraps IPv6 literals in brackets.
+  if (host.startsWith("[") && host.endsWith("]")) return true;
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
+}

--- a/tests/unit/sources-serbia.test.ts
+++ b/tests/unit/sources-serbia.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMupPortal,
+  normalizeSerbiaBorders,
+  SERBIA_BORDERS_SOURCE,
+} from "@/lib/sources/serbia-borders";
+import {
+  parseTollViewer,
+  normalizeSerbiaTolls,
+  SERBIA_TOLLS_SOURCE,
+} from "@/lib/sources/serbia-tolls";
+import {
+  SERBIA_BORDER_SITES,
+  SERBIA_TOLL_PLAZAS,
+  isBareIpHost,
+  decodeHtmlEntities,
+} from "@/lib/sources/serbia.data";
+import { CameraArray } from "@/lib/types";
+import { isAllowed } from "@/lib/proxy/allowlist";
+import { isHlsAllowed } from "@/lib/proxy/hls-allowlist";
+
+// Every fixture below is REAL markup, copied byte-for-byte out of the two live
+// portals on 2026-08-18. Hand-written HTML would have hidden both of the things
+// these adapters exist to survive: MUP listing a crossing's two streams in
+// reverse order, and toll4all serving a tile's poster from a different subdomain
+// than its stream.
+
+// CYRILLIC, because that is what the adapter actually receives. The Latin
+// rendering below exists too, and the difference is not cosmetic: the portal
+// serves Latin only behind a `!ut/p/z1/...` navigational state token, and
+// Cyrillic from the bare path the adapter requests. The first version of this
+// fixture was the Latin one, captured through a browser-style URL, and it would
+// have made every name assertion here pass while production produced different
+// strings. Both are pinned so the parser stays script-agnostic.
+const MUP_FIXTURE = `
+<li id="id_31b04cbf-2f35-4f3a-85e7-a57d7129b2df" >
+  <a href="#" onclick="toggleCamera('31b04cbf-2f35-4f3a-85e7-a57d7129b2df','https://kamere.mup.gov.rs:4443/Horgos/horgos1.m3u8', 'https://kamere.mup.gov.rs:4443/Horgos/horgos2.m3u8');return false;">
+         Гранични прелаз Хоргош
+  </a>
+</li><li id="id_1d38255b-5e1a-44f7-ad15-3a9e4b441045" >
+  <a href="#" onclick="toggleCamera('1d38255b-5e1a-44f7-ad15-3a9e4b441045','https://kamere.mup.gov.rs:4443/Djala/djala2.m3u8', 'https://kamere.mup.gov.rs:4443/Djala/djala1.m3u8');return false;">
+         Гранични прелаз Ђала
+  </a>
+</li>`;
+
+/** The same two crossings as served through the state-token URL: Latin, and the
+ *  only place the `&scaron;` entity appears. */
+const MUP_FIXTURE_LATIN = `
+<li id="id_bf4ca0f6-b736-402f-a0a8-88df34899897" >
+  <a href="#" onclick="toggleCamera('bf4ca0f6-b736-402f-a0a8-88df34899897','https://kamere.mup.gov.rs:4443/Horgos/horgos1.m3u8', 'https://kamere.mup.gov.rs:4443/Horgos/horgos2.m3u8');return false;">
+         Granični prelaz Horgo&scaron;
+  </a>
+</li><li id="id_7a3d5b15-612a-49f6-bd90-ae6792844071" >
+  <a href="#" onclick="toggleCamera('7a3d5b15-612a-49f6-bd90-ae6792844071','https://kamere.mup.gov.rs:4443/Djala/djala2.m3u8', 'https://kamere.mup.gov.rs:4443/Djala/djala1.m3u8');return false;">
+         Granični prelaz Đala
+  </a>
+</li>`;
+
+const TOLL_FIXTURE = `
+<div class="cam-item" poster="https://cam.bitinfo.co.rs/front_pan_cam1/index.jpg" src="https://cam.bitinfo.co.rs/front_pan_cam1/index.m3u8">
+              <span>Stara Pazova Izlaz</span>
+              <img class="cam-item__icon" src="./assets/cam-icon.png" alt="Kamera" />
+            </div>
+<div class="cam-item" poster="https://jpps.bitinfo.co.rs/side_pan_cam3/index.jpg" src="https://cam.bitinfo.co.rs/side_pan_cam3/index.m3u8">
+              <span>Ni&#353; Sever Izlaz</span>
+              <img class="cam-item__icon" src="./assets/cam-icon.png" alt="Kamera" />
+            </div>
+<div class="cam-item" poster="https://jpps.bitinfo.co.rs/side_pan_cam1/index.jpg" src="https://cam.bitinfo.co.rs/side_pan_cam1/index.m3u8">
+              <span>Leskovac Izlaz</span>
+            </div>
+        <video id="my-video" class="video-js cam-modal-video" controls data-setup="{}">
+          <source src="https://cam.bitinfo.co.rs/cam1.m3u8" type="application/x-mpegURL" />
+        </video>`;
+
+describe("MUP border-crossing portal", () => {
+  it("reads both streams of every crossing off the real markup", () => {
+    const streams = parseMupPortal(MUP_FIXTURE);
+    expect(streams).toHaveLength(4);
+    expect(streams.map((s) => s.key)).toEqual(["Horgos", "Horgos", "Djala", "Djala"]);
+  });
+
+  // The portal prints Đala's SECOND camera first. Numbering off the markup
+  // order would have silently swapped the two, and nothing downstream could
+  // have caught it — both URLs resolve and both play.
+  it("numbers a camera from the operator's filename, not the page order", () => {
+    const djala = parseMupPortal(MUP_FIXTURE).filter((s) => s.key === "Djala");
+    expect(djala.map((s) => s.index)).toEqual([2, 1]);
+    expect(djala.find((s) => s.index === 1)!.streamUrl).toContain("djala1.m3u8");
+    expect(djala.find((s) => s.index === 2)!.streamUrl).toContain("djala2.m3u8");
+  });
+
+  it("keeps the ministry's own name, in the script it publishes", () => {
+    const [horgos] = parseMupPortal(MUP_FIXTURE);
+    expect(horgos.name).toBe("Гранични прелаз Хоргош");
+  });
+
+  // Same crossings, Latin rendering, entity-escaped s-caron. The join keys come
+  // off the URL, so the script the portal happens to serve changes the label and
+  // nothing else - no coordinate, no id, no camera dropped.
+  it("parses the Latin rendering identically apart from the label", () => {
+    const cyr = parseMupPortal(MUP_FIXTURE);
+    const lat = parseMupPortal(MUP_FIXTURE_LATIN);
+    expect(lat.map((s) => `${s.key}-${s.index}`)).toEqual(cyr.map((s) => `${s.key}-${s.index}`));
+    expect(lat[0].name).toBe("Granični prelaz Horgoš");
+    expect(normalizeSerbiaBorders(lat).map((c) => c.id)).toEqual(
+      normalizeSerbiaBorders(cyr).map((c) => c.id),
+    );
+  });
+
+  it("normalizes into schema-valid Cameras", () => {
+    const cams = normalizeSerbiaBorders(parseMupPortal(MUP_FIXTURE));
+    expect(cams).toHaveLength(4);
+    expect(() => CameraArray.parse(cams)).not.toThrow();
+  });
+
+  it("maps id, country, coords and stream", () => {
+    const cams = normalizeSerbiaBorders(parseMupPortal(MUP_FIXTURE));
+    const cam = cams.find((c) => c.id === "mup-rs:horgos-1")!;
+    expect(cam.source).toBe("mup-rs");
+    expect(cam.country).toBe("RS");
+    expect(cam.region).toBe("Border crossings");
+    expect(cam.name).toBe("Гранични прелаз Хоргош (kamera 1)");
+    // The motorway crossing on the A1, not the disused "Horgoš 2" 600 m east.
+    expect(cam.lat).toBeCloseTo(46.1733, 4);
+    expect(cam.lon).toBeCloseTo(19.97584, 4);
+    expect(cam.streamUrl).toBe("https://kamere.mup.gov.rs:4443/Horgos/horgos1.m3u8");
+    expect(cam.mediaType).toBe("video");
+    // MUP publishes no still, and claiming one would render a broken tile.
+    expect(cam.imageUrl).toBeUndefined();
+    expect(cam.attribution).toBe(SERBIA_BORDERS_SOURCE.attribution);
+  });
+
+  // A crossing we have not geolocated must vanish, not land on a guessed pin.
+  it("drops a crossing that has no verified coordinate", () => {
+    const invented = MUP_FIXTURE.replace(/Horgos/g, "Nekakav");
+    expect(parseMupPortal(invented)).toHaveLength(4);
+    expect(normalizeSerbiaBorders(parseMupPortal(invented))).toHaveLength(2);
+  });
+
+  it("refuses a stream that is not an https m3u8 on the ministry's host", () => {
+    const swapped = MUP_FIXTURE.replace("https://kamere.mup.gov.rs:4443/Horgos/horgos1.m3u8", "https://evil.example/Horgos/horgos1.m3u8");
+    const keys = parseMupPortal(swapped).map((s) => `${s.key}-${s.index}`);
+    expect(keys).not.toContain("Horgos-1");
+    expect(keys).toContain("Horgos-2");
+  });
+});
+
+describe("JP Putevi Srbije toll viewer", () => {
+  it("reads a tile whose poster and stream are on DIFFERENT subdomains", () => {
+    const tiles = parseTollViewer(TOLL_FIXTURE);
+    const nis = tiles.find((t) => t.slug === "side_pan_cam3");
+    expect(nis).toBeDefined();
+    expect(nis!.imageUrl).toContain("jpps.bitinfo.co.rs");
+    expect(nis!.streamUrl).toContain("cam.bitinfo.co.rs");
+  });
+
+  it("decodes the numeric entities and splits off the direction word", () => {
+    const nis = parseTollViewer(TOLL_FIXTURE).find((t) => t.slug === "side_pan_cam3")!;
+    expect(nis.label).toBe("Niš Sever Izlaz");
+    expect(nis.station).toBe("Niš Sever");
+    expect(nis.direction).toBe("Izlaz");
+  });
+
+  // The page carries a loose player <source> with no name and no place.
+  it("ignores a stream that is not inside a named tile", () => {
+    const slugs = parseTollViewer(TOLL_FIXTURE).map((t) => t.slug);
+    expect(slugs).toEqual(["front_pan_cam1", "side_pan_cam3", "side_pan_cam1"]);
+    expect(slugs).not.toContain("cam1");
+  });
+
+  it("normalizes into schema-valid Cameras", () => {
+    const cams = normalizeSerbiaTolls(parseTollViewer(TOLL_FIXTURE));
+    expect(() => CameraArray.parse(cams)).not.toThrow();
+  });
+
+  it("maps id, coords, both media types and the operator's direction", () => {
+    const cams = normalizeSerbiaTolls(parseTollViewer(TOLL_FIXTURE));
+    const cam = cams.find((c) => c.id === "putevi-rs:front_pan_cam1")!;
+    expect(cam.source).toBe("putevi-rs");
+    expect(cam.country).toBe("RS");
+    expect(cam.region).toBe("Motorway tolls");
+    expect(cam.name).toBe("Stara Pazova Izlaz");
+    expect(cam.direction).toBe("Izlaz");
+    expect(cam.lat).toBeCloseTo(45.00648, 4);
+    expect(cam.lon).toBeCloseTo(20.20132, 4);
+    expect(cam.mediaType).toBe("both");
+    expect(cam.attribution).toBe(SERBIA_TOLLS_SOURCE.attribution);
+  });
+
+  // Leskovac parses fine and is still dropped: OSM has two plazas of that name
+  // 15 km apart and the operator does not say which. See serbia.data.ts.
+  it("drops a plaza whose coordinate could not be established", () => {
+    const tiles = parseTollViewer(TOLL_FIXTURE);
+    expect(tiles.some((t) => t.station === "Leskovac")).toBe(true);
+    const cams = normalizeSerbiaTolls(tiles);
+    expect(cams.some((c) => c.name.startsWith("Leskovac"))).toBe(false);
+  });
+});
+
+// The proxies are the only path a camera's bytes can take, so an adapter that
+// emits a URL no rule matches ships a tile that renders "not answering".
+describe("the emitted URLs are actually proxyable", () => {
+  it("every toll poster passes the image allowlist", () => {
+    const cams = normalizeSerbiaTolls(parseTollViewer(TOLL_FIXTURE));
+    expect(cams.length).toBeGreaterThan(0);
+    for (const cam of cams) {
+      expect(isAllowed(new URL(cam.imageUrl!))).toBe(true);
+    }
+  });
+
+  it("every toll stream is allowed and carries the Referer the host demands", () => {
+    const cams = normalizeSerbiaTolls(parseTollViewer(TOLL_FIXTURE));
+    for (const cam of cams) {
+      const verdict = isHlsAllowed(new URL(cam.streamUrl!));
+      expect(verdict.ok).toBe(true);
+      // Without the trailing slash bitinfo answers 403.
+      expect(verdict.referer).toBe("https://kamere.toll4all.com/");
+    }
+  });
+
+  it("every border stream is allowed, and asks for no Referer", () => {
+    const cams = normalizeSerbiaBorders(parseMupPortal(MUP_FIXTURE));
+    for (const cam of cams) {
+      const verdict = isHlsAllowed(new URL(cam.streamUrl!));
+      expect(verdict.ok).toBe(true);
+      expect(verdict.referer).toBeUndefined();
+    }
+  });
+});
+
+// A rule, not a hand-filter: the directory that pointed at these operators also
+// lists unsecured MJPEG boxes on bare IP:port addresses. Those are somebody's
+// leaked camera, not a published feed, and they must stay out even if a future
+// edit pastes one in.
+describe("bare-IP hosts are rejected in code", () => {
+  it.each([
+    "http://93.87.72.254:8084/mjpg/video.mjpg",
+    "http://109.233.191.130:8090/cam_1.jpg",
+    "http://185.37.168.3:5000/cgi-bin/faststream.jpg",
+    "https://[2001:db8::1]/stream.m3u8",
+    "not a url at all",
+  ])("rejects %s", (url) => {
+    expect(isBareIpHost(url)).toBe(true);
+  });
+
+  it("accepts the operators' real hosts", () => {
+    expect(isBareIpHost("https://kamere.mup.gov.rs:4443/Gradina/gradina1.m3u8")).toBe(false);
+    expect(isBareIpHost("https://cam.bitinfo.co.rs/front_pan_cam1/index.jpg")).toBe(false);
+  });
+
+  it("keeps a raw-IP stream out of the border feed", () => {
+    const swapped = MUP_FIXTURE.replace("https://kamere.mup.gov.rs:4443/Horgos/horgos1.m3u8", "https://93.87.72.254:4443/Horgos/horgos1.m3u8");
+    expect(parseMupPortal(swapped).map((s) => `${s.key}-${s.index}`)).not.toContain("Horgos-1");
+  });
+
+  it("keeps a raw-IP poster out of the toll feed", () => {
+    const swapped = TOLL_FIXTURE.replace("https://cam.bitinfo.co.rs/front_pan_cam1/index.jpg", "https://93.87.72.254/front_pan_cam1/index.jpg");
+    expect(parseTollViewer(swapped).map((t) => t.slug)).not.toContain("front_pan_cam1");
+  });
+});
+
+describe("the hand-verified gazetteer", () => {
+  it("puts every coordinate inside Serbia", () => {
+    for (const p of [...SERBIA_BORDER_SITES, ...SERBIA_TOLL_PLAZAS]) {
+      expect(p.lat).toBeGreaterThan(41.8);
+      expect(p.lat).toBeLessThan(46.3);
+      expect(p.lon).toBeGreaterThan(18.8);
+      expect(p.lon).toBeLessThan(23.1);
+    }
+  });
+
+  it("has no duplicate join keys", () => {
+    const keys = SERBIA_BORDER_SITES.map((s) => s.key.toLowerCase());
+    expect(new Set(keys).size).toBe(keys.length);
+    const stations = SERBIA_TOLL_PLAZAS.map((p) => p.station.toLowerCase());
+    expect(new Set(stations).size).toBe(stations.length);
+  });
+
+  it("records where every coordinate came from", () => {
+    for (const p of [...SERBIA_BORDER_SITES, ...SERBIA_TOLL_PLAZAS]) {
+      expect(p.osm).toMatch(/^(node|way)\/\d+/);
+    }
+  });
+
+  it("covers all 16 crossings the portal carries", () => {
+    expect(SERBIA_BORDER_SITES).toHaveLength(16);
+  });
+});
+
+describe("decodeHtmlEntities", () => {
+  it("handles the named, decimal and hex forms the two portals use", () => {
+    expect(decodeHtmlEntities("Horgo&scaron;")).toBe("Horgoš");
+    expect(decodeHtmlEntities("&Scaron;id")).toBe("Šid");
+    expect(decodeHtmlEntities("Ni&#353; Sever")).toBe("Niš Sever");
+    expect(decodeHtmlEntities("Po&#382;arevac")).toBe("Požarevac");
+    expect(decodeHtmlEntities("Pakovra&#x107;e")).toBe("Pakovraće");
+  });
+
+  it("leaves an entity it does not know alone rather than mangling it", () => {
+    expect(decodeHtmlEntities("A &frobnicate; B")).toBe("A &frobnicate; B");
+  });
+});


### PR DESCRIPTION
Serbia had **0** cameras in the registry. It now has **62**, from the two operators that publish them.

| feed | cameras | what |
|---|---|---|
| `mup-rs` | 32 | MUP border crossings — 16 crossings × 2, live HLS |
| `putevi-rs` | 30 | JP Putevi Srbije toll plazas — 15 × entry/exit, poster JPEG **and** HLS |

## Gate

```
npx tsc --noEmit   ->  exit 0, no output
Test Files  248 passed (248)
Tests  2071 passed (2071)
```

Baseline 246/2037, so this is +2 files / +34 tests. Run in this worktree on the exact tree committed, after deleting the temporary live probe.

Vercel preview build: **SUCCESS**.

## Second commit: the CLAUDE.md counts

`CLAUDE.md` stated "11 feeds" and "11 adapters, 7 countries". Both were **already wrong before this branch** - the tree held 12 feeds across 8 countries, because `cetsp` landed Brazil without the doc moving - and Serbia takes the real figures to 14 and 9. Corrected here rather than in a follow-up so there is never a window where `main` states a number this branch is what made wrong.

The correction is the smaller half. Nothing checks a sentence, which is why it survived twice, so `tests/unit/claude-md-counts.test.ts` now reads `CLAUDE.md`, extracts the counts from both places they appear, and asserts them against `CAMERA_FEED_COUNT` and the country literals the adapters declare. I checked the test actually fails before trusting it: editing the doc to 13 reds it with `expected 13 to be 14`.

Same pattern the repo already uses one row further down that table, where `console-presets.test.ts` and `tour-board-copy.test.ts` exist so the board count "cannot silently rot".

One limit, recorded in the test rather than glossed: the country scan reads literal `country: "XX"` assignments, which is every camera adapter today. An adapter deriving its country from upstream data would be invisible to it, so a red there means re-measure, not automatically "the doc lies".

## Why 62 and not the 203 we were pointed at

The request came with a directory, kameresrbije.rs. Its own privacy page states it "only relays publicly available video streams from external sources" and does "not hold the rights to these streams" — so it cannot grant a redistribution right it says it does not have. Its `robots.txt` does explicitly allow crawling `/cameras-all.json`, which is a real permission for the **list** and not a licence for the **video**.

So it is treated as a pointer, not a source of record. Every camera here is read from the operator that actually publishes it:

- **MUP** — parsed from `www.mup.gov.rs`, the ministry's own portal.
- **JP Putevi Srbije** — parsed from `kamere.toll4all.com`, which is titled "Kamere | JP Putevi Srbije" and carries their logo; OSM independently tags the same plazas `operator=ЈП „Путеви Србије"`.

Neither publishes an open-data licence, so the `license` field says exactly that rather than inventing one — the same shape `cetsp` already uses for the same gap.

### The 141 dropped for provenance

Not attributable to a named operator with a checkable policy: srbija-nadlanu, streamer.devnet.rs, infokop, live.banja.top, ipcamlive, YouTube channels, ski resorts, private webcams.

### The 8 dropped by rule

`isBareIpHost()` in `serbia.data.ts` rejects any URL whose host is a bare IP literal. This is a **rule, not a hand-written exclusion list**, because the failure recurs: the directory also lists MJPEG boxes on bare `IP:port` (`93.87.72.254:8084`, `109.233.191.130:8090`, `185.37.168.3:5000`). Those are somebody's leaked camera, not a published feed, and aggregating them into a searchable map is a different product. Both adapters run every URL through it, and there are seven cases including "keeps a raw-IP stream out of the border feed".

### The 8 dropped for want of a coordinate

Neither operator publishes lat/lon, so coordinates come from OpenStreetMap, matched **by hand**. Four toll plazas could not be pinned to a named OSM element and were dropped rather than guessed:

- **Leskovac** — OSM has two plazas of that name 15 km apart; toll4all says only "Leskovac". A coin flip.
- **Vrčin** — no plaza of that name in OSM. The nearest is "Београд", plausibly the same plaza under another name, and "plausibly" is not the same claim.
- **Ruma**, **Vrba** — match only *unnamed* OSM booths.

Recoverable in a follow-up given one authoritative answer per plaza. The reasoning is written per-plaza into `serbia.data.ts`, not just here.

The first pass matched names automatically and got it wrong in exactly the way `brazil.data.ts` warns about: a lossy fold of "Đala" to "ala" matched the crossing at **Bačka Palanka, 105 km away on a different border**. That is why every row is hand-read and carries the OSM element it came from.

## Two findings that would otherwise have shipped green

Both came from building fixtures out of real copied markup instead of plausible HTML.

1. **The toll viewer splits media across two subdomains.** 24 posters on `cam.bitinfo.co.rs`, 14 on `jpps.bitinfo.co.rs`, while all 38 streams are on `cam`. The first adapter pinned one host and silently dropped Niš, Novi Sad, Smederevo, Požarevac, Pakovraće and Leskovac. Tiles are now paired on camera **slug**, deliberately not on host.

2. **The MUP portal picks its alphabet from the URL.** The `!ut/p/z1/...` state-token URL renders Latin; the stable bare path the adapter requests renders Cyrillic. The first fixture was Latin, so every name assertion would have passed while production produced different strings. `?locale=sr-Latn-RS`, `?lang=lat` and a `/sr-lat/` path were all tried and all still answer Cyrillic, so names ship as the ministry publishes them. The Cyrillic fixture is now primary and the Latin one is kept as a second case proving the parser is script-agnostic — the key, the camera number and the coordinate all come from the URL and the gazetteer, never from the label.

## Design notes for review

- **Two feed keys, not one.** `mergeResults` keeps last-good *per feed*, so folding both operators behind a single `serbia` key would mark the roads company's cameras stale because the ministry had a bad round.
- **No `budgetMs`, and that is measured.** MUP portal 0.78–1.25s over five runs (~104 KB); toll viewer 0.30–0.62s (~16 KB). The 10s default clears both by roughly 8x. Each adapter sets its own `AbortSignal.timeout(15_000)`.
- **A 200 that parses to nothing throws**, so `registry.ts` keeps last-good rather than silently emptying Serbia.
- **A crossing or plaza with no gazetteer row is dropped**, so a seventeenth crossing stays off the map until somebody geolocates it rather than landing on a guessed pin.
- **MUP cameras are `mediaType: "video"` with no `imageUrl`** — the ministry publishes no still, and claiming one would render a broken tile. The wall already handles this via the `▶ Live` path.
- **The two camera numbers per crossing are not labelled entry/exit.** The portal labels neither, and page order does not encode it (Đala lists `djala2` first). The number comes from the operator's own filename and claims nothing more.

## Scope

```
lib/sources/serbia.data.ts      new  gazetteer + isBareIpHost + entity decode
lib/sources/serbia-borders.ts   new  MUP adapter
lib/sources/serbia-tolls.ts     new  Putevi Srbije adapter
tests/unit/sources-serbia.test.ts new
lib/sources/registry.ts         +2 imports, +2 SOURCES entries, nothing else
lib/proxy/hls-allowlist.ts      +2 rules; `referer` made optional (MUP needs none)
lib/proxy/allowlist.ts          +2 poster rules
lib/sources/catalog.ts          one attribution string
lib/icons/svg.ts                +2 CAMERA_REGIONS entries
CLAUDE.md                       2 corrected counts        (2nd commit)
tests/unit/claude-md-counts.test.ts new, pins them        (2nd commit)
```

No overlap with #113/#114/#115/#116 — does not touch `app/api/cameras/route.ts`, `lib/sources/select.ts`, `lib/seo/*` or any feedback file.

## Verified live, not mocked

Both `fetchRegistry()` calls were run against the real portals: **32** and **30** cameras returned, with every emitted URL passing its own allowlist (`isAllowed` for posters, `isHlsAllowed` for streams, and the toll rule carrying the `https://kamere.toll4all.com/` Referer that host demands — without the trailing slash it answers 403). That probe was temporary and is not committed.

## One thing a reviewer should decide

Serbia will appear at `/cameras/rs` with regions "Border crossings" and "Motorway tolls". Border camera **names are Cyrillic** and toll names are Latin, because each is the operator's own wording. That is internally inconsistent for one country. I judged operator-verbatim to be the right rule — it is what `brazil.data.ts` argues for — but it is a visible product call and worth a second opinion.
