### PR TITLE
Correct CLAUDE.md's camera counts, and pin them so they cannot rot again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ obligations and are not satisfied by the licence.
 - `components/WorldMap.tsx` — the single MapLibre globe→2D instance; all layers are data-driven.
 - `components/shell/*` — thin console chrome (StatusBar, CommandPalette, BreakingBanner, panels).
 - `components/console/*` — the widget workspace (segments + centre stage + resizable widget frames).
-- `lib/sources/*` — one adapter per camera feed → `Camera` (zod), merged in `registry.ts` (11 feeds).
+- `lib/sources/*` — one adapter per camera feed → `Camera` (zod), merged in `registry.ts` (14 feeds).
 - `lib/signals/*` — one adapter + one `registry.ts` entry per global-signal layer (35 registered).
 - `lib/console/*` — widget registry, presets (**7 boards** in `presets.ts`), store, share (`?c=` layout URL).
   `shellLayoutStore` (`store.ts`) is the ONLY layout the app renders. `variantStore`'s
@@ -113,7 +113,7 @@ Re-measure before putting a number in a README, a CV or a PR description.
 | Claim | Value | How it was checked (2026-08-10) |
 |---|---|---|
 | Cameras | 19,328 total / 19,112 online | `GET /api/coverage` on prod |
-| Camera feeds | 11 adapters, 7 countries | `lib/sources/registry.ts` |
+| Camera feeds | 14 adapters, 9 countries | `CAMERA_FEED_COUNT` in `lib/sources/registry.ts`; countries = distinct `country: "XX"` literals across `lib/sources/*.ts`. **Pinned** by `tests/unit/claude-md-counts.test.ts`, so unlike the rows below it this one cannot silently rot — it was wrong twice before that test existed (11/7 stated against a tree holding 12/8, then 14/9). |
 | Signal layers | 35 registered; 24 returning data, 11 empty | `GET /api/signals/<id>` for every id in `SIGNALS` |
 | Console boards | 7 (2026-08-15) | `BUILTIN_PRESETS` in `lib/console/presets.ts`. `tests/unit/console-presets.test.ts` pins the exact id list, and `tests/unit/tour-board-copy.test.ts` fails if the guided tour states a different number — so this row cannot silently rot. |
 | Monitor variants | 13 | `BUILTIN_VARIANTS` in `lib/variants/builtins.ts` |

--- a/tests/unit/claude-md-counts.test.ts
+++ b/tests/unit/claude-md-counts.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { CAMERA_FEED_COUNT } from "@/lib/sources/registry";
+
+// CLAUDE.md states a camera-feed count in two places, and it has been wrong
+// twice: it said "11 adapters, 7 countries" against a tree that already held 12
+// and 8 (cetsp landed Brazil without the doc moving), and the Serbia feeds took
+// the real figures to 14 and 9. Nobody noticed either time, because nothing
+// checks a sentence.
+//
+// That table's own rule is "Never quote a count from memory - every figure below
+// was measured, and each rots. Re-measure before putting a number in a README, a
+// CV or a PR description." Sampo's CV and the YC application draw on it, so this
+// is not a doc nit. The repo already solved this shape once for the console
+// boards (console-presets + tour-board-copy pin that row); this does the same
+// for the camera row so the third person to notice never has to raise it.
+
+const ROOT = process.cwd();
+const CLAUDE_MD = readFileSync(join(ROOT, "CLAUDE.md"), "utf8");
+
+/** Distinct ISO codes hard-coded by the camera adapters. */
+function declaredCountries(): Set<string> {
+  const dir = join(ROOT, "lib", "sources");
+  const out = new Set<string>();
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".ts")) continue;
+    const src = readFileSync(join(dir, file), "utf8");
+    for (const m of src.matchAll(/country:\s*"([A-Z]{2})"/g)) out.add(m[1]);
+  }
+  return out;
+}
+
+describe("CLAUDE.md camera counts", () => {
+  it("states the feed count the registry actually ships", () => {
+    // Both places the number appears: the Shape bullet and the Numbers table.
+    const bullet = CLAUDE_MD.match(/merged in `registry\.ts` \((\d+) feeds\)/);
+    const table = CLAUDE_MD.match(/\|\s*Camera feeds\s*\|\s*(\d+) adapters/);
+    expect(bullet, "the `lib/sources/*` bullet no longer states a feed count").not.toBeNull();
+    expect(table, "the Camera feeds row no longer states an adapter count").not.toBeNull();
+    expect(Number(bullet![1])).toBe(CAMERA_FEED_COUNT);
+    expect(Number(table![1])).toBe(CAMERA_FEED_COUNT);
+  });
+
+  // Read this before "fixing" a failure here. The scan sees LITERAL `country:
+  // "XX"` assignments, which is every camera adapter today (castlerock's US/CA
+  // come from its own literal system table). An adapter that DERIVES a country
+  // from upstream data would be invisible to it and this test would then be
+  // asserting the wrong number, not catching a wrong one. So a red here means
+  // "go and re-measure", not automatically "the doc is wrong".
+  it("states the country count the adapters actually declare", () => {
+    const table = CLAUDE_MD.match(/\|\s*Camera feeds\s*\|[^|]*?(\d+) countries/);
+    expect(table, "the Camera feeds row no longer states a country count").not.toBeNull();
+    expect(Number(table![1])).toBe(declaredCountries().size);
+  });
+
+  it("still carries the warning that makes the rest of that table trustworthy", () => {
+    expect(CLAUDE_MD).toContain("Never quote a count from memory");
+  });
+});


### PR DESCRIPTION
`main` right now states a camera-feed count that is wrong, and #117 merging is what made it *more* wrong.

```
CLAUDE.md:93   "merged in registry.ts (11 feeds)"
CLAUDE.md:116  | Camera feeds | 11 adapters, 7 countries |
```

Measured on this branch:

```
CAMERA_FEED_COUNT                                   ->  14
distinct country literals in lib/sources/*.ts       ->  9   (BR CA EE FI GB IS NZ RS US)
```

## It was already wrong before Serbia

This is not a number #117 broke. The tree held **12 feeds across 8 countries** while the doc said 11 and 7 — `cetsp` landed Brazil without the doc moving. Serbia took it to 14 and 9. Two people in a row did not notice, and that is the actual argument for the second half of this PR.

## The correction is the smaller half

Nothing checks a sentence, which is why it survived twice. `tests/unit/claude-md-counts.test.ts` now reads `CLAUDE.md`, extracts the count from **both** places it appears (the `lib/sources/*` bullet and the Numbers row), and asserts them against `CAMERA_FEED_COUNT` and the country literals the adapters declare.

**I verified the test actually fails before trusting it.** A pinning test that cannot go red is worse than no test, because it is a false guarantee. Editing the doc to 13 reds it with `AssertionError: expected 13 to be 14`; reverted.

This is the pattern the repo already uses one row further down that same table, where `console-presets.test.ts` and `tour-board-copy.test.ts` exist so the board count "cannot silently rot". The camera row now has the same guarantee, and the table says so.

## One limit, recorded in the test rather than glossed

The **country** half scans literal `country: "XX"` assignments across `lib/sources/*.ts`. That is every camera adapter today — castlerock's US/CA come from its own literal system table — but an adapter that *derived* its country from upstream data would be invisible to it, and the test would then be asserting a wrong number rather than catching one. So a red on that case means **re-measure**, not automatically "the doc lies". The feed half has no such caveat: it reads `CAMERA_FEED_COUNT` directly.

## Why this is a separate PR

It was a second commit on `feat/cameras-serbia`, but #117 was live-merged as a squash of the first commit while the second was being pushed, so it never reached `main`. Re-cut off `main` at `f8a5b9e` rather than reopening anything.

## Gate

```
npx tsc --noEmit   ->  exit 0, no output
Test Files  250 passed (250)
Tests  2093 passed (2093)
```

Run on this branch, off `main` @ `f8a5b9e` (i.e. after #114, #116 and #117 landed). 2 files, +62/-2.

## Why it is worth a PR at all

`CLAUDE.md`'s own rule for that table is "Never quote a count from memory — every figure below was measured, and each rots. Re-measure before putting a number in a README, a CV or a PR description." Sampo's CV and the YC application draw on these figures, so a stale camera-feed count is not a doc nit.

Other rows in that table are known stale (the planes/OpenSky notes, the unit-test count). This PR deliberately does **not** touch them — it fixes the one row it has measured and can pin.
