### PR TITLE
Say what was measured in the snapshot comments, and cite what was not

### DIFF
--- a/lib/seo/registrySnapshot.ts
+++ b/lib/seo/registrySnapshot.ts
@@ -40,11 +40,18 @@
 // TWO RULES FOR ANYTHING ADDED BELOW.
 //
 //   1. KEEP ENTRIES SMALL. These are stored in the same incremental cache that backs
-//      ISR, and Vercel caps a Data Cache entry at 2 MB. The whole registry is ~6.4 MB
-//      of JSON, so it must never be cached whole; every reader here returns only the
-//      rows its page renders. The region reader is keyed by page number for this
-//      reason — US/Florida alone is 4,838 cameras, and REGION_PAGE_SIZE bounds a
-//      cached slice at 500 rows.
+//      ISR, which has a documented per-entry size limit (2 MB on Vercel at the time of
+//      writing — a vendor limit, taken from their docs and NOT measured here; an
+//      oversized entry is declined SILENTLY, so the failure looks like the cache
+//      simply never working). The whole registry is ~6.4 MB of JSON, measured
+//      (6,443,932 bytes on prod, 2026-08-18), so it must never be cached whole; every
+//      reader here returns only the rows its page renders.
+//
+//      The region reader is keyed by page number because one region can be thousands
+//      of cameras — the largest, US/Florida, measured 4,646 in the 2026-08-18 snapshot
+//      and 4,838 four days earlier, which is the point: it moves, so do not rely on
+//      either figure. REGION_PAGE_SIZE is what actually bounds a cached slice, at 500
+//      rows, and that is a constant rather than a measurement.
 //   2. NEVER CALL A DYNAMIC API IN A CALLBACK. `headers()`, `cookies()` and friends
 //      throw inside `unstable_cache`. That is the same property that makes this work.
 //

--- a/lib/seo/registrySnapshot.ts
+++ b/lib/seo/registrySnapshot.ts
@@ -39,13 +39,19 @@
 //
 // TWO RULES FOR ANYTHING ADDED BELOW.
 //
-//   1. KEEP ENTRIES SMALL. These are stored in the same incremental cache that backs
-//      ISR, which has a documented per-entry size limit (2 MB on Vercel at the time of
-//      writing — a vendor limit, taken from their docs and NOT measured here; an
-//      oversized entry is declined SILENTLY, so the failure looks like the cache
-//      simply never working). The whole registry is ~6.4 MB of JSON, measured
-//      (6,443,932 bytes on prod, 2026-08-18), so it must never be cached whole; every
-//      reader here returns only the rows its page renders.
+//   1. KEEP ENTRIES SMALL. `unstable_cache` writes to Vercel's Data cache, whose
+//      documented item-size limit is 2 MB — "items larger won't be cached"
+//      (vercel.com/docs/caching/runtime-cache/data-cache, "Limits and usage",
+//      last updated 2026-07-27). That wording is the reason this rule is worth
+//      stating: an oversized entry does not throw, it SILENTLY never caches, so the
+//      symptom is a caching fix that looks fine and does nothing. It is a vendor
+//      limit, cited rather than measured — an oversized entry produces no local
+//      signal to measure. Re-check it against that page, not against this comment.
+//
+//      The whole registry is ~6.4 MB of JSON — measured, 6,443,932 bytes on prod
+//      2026-08-18 — so it must never be cached whole; every reader here returns only
+//      the rows its page renders. For scale, the directory snapshot measures 1,663
+//      bytes.
 //
 //      The region reader is keyed by page number because one region can be thousands
 //      of cameras — the largest, US/Florida, measured 4,646 in the 2026-08-18 snapshot

--- a/tests/unit/seo-page-caching.test.ts
+++ b/tests/unit/seo-page-caching.test.ts
@@ -60,12 +60,14 @@ test("every cached reader declares a revalidate window", () => {
 });
 
 test("the snapshot never caches the whole registry", () => {
-  // The incremental cache has a documented per-entry size limit (2 MB on Vercel at the
-  // time of writing - their figure, not one measured here), and the full camera array
-  // is ~6.4 MB of JSON (6,443,932 bytes, measured on prod 2026-08-18). So a reader
-  // that returned `cameras` wholesale would fail to store - and fail SILENTLY, falling
-  // back to recomputing on every request, which is the exact cost this module exists
-  // to remove.
+  // Vercel's Data cache - what unstable_cache writes to - documents a 2 MB item-size
+  // limit, "items larger won't be cached"
+  // (vercel.com/docs/caching/runtime-cache/data-cache, last updated 2026-07-27). Cited,
+  // not measured: an oversized entry produces no local signal. The full camera array is
+  // ~6.4 MB of JSON (6,443,932 bytes, measured on prod 2026-08-18), so a reader
+  // returning `cameras` wholesale would fail to store - and fail SILENTLY, falling back
+  // to recomputing on every request, which is the exact cost this module exists to
+  // remove.
   const text = source("lib/seo/registrySnapshot.ts");
   expect(text).toContain("pageSlice(");
   expect(text).not.toMatch(/return\s+await\s+getRegistry\(\)/);

--- a/tests/unit/seo-page-caching.test.ts
+++ b/tests/unit/seo-page-caching.test.ts
@@ -60,10 +60,12 @@ test("every cached reader declares a revalidate window", () => {
 });
 
 test("the snapshot never caches the whole registry", () => {
-  // A Vercel Data Cache entry is capped at 2 MB and the full camera array is ~6.4 MB
-  // of JSON, so a reader that returns `cameras` wholesale would fail to store - and
-  // fail SILENTLY, falling back to recomputing on every request, which is the exact
-  // cost this module exists to remove.
+  // The incremental cache has a documented per-entry size limit (2 MB on Vercel at the
+  // time of writing - their figure, not one measured here), and the full camera array
+  // is ~6.4 MB of JSON (6,443,932 bytes, measured on prod 2026-08-18). So a reader
+  // that returned `cameras` wholesale would fail to store - and fail SILENTLY, falling
+  // back to recomputing on every request, which is the exact cost this module exists
+  // to remove.
   const text = source("lib/seo/registrySnapshot.ts");
   expect(text).toContain("pageSlice(");
   expect(text).not.toMatch(/return\s+await\s+getRegistry\(\)/);


### PR DESCRIPTION
Comment accuracy only. **No behaviour change, no logic touched** — two files, comments and one test comment.

This came out of an audit prompted by @cameras finding an overstated claim in their own merged code. Four of us checked our own merged comments and found four between us. Nothing broken; four public claims in a public repo that were stronger than the evidence behind them.

## 1. A number I did not measure

`lib/seo/registrySnapshot.ts` said **"US/Florida alone is 4,838 cameras"**.

I never measured that. I lifted it from `lib/seo/directory.ts`'s own comment — which measured it on 2026-08-14 against a 20,246-camera registry — and restated it as current fact in a new file. Measured against today's snapshot:

```
US/Florida    4,646        US/Georgia   3,443
US/New York   1,973        total       18,948
```

It had already moved ~200 in four days. That is precisely what CLAUDE.md's own rule in the Numbers section is warning about: *"every figure below was measured, and each rots."*

The sharper version of the lesson, and the reason this is worth a PR rather than a quiet edit: **quoting another file's comment is not measuring.** It reads exactly like sourcing, and it silently inherits that comment's age.

Fixed by giving both figures *with their dates*, saying outright not to rely on either, and pointing at what actually bounds a cached slice — `REGION_PAGE_SIZE`, a constant, which cannot rot.

## 2. A vendor limit I asserted rather than cited

Both files said **"Vercel caps a Data Cache entry at 2 MB"**. Correct, and load-bearing — it is why every reader returns page-shaped data rather than the registry. But I had not checked it, and @lead then measured `getDirectory`'s entry at 1,663 bytes *against my unverified threshold* and reported the pair as a verification. Their words: a measurement against an unverified threshold is half a verification.

Now checked and cited, with the wording that makes the rule matter:

> Item size — **2 MB (items larger won't be cached)**
> — `vercel.com/docs/caching/runtime-cache/data-cache`, "Limits and usage", last updated 2026-07-27

"Won't be cached" rather than "will error" is the whole point. An oversized entry does not throw, it **silently never caches** — so the symptom is a caching fix that looks fine and does nothing. Same failure shape as the route-export bug #121 just fixed: silence.

The citation also confirms the limit applies to the right store. Data cache is what backs *"Next.js caching APIs such as `fetch` or `unstable_cache`"*, which is what this module uses. Runtime cache is a separate store that happens to carry the same item-size limit — identical design constraint either way, but they do not share space. Without that line the citation would be a number attached to possibly the wrong cache.

The measured 1,663 bytes is recorded alongside it, so the comment carries both halves — the vendor's threshold and our distance from it — instead of a ratio whose denominator nobody had checked.

## The one I went looking for and could not fault

`lib/sources/select.ts` says non-finite coordinates are out of scope "because `Camera` is zod-parsed". I wrote that without checking, and went in **expecting it to be wrong** — bare `z.number()` accepting `NaN` is a well-known zod footgun. Measured on the version we ship:

```
zod 3.24.1   z.number().safeParse(NaN)                 -> false
             z.number().gte(-90).lte(90) vs NaN/±Inf   -> false, false, false
```

It holds, and holds twice over. No change needed — but it held by luck rather than evidence, and if that schema were ever relaxed to a bare unbounded number the guarantee would vanish silently. Reporting the clean result because a negative finding is evidence too.

## Not for this session

The same Vercel page notes that Next.js 15+ is now pointed at **Runtime cache** rather than Data cache. We ship 15.5.19 on `unstable_cache`. It works, it is documented, the limit is identical, and nothing needs changing today — recorded in the commit message so it is somewhere durable if anyone revisits this area.

```
npx tsc --noEmit  ->  exit 0
Test Files  254 passed (254)
     Tests  2184 passed (2184)
```
Merged `origin/main` at 2280bf4 (with #115 and #121 landed) before measuring.
