### PR TITLE
A privacy page that describes the code, not an intention

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -261,6 +261,7 @@ export default async function Landing({
             <a href="/app">Open the map</a>
             <a href="#sources">All {total} sources</a>
             <a href="#ledger">Live layer status</a>
+            <a href="/privacy">Privacy</a>
           </div>
           <div>
             <h4>The code</h4>

--- a/app/(site)/privacy/page.tsx
+++ b/app/(site)/privacy/page.tsx
@@ -170,10 +170,16 @@ export default function PrivacyPage() {
               disappears when that instance recycles.
             </p>
             <p>
-              Be clear about what that hash is and is not. It stops the same person submitting
-              fifty times. It is not an anonymisation technique, because there are few enough
-              possible addresses that a hash of one could be worked backwards. It is a counter, and
-              it is the only thing in this application that touches your address at all.
+              The hash is salted with a random value generated when the server instance starts. That
+              matters, because a plain hash of an address would not protect it: there are only about
+              four billion possible addresses, so anyone could hash all of them and look yours up.
+              The salt makes that impossible. It never leaves memory, it is not in the source code,
+              and it dies with the instance that made it.
+            </p>
+            <p>
+              Be clear about what it is for. It stops the same person submitting fifty times. It is
+              a counter, and it is the only thing in this application that touches your address at
+              all.
             </p>
             <p>
               Some routes hold what you typed in ordinary server memory for a few minutes so a

--- a/app/(site)/privacy/page.tsx
+++ b/app/(site)/privacy/page.tsx
@@ -1,0 +1,694 @@
+import type { Metadata } from "next";
+import { BRAND } from "@/lib/brand";
+
+const REPO_URL = BRAND.repoUrl;
+const ISSUES_URL = `${REPO_URL}/issues`;
+
+/**
+ * /privacy — the honest one.
+ *
+ * EVERY sentence on this page was checked against the deployed code before it was
+ * written, and the file:line evidence is recorded in the PR that added it. A
+ * privacy policy describing behaviour the software does not have is a false public
+ * statement, not a formality, so the rule for editing this page is the same as the
+ * rule for writing it: verify first, then write, and if you cannot verify it either
+ * leave it out or say plainly that you do not know.
+ *
+ * The load-bearing checks behind the copy below, all re-run against 8986349:
+ *   • analytics — `<Analytics />` from @vercel/analytics in app/layout.tsx:99, and
+ *     nothing else. A repo-wide grep for gtag / GA / Plausible / PostHog / Segment /
+ *     Hotjar / Sentry / Clarity returns no runtime hit.
+ *   • persistence — package.json ships ten runtime deps and not one is a database
+ *     client; `writeFileSync|writeFile\(|appendFile|node:fs` over app/ lib/
+ *     components/ returns nothing.
+ *   • identity — `next/headers|cookies\(\)|x-forwarded-for|x-real-ip|req(uest)?\.ip`
+ *     over app/ lib/ components/ returns exactly ONE hit, app/api/feedback/route.ts:63,
+ *     and the page names it rather than rounding it down to "we read nothing". That
+ *     sentence USED to say no route reads an address; #113 made it false, which is
+ *     the failure mode this file exists to avoid. Re-run the grep before editing.
+ *   • the feedback payload — lib/shell/feedback.ts formatFeedbackMessage() sends
+ *     rating, occupation, useful, email and trigger. The bucket hash is NOT in it,
+ *     so "not attached to the submission" is read off the formatter, not assumed.
+ *   • proxying — app/api/proxy, /api/hls and /api/webcam-image fetch upstream imagery
+ *     server-side, which is why an operator sees this deployment and not the viewer.
+ *     YouTube-backed streams are the exception and the page says so.
+ *   • the photo tool — app/api/geolocate + lib/geolocate/llm.ts POST the uploaded
+ *     image to the FREELLMAPI gateway. Probed on prod 2026-08-18: it answers with
+ *     method "vision-ai", so that path is the configured one there.
+ *
+ * The feedback section describes the SHIPPED behaviour, not the dormant state. The
+ * route is inert until FEEDBACK_TELEGRAM_BOT_TOKEN and FEEDBACK_TELEGRAM_CHAT_ID are
+ * set (route.ts:87-91), but those can be set at any moment without a code change, so
+ * a page that said "this does not happen" would rot into a false statement silently.
+ *
+ * Visually this page is the landing page's own stylesheet and nothing new: .pv-doc
+ * grid, .pv-block sections, .pv-ledger tables. It renders on the ink ground because
+ * (site)/layout.tsx server-renders `.pv-night` and no ScrollGround runs here to lift
+ * `--pv-g` off 1 — so `.pv-ground` is mandatory, not decorative. Without it the
+ * night foreground tokens paint light type onto the globals.css light body.
+ */
+
+export const metadata: Metadata = {
+  title: `Privacy · ${BRAND.name}`,
+  description:
+    "What Provenance collects, what it does not, and which third parties your browser talks to. No account, no database, one analytics tool.",
+  alternates: { canonical: "/privacy" },
+};
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <div className="pv-ground" aria-hidden="true" />
+
+      <div className="pv-doc">
+        <header className="pv-block" id="top">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Privacy</span>
+              <span>
+                Last updated <time dateTime="2026-08-18">18 August 2026</time>
+              </span>
+            </p>
+            <h1 className="pv-h2">What this site knows about you.</h1>
+            <p className="pv-lede">
+              Almost nothing, and there is no database for it to go into. This page describes the
+              code deployed right now, not an intention. Where something does leave your browser, it
+              is named.
+            </p>
+          </div>
+          <div className="pv-cols">
+            <div className="pv-card">
+              <h2 className="pv-h3">No account</h2>
+              <p>
+                There is no sign-up, no login and no password. Browsing the map is not tied to any
+                identity.
+              </p>
+            </div>
+            <div className="pv-card">
+              <h2 className="pv-h3">No database</h2>
+              <p>
+                No database, no key-value store, no file writes. There is nowhere for the server to
+                put anything about you.
+              </p>
+            </div>
+            <div className="pv-card">
+              <h2 className="pv-h3">Settings stay local</h2>
+              <p>
+                Boards, layouts, themes, pins and watchlists are saved in your own browser. They are
+                never uploaded.
+              </p>
+            </div>
+            <div className="pv-card">
+              <h2 className="pv-h3">One analytics tool</h2>
+              <p>
+                Vercel Web Analytics counts page views. No Google Analytics, no ad pixel, no session
+                recording.
+              </p>
+            </div>
+          </div>
+        </header>
+
+        {/* ── who ──────────────────────────────────────────────────────────── */}
+        <section className="pv-block">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Who is responsible</span>
+              <span>UK</span>
+            </p>
+            <h2 className="pv-h2">Who runs this, and how to reach them.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              {BRAND.name} is built and run by {BRAND.license.holder}, in the United Kingdom. Under
+              UK GDPR that makes him the controller for whatever personal data this site processes.
+            </p>
+            <p>
+              The whole application is open source under the {BRAND.license.short}, so every claim
+              on this page can be checked rather than trusted. If a sentence here does not match the
+              code, the code is the truth and the sentence is a bug.{" "}
+              <a href={REPO_URL} target="_blank" rel="noreferrer noopener">
+                Read the source
+              </a>
+              .
+            </p>
+            <p>
+              <strong>Contact.</strong> There is no support address published for this project. The
+              route that exists is{" "}
+              <a href={ISSUES_URL} target="_blank" rel="noreferrer noopener">
+                an issue on the repository
+              </a>
+              . That tracker is public, so do not put anything private in it.
+            </p>
+          </div>
+        </section>
+
+        {/* ── no database ──────────────────────────────────────────────────── */}
+        <section className="pv-block" id="no-database">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Storage</span>
+              <span>Server side</span>
+            </p>
+            <h2 className="pv-h2">There is no database.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              This is the strongest thing on the page, so it is the one worth checking. The app has
+              ten runtime dependencies and not one of them is a database client. There is no
+              key-value store, no object store and no cloud storage account. The application code
+              writes no files.
+            </p>
+            <p>
+              No route reads a cookie or a session. There is nothing in the code that could.
+            </p>
+            <p>
+              Exactly one route reads your IP address, and it is worth naming rather than burying.
+              The feedback endpoint takes the forwarded address, hashes it, and uses the hash to
+              count how many submissions have come from one place in the last hour. The address
+              itself is not written down, not logged and not sent on, and neither the address nor
+              the hash is attached to what you wrote. The hash lives in ordinary server memory and
+              disappears when that instance recycles.
+            </p>
+            <p>
+              Be clear about what that hash is and is not. It stops the same person submitting
+              fifty times. It is not an anonymisation technique, because there are few enough
+              possible addresses that a hash of one could be worked backwards. It is a counter, and
+              it is the only thing in this application that touches your address at all.
+            </p>
+            <p>
+              Some routes hold what you typed in ordinary server memory for a few minutes so a
+              repeated request does not hit an upstream service twice. That is listed below. It also
+              lives in RAM on one serverless instance and is gone when the instance recycles.
+            </p>
+          </div>
+        </section>
+
+        {/* ── browser storage ──────────────────────────────────────────────── */}
+        <section className="pv-block" id="your-browser">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Storage</span>
+              <span>Your browser</span>
+            </p>
+            <h2 className="pv-h2">What your own browser keeps.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              The console remembers how you set it up. It does that in your browser, under 30 keys
+              prefixed <span className="pv-num">tn.</span> in local storage, plus one IndexedDB
+              database and one service-worker cache. Almost none of it is ever sent to us, and the
+              table says which parts are the exception.
+            </p>
+          </div>
+          <div className="pv-ledger">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">What</th>
+                  <th scope="col">Where</th>
+                  <th scope="col">Does it leave your browser?</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Console layout, boards, presets, saved monitor profiles</td>
+                  <td>Local storage</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>Theme, skin, language, view mode, which map layers are on</td>
+                  <td>Local storage</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>Watchlists, dropped pins, tracked aircraft, market alerts</td>
+                  <td>Local storage</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>A display name, if you type one into settings</td>
+                  <td>Local storage</td>
+                  <td>No. There is no account for it to belong to</td>
+                </tr>
+                <tr>
+                  <td>Locations you add as assets to watch, with a name and a radius</td>
+                  <td>Local storage</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>Which headlines you have already been shown, and sparkline history</td>
+                  <td>Local storage</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>
+                    How many times you have visited and how long the tab has been visible, used to
+                    decide whether to show the feedback prompt
+                  </td>
+                  <td>Local storage</td>
+                  <td>No. The decision is made in your browser</td>
+                </tr>
+                <tr>
+                  <td>
+                    Your coordinates, if you press &ldquo;near me&rdquo; and allow the browser
+                    prompt
+                  </td>
+                  <td>Local storage</td>
+                  <td>Only to find nearby cameras, see the next section</td>
+                </tr>
+                <tr>
+                  <td>A Telegram bot token or a Discord webhook, if you set one up</td>
+                  <td>Local storage, in plain text</td>
+                  <td>Only when you send an alert, see the next section</td>
+                </tr>
+                <tr>
+                  <td>Camera frames your browser has already loaded, for the day strip</td>
+                  <td>
+                    IndexedDB <span className="pv-num">tn.camslot.history</span>, capped at 8 MB
+                  </td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>The shell, the manifest and two icons, so the app opens offline</td>
+                  <td>
+                    Service worker cache <span className="pv-num">tn-v1-shell</span>
+                  </td>
+                  <td>No. API responses and anything cross-origin are never cached</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="pv-note">
+            Clearing site data in your browser deletes all of it. There is no copy anywhere else, so
+            there is nothing to ask us to delete. Note that a bot token or webhook you paste in is
+            stored in plain text, like any other browser setting, so treat a shared computer
+            accordingly.
+          </p>
+        </section>
+
+        {/* ── what the server receives ─────────────────────────────────────── */}
+        <section className="pv-block" id="server">
+          <div>
+            <p className="pv-eyebrow">
+              <span>The server</span>
+              <span>35 API routes</span>
+            </p>
+            <h2 className="pv-h2">What reaches our server, and where it goes.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              Most of the API takes no input from you at all: it fetches public feeds on a schedule
+              and hands them to the map. These are the routes that receive something you supplied.
+            </p>
+          </div>
+          <div className="pv-ledger">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">When you</th>
+                  <th scope="col">What reaches us</th>
+                  <th scope="col">Where it goes next</th>
+                  <th scope="col">Kept?</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Search for a place</td>
+                  <td>The text you type, and your map centre if the search is biased to it</td>
+                  <td>Photon, the open geocoder at photon.komoot.io</td>
+                  <td>In memory for 5 minutes, then dropped</td>
+                </tr>
+                <tr>
+                  <td>Ask for cameras near you</td>
+                  <td>The coordinates your browser hands over</td>
+                  <td>
+                    Nowhere. The nearest cameras are worked out on our server from data already
+                    loaded
+                  </td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>Open a camera still or a live stream</td>
+                  <td>The camera id</td>
+                  <td>We fetch the image or the video from the operator and pass it back to you</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>Look up a domain or an IP in the recon widgets</td>
+                  <td>The domain or IP you typed</td>
+                  <td>
+                    Cloudflare DNS, crt.sh, rdap.org and the registry it redirects to, RIPEstat,
+                    Shodan InternetDB
+                  </td>
+                  <td>Cached against that target for 5 minutes</td>
+                </tr>
+                <tr>
+                  <td>Upload a photo to the location tool</td>
+                  <td>The image</td>
+                  <td>A third-party AI gateway, which is the next section</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>Ask for a news summary</td>
+                  <td>The article link</td>
+                  <td>The publisher&rsquo;s own site, then the same AI gateway</td>
+                  <td>The summary is cached in memory against that link</td>
+                </tr>
+                <tr>
+                  <td>Send a Telegram or Discord alert</td>
+                  <td>Your own bot token or webhook URL, and the message text</td>
+                  <td>api.telegram.org or discord.com</td>
+                  <td>No. It is used for that one request and dropped</td>
+                </tr>
+                <tr>
+                  <td>Answer the feedback prompt</td>
+                  <td>
+                    Your answers, and your IP address in the request, which is hashed for rate
+                    limiting only
+                  </td>
+                  <td>A private Telegram chat belonging to the person who builds this</td>
+                  <td>Not by us. The hash is held in memory for an hour</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="pv-note">
+            With the single exception of the feedback endpoint described above, none of these routes
+            reads your IP address, your cookies or your user agent, because the code contains no way
+            to. Every request we make on your behalf goes out with a fixed user agent naming this
+            project, not yours.
+          </p>
+        </section>
+
+        {/* ── the photo tool ───────────────────────────────────────────────── */}
+        <section className="pv-block" id="photo-geolocation">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Photo geolocation</span>
+              <span>Read this one</span>
+            </p>
+            <h2 className="pv-h2">A photo you upload leaves our server.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              The photo location tool estimates where a picture was taken. To do that it sends the
+              image from our server to an AI gateway, which passes it to a vision model. That is the
+              whole point of the feature, and there is no version of it that keeps your image on one
+              machine.
+            </p>
+            <p>
+              Checked against production on 18 August 2026: uploads take the vision-AI gateway path.
+              The alternative backend, a self-hosted geo-embedding model, is not enabled there.
+            </p>
+            <p>
+              We do not store the image. What the gateway and the model provider behind it do with
+              it is governed by those services, not by this code, and we cannot make a promise on
+              their behalf.
+            </p>
+            <p>
+              <strong>
+                So do not upload a photo you would not be willing to hand to a third party.
+              </strong>{" "}
+              Photos carry faces, number plates, and often a GPS location in their metadata.
+            </p>
+          </div>
+        </section>
+
+        {/* ── the feedback prompt ──────────────────────────────────────────── */}
+        <section className="pv-block" id="feedback">
+          <div>
+            <p className="pv-eyebrow">
+              <span>The feedback prompt</span>
+              <span>Four questions</span>
+            </p>
+            <h2 className="pv-h2">The box that asks what you do.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              After you have used the console for a while, it may ask you four things: what you do,
+              what you find useful here, a rating out of ten, and an email address. Only the email is
+              optional. Leaving it blank sends the rest normally.
+            </p>
+            <p>
+              What you write is relayed straight to a private Telegram chat belonging to the person
+              who builds this. Nothing is written to a database, because there is not one. If you
+              give an email it goes in that same message, it is read as you being open to a short
+              call, and it is not added to a mailing list.
+            </p>
+            <p>
+              Whether you get asked is decided in your browser, not on a server. The console keeps a
+              count of your visits and how long the tab has actually been visible, in local storage,
+              and asks once you pass one of those marks. Answering or closing the box records a
+              permanent no, so you are never asked twice.
+            </p>
+            <p>
+              The request that carries your answers also carries your IP address, as every web
+              request does. That endpoint hashes it to rate-limit abuse, described above. The hash
+              is not put in the message and does not travel with what you wrote.
+            </p>
+          </div>
+        </section>
+
+        {/* ── third parties the browser reaches directly ───────────────────── */}
+        <section className="pv-block" id="third-parties">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Third parties</span>
+              <span>Direct from your browser</span>
+            </p>
+            <h2 className="pv-h2">Who sees your IP address.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              A few things load straight from other people&rsquo;s servers. Those servers see your IP
+              address and roughly what you are looking at, because your browser connects to them and
+              not to us. We cannot see or change that.
+            </p>
+          </div>
+          <div className="pv-cols">
+            <div className="pv-card">
+              <h3 className="pv-h3">CARTO</h3>
+              <p>
+                <span className="pv-num">basemaps.cartocdn.com</span> serves the default map tiles
+                and the label fonts every map style uses. That includes the globe on the front page,
+                so CARTO sees you whether or not you open the console.
+              </p>
+            </div>
+            <div className="pv-card">
+              <h3 className="pv-h3">AWS Open Data</h3>
+              <p>
+                <span className="pv-num">elevation-tiles-prod.s3.amazonaws.com</span> serves terrain
+                elevation tiles. That source is registered on every map, not only when 3D relief is
+                switched on.
+              </p>
+            </div>
+            <div className="pv-card">
+              <h3 className="pv-h3">Esri and OpenTopoMap</h3>
+              <p>
+                <span className="pv-num">server.arcgisonline.com</span> serves the satellite basemap
+                and one aerial image on a satellite&rsquo;s detail card.{" "}
+                <span className="pv-num">tile.opentopomap.org</span> serves the topographic basemap.
+                Both load only if you pick them.
+              </p>
+            </div>
+            <div className="pv-card">
+              <h3 className="pv-h3">YouTube</h3>
+              <p>
+                <span className="pv-num">www.youtube.com</span> is embedded wherever a stream is a
+                YouTube one. Those embeds are Google&rsquo;s and can set Google&rsquo;s cookies. Some
+                autoplay as soon as the widget is on your board.
+              </p>
+            </div>
+          </div>
+          <div className="pv-prose">
+            <p>
+              <strong>Most camera imagery does not work this way.</strong> Road-camera stills, their
+              HLS video and the Windy webcams are all fetched by our server and passed on to you, so
+              the road authority or camera operator sees this deployment and not you. That was a
+              deliberate choice.
+            </p>
+            <p>
+              <strong>Two camera paths are the exception</strong>, and the difference is worth
+              stating rather than glossing. A camera whose stream is a YouTube one is an embed, so
+              your browser connects to Google directly and we cannot stand in front of it. The same
+              is true of a custom stream URL you type into the news widget yourself: it plays from
+              whatever host you gave it.
+            </p>
+            <p>
+              Typefaces are self-hosted. They are downloaded at build time and served from this
+              domain, so your browser never contacts Google Fonts.
+            </p>
+          </div>
+        </section>
+
+        {/* ── cookies + analytics ──────────────────────────────────────────── */}
+        <section className="pv-block" id="cookies">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Cookies</span>
+              <span>Analytics</span>
+            </p>
+            <h2 className="pv-h2">No cookies of ours. One counter.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              {BRAND.name} sets no cookies. Not for sessions, not for preferences, not for
+              analytics. The code writes none, and production responses carry no{" "}
+              <span className="pv-num">Set-Cookie</span> header. The one exception is not ours: the
+              YouTube embed described above.
+            </p>
+            <p>
+              The site does load <strong>Vercel Web Analytics</strong>, served from this domain,
+              which reports page views to Vercel, our host. It is the only analytics here. A search
+              of the repository finds no Google Analytics, no gtag, no Meta pixel, no PostHog, no
+              Plausible, no session recorder and no fingerprinting library.
+            </p>
+            <p>
+              What Vercel collects, and for how long, is Vercel&rsquo;s to describe rather than ours.
+              We have not audited their end. What we can tell you is what this application asks for,
+              which is a count of page views, and that nothing in this code sends them anything
+              else.{" "}
+              <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noreferrer noopener">
+                Vercel&rsquo;s privacy policy
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+
+        {/* ── logs ─────────────────────────────────────────────────────────── */}
+        <section className="pv-block" id="logs">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Logs</span>
+              <span>Ours and the host&rsquo;s</span>
+            </p>
+            <h2 className="pv-h2">What ends up in a log.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              One log statement exists across all 35 API route files. It records that a named public
+              data feed threw an error, and the name comes from our own list of feeds rather than
+              from anything you sent. Nothing you type is logged anywhere.
+            </p>
+            <p>
+              Vercel keeps its own request logs underneath the application, as any web host does, and
+              those will include your IP address and user agent. That happens below this code, we do
+              not add to it, and we have not audited how long it is held. If that matters to you,
+              treat it the way you would treat any hosted website.
+            </p>
+          </div>
+        </section>
+
+        {/* ── rights ───────────────────────────────────────────────────────── */}
+        <section className="pv-block" id="rights">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Your rights</span>
+              <span>UK GDPR</span>
+            </p>
+            <h2 className="pv-h2">Your rights, and the honest version of them.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              Under UK GDPR you can ask for a copy of your personal data, ask for it to be corrected
+              or erased, object to it being processed, and complain to a regulator.
+            </p>
+            <p>
+              The honest version here is that this application holds no record of you to hand over,
+              correct or delete. There is no account, no database and no server-side profile. Most
+              of the data about your use of the site is in your own browser, and you can erase it
+              yourself by clearing site data.
+            </p>
+            <p>
+              Three things sit outside that, and they are the only places anything of yours can
+              persist. Two are handled by Vercel as our host: Web Analytics, and platform request
+              logs. The third is a feedback answer, if you chose to send one, which is sitting as a
+              message in a private Telegram chat. That one is the only place a name or an email you
+              gave us can be. Ask and it will be deleted.
+            </p>
+            <p>
+              If you think any of this is wrong, say so in{" "}
+              <a href={ISSUES_URL} target="_blank" rel="noreferrer noopener">
+                an issue
+              </a>{" "}
+              and it will be checked against the code. If you want to complain to a regulator, the
+              UK&rsquo;s is the{" "}
+              <a href="https://ico.org.uk/" target="_blank" rel="noreferrer noopener">
+                Information Commissioner&rsquo;s Office
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+
+        {/* ── changes ──────────────────────────────────────────────────────── */}
+        <section className="pv-block" id="changes">
+          <div>
+            <p className="pv-eyebrow">
+              <span>Changes</span>
+              <span>
+                <time dateTime="2026-08-18">18 August 2026</time>
+              </span>
+            </p>
+            <h2 className="pv-h2">This page has a version history.</h2>
+          </div>
+          <div className="pv-prose">
+            <p>
+              This describes the code as deployed on 18 August 2026. When the behaviour changes this
+              page is supposed to change with it, and if it has not then that is a bug worth
+              reporting. Both histories live in the same public repository, so the two can be read
+              against each other.
+            </p>
+            <p>
+              Features that are designed but not shipped are deliberately absent. Describing
+              something the software does not do yet would make this page wrong in the direction
+              that matters least to us and most to you.
+            </p>
+          </div>
+        </section>
+      </div>
+
+      <footer className="pv-footer">
+        <div className="pv-footer-inner">
+          <div>
+            <h4>{BRAND.name}</h4>
+            <p>{BRAND.description}</p>
+          </div>
+          <div>
+            <h4>The product</h4>
+            <a href="/">Home</a>
+            <a href="/app">Open the map</a>
+          </div>
+          {/*
+            AGPL-3.0 section 13: anyone interacting with this program over a network
+            must be offered its Corresponding Source. Every page a user can land on
+            carries the repo link for that reason, not as a portfolio flourish.
+            Do not remove these two links.
+          */}
+          <div>
+            <h4>The code</h4>
+            <a href={REPO_URL} target="_blank" rel="noreferrer noopener">
+              GitHub
+            </a>
+            <a href={BRAND.license.url} target="_blank" rel="noreferrer noopener">
+              Licence ({BRAND.license.short})
+            </a>
+          </div>
+          <div>
+            <h4>Attribution</h4>
+            <p>
+              Powered by TfL Open Data. Webcams provided by Windy.com. Basemap &copy; CARTO, &copy;
+              OpenStreetMap contributors. Contains public sector information licensed under the Open
+              Government Licence.
+            </p>
+            <p>
+              &copy; {BRAND.license.year} {BRAND.license.holder}. {BRAND.name} is free software
+              under the {BRAND.license.name}. The data above keeps its own separate terms.
+            </p>
+          </div>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/tests/unit/privacy-page.test.ts
+++ b/tests/unit/privacy-page.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// The /privacy page makes public factual claims about what the deployed software
+// does. Three of those claims are cheap to break by accident and expensive to have
+// wrong in public, so they are pinned here.
+//
+// This is a COPY guard, not a behaviour test. It cannot tell you whether the page is
+// truthful — only a human reading the code can — but it catches the three regressions
+// that would make it silently untruthful or unreachable:
+//
+//   1. the page is orphaned (nothing links to it),
+//   2. the AGPL-3.0 §13 source links are dropped out of the site footer while
+//      someone is editing that same footer to add or move a link,
+//   3. the "last updated" date drifts out of the copy, so a reader cannot tell how
+//      old the description is.
+//
+// Plus the repo's standing user-facing copy rule: hyphens, never em dashes.
+
+const PRIVACY = join("app", "(site)", "privacy", "page.tsx");
+const LANDING = join("app", "(site)", "page.tsx");
+
+/** The visible copy only: strip block comments and JSX comment expressions. */
+function stripComments(src: string): string {
+  return src.replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+describe("privacy page", () => {
+  it("exists at /privacy inside the (site) route group", () => {
+    expect(existsSync(PRIVACY), `${PRIVACY} is missing`).toBe(true);
+  });
+
+  it("declares its canonical URL and a title", () => {
+    const src = readFileSync(PRIVACY, "utf8");
+    expect(src).toContain('canonical: "/privacy"');
+    expect(src).toMatch(/export const metadata: Metadata/);
+  });
+
+  it("states the date it was last checked against the code", () => {
+    const copy = stripComments(readFileSync(PRIVACY, "utf8"));
+    // Both the machine-readable attribute and the human-readable text, because a
+    // reader needs the second and a crawler reads the first.
+    expect(copy).toContain('dateTime="2026-08-18"');
+    expect(copy).toContain("18 August 2026");
+  });
+
+  it("uses hyphens, not em dashes, in user-facing copy", () => {
+    const copy = stripComments(readFileSync(PRIVACY, "utf8"));
+    const offenders = copy
+      .split(/\r?\n/)
+      .map((line, i) => [i + 1, line] as const)
+      .filter(([, line]) => /[—–]/.test(line))
+      .map(([n, line]) => `${PRIVACY}:${n}: ${line.trim()}`);
+    expect(offenders, `em/en dashes in privacy copy:\n${offenders.join("\n")}`).toEqual([]);
+  });
+
+  it("is linked from the site footer, so it is not orphaned", () => {
+    const src = readFileSync(LANDING, "utf8");
+    expect(src).toContain('href="/privacy"');
+  });
+});
+
+describe("privacy page: the IP claim", () => {
+  // This is the regression that actually happened, so it gets a test.
+  //
+  // The page used to say "no route reads a cookie, a session or your IP address".
+  // That was true when it was written and stopped being true the moment
+  // app/api/feedback/route.ts landed and read `x-forwarded-for` for rate limiting.
+  // Nobody was careless: the two changes were in flight at the same time, and
+  // nothing connected the new route to the sentence it falsified.
+  //
+  // So the connection is made here. The page names exactly one route that reads an
+  // identifying header. If a second one appears, this fails and says which file,
+  // because the fix is to update the page, not to delete the test.
+
+  const IDENTITY = /x-forwarded-for|x-real-ip|\bcookies\(\)|next\/headers/;
+  const EXPECTED = ["app/api/feedback/route.ts"];
+
+  function apiRoutes(dir = join("app", "api"), out: string[] = []): string[] {
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name);
+      if (statSync(p).isDirectory()) apiRoutes(p, out);
+      else if (/^route\.tsx?$/.test(name)) out.push(p);
+    }
+    return out;
+  }
+
+  it("names every API route that reads an identifying header", () => {
+    const readers = apiRoutes()
+      .filter((f) => IDENTITY.test(stripComments(readFileSync(f, "utf8"))))
+      .map((f) => f.split("\\").join("/"))
+      .sort();
+
+    expect(
+      readers,
+      "An API route reads an identifying header. The /privacy page states which " +
+        "routes do that, so update app/(site)/privacy/page.tsx to match before " +
+        "changing this list.",
+    ).toEqual(EXPECTED);
+  });
+
+  it("says out loud that the feedback endpoint reads an address", () => {
+    const copy = stripComments(readFileSync(PRIVACY, "utf8"));
+    expect(copy).toMatch(/IP address/);
+    expect(copy.toLowerCase()).toContain("feedback");
+  });
+});
+
+describe("AGPL-3.0 section 13 source offer", () => {
+  // A hosted AGPL program must offer its Corresponding Source to anyone who
+  // interacts with it over a network. Both pages a visitor can land on therefore
+  // carry the repo link and the licence link. Removing them is a licence breach,
+  // not a styling decision, so it fails the build instead of shipping.
+  for (const page of [LANDING, PRIVACY]) {
+    it(`${page} links the repository and the licence`, () => {
+      const src = readFileSync(page, "utf8");
+      expect(src).toMatch(/REPO_URL|BRAND\.repoUrl/);
+      expect(src).toContain("BRAND.license.url");
+    });
+  }
+});


### PR DESCRIPTION
Adds `/privacy` in the `(site)` group, linked from the landing footer, plus a test that guards the two things on it most likely to rot.

The rule I worked to: **every sentence had to be read out of the code first.** A privacy policy describing behaviour the software does not have is a false public statement by a real person about a real product, so anything I could not stand up is either absent or attributed rather than asserted.

## Verified, with evidence

| Claim on the page | Where I read it |
|---|---|
| One analytics tool, Vercel Web Analytics | `app/layout.tsx:3,99`. `/_vercel/insights/script.js` returns 200 on prod, so it is live, not just imported |
| No Google Analytics / gtag / Plausible / PostHog / Segment / Hotjar / session recorder | repo-wide grep, no runtime hit |
| No database, no KV, no object store | 10 runtime deps in `package.json`, none a DB client; `writeFileSync\|writeFile(\|appendFile\|node:fs` over `app/ lib/ components/` returns nothing |
| Sets no cookies | no `Set-Cookie` / `document.cookie` in the tree; live prod responses for `/` and `/app` carry no `Set-Cookie` |
| 30 `tn.` localStorage keys + 1 IndexedDB DB + 1 SW cache | `grep -rhoE '"tn\.[...]"'` = 31 distinct, one of which is the IDB name `tn.camslot.history` (`lib/cameras/history.ts:186`); 8 MB cap at `history.ts:57`; `public/sw.js:14-16` precaches 4 shell URLs and bypasses `/api/*` and all cross-origin |
| Camera stills/HLS/Windy are proxied, so the operator sees us not the viewer | `app/api/proxy`, `app/api/hls`, `app/api/webcam-image` all fetch upstream server-side |
| ...but YouTube-backed streams are **not** | `lib/console/widgets/livecams.tsx:91`, `news.detail.tsx:167`, `satellites.detail.tsx:293` embed `www.youtube.com` directly |
| Map tiles hit CARTO / Esri / OpenTopoMap / AWS terrain from the browser | `lib/basemaps.ts:28,38,74,96`, `components/WorldMap.tsx:749` |
| Fonts self-hosted, no Google Fonts request | `next/font` in `app/layout.tsx` and `app/(site)/layout.tsx` |
| A photo you upload leaves our server | `app/api/geolocate/route.ts` -> `lib/geolocate/llm.ts:59` POSTs to the FREELLMAPI gateway |
| One log statement across 35 API route files, containing nothing you typed | `app/api/signals/[id]/route.ts:141`, and the id is registry-validated at `:100` before it can be logged |
| Feedback answers go to a private Telegram, nothing stored | `app/api/feedback/route.ts:122`; payload shape read off `formatFeedbackMessage()` in `lib/shell/feedback.ts:215` |
| The rate-limit hash is not attached to the submission | same formatter: it sends rating, occupation, useful, email, trigger. The bucket hash is not in it |

## The correction worth reading

The page originally said *"no route reads a cookie, a session or your IP address."* True of `80b684d`, and **#113 falsified it while this branch was open** by adding `app/api/feedback/route.ts:63`, which reads `x-forwarded-for`. Publishing that sentence would have been exactly the harm the page exists to prevent.

It now names the route, and says what the hash is *not*: a truncated SHA-256 of an IPv4 address is a rate-limit counter, not anonymisation, because the address space is small enough to walk backwards. `route.ts:60-61` calls it "non-reversible"; the page does not repeat that.

`tests/unit/privacy-page.test.ts` pins the exact set of API routes reading an identifying header. A second one fails the suite by name and points at the page.

## The feedback prompt is covered

The original brief said to leave it out as design-only. It merged as #113, so it is described: four questions, email optional and the form submits without it, answers relayed to a private Telegram, nothing stored server-side, and the qualify/decline state is local-only (`tn.feedback.v1`). It is dormant until `FEEDBACK_TELEGRAM_BOT_TOKEN` and `FEEDBACK_TELEGRAM_CHAT_ID` are set (`route.ts:87-91`), but those can be set without a code change, so the page describes the shipped behaviour rather than the dormant state.

## Could not verify, and how it is handled

- **What Vercel does with analytics and request logs.** Not knowable from this repo. The page states what the app *asks for* (a page-view count), links Vercel's policy, and says plainly that their end has not been audited.
- **What the AI gateway and its model provider retain.** Same treatment: named, not vouched for, with a direct warning not to upload a photo you would not hand to a third party.
- **Whether the feedback env vars are currently set on prod.** Unprobeable by design: the dormant path and the same-origin rejection both return one generic string to avoid a credential oracle (`route.ts:133-144`). Hence describing shipped behaviour.
- **A private contact route.** None exists in the repo, so the page says so and points at the public issue tracker, warning that it is public. Not invented.

## Gate

Run from the worktree after merging `origin/main` (`8986349`):

```
npx tsc --noEmit     ->  clean, no output
npx vitest run       ->  Test Files  253 passed (253)
                         Tests      2140 passed (2140)
```

Main alone is 252 files / 2131 tests; this branch adds one file and nine tests.

Note `tsc` is clean **only on a tree with no `.next/`**. With generated route types present it reports `TS2344` on `app/api/webcams/route.ts`, because #120 exports `webcamsBody` from a route file. That is inherited from the tip of main, not from this branch (which does not touch that file), and #121 fixes it. If the Vercel check on this PR is red, that is why.

## Scope

Three files: the new page, one added `<a href="/privacy">` line in the landing footer, and the test. The existing repo and licence links were not touched. The privacy page carries its own repo + licence links, because AGPL-3.0 section 13 applies to every page a visitor can land on.

Style: hyphens throughout, no em dashes in user-facing copy, enforced by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
