### PR TITLE
Answer 404 on every verb, not 405 on two of them

### DIFF
--- a/app/api/admin/discover/route.ts
+++ b/app/api/admin/discover/route.ts
@@ -31,6 +31,23 @@ export const dynamic = "force-dynamic";
 // dev server, where the setting does nothing at all. A limit that only ever applies
 // where the route cannot run is not a limit, it is a way to break a deploy.
 
+/**
+ * A GET to a POST-only route is answered by Next with 405 before any handler runs, so
+ * these three routes said "method not allowed" in production while every other admin
+ * route said 404. That is a small thing and it is still a difference between what the
+ * /privacy page claims and what the deployment does: the page tells a reader that every
+ * route under here returns 404 and invites them to check. Two of the three verbs
+ * disagreed.
+ *
+ * Nothing was reachable either way -- the POST 404s -- and the route's existence is in a
+ * public repository anyway, so this is not a leak. It is a sentence on a page whose only
+ * value is being exactly true, and the cheaper fix was to correct the page. Correcting
+ * the deployment is the right one.
+ */
+export async function GET() {
+  return new Response(null, { status: 404 });
+}
+
 export async function POST(req: Request) {
   if (isProduction()) {
     return new NextResponse(null, { status: 404 });

--- a/app/api/admin/promote/route.ts
+++ b/app/api/admin/promote/route.ts
@@ -22,6 +22,23 @@ import { PROMOTED_FILE_HEADER } from "@/lib/discovery/devOnly";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * A GET to a POST-only route is answered by Next with 405 before any handler runs, so
+ * these three routes said "method not allowed" in production while every other admin
+ * route said 404. That is a small thing and it is still a difference between what the
+ * /privacy page claims and what the deployment does: the page tells a reader that every
+ * route under here returns 404 and invites them to check. Two of the three verbs
+ * disagreed.
+ *
+ * Nothing was reachable either way -- the POST 404s -- and the route's existence is in a
+ * public repository anyway, so this is not a leak. It is a sentence on a page whose only
+ * value is being exactly true, and the cheaper fix was to correct the page. Correcting
+ * the deployment is the right one.
+ */
+export async function GET() {
+  return new Response(null, { status: 404 });
+}
+
 export async function POST(req: Request) {
   if (isProduction()) {
     return new NextResponse(null, { status: 404 });

--- a/app/api/admin/verdict/route.ts
+++ b/app/api/admin/verdict/route.ts
@@ -28,6 +28,23 @@ export const dynamic = "force-dynamic";
 const CAMERA_VERDICTS = new Set(["good", "bad-image", "bad-pin", "not-a-camera", "unsure"]);
 const FEED_VERDICTS = new Set(["admit", "reject", "hold"]);
 
+/**
+ * A GET to a POST-only route is answered by Next with 405 before any handler runs, so
+ * these three routes said "method not allowed" in production while every other admin
+ * route said 404. That is a small thing and it is still a difference between what the
+ * /privacy page claims and what the deployment does: the page tells a reader that every
+ * route under here returns 404 and invites them to check. Two of the three verbs
+ * disagreed.
+ *
+ * Nothing was reachable either way -- the POST 404s -- and the route's existence is in a
+ * public repository anyway, so this is not a leak. It is a sentence on a page whose only
+ * value is being exactly true, and the cheaper fix was to correct the page. Correcting
+ * the deployment is the right one.
+ */
+export async function GET() {
+  return new Response(null, { status: 404 });
+}
+
 export async function POST(req: Request) {
   if (isProduction()) {
     return new NextResponse(null, { status: 404 });


### PR DESCRIPTION
/privacy tells a reader that every route under /admin returns 404 on this deployment, and invites them to check. Measured on prod after #128 landed:

```
POST /api/admin/promote  -> 404
GET  /api/admin/promote  -> 405
HEAD /api/admin/promote  -> 405
```

Next answers an unimplemented method with 405 before any handler runs, so the three POST-only routes disagreed with the page on two verbs out of three.

Nothing was reachable either way and the routes are in a public repo, so this is not a disclosure. It is a sentence on a page whose entire value is being exactly true. The cheaper fix was to soften the sentence; this is the right one.