### PR TITLE
main does not build: get the webcams helpers out of the route module

### DIFF
--- a/app/api/webcams/route.ts
+++ b/app/api/webcams/route.ts
@@ -1,130 +1,20 @@
 import { getWebcams } from "@/lib/webcams/registry";
-import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
-import { WINDY_SOURCE } from "@/lib/sources/windy";
-import { describeCoverage } from "@/lib/signals/coverage";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { webcamsBody, webcamsCacheControl } from "@/lib/webcams/body";
 
 export const dynamic = "force-dynamic";
 
-/**
- * Shared-cache lifetime, and the reasoning is NOT the registry's.
- *
- * lib/webcams/registry.ts holds its sample for 8 minutes, deliberately under Windy's
- * ~10-minute image-token expiry. That ceiling protects TOKENS, and there are none in
- * this response: the route ships thin markers and the dossier re-resolves a fresh
- * image per view through /api/webcam-image. So the token clock does not bind here.
- *
- * What does bind is honesty, and this body is the easy case — it carries no timestamp
- * at all, absolute or relative, so a cached copy cannot under-report anything's age.
- * Compare /api/planes, whose `staleness.ageMs` is relative and freezes under a cache;
- * that is why its TTL is 20 s and this one can be the same 60 s as /api/cameras. What
- * moves in this body is a webcam's position, title and `available` flag, on the order
- * of the 8-minute sample behind it.
- *
- * As with /api/cameras this is about not paying an invocation per visitor, not about
- * protecting the upstream — getWebcams() already shields Windy.
- */
-const WEBCAMS_TTL_MS = 60_000;
-
-/**
- * The serialised body, held until the registry publishes a new sample.
- *
- * WHY. 2,000 webcams, 425 KB of JSON measured on prod, rebuilt on every request
- * because this route had no cache header at all — so the edge never answered one and
- * every visitor cost an invocation AND a full re-serialisation. The answer was
- * byte-for-byte the same each time until the 8-minute sample rolled over.
- *
- * WHY IDENTITY IS THE RIGHT KEY. `getWebcams()` returns `cache.sample`, and
- * `refresh()` only ever REPLACES that object — including on the failure path, where it
- * rewrites the timestamp but re-uses the same sample rather than mutating it. So
- * `from === sample` is true exactly while the contents are unchanged, and a new sample
- * recomputes. Nothing in the body depends on the clock: `describeWebcamSample` and
- * `describeCoverage` are both pure over the sample, so there is no second expiry to
- * keep in step.
- *
- * Same shape as the memo in app/api/cameras/route.ts. One entry, per isolate, and it
- * lowers peak memory rather than raising it — one retained string instead of 425 KB of
- * garbage per request.
- */
-let serialised: { from: WebcamSample; body: string } | null = null;
-
-/**
- * GET /api/webcams — a global sample of Windy webcams as thin markers (the
- * x-windy-api-key is added server-side; it never reaches the client). Distinct
- * from /api/cameras: webcams are their own layer and never fold into the
- * road-camera count.
- *
- * Image URLs are intentionally omitted here — their tokens are short-lived, so
- * the dossier re-resolves a fresh image per view through /api/webcam-image.
- *
- * TRUNCATION HONESTY. The merged global sample is capped at MAX_WEBCAMS (2000);
- * before this the cap shipped with nothing disclosing it, so `count` was the
- * ceiling wearing the costume of a measurement — the exact defect the coverage
- * contract exists to prevent. `sample.coverage` (lib/signals/coverage.ts,
- * attached in lib/webcams/normalize.ts's toWebcams()) now carries the true
- * pre-cap total, so this can say "2,000 of N" instead of a bare 2,000.
- *
- * DESIGN DECISION — SIGNAL style ("N of M"), not the camera style. Cameras'
- * /api/coverage reports {feeds: {answered, total, stale}} because a camera total
- * is a SUM ACROSS ELEVEN INDEPENDENT NETWORKS, any of which can be down on a
- * given refresh — the denominator that matters there is "how many of our feeds
- * answered". Webcams have exactly ONE upstream (Windy) and no per-feed health
- * dimension to report; the only thing being hidden is a single render cap over
- * one merged pool of rows. That is precisely what lib/signals/coverage.ts's
- * applyCap/coverageCountLabel contract was built for (it already backs
- * /api/planes and /api/signals/<id> for the same reason), so reusing it costs
- * nothing, and inventing a "feeds" shape for a single source would just be
- * duplication with no real denominator to put in it.
- *
- * Returns {count, webcams[], dormant, note, attribution, coverage?}. `note` is a
- * plain sentence describing what actually happened upstream, so an empty layer
- * can always explain itself instead of silently looking like "no webcams exist".
- * `coverage` is present only when the sample declared one (i.e. not dormant) —
- * its absence means "not declared", never "nothing was truncated".
- */
-export function webcamsBody(sample: WebcamSample): string {
-  if (serialised && serialised.from === sample) return serialised.body;
-  // `city` and `categories` survive lib/webcams/normalize.ts but used to be dropped
-  // here. They are what lets a caller filter to squares, promenades and old towns
-  // instead of matching on title text — the difference between finding the
-  // pedestrian-zone cameras this layer is mostly useful for and guessing at them.
-  const thin = sample.webcams.map((w) => ({
-    id: w.id,
-    title: w.title,
-    lat: w.lat,
-    lon: w.lon,
-    country: w.country,
-    region: w.region,
-    city: w.city,
-    categories: w.categories,
-    available: w.available,
-    detailUrl: w.detailUrl,
-  }));
-  const body = JSON.stringify({
-    count: thin.length,
-    webcams: thin,
-    dormant: sample.dormant,
-    note: describeWebcamSample(sample),
-    attribution: WINDY_SOURCE.attribution,
-    ...(sample.coverage ? { coverage: describeCoverage(sample.coverage) } : {}),
-  });
-  serialised = { from: sample, body };
-  return body;
-}
-
-/** Test seam, matching the house pattern in lib/webcams/search.ts. */
-export function __resetWebcamsBody(): void {
-  serialised = null;
-}
+// A route module may export ONLY the fields Next recognises; `webcamsBody` and its
+// test seam therefore live in lib/webcams/body.ts, where the reasoning is written up.
+// That file also carries the route documentation - what this endpoint returns, why the
+// coverage record is shaped the way it is, and why no image URL ever leaves here.
 
 export async function GET() {
-  const sample = await getWebcams();
-  // `Response.json` is not used here only because the body is already a string;
-  // it sets exactly this Content-Type, so the response is unchanged on the wire.
-  return new Response(webcamsBody(sample), {
+  // `Response.json` is not used only because the body is already a string; it sets
+  // exactly this Content-Type, so the response is unchanged on the wire.
+  return new Response(webcamsBody(await getWebcams()), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": edgeCacheControl(WEBCAMS_TTL_MS, 300_000),
+      "Cache-Control": webcamsCacheControl(),
     },
   });
 }

--- a/lib/webcams/body.ts
+++ b/lib/webcams/body.ts
@@ -1,0 +1,136 @@
+import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
+import { WINDY_SOURCE } from "@/lib/sources/windy";
+import { describeCoverage } from "@/lib/signals/coverage";
+import { edgeCacheControl } from "@/lib/http/cache";
+
+// The body of GET /api/webcams, and its edge-cache policy.
+//
+// WHY THIS IS NOT IN THE ROUTE FILE. A Next.js App Router route module may only export
+// the names Next recognises - the HTTP verbs plus dynamic, revalidate, runtime,
+// dynamicParams, fetchCache, preferredRegion, maxDuration and generateStaticParams.
+// Anything else is a HARD BUILD FAILURE:
+//
+//     Type error: Route "app/api/webcams/route.ts" does not match the required types
+//     of a Next.js Route. "webcamsBody" is not a valid Route export field.
+//
+// and - this is the part worth knowing - `npx tsc --noEmit` and the whole vitest suite
+// pass anyway. The route-export contract is checked only inside `next build`, during
+// "Linting and checking validity of types", AFTER tsc has already been satisfied. So a
+// helper exported from a route file for a test to import looks completely green locally
+// and fails the deployment. Helpers live here; the route imports one function.
+
+/**
+ * Shared-cache lifetime, and the reasoning is NOT the registry's.
+ *
+ * lib/webcams/registry.ts holds its sample for 8 minutes, deliberately under Windy's
+ * ~10-minute image-token expiry. That ceiling protects TOKENS, and there are none in
+ * this response: the route ships thin markers and the dossier re-resolves a fresh
+ * image per view through /api/webcam-image. So the token clock does not bind here.
+ *
+ * What does bind is honesty, and this body is the easy case — it carries no timestamp
+ * at all, absolute or relative, so a cached copy cannot under-report anything's age.
+ * Compare /api/planes, whose `staleness.ageMs` is relative and freezes under a cache;
+ * that is why its TTL is 20 s and this one can be the same 60 s as /api/cameras. What
+ * moves in this body is a webcam's position, title and `available` flag, on the order
+ * of the 8-minute sample behind it.
+ *
+ * As with /api/cameras this is about not paying an invocation per visitor, not about
+ * protecting the upstream — getWebcams() already shields Windy.
+ */
+const WEBCAMS_TTL_MS = 60_000;
+
+/**
+ * The serialised body, held until the registry publishes a new sample.
+ *
+ * WHY. 2,000 webcams, 425 KB of JSON measured on prod, rebuilt on every request
+ * because this route had no cache header at all — so the edge never answered one and
+ * every visitor cost an invocation AND a full re-serialisation. The answer was
+ * byte-for-byte the same each time until the 8-minute sample rolled over.
+ *
+ * WHY IDENTITY IS THE RIGHT KEY. `getWebcams()` returns `cache.sample`, and
+ * `refresh()` only ever REPLACES that object — including on the failure path, where it
+ * rewrites the timestamp but re-uses the same sample rather than mutating it. So
+ * `from === sample` is true exactly while the contents are unchanged, and a new sample
+ * recomputes. Nothing in the body depends on the clock: `describeWebcamSample` and
+ * `describeCoverage` are both pure over the sample, so there is no second expiry to
+ * keep in step.
+ *
+ * Same shape as the memo in app/api/cameras/route.ts. One entry, per isolate, and it
+ * lowers peak memory rather than raising it — one retained string instead of 425 KB of
+ * garbage per request.
+ */
+let serialised: { from: WebcamSample; body: string } | null = null;
+
+/**
+ * GET /api/webcams — a global sample of Windy webcams as thin markers (the
+ * x-windy-api-key is added server-side; it never reaches the client). Distinct
+ * from /api/cameras: webcams are their own layer and never fold into the
+ * road-camera count.
+ *
+ * Image URLs are intentionally omitted here — their tokens are short-lived, so
+ * the dossier re-resolves a fresh image per view through /api/webcam-image.
+ *
+ * TRUNCATION HONESTY. The merged global sample is capped at MAX_WEBCAMS (2000);
+ * before this the cap shipped with nothing disclosing it, so `count` was the
+ * ceiling wearing the costume of a measurement — the exact defect the coverage
+ * contract exists to prevent. `sample.coverage` (lib/signals/coverage.ts,
+ * attached in lib/webcams/normalize.ts's toWebcams()) now carries the true
+ * pre-cap total, so this can say "2,000 of N" instead of a bare 2,000.
+ *
+ * DESIGN DECISION — SIGNAL style ("N of M"), not the camera style. Cameras'
+ * /api/coverage reports {feeds: {answered, total, stale}} because a camera total
+ * is a SUM ACROSS ELEVEN INDEPENDENT NETWORKS, any of which can be down on a
+ * given refresh — the denominator that matters there is "how many of our feeds
+ * answered". Webcams have exactly ONE upstream (Windy) and no per-feed health
+ * dimension to report; the only thing being hidden is a single render cap over
+ * one merged pool of rows. That is precisely what lib/signals/coverage.ts's
+ * applyCap/coverageCountLabel contract was built for (it already backs
+ * /api/planes and /api/signals/<id> for the same reason), so reusing it costs
+ * nothing, and inventing a "feeds" shape for a single source would just be
+ * duplication with no real denominator to put in it.
+ *
+ * Returns {count, webcams[], dormant, note, attribution, coverage?}. `note` is a
+ * plain sentence describing what actually happened upstream, so an empty layer
+ * can always explain itself instead of silently looking like "no webcams exist".
+ * `coverage` is present only when the sample declared one (i.e. not dormant) —
+ * its absence means "not declared", never "nothing was truncated".
+ */
+export function webcamsBody(sample: WebcamSample): string {
+  if (serialised && serialised.from === sample) return serialised.body;
+  // `city` and `categories` survive lib/webcams/normalize.ts but used to be dropped
+  // here. They are what lets a caller filter to squares, promenades and old towns
+  // instead of matching on title text — the difference between finding the
+  // pedestrian-zone cameras this layer is mostly useful for and guessing at them.
+  const thin = sample.webcams.map((w) => ({
+    id: w.id,
+    title: w.title,
+    lat: w.lat,
+    lon: w.lon,
+    country: w.country,
+    region: w.region,
+    city: w.city,
+    categories: w.categories,
+    available: w.available,
+    detailUrl: w.detailUrl,
+  }));
+  const body = JSON.stringify({
+    count: thin.length,
+    webcams: thin,
+    dormant: sample.dormant,
+    note: describeWebcamSample(sample),
+    attribution: WINDY_SOURCE.attribution,
+    ...(sample.coverage ? { coverage: describeCoverage(sample.coverage) } : {}),
+  });
+  serialised = { from: sample, body };
+  return body;
+}
+
+/** Test seam, matching the house pattern in lib/webcams/search.ts. */
+export function __resetWebcamsBody(): void {
+  serialised = null;
+}
+
+/** The Cache-Control this route answers with. Lives beside the TTL it is derived from. */
+export function webcamsCacheControl(): string {
+  return edgeCacheControl(WEBCAMS_TTL_MS, 300_000);
+}

--- a/tests/unit/route-export-contract.test.ts
+++ b/tests/unit/route-export-contract.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { expect, test } from "vitest";
+
+/**
+ * A Next.js route or page module may export ONLY the names Next recognises. Anything
+ * else is a hard build failure:
+ *
+ *     Type error: Route "app/api/webcams/route.ts" does not match the required types
+ *     of a Next.js Route. "webcamsBody" is not a valid Route export field.
+ *
+ * WHY THIS TEST EXISTS RATHER THAN A CODE REVIEW NOTE. The house gate is
+ * `npx tsc --noEmit && npm test`, and BOTH PASS on a file that breaks this rule. The
+ * route-export contract is checked only inside `next build`, during "Linting and
+ * checking validity of types", after tsc has already been satisfied. So the failure
+ * mode is: green locally, green in the suite, dead on deploy - and it reached `main`
+ * exactly once that way, in the commit this test was added to fix.
+ *
+ * It is a tempting mistake because the motive is good. You write a helper in a route
+ * file, you want a unit test for it, so you export it. The fix is always the same:
+ * move the helper to `lib/` and have the route import it. That is better anyway - the
+ * helper becomes testable without pulling a route module into the test.
+ *
+ * The allowed list is Next's, not ours. If a future Next version adds a segment
+ * option, add it here with a link, do not widen the check.
+ */
+const ALLOWED = new Set([
+  // HTTP verbs a route handler may implement
+  "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+  // route segment config
+  "dynamic", "dynamicParams", "revalidate", "fetchCache", "runtime",
+  "preferredRegion", "maxDuration", "experimental_ppr",
+  // page/layout conventions
+  "default", "metadata", "generateMetadata", "generateStaticParams",
+  "generateViewport", "viewport", "generateImageMetadata", "alt", "size",
+  "contentType", "config",
+]);
+
+const APP = resolve(process.cwd(), "app");
+const MODULE_NAMES = /^(route|page|layout|template|default|error|loading|not-found|opengraph-image|twitter-image|icon|apple-icon|sitemap|robots|manifest)\.(ts|tsx|js|jsx)$/;
+
+function routeModules(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) routeModules(full, found);
+    else if (MODULE_NAMES.test(entry.name)) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Exported binding names, read off the source.
+ *
+ * Deliberately a parse of the text rather than an import: importing every route module
+ * would execute them, and several reach for adapters and environment at module scope.
+ * `export type` and `export interface` are skipped - they are erased at compile time
+ * and Next never sees them.
+ */
+function exportedNames(source: string): string[] {
+  const names: string[] = [];
+  const decl = /^export\s+(?!type\b|interface\b)(?:async\s+)?(?:function\*?|const|let|var|class)\s+([A-Za-z_$][\w$]*)/gm;
+  for (const m of source.matchAll(decl)) names.push(m[1]);
+  if (/^export\s+default\b/m.test(source)) names.push("default");
+  // `export { a, b as c }` - the exported (right-hand) name is the one Next reads.
+  for (const m of source.matchAll(/^export\s*\{([^}]*)\}/gm)) {
+    for (const part of m[1].split(",")) {
+      const piece = part.trim();
+      if (!piece || piece.startsWith("type ")) continue;
+      names.push((piece.split(/\s+as\s+/).pop() ?? piece).trim());
+    }
+  }
+  return names;
+}
+
+const MODULES = routeModules(APP).map((f) => relative(process.cwd(), f).replace(/\\/g, "/"));
+
+test("there are route modules to check", () => {
+  // A silent zero here would make every case below vacuously pass.
+  expect(MODULES.length).toBeGreaterThan(30);
+});
+
+test.each(MODULES)("%s exports only fields Next.js recognises", (file) => {
+  const offenders = exportedNames(readFileSync(file, "utf8")).filter((n) => !ALLOWED.has(n));
+
+  // Named so the failure tells you what to move and where, rather than just going red.
+  expect(
+    offenders,
+    `${file} exports ${offenders.join(", ")}, which Next rejects at build time. ` +
+      "Move the helper into lib/ and import it from the route.",
+  ).toEqual([]);
+});

--- a/tests/unit/webcams-body-memo.test.ts
+++ b/tests/unit/webcams-body-memo.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/webcams/fetch", async (importOriginal) => ({
   describeWebcamSample: () => describeWebcamSample(),
 }));
 
-const { webcamsBody, __resetWebcamsBody } = await import("@/app/api/webcams/route");
+const { webcamsBody, __resetWebcamsBody } = await import("@/lib/webcams/body");
 
 const webcam = (id: string, over: Record<string, unknown> = {}) => ({
   id,


### PR DESCRIPTION
> **`main` does not build right now. This fixes it.** My #120 is the cause.

## What broke

#120 exported `webcamsBody` and `__resetWebcamsBody` from `app/api/webcams/route.ts` so the test could import them. A Next.js route module may export **only** the names Next recognises, so that is a hard build failure:

```
Type error: Route "app/api/webcams/route.ts" does not match the required types
of a Next.js Route. "webcamsBody" is not a valid Route export field.
```

Production is still serving the **pre-#120** build — `/api/webcams` answers `Cache-Control: public, max-age=0, must-revalidate`, which is the old header. The deployment never went live.

## The fix

The helpers move to `lib/webcams/body.ts` unchanged. The memo, its identity key and the edge TTL are all untouched — only where the symbols live has changed. The route now exports `dynamic` and `GET` and nothing else, and the test imports from the lib module, which is better anyway: it no longer pulls a route module into a unit test.

## Why it got through, which matters more than the fix

`npx tsc --noEmit` passes on the broken file. So does the whole suite. **The route-export contract is checked only inside `next build`**, during "Linting and checking validity of types", *after* tsc has already been satisfied.

So the house gate cannot see it, and the failure mode is: green locally, green in the suite, dead on deploy. It is a tempting mistake because the motive is good — you write a helper in a route file, you want a unit test for it, so you export it.

## So the gate now catches it

`tests/unit/route-export-contract.test.ts` parses every module under `app/` and asserts each exports only fields Next accepts. 48 modules, one case each, plus a guard that the file list is non-empty so a broken glob cannot make them all pass vacuously. It reads the source rather than importing, because importing every route would execute modules that reach for adapters and environment at module scope.

**Injected the real regression, not an easy one** — the exact shape that reached `main`, an extra exported helper on that same route file:

```
app/api/webcams/route.ts exports webcamsBody2, which Next rejects at build time.
Move the helper into lib/ and import it from the route.
expected [ 'webcamsBody2' ] to deeply equal []
```

The message names the file, the offending symbol and the fix, so the next person to hit this does not have to read a Vercel build log to work out what happened.

## Note for the other open branch

#115 has the same defect on `app/api/cameras/route.ts` and its Vercel check is red for exactly this reason. Fixing it there the same way, on top of this.

```
npx tsc --noEmit  ->  exit 0
Test Files  253 passed (253)
     Tests  2180 passed (2180)
```
Branch cut off `origin/main` at 8986349, whose baseline is 252 / 2131. This adds one file and 49 cases.
