### PR TITLE
Camera pages track the registry's refresh, not an hour

### DIFF
--- a/app/camera/[id]/page.tsx
+++ b/app/camera/[id]/page.tsx
@@ -26,7 +26,10 @@ import {
  * refresh interval. Everything the server renders - name, place, operator, cadence,
  * neighbours - changes at the speed of the registry, not the speed of traffic.
  */
-export const revalidate = 3_600;
+export const revalidate = 300; // = REGISTRY_TTL_MS. Must stay equal to CAMERA_TTL_SECONDS
+// in lib/seo/registrySnapshot.ts; a `revalidate` export has to be a literal Next can read
+// statically, so it cannot import the constant. tests/unit/seo-page-caching.test.ts pins
+// the three together.
 
 /**
  * Returns NO paths, and that empty array is the entire point.

--- a/lib/seo/registrySnapshot.ts
+++ b/lib/seo/registrySnapshot.ts
@@ -54,7 +54,7 @@
 
 import { unstable_cache } from "next/cache";
 import type { Camera } from "@/lib/types";
-import { getRegistry } from "@/lib/sources/registry";
+import { REGISTRY_TTL_MS, getRegistry } from "@/lib/sources/registry";
 import { findById, nearest } from "@/lib/sources/select";
 import { camerasInRegion, groupByCountry, pageSlice, type CountryGroup } from "@/lib/seo/directory";
 import { REGION_PAGE_SIZE } from "@/lib/seo/paths";
@@ -62,8 +62,17 @@ import { REGION_PAGE_SIZE } from "@/lib/seo/paths";
 /** Matches `revalidate` on app/cameras/**. The directory moves at the speed of a feed being added. */
 const DIRECTORY_TTL_SECONDS = 86_400;
 
-/** Matches `revalidate` on app/camera/[id]/page.tsx. */
-const CAMERA_TTL_SECONDS = 3_600;
+/**
+ * Matches `revalidate` on app/camera/[id]/page.tsx, and is DERIVED rather than typed.
+ *
+ * Sampo's call, 2026-08-18: track the registry's own refresh rather than the hour the
+ * page used to declare. `available` - the "not answering at the last check" line - is
+ * the one field on that page that genuinely moves, and an hour of it was more slack
+ * than the saving was worth. At the registry's own cadence the page is never staler
+ * than the data behind it, which is the tightest window that means anything: a shorter
+ * one would re-render to fetch a snapshot that had not changed.
+ */
+const CAMERA_TTL_SECONDS = REGISTRY_TTL_MS / 1_000;
 
 /**
  * Everything `/cameras` and `/cameras/[country]` render, in one small object.

--- a/lib/sources/registry.ts
+++ b/lib/sources/registry.ts
@@ -15,7 +15,16 @@ import { fetchRegistry as fetchSerbiaBorders } from "@/lib/sources/serbia-border
 import { fetchRegistry as fetchSerbiaTolls } from "@/lib/sources/serbia-tolls";
 import { findById, nearest } from "@/lib/sources/select";
 
-const TTL_MS = 5 * 60 * 1000;
+/**
+ * How long the merged camera set is served before a refresh is kicked off.
+ *
+ * Exported because the SEO pages' `revalidate` is DERIVED from it rather than typed
+ * (lib/seo/registrySnapshot.ts). A camera page cannot be fresher than the registry
+ * behind it, so a page window shorter than this buys nothing but re-renders, and one
+ * longer than this decides how far behind the registry the page is allowed to sit.
+ * Keeping it one number stops the two drifting apart silently.
+ */
+export const REGISTRY_TTL_MS = 5 * 60 * 1000;
 
 /**
  * How long a feed gets before its round is treated as a timeout, unless it
@@ -214,7 +223,7 @@ export function feedHealth(): FeedHealth[] {
 // very first (cold) call, with no cache at all, waits for the fetch — important
 // now that Castle Rock pages ~100 requests and a cold load can take ~40s.
 export async function getRegistry(): Promise<Camera[]> {
-  if (cache && Date.now() - cache.at < TTL_MS) return cache.cameras;
+  if (cache && Date.now() - cache.at < REGISTRY_TTL_MS) return cache.cameras;
   if (!inflight) {
     inflight = refresh()
       .catch((e) => {

--- a/tests/unit/seo-page-caching.test.ts
+++ b/tests/unit/seo-page-caching.test.ts
@@ -18,7 +18,7 @@ import { expect, test } from "vitest";
  * Cache", and Next 15 makes every `fetch` uncached by default. `getRegistry()`
  * fetches whenever its 5-minute module cache is cold. So a page importing it
  * directly renders correctly, passes every test, deploys green, and quietly costs a
- * full server render on every one of the ~19k crawlable URLs.
+ * full server render on every one of the ~20k crawlable URLs.
  *
  * Reading through `lib/seo/registrySnapshot` instead puts an `unstable_cache`
  * boundary in the way, and its callback runs in a swapped work-unit store so the
@@ -97,4 +97,32 @@ test.each(PARAMETERISED_PAGES)("%s does not force-static its way out of it", (pa
   // Anchored on `export const` so the warning ABOUT force-static in the page's own
   // comment does not trip it.
   expect(source(page)).not.toMatch(/export\s+const\s+dynamic\s*=\s*["']force-static["']/);
+});
+
+/**
+ * The camera page's `revalidate` must equal the registry's own TTL.
+ *
+ * Next needs `revalidate` to be a statically-analysable literal, so the page cannot
+ * import the constant and the number has to be written out by hand - which is exactly
+ * how it drifts. Three places have to agree and nothing else makes them:
+ *   lib/sources/registry.ts       REGISTRY_TTL_MS      (the real cadence)
+ *   lib/seo/registrySnapshot.ts   CAMERA_TTL_SECONDS   (derived, so it cannot drift)
+ *   app/camera/[id]/page.tsx      export const revalidate   (a literal, so it can)
+ *
+ * A page window SHORTER than the registry's re-renders to fetch a snapshot that has
+ * not changed. A LONGER one decides how far behind the data the page may sit, which
+ * is a product decision and not something to arrive at by forgetting to update it.
+ */
+test("the camera page revalidate tracks the registry's own refresh", async () => {
+  const { REGISTRY_TTL_MS } = await import("@/lib/sources/registry");
+  const declared = source("app/camera/[id]/page.tsx").match(
+    /export const revalidate = ([0-9_]+)/,
+  );
+
+  expect(declared).not.toBeNull();
+  expect(Number(declared![1].replace(/_/g, ""))).toBe(REGISTRY_TTL_MS / 1_000);
+});
+
+test("the cached camera reader derives its window rather than repeating the number", () => {
+  expect(source("lib/seo/registrySnapshot.ts")).toContain("REGISTRY_TTL_MS / 1_000");
 });


### PR DESCRIPTION
Follow-on to #114, which is merged and **now verified on production**.

## #114 works. Measured on prod just now

```
BEFORE (same URL, four consecutive requests)
  X-Vercel-Cache: MISS  x4        Age: 0  x4
  Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
  X-Nextjs-Prerender: (absent)

AFTER
  /camera/tfl:JamCams_00002.00865   HIT, HIT, HIT      Age 289 / 289 / 290   X-Nextjs-Prerender: 1
  /cameras/gb/london                HIT, HIT           Age 299               X-Nextjs-Prerender: 1
```

And the case that would have been the bad outcome - a camera page nobody had ever requested, so it had to be generated on demand:

```
/camera/tripcheck:1001    hit1  200  MISS  X-Nextjs-Prerender: 1
                          hit2  200  HIT   X-Nextjs-Prerender: 1
```

200 and generated, not 404. That confirms `fallback: null` (blocking) rather than `fallback: false`, which was the specific way the `generateStaticParams` half could have gone wrong.

## What this PR changes

You picked "tighter on camera pages" from the freshness table. So `revalidate` on `/camera/[id]` goes **3600 -> 300**, which is `REGISTRY_TTL_MS`.

That is the tightest window that means anything. Shorter would re-render to fetch a snapshot that had not changed, because `getRegistry()` hands back the same cached array until its own 5-minute TTL expires. `available` - the "not answering at the last check" line - is the one field on that page that genuinely moves, and it now moves as fast as the registry does.

Region and country listings keep 86400. A region's camera list changes when a feed is added, not during a day.

## Derived, not typed in three places

| where | what | how it stays right |
|---|---|---|
| `lib/sources/registry.ts` | `REGISTRY_TTL_MS` | the real cadence, now exported |
| `lib/seo/registrySnapshot.ts` | `CAMERA_TTL_SECONDS` | computed from it, cannot drift |
| `app/camera/[id]/page.tsx` | `export const revalidate` | a literal - Next analyses it statically, so it cannot import a constant |

Only the third can drift, so a test imports `REGISTRY_TTL_MS` and asserts they agree.

**Watched it go red for the regression it is actually for.** The easy injection — edit the page literal back to `3_600` — proves the test compares *something*. It does not prove it catches the failure I care about, which is the opposite direction: nobody touches the page at all, somebody retunes the registry and the page silently keeps claiming the old window. So I ran that one instead. Changed `REGISTRY_TTL_MS` to `2 * 60 * 1000`, left `app/camera/[id]/page.tsx` untouched:

```
AssertionError: expected 300 to be 120
```

300 is the page's literal, 120 is the new `REGISTRY_TTL_MS / 1000`. The direction of that message is the proof it read the constant at runtime and compared it against the page, rather than going red for an unrelated reason. Registry restored, tree clean, 18 cases back to green.

The invariant is not true by construction: `revalidate` has to be a literal Next can analyse statically, so nothing but this test keeps the two artefacts in step.

## Cost

More ISR revalidations - each requested page regenerates up to once per 5 min instead of once per hour. Still far below the pre-#114 state, where every request rendered from scratch with no ceiling at all. Only pages someone actually asks for revalidate.

```
npx tsc --noEmit  ->  exit 0
Test Files  249 passed (249)
     Tests  2092 passed (2092)
```

