### PR TITLE
Correct a Referer claim in the Serbia toll adapter that was never measured

### DIFF
--- a/lib/proxy/hls-allowlist.ts
+++ b/lib/proxy/hls-allowlist.ts
@@ -11,11 +11,14 @@ const RULES: HlsRule[] = [
   // Serbia — MUP border crossings. Playlists carry ABSOLUTE segment URLs on the
   // same host, and no Referer is required (measured).
   { match: (h) => h === "kamere.mup.gov.rs", prefix: "/" },
-  // Serbia — JP Putevi Srbije toll plazas. 403s without a Referer, and the
-  // TRAILING SLASH matters: "https://kamere.toll4all.com" alone is refused.
-  // Segment URIs are relative, so rewritePlaylist resolves them onto the same
-  // host and they come back through this rule. Two subdomains because the
-  // operator splits front-plaza and side-plaza cameras across them.
+  // Serbia — JP Putevi Srbije toll plazas. cam.bitinfo.co.rs 403s without a
+  // Referer, and the TRAILING SLASH matters: "https://kamere.toll4all.com"
+  // alone is refused. jpps.bitinfo.co.rs does NOT enforce it (measured: 200
+  // with no Referer) and is covered by the same rule anyway, because sending
+  // one where it is not required is harmless and a second rule would only be
+  // one more thing to keep in step. Segment URIs are relative, so
+  // rewritePlaylist resolves them onto the same host and they come back
+  // through this rule.
   {
     match: (h) => h === "cam.bitinfo.co.rs" || h === "jpps.bitinfo.co.rs",
     prefix: "/",

--- a/lib/sources/serbia-tolls.ts
+++ b/lib/sources/serbia-tolls.ts
@@ -39,8 +39,21 @@ const VIEWER_URL = "https://kamere.toll4all.com/";
  * the 38 STREAMS is on cam.bitinfo.co.rs. Pinning this adapter to one host
  * looked right against the camera list that pointed us here and would have
  * dropped Niš, Novi Sad, Smederevo, Požarevac, Pakovraće and Leskovac without
- * saying so. Both hosts were checked directly: jpps serves the same JPEGs, and
- * the same HLS, under the same Referer rule.
+ * saying so.
+ *
+ * The two hosts are NOT configured alike, and the original version of this
+ * comment said they were. Measured:
+ *
+ *   cam .../index.m3u8   no Referer -> 403      with Referer -> 200
+ *   jpps.../index.m3u8   no Referer -> 200      with Referer -> 200
+ *   jpps.../index.jpg    no Referer -> 200
+ *
+ * So only cam enforces hotlink protection; jpps accepts the Referer we send but
+ * does not require it. That costs nothing today - every one of the 38 streams
+ * is on cam, so no camera reaches jpps over HLS at all, and an unnecessary
+ * Referer is harmless - but "under the same Referer rule" was a claim nobody had
+ * measured, and a comment that overstates what was checked is how the next
+ * person inherits a wrong assumption.
  */
 const MEDIA_HOSTS = new Set(["cam.bitinfo.co.rs", "jpps.bitinfo.co.rs"]);
 


### PR DESCRIPTION
Comments only. No logic change, no behaviour change.

Two comments in my own merged Serbia work (#117) said the operator's two media hosts are "under the same Referer rule". They are not.

## Measured

```
cam.bitinfo.co.rs  /front_pan_cam1/index.m3u8   no Referer -> 403   with Referer -> 200
jpps.bitinfo.co.rs /side_pan_cam3/index.m3u8    no Referer -> 200   with Referer -> 200
jpps.bitinfo.co.rs /side_pan_cam3/index.jpg     no Referer -> 200
```

Only `cam` enforces hotlink protection. `jpps` accepts the Referer we send but does not require it.

What I had actually checked, when writing the adapter, was that jpps **answers 200 with the Referer attached**. I wrote that up as though I had checked it **needed** one. I measured something adjacent to the claim and rounded it up.

## Nothing is broken, and nothing changes

All 38 streams are on `cam`, so no camera reaches `jpps` over HLS at all, and sending an unnecessary Referer to a host that ignores it is harmless.

Both hosts deliberately stay under **one** allowlist rule. Splitting them would buy nothing and add a second thing to keep in step. The comment now says that, and states the measurement, instead of implying the two are configured alike.

## Why it is worth a commit

The claim was false, it was in merged code, and this repo is public. A comment that overstates what was verified is how the next person inherits a wrong assumption about an upstream they have not tested — and nothing will ever make it go red. No test, no build, no reviewer.

Found by auditing my own comments after @lead caught the same shape in the feedback route's "non-reversible" bucket key. Independently confirmed on the bus by lead, whose first probe hit a path that does not exist on either host and would have "failed to reproduce" it — the same error one level up.

## Gate

```
npx tsc --noEmit   ->  exit 0, no output
Test Files  254 passed (254)
Tests  2190 passed (2190)
```

Rebased onto `main` @ `03feec0` and re-gated there rather than quoting the numbers from when it was cut off `8986349`.
