### PR TITLE
Give /api/webcams the edge cache header it never had, and build its body once

### DIFF
--- a/app/api/webcams/route.ts
+++ b/app/api/webcams/route.ts
@@ -1,9 +1,52 @@
 import { getWebcams } from "@/lib/webcams/registry";
-import { describeWebcamSample } from "@/lib/webcams/fetch";
+import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
 import { WINDY_SOURCE } from "@/lib/sources/windy";
 import { describeCoverage } from "@/lib/signals/coverage";
+import { edgeCacheControl } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Shared-cache lifetime, and the reasoning is NOT the registry's.
+ *
+ * lib/webcams/registry.ts holds its sample for 8 minutes, deliberately under Windy's
+ * ~10-minute image-token expiry. That ceiling protects TOKENS, and there are none in
+ * this response: the route ships thin markers and the dossier re-resolves a fresh
+ * image per view through /api/webcam-image. So the token clock does not bind here.
+ *
+ * What does bind is honesty, and this body is the easy case — it carries no timestamp
+ * at all, absolute or relative, so a cached copy cannot under-report anything's age.
+ * Compare /api/planes, whose `staleness.ageMs` is relative and freezes under a cache;
+ * that is why its TTL is 20 s and this one can be the same 60 s as /api/cameras. What
+ * moves in this body is a webcam's position, title and `available` flag, on the order
+ * of the 8-minute sample behind it.
+ *
+ * As with /api/cameras this is about not paying an invocation per visitor, not about
+ * protecting the upstream — getWebcams() already shields Windy.
+ */
+const WEBCAMS_TTL_MS = 60_000;
+
+/**
+ * The serialised body, held until the registry publishes a new sample.
+ *
+ * WHY. 2,000 webcams, 425 KB of JSON measured on prod, rebuilt on every request
+ * because this route had no cache header at all — so the edge never answered one and
+ * every visitor cost an invocation AND a full re-serialisation. The answer was
+ * byte-for-byte the same each time until the 8-minute sample rolled over.
+ *
+ * WHY IDENTITY IS THE RIGHT KEY. `getWebcams()` returns `cache.sample`, and
+ * `refresh()` only ever REPLACES that object — including on the failure path, where it
+ * rewrites the timestamp but re-uses the same sample rather than mutating it. So
+ * `from === sample` is true exactly while the contents are unchanged, and a new sample
+ * recomputes. Nothing in the body depends on the clock: `describeWebcamSample` and
+ * `describeCoverage` are both pure over the sample, so there is no second expiry to
+ * keep in step.
+ *
+ * Same shape as the memo in app/api/cameras/route.ts. One entry, per isolate, and it
+ * lowers peak memory rather than raising it — one retained string instead of 425 KB of
+ * garbage per request.
+ */
+let serialised: { from: WebcamSample; body: string } | null = null;
 
 /**
  * GET /api/webcams — a global sample of Windy webcams as thin markers (the
@@ -39,8 +82,8 @@ export const dynamic = "force-dynamic";
  * `coverage` is present only when the sample declared one (i.e. not dormant) —
  * its absence means "not declared", never "nothing was truncated".
  */
-export async function GET() {
-  const sample = await getWebcams();
+export function webcamsBody(sample: WebcamSample): string {
+  if (serialised && serialised.from === sample) return serialised.body;
   // `city` and `categories` survive lib/webcams/normalize.ts but used to be dropped
   // here. They are what lets a caller filter to squares, promenades and old towns
   // instead of matching on title text — the difference between finding the
@@ -57,12 +100,31 @@ export async function GET() {
     available: w.available,
     detailUrl: w.detailUrl,
   }));
-  return Response.json({
+  const body = JSON.stringify({
     count: thin.length,
     webcams: thin,
     dormant: sample.dormant,
     note: describeWebcamSample(sample),
     attribution: WINDY_SOURCE.attribution,
     ...(sample.coverage ? { coverage: describeCoverage(sample.coverage) } : {}),
+  });
+  serialised = { from: sample, body };
+  return body;
+}
+
+/** Test seam, matching the house pattern in lib/webcams/search.ts. */
+export function __resetWebcamsBody(): void {
+  serialised = null;
+}
+
+export async function GET() {
+  const sample = await getWebcams();
+  // `Response.json` is not used here only because the body is already a string;
+  // it sets exactly this Content-Type, so the response is unchanged on the wire.
+  return new Response(webcamsBody(sample), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": edgeCacheControl(WEBCAMS_TTL_MS, 300_000),
+    },
   });
 }

--- a/tests/unit/webcams-body-memo.test.ts
+++ b/tests/unit/webcams-body-memo.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebcamSample } from "@/lib/webcams/fetch";
+
+// /api/webcams shipped 425 KB of JSON per request with NO cache header, so the edge
+// never answered one: every visitor cost an invocation and a full re-serialisation of
+// an answer that only changes when the 8-minute Windy sample rolls over.
+//
+// As with the camera memo, the string is identical either way, so what gets asserted
+// is the WORK: the note is composed once per sample, and a replaced sample recomputes.
+
+const describeWebcamSample = vi.fn(() => "one sample, described once");
+vi.mock("@/lib/webcams/fetch", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/webcams/fetch")>()),
+  describeWebcamSample: () => describeWebcamSample(),
+}));
+
+const { webcamsBody, __resetWebcamsBody } = await import("@/app/api/webcams/route");
+
+const webcam = (id: string, over: Record<string, unknown> = {}) => ({
+  id,
+  title: `Webcam ${id}`,
+  lat: 40.4,
+  lon: -3.7,
+  country: "ES",
+  region: "Madrid",
+  city: "Madrid",
+  categories: ["square"],
+  available: true,
+  detailUrl: `https://www.windy.com/webcams/${id}`,
+  imageUrl: `https://images.windy.com/${id}.jpg?token=SHORTLIVED`,
+  thumbnailUrl: `https://images.windy.com/${id}-thumb.jpg?token=SHORTLIVED`,
+  ...over,
+});
+
+const sampleOf = (...ids: string[]): WebcamSample =>
+  ({
+    webcams: ids.map((id) => webcam(id)),
+    dormant: false,
+    pagesOk: 4,
+    pagesFailed: 0,
+    statuses: [],
+    mapping: null,
+  }) as unknown as WebcamSample;
+
+beforeEach(() => {
+  __resetWebcamsBody();
+  describeWebcamSample.mockClear();
+});
+
+describe("webcamsBody", () => {
+  it("serialises once for a given sample", () => {
+    const sample = sampleOf("a", "b", "c");
+
+    const first = webcamsBody(sample);
+    const second = webcamsBody(sample);
+
+    expect(second).toBe(first);
+    expect(describeWebcamSample).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds when the registry publishes a new sample", () => {
+    const before = sampleOf("a");
+    const after = sampleOf("a", "b");
+
+    expect(JSON.parse(webcamsBody(before)).count).toBe(1);
+    describeWebcamSample.mockClear();
+    expect(JSON.parse(webcamsBody(after)).count).toBe(2);
+    expect(describeWebcamSample).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys on identity, so two equal-looking samples are separate publications", () => {
+    // refresh() builds a fresh sample each round. The memo cannot know two are equal
+    // without doing the work it exists to avoid.
+    webcamsBody(sampleOf("a"));
+    describeWebcamSample.mockClear();
+    webcamsBody(sampleOf("a"));
+
+    expect(describeWebcamSample).toHaveBeenCalledTimes(1);
+  });
+
+  it("never lets a short-lived Windy image token into the response", () => {
+    // The dossier re-resolves images through /api/webcam-image precisely because these
+    // tokens expire in ~10 minutes. Caching the body makes leaking one worse, not
+    // better, so the projection is pinned rather than trusted.
+    const body = webcamsBody(sampleOf("windy:1"));
+
+    expect(body).not.toContain("SHORTLIVED");
+    expect(body).not.toContain("imageUrl");
+    expect(body).not.toContain("thumbnailUrl");
+    expect(JSON.parse(body).webcams[0]).toMatchObject({
+      id: "windy:1",
+      title: "Webcam windy:1",
+      country: "ES",
+      city: "Madrid",
+      categories: ["square"],
+      available: true,
+    });
+  });
+
+  it("carries the layer's own explanation of what happened upstream", () => {
+    const body = JSON.parse(webcamsBody(sampleOf("a")));
+    expect(body.note).toBe("one sample, described once");
+    expect(body.dormant).toBe(false);
+    expect(typeof body.attribution).toBe("string");
+  });
+});


### PR DESCRIPTION
Sampo asked for this one directly after reviewing the CPU findings.

## What was wrong

`/api/webcams` is `force-dynamic` and had **no `Cache-Control` at all**. Measured on prod:

```
1,621 webcams
425,322 bytes
X-Vercel-Cache: MISS   (nothing to cache against)
```

So the edge answered nothing. Every visitor cost an invocation *and* a full re-serialisation of a byte-identical answer, because the underlying sample only rolls over every 8 minutes.

## Two changes, and the header is the larger one

**1. The edge header** - 60s shared TTL, 300s `stale-while-revalidate`, matching `/api/cameras`.

The reasoning is deliberately **not** the registry's. `lib/webcams/registry.ts` holds its sample for 8 minutes to stay under Windy's ~10-minute image-token expiry — that ceiling protects **tokens**, and this response carries none. It ships thin markers; the dossier re-resolves images through `/api/webcam-image`.

What would otherwise bind is honesty, and this is the easy case: **the body carries no timestamp at all**, absolute or relative, so a cached copy cannot under-report anything's age. Compare `/api/planes`, whose `staleness.ageMs` is relative and freezes under a cache — that is why its TTL is 20s and this one need not be. What moves here is a webcam's position, title and `available` flag, on the order of the 8-minute sample behind it.

**2. The memo** - same shape as #115. The serialised body is held against the `WebcamSample` object identity.

`getWebcams()` returns `cache.sample`, and `refresh()` only ever *replaces* that object — including on the failure path, where it rewrites the timestamp but re-uses the same sample rather than mutating it. So `from === sample` is true exactly while the contents are unchanged. Nothing in the body depends on the clock: `describeWebcamSample` and `describeCoverage` are both pure over the sample, so there is no second expiry to keep in step with.

Profiled against the live payload at **2.35 ms of CPU per call**. Real, but honestly smaller than `/api/cameras`' 24.3 ms — and smaller than the invocation the header now avoids outright. I would rather state that than inflate it.

## Response body is unchanged on the wire

`Response.json` is dropped only because the body is already a string; it sets exactly the `Content-Type` set here. Projection, field order and the `coverage` contract are untouched. The `Cache-Control` header is new — that is the intended change.

## Tests

The memo cannot be observed from its return value, so the test asserts the *work*. **Watched it go red for the right reason before trusting it** — disabling the identity check fails with:

```
AssertionError: expected "spy" to be called 1 times, but got 2 times
```

which is the call count, not an unrelated match.

It also pins that **no short-lived Windy image token reaches the response**. That check matters more once the body is cacheable: caching a leaked token makes it worse, not better. The fixtures deliberately carry `imageUrl`/`thumbnailUrl` with token query strings, and the test asserts none of it survives the projection.

```
npx tsc --noEmit  ->  exit 0
Test Files  250 passed (250)
     Tests  2095 passed (2095)
```
Branch cut off `origin/main` at f8a5b9e; baseline there is 249 / 2090, so this adds one file and five cases.

## Scope

`app/api/webcams/route.ts` plus its new test. No overlap with #115, #119, #113 or #118.
