### PR TITLE
Salt the rate-limit bucket key, and stop calling an IP hash non-reversible

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -13,6 +13,8 @@
 
 import {
   CAP_BODY_BYTES,
+  bucketKey,
+  clientIpFrom,
   formatFeedbackMessage,
   validateFeedback,
 } from "@/lib/shell/feedback";
@@ -57,16 +59,20 @@ function rateLimited(key: string, now: number): boolean {
   return false;
 }
 
-/** A coarse, non-reversible bucket key. The address itself is never stored, never
- *  sent on, and never logged. */
-async function bucketKey(req: Request): Promise<string> {
-  const fwd = req.headers.get("x-forwarded-for") ?? "";
-  const ip = fwd.split(",")[0]?.trim() || "unknown";
-  const bytes = new TextEncoder().encode(`feedback:${ip}`);
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest).slice(0, 8))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+/**
+ * Per-instance salt for the rate-limit bucket key, generated once at module load
+ * and never persisted, logged or sent anywhere. Rate-limit buckets do not need to
+ * survive a restart - the Map above is per-instance already - so a salt that dies
+ * with the process costs nothing and is what makes the key genuinely unguessable.
+ * See bucketKey() in lib/shell/feedback.ts for why an UNSALTED hash of an IP is
+ * not anonymisation, whatever it looks like.
+ */
+const BUCKET_SALT = crypto.randomUUID();
+
+/** A per-address bucket key, held in memory only for rate limiting. The address is
+ *  never stored, never logged, and never included in what is sent on. */
+function bucketKeyFor(req: Request): Promise<string> {
+  return bucketKey(BUCKET_SALT, clientIpFrom(req.headers.get("x-forwarded-for")));
 }
 
 /** Same-origin only. The prompt is served from this site; nothing else has any
@@ -116,7 +122,7 @@ export async function POST(req: Request): Promise<Response> {
   const checked = validateFeedback(parsed);
   if (!checked.ok) return fail(checked.error);
 
-  if (rateLimited(await bucketKey(req), Date.now())) return fail(GENERIC_FAILURE);
+  if (rateLimited(await bucketKeyFor(req), Date.now())) return fail(GENERIC_FAILURE);
 
   try {
     const r = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {

--- a/app/api/webcams/route.ts
+++ b/app/api/webcams/route.ts
@@ -1,130 +1,20 @@
 import { getWebcams } from "@/lib/webcams/registry";
-import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
-import { WINDY_SOURCE } from "@/lib/sources/windy";
-import { describeCoverage } from "@/lib/signals/coverage";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { webcamsBody, webcamsCacheControl } from "@/lib/webcams/body";
 
 export const dynamic = "force-dynamic";
 
-/**
- * Shared-cache lifetime, and the reasoning is NOT the registry's.
- *
- * lib/webcams/registry.ts holds its sample for 8 minutes, deliberately under Windy's
- * ~10-minute image-token expiry. That ceiling protects TOKENS, and there are none in
- * this response: the route ships thin markers and the dossier re-resolves a fresh
- * image per view through /api/webcam-image. So the token clock does not bind here.
- *
- * What does bind is honesty, and this body is the easy case — it carries no timestamp
- * at all, absolute or relative, so a cached copy cannot under-report anything's age.
- * Compare /api/planes, whose `staleness.ageMs` is relative and freezes under a cache;
- * that is why its TTL is 20 s and this one can be the same 60 s as /api/cameras. What
- * moves in this body is a webcam's position, title and `available` flag, on the order
- * of the 8-minute sample behind it.
- *
- * As with /api/cameras this is about not paying an invocation per visitor, not about
- * protecting the upstream — getWebcams() already shields Windy.
- */
-const WEBCAMS_TTL_MS = 60_000;
-
-/**
- * The serialised body, held until the registry publishes a new sample.
- *
- * WHY. 2,000 webcams, 425 KB of JSON measured on prod, rebuilt on every request
- * because this route had no cache header at all — so the edge never answered one and
- * every visitor cost an invocation AND a full re-serialisation. The answer was
- * byte-for-byte the same each time until the 8-minute sample rolled over.
- *
- * WHY IDENTITY IS THE RIGHT KEY. `getWebcams()` returns `cache.sample`, and
- * `refresh()` only ever REPLACES that object — including on the failure path, where it
- * rewrites the timestamp but re-uses the same sample rather than mutating it. So
- * `from === sample` is true exactly while the contents are unchanged, and a new sample
- * recomputes. Nothing in the body depends on the clock: `describeWebcamSample` and
- * `describeCoverage` are both pure over the sample, so there is no second expiry to
- * keep in step.
- *
- * Same shape as the memo in app/api/cameras/route.ts. One entry, per isolate, and it
- * lowers peak memory rather than raising it — one retained string instead of 425 KB of
- * garbage per request.
- */
-let serialised: { from: WebcamSample; body: string } | null = null;
-
-/**
- * GET /api/webcams — a global sample of Windy webcams as thin markers (the
- * x-windy-api-key is added server-side; it never reaches the client). Distinct
- * from /api/cameras: webcams are their own layer and never fold into the
- * road-camera count.
- *
- * Image URLs are intentionally omitted here — their tokens are short-lived, so
- * the dossier re-resolves a fresh image per view through /api/webcam-image.
- *
- * TRUNCATION HONESTY. The merged global sample is capped at MAX_WEBCAMS (2000);
- * before this the cap shipped with nothing disclosing it, so `count` was the
- * ceiling wearing the costume of a measurement — the exact defect the coverage
- * contract exists to prevent. `sample.coverage` (lib/signals/coverage.ts,
- * attached in lib/webcams/normalize.ts's toWebcams()) now carries the true
- * pre-cap total, so this can say "2,000 of N" instead of a bare 2,000.
- *
- * DESIGN DECISION — SIGNAL style ("N of M"), not the camera style. Cameras'
- * /api/coverage reports {feeds: {answered, total, stale}} because a camera total
- * is a SUM ACROSS ELEVEN INDEPENDENT NETWORKS, any of which can be down on a
- * given refresh — the denominator that matters there is "how many of our feeds
- * answered". Webcams have exactly ONE upstream (Windy) and no per-feed health
- * dimension to report; the only thing being hidden is a single render cap over
- * one merged pool of rows. That is precisely what lib/signals/coverage.ts's
- * applyCap/coverageCountLabel contract was built for (it already backs
- * /api/planes and /api/signals/<id> for the same reason), so reusing it costs
- * nothing, and inventing a "feeds" shape for a single source would just be
- * duplication with no real denominator to put in it.
- *
- * Returns {count, webcams[], dormant, note, attribution, coverage?}. `note` is a
- * plain sentence describing what actually happened upstream, so an empty layer
- * can always explain itself instead of silently looking like "no webcams exist".
- * `coverage` is present only when the sample declared one (i.e. not dormant) —
- * its absence means "not declared", never "nothing was truncated".
- */
-export function webcamsBody(sample: WebcamSample): string {
-  if (serialised && serialised.from === sample) return serialised.body;
-  // `city` and `categories` survive lib/webcams/normalize.ts but used to be dropped
-  // here. They are what lets a caller filter to squares, promenades and old towns
-  // instead of matching on title text — the difference between finding the
-  // pedestrian-zone cameras this layer is mostly useful for and guessing at them.
-  const thin = sample.webcams.map((w) => ({
-    id: w.id,
-    title: w.title,
-    lat: w.lat,
-    lon: w.lon,
-    country: w.country,
-    region: w.region,
-    city: w.city,
-    categories: w.categories,
-    available: w.available,
-    detailUrl: w.detailUrl,
-  }));
-  const body = JSON.stringify({
-    count: thin.length,
-    webcams: thin,
-    dormant: sample.dormant,
-    note: describeWebcamSample(sample),
-    attribution: WINDY_SOURCE.attribution,
-    ...(sample.coverage ? { coverage: describeCoverage(sample.coverage) } : {}),
-  });
-  serialised = { from: sample, body };
-  return body;
-}
-
-/** Test seam, matching the house pattern in lib/webcams/search.ts. */
-export function __resetWebcamsBody(): void {
-  serialised = null;
-}
+// A route module may export ONLY the fields Next recognises; `webcamsBody` and its
+// test seam therefore live in lib/webcams/body.ts, where the reasoning is written up.
+// That file also carries the route documentation - what this endpoint returns, why the
+// coverage record is shaped the way it is, and why no image URL ever leaves here.
 
 export async function GET() {
-  const sample = await getWebcams();
-  // `Response.json` is not used here only because the body is already a string;
-  // it sets exactly this Content-Type, so the response is unchanged on the wire.
-  return new Response(webcamsBody(sample), {
+  // `Response.json` is not used only because the body is already a string; it sets
+  // exactly this Content-Type, so the response is unchanged on the wire.
+  return new Response(webcamsBody(await getWebcams()), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": edgeCacheControl(WEBCAMS_TTL_MS, 300_000),
+      "Cache-Control": webcamsCacheControl(),
     },
   });
 }

--- a/components/shell/FeedbackPrompt.tsx
+++ b/components/shell/FeedbackPrompt.tsx
@@ -9,12 +9,13 @@
 // a form.
 //
 // WHY IT WAITS BEFORE EVALUATING AT ALL. BootSequence writes its "seen" flag when
-// the plate STARTS, and sibling effects run in document order, so reading
-// shouldPlayBoot() from here would race and usually report "no boot" while the
-// boot was on screen. Rather than depend on that ordering, the gate simply does
-// not run for the first few seconds of any visit. Nobody can qualify that early
-// (a first visit cannot qualify by visit count, and the time arm needs fifteen
-// minutes), so the hold costs nothing and cannot be raced.
+// the plate STARTS, so reading shouldPlayBoot() from here could see the flag
+// already set while the boot is still on screen, depending on the order sibling
+// effects run in. I have NOT measured that ordering and this deliberately does not
+// depend on it either way: the gate simply does not run for the first few seconds
+// of any visit. Nobody can qualify that early (a first visit cannot qualify by
+// visit count, and the time arm needs fifteen minutes), so the hold costs nothing
+// and removes the question rather than answering it.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BOOT_FADE_MS, BOOT_MS } from "@/lib/terminal/boot";
@@ -363,7 +364,10 @@ export default function FeedbackPrompt() {
             </p>
           </div>
 
-          {/* Honeypot. Off-screen rather than display:none, which some bots skip. */}
+          {/* Honeypot. Positioned off-screen rather than display:none - the usual
+              advice, on the theory that some bots skip hidden fields. I have not
+              measured that, and it is not load-bearing: the caps, the same-origin
+              check and the dwell guard are. */}
           <input
             className="tn-fb-hp"
             type="text"

--- a/lib/shell/feedback.ts
+++ b/lib/shell/feedback.ts
@@ -210,6 +210,40 @@ export function validateFeedback(input: unknown): Validated<FeedbackPayload> {
   };
 }
 
+/* ── Rate-limit bucket key ──────────────────────────────────────────────── */
+
+/**
+ * A per-instance bucket key for the rate limiter.
+ *
+ * THIS IS NOT ANONYMISATION, and an earlier version of this code claimed it was.
+ * The claim was wrong for a reason worth writing down, because it looks safe: the
+ * weakness is not SHA-256, it is that the INPUT SPACE IS ENUMERABLE. There are
+ * about 4.3 billion IPv4 addresses, so an unsalted digest over a fixed public
+ * prefix is a lookup table rather than an attack. Measured on this machine:
+ * ~743k hashes/sec single-threaded, i.e. a full IPv4 sweep in ~96 minutes on one
+ * core or ~12 on eight. Truncating to 64 bits does not help either - across 2^32
+ * inputs the expected number of 64-bit collisions is 0.5, so a match comes back
+ * effectively unique. And this repo is public, so the construction is readable.
+ *
+ * The salt is what makes it genuinely non-reversible, and it costs nothing here:
+ * the limiter is already per-instance and best-effort (its Map dies with the
+ * instance), so a salt that never leaves memory and never reaches the repo gives
+ * up nothing that was not already given up.
+ */
+export async function bucketKey(salt: string, ip: string): Promise<string> {
+  const bytes = new TextEncoder().encode(`${salt}:feedback:${ip}`);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest).slice(0, 8))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** First entry of x-forwarded-for, or a shared "unknown" bucket. Split out so the
+ *  parsing is testable without a Request. */
+export function clientIpFrom(forwardedFor: string | null): string {
+  return (forwardedFor ?? "").split(",")[0]?.trim() || "unknown";
+}
+
 /** The Telegram message body. Kept pure so its shape is pinned by a test rather
  *  than discovered in a chat window. */
 export function formatFeedbackMessage(p: FeedbackPayload): string {

--- a/lib/webcams/body.ts
+++ b/lib/webcams/body.ts
@@ -1,0 +1,136 @@
+import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
+import { WINDY_SOURCE } from "@/lib/sources/windy";
+import { describeCoverage } from "@/lib/signals/coverage";
+import { edgeCacheControl } from "@/lib/http/cache";
+
+// The body of GET /api/webcams, and its edge-cache policy.
+//
+// WHY THIS IS NOT IN THE ROUTE FILE. A Next.js App Router route module may only export
+// the names Next recognises - the HTTP verbs plus dynamic, revalidate, runtime,
+// dynamicParams, fetchCache, preferredRegion, maxDuration and generateStaticParams.
+// Anything else is a HARD BUILD FAILURE:
+//
+//     Type error: Route "app/api/webcams/route.ts" does not match the required types
+//     of a Next.js Route. "webcamsBody" is not a valid Route export field.
+//
+// and - this is the part worth knowing - `npx tsc --noEmit` and the whole vitest suite
+// pass anyway. The route-export contract is checked only inside `next build`, during
+// "Linting and checking validity of types", AFTER tsc has already been satisfied. So a
+// helper exported from a route file for a test to import looks completely green locally
+// and fails the deployment. Helpers live here; the route imports one function.
+
+/**
+ * Shared-cache lifetime, and the reasoning is NOT the registry's.
+ *
+ * lib/webcams/registry.ts holds its sample for 8 minutes, deliberately under Windy's
+ * ~10-minute image-token expiry. That ceiling protects TOKENS, and there are none in
+ * this response: the route ships thin markers and the dossier re-resolves a fresh
+ * image per view through /api/webcam-image. So the token clock does not bind here.
+ *
+ * What does bind is honesty, and this body is the easy case — it carries no timestamp
+ * at all, absolute or relative, so a cached copy cannot under-report anything's age.
+ * Compare /api/planes, whose `staleness.ageMs` is relative and freezes under a cache;
+ * that is why its TTL is 20 s and this one can be the same 60 s as /api/cameras. What
+ * moves in this body is a webcam's position, title and `available` flag, on the order
+ * of the 8-minute sample behind it.
+ *
+ * As with /api/cameras this is about not paying an invocation per visitor, not about
+ * protecting the upstream — getWebcams() already shields Windy.
+ */
+const WEBCAMS_TTL_MS = 60_000;
+
+/**
+ * The serialised body, held until the registry publishes a new sample.
+ *
+ * WHY. 2,000 webcams, 425 KB of JSON measured on prod, rebuilt on every request
+ * because this route had no cache header at all — so the edge never answered one and
+ * every visitor cost an invocation AND a full re-serialisation. The answer was
+ * byte-for-byte the same each time until the 8-minute sample rolled over.
+ *
+ * WHY IDENTITY IS THE RIGHT KEY. `getWebcams()` returns `cache.sample`, and
+ * `refresh()` only ever REPLACES that object — including on the failure path, where it
+ * rewrites the timestamp but re-uses the same sample rather than mutating it. So
+ * `from === sample` is true exactly while the contents are unchanged, and a new sample
+ * recomputes. Nothing in the body depends on the clock: `describeWebcamSample` and
+ * `describeCoverage` are both pure over the sample, so there is no second expiry to
+ * keep in step.
+ *
+ * Same shape as the memo in app/api/cameras/route.ts. One entry, per isolate, and it
+ * lowers peak memory rather than raising it — one retained string instead of 425 KB of
+ * garbage per request.
+ */
+let serialised: { from: WebcamSample; body: string } | null = null;
+
+/**
+ * GET /api/webcams — a global sample of Windy webcams as thin markers (the
+ * x-windy-api-key is added server-side; it never reaches the client). Distinct
+ * from /api/cameras: webcams are their own layer and never fold into the
+ * road-camera count.
+ *
+ * Image URLs are intentionally omitted here — their tokens are short-lived, so
+ * the dossier re-resolves a fresh image per view through /api/webcam-image.
+ *
+ * TRUNCATION HONESTY. The merged global sample is capped at MAX_WEBCAMS (2000);
+ * before this the cap shipped with nothing disclosing it, so `count` was the
+ * ceiling wearing the costume of a measurement — the exact defect the coverage
+ * contract exists to prevent. `sample.coverage` (lib/signals/coverage.ts,
+ * attached in lib/webcams/normalize.ts's toWebcams()) now carries the true
+ * pre-cap total, so this can say "2,000 of N" instead of a bare 2,000.
+ *
+ * DESIGN DECISION — SIGNAL style ("N of M"), not the camera style. Cameras'
+ * /api/coverage reports {feeds: {answered, total, stale}} because a camera total
+ * is a SUM ACROSS ELEVEN INDEPENDENT NETWORKS, any of which can be down on a
+ * given refresh — the denominator that matters there is "how many of our feeds
+ * answered". Webcams have exactly ONE upstream (Windy) and no per-feed health
+ * dimension to report; the only thing being hidden is a single render cap over
+ * one merged pool of rows. That is precisely what lib/signals/coverage.ts's
+ * applyCap/coverageCountLabel contract was built for (it already backs
+ * /api/planes and /api/signals/<id> for the same reason), so reusing it costs
+ * nothing, and inventing a "feeds" shape for a single source would just be
+ * duplication with no real denominator to put in it.
+ *
+ * Returns {count, webcams[], dormant, note, attribution, coverage?}. `note` is a
+ * plain sentence describing what actually happened upstream, so an empty layer
+ * can always explain itself instead of silently looking like "no webcams exist".
+ * `coverage` is present only when the sample declared one (i.e. not dormant) —
+ * its absence means "not declared", never "nothing was truncated".
+ */
+export function webcamsBody(sample: WebcamSample): string {
+  if (serialised && serialised.from === sample) return serialised.body;
+  // `city` and `categories` survive lib/webcams/normalize.ts but used to be dropped
+  // here. They are what lets a caller filter to squares, promenades and old towns
+  // instead of matching on title text — the difference between finding the
+  // pedestrian-zone cameras this layer is mostly useful for and guessing at them.
+  const thin = sample.webcams.map((w) => ({
+    id: w.id,
+    title: w.title,
+    lat: w.lat,
+    lon: w.lon,
+    country: w.country,
+    region: w.region,
+    city: w.city,
+    categories: w.categories,
+    available: w.available,
+    detailUrl: w.detailUrl,
+  }));
+  const body = JSON.stringify({
+    count: thin.length,
+    webcams: thin,
+    dormant: sample.dormant,
+    note: describeWebcamSample(sample),
+    attribution: WINDY_SOURCE.attribution,
+    ...(sample.coverage ? { coverage: describeCoverage(sample.coverage) } : {}),
+  });
+  serialised = { from: sample, body };
+  return body;
+}
+
+/** Test seam, matching the house pattern in lib/webcams/search.ts. */
+export function __resetWebcamsBody(): void {
+  serialised = null;
+}
+
+/** The Cache-Control this route answers with. Lives beside the TTL it is derived from. */
+export function webcamsCacheControl(): string {
+  return edgeCacheControl(WEBCAMS_TTL_MS, 300_000);
+}

--- a/tests/unit/feedback.test.ts
+++ b/tests/unit/feedback.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
+  bucketKey,
+  clientIpFrom,
   CAP_EMAIL,
   CAP_OCCUPATION,
   CAP_USEFUL,
@@ -289,6 +291,51 @@ describe("validateFeedback", () => {
     for (const bad of [null, undefined, "string", 42, []]) {
       expect(validateFeedback(bad).ok).toBe(false);
     }
+  });
+});
+
+/* ── The rate-limit bucket key ────────────────────────────────────────────── */
+
+describe("bucketKey", () => {
+  // The property the limiter needs: the same visitor lands in the same bucket.
+  test("is stable for the same salt and address", async () => {
+    expect(await bucketKey("s", "203.0.113.7")).toBe(await bucketKey("s", "203.0.113.7"));
+  });
+
+  test("separates different addresses", async () => {
+    expect(await bucketKey("s", "203.0.113.7")).not.toBe(await bucketKey("s", "203.0.113.8"));
+  });
+
+  // THE POINT OF THE SALT. Without it this is an unsalted digest over ~4.3 billion
+  // enumerable IPv4 candidates and a fixed prefix in a PUBLIC repo, which is a
+  // lookup table, not a one-way function - measured at ~743k hashes/sec on one
+  // core, so a full sweep is ~96 min single-threaded and ~12 min on eight. This
+  // case fails the moment someone drops the salt back out, which is the change to
+  // be afraid of.
+  test("the same address under different salts shares nothing", async () => {
+    const a = await bucketKey("salt-one", "203.0.113.7");
+    const b = await bucketKey("salt-two", "203.0.113.7");
+    expect(a).not.toBe(b);
+    // And it must not be the unsalted digest either - i.e. the salt is genuinely
+    // mixed in rather than appended somewhere ignorable.
+    expect(a).not.toBe(await bucketKey("", "203.0.113.7"));
+  });
+
+  test("is a short fixed-width hex key", async () => {
+    expect(await bucketKey("s", "203.0.113.7")).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("clientIpFrom", () => {
+  test("takes the first hop and trims it", () => {
+    expect(clientIpFrom("203.0.113.7, 70.41.3.18, 150.172.238.178")).toBe("203.0.113.7");
+    expect(clientIpFrom("  203.0.113.7  ")).toBe("203.0.113.7");
+  });
+
+  test("falls back to a shared bucket rather than throwing", () => {
+    expect(clientIpFrom(null)).toBe("unknown");
+    expect(clientIpFrom("")).toBe("unknown");
+    expect(clientIpFrom(",  ,")).toBe("unknown");
   });
 });
 

--- a/tests/unit/route-export-contract.test.ts
+++ b/tests/unit/route-export-contract.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { expect, test } from "vitest";
+
+/**
+ * A Next.js route or page module may export ONLY the names Next recognises. Anything
+ * else is a hard build failure:
+ *
+ *     Type error: Route "app/api/webcams/route.ts" does not match the required types
+ *     of a Next.js Route. "webcamsBody" is not a valid Route export field.
+ *
+ * WHY THIS TEST EXISTS RATHER THAN A CODE REVIEW NOTE. The house gate is
+ * `npx tsc --noEmit && npm test`, and BOTH PASS on a file that breaks this rule. The
+ * route-export contract is checked only inside `next build`, during "Linting and
+ * checking validity of types", after tsc has already been satisfied. So the failure
+ * mode is: green locally, green in the suite, dead on deploy - and it reached `main`
+ * exactly once that way, in the commit this test was added to fix.
+ *
+ * It is a tempting mistake because the motive is good. You write a helper in a route
+ * file, you want a unit test for it, so you export it. The fix is always the same:
+ * move the helper to `lib/` and have the route import it. That is better anyway - the
+ * helper becomes testable without pulling a route module into the test.
+ *
+ * The allowed list is Next's, not ours. If a future Next version adds a segment
+ * option, add it here with a link, do not widen the check.
+ */
+const ALLOWED = new Set([
+  // HTTP verbs a route handler may implement
+  "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+  // route segment config
+  "dynamic", "dynamicParams", "revalidate", "fetchCache", "runtime",
+  "preferredRegion", "maxDuration", "experimental_ppr",
+  // page/layout conventions
+  "default", "metadata", "generateMetadata", "generateStaticParams",
+  "generateViewport", "viewport", "generateImageMetadata", "alt", "size",
+  "contentType", "config",
+]);
+
+const APP = resolve(process.cwd(), "app");
+const MODULE_NAMES = /^(route|page|layout|template|default|error|loading|not-found|opengraph-image|twitter-image|icon|apple-icon|sitemap|robots|manifest)\.(ts|tsx|js|jsx)$/;
+
+function routeModules(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) routeModules(full, found);
+    else if (MODULE_NAMES.test(entry.name)) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Exported binding names, read off the source.
+ *
+ * Deliberately a parse of the text rather than an import: importing every route module
+ * would execute them, and several reach for adapters and environment at module scope.
+ * `export type` and `export interface` are skipped - they are erased at compile time
+ * and Next never sees them.
+ */
+function exportedNames(source: string): string[] {
+  const names: string[] = [];
+  const decl = /^export\s+(?!type\b|interface\b)(?:async\s+)?(?:function\*?|const|let|var|class)\s+([A-Za-z_$][\w$]*)/gm;
+  for (const m of source.matchAll(decl)) names.push(m[1]);
+  if (/^export\s+default\b/m.test(source)) names.push("default");
+  // `export { a, b as c }` - the exported (right-hand) name is the one Next reads.
+  for (const m of source.matchAll(/^export\s*\{([^}]*)\}/gm)) {
+    for (const part of m[1].split(",")) {
+      const piece = part.trim();
+      if (!piece || piece.startsWith("type ")) continue;
+      names.push((piece.split(/\s+as\s+/).pop() ?? piece).trim());
+    }
+  }
+  return names;
+}
+
+const MODULES = routeModules(APP).map((f) => relative(process.cwd(), f).replace(/\\/g, "/"));
+
+test("there are route modules to check", () => {
+  // A silent zero here would make every case below vacuously pass.
+  expect(MODULES.length).toBeGreaterThan(30);
+});
+
+test.each(MODULES)("%s exports only fields Next.js recognises", (file) => {
+  const offenders = exportedNames(readFileSync(file, "utf8")).filter((n) => !ALLOWED.has(n));
+
+  // Named so the failure tells you what to move and where, rather than just going red.
+  expect(
+    offenders,
+    `${file} exports ${offenders.join(", ")}, which Next rejects at build time. ` +
+      "Move the helper into lib/ and import it from the route.",
+  ).toEqual([]);
+});

--- a/tests/unit/webcams-body-memo.test.ts
+++ b/tests/unit/webcams-body-memo.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/webcams/fetch", async (importOriginal) => ({
   describeWebcamSample: () => describeWebcamSample(),
 }));
 
-const { webcamsBody, __resetWebcamsBody } = await import("@/app/api/webcams/route");
+const { webcamsBody, __resetWebcamsBody } = await import("@/lib/webcams/body");
 
 const webcam = (id: string, over: Record<string, unknown> = {}) => ({
   id,


### PR DESCRIPTION
A comment in merged code made a claim that is not true, and the code now matches the honest version of it. Found by the privacy agent declining to repeat the claim on the privacy page, and raised by the coordinator.

**Nothing was leaking and no behaviour was wrong.** The bucket key lives in a module-level `Map` on one ephemeral instance, is never stored, never logged, and is not attached to the submission - `formatFeedbackMessage` sends rating, occupation, useful, email and trigger, and nothing else. What was wrong was the sentence.

## The false claim

`app/api/feedback/route.ts` described its rate-limit bucket key as "a coarse, **non-reversible** bucket key". It hashed `feedback:${ip}` with SHA-256 and kept 64 bits.

That is not non-reversible, and the weakness is not SHA-256 - it is that **the input space is enumerable**. There are ~4.3 billion IPv4 addresses, the prefix is a fixed literal, and this repo is public, so the construction is readable by anyone. Measured on this machine rather than asserted:

```
743,000 hashes/sec, single-threaded node
full IPv4 sweep:  ~96 minutes on one core
                  ~12 minutes on eight
expected 64-bit collisions across 2^32 inputs: 0.50
```

So truncating to 64 bits does not help either - a match comes back effectively unique. It is a lookup table, not an attack.

## The fix

**Salt it.** A random per-instance salt (`crypto.randomUUID()` at module load) mixed into the digest. This costs nothing that was not already given up: the limiter is per-instance and best-effort by design - its `Map` dies with the instance - so a salt that dies with it too changes no behaviour and never reaches the repo.

**Say what it does.** The comment now states it is a per-address bucket key held in memory for rate limiting, and the `lib` function carries the full reasoning above so the next person does not have to rediscover why an unsalted IP hash is not anonymisation.

The derivation moved to `lib/shell/feedback.ts` so it is testable, which also keeps the route's exports to `runtime` and `POST` only - it passes `route-export-contract` (49/49).

## Negative check

Injected the regression I am actually afraid of - someone simplifying the salt back out:

```
× bucketKey > the same address under different salts shares nothing
  → expected '6c04beb4cb930527' not to be '6c04beb4cb930527'
```

Two different salts producing an identical digest is exactly the proof that the salt is not mixed in. Restored, back to green.

## Two more comments I corrected while I was in there

Prompted by cameras' point that nothing will ever make a false comment go red. I re-read my own and found two that were stronger than my evidence:

- I claimed React "sibling effects run in document order" as fact. I never measured it. The design deliberately does not depend on it (the gate holds for a few seconds instead), so the comment now says that rather than asserting the ordering.
- I claimed the honeypot is off-screen rather than `display:none` because "some bots skip hidden fields". That is received wisdom I have not measured, and it is not load-bearing. Now stated as such.

## Verification

```
npx tsc --noEmit             ->  exit 0, no output
Test Files  253 passed (253)
Tests       2186 passed (2186)
route-export-contract        ->  49 passed (49)
```

#121's tree is 253 / 2180, so this is **+6 cases** and no new file.

## Merge order

Cut off `main` @ 8986349 with `fix/route-exports` merged in, so it stands green on its own rather than inheriting main's failed deploy. If #121 lands first those commits become a no-op here - either order works.