### PR TITLE
A traffic dashboard over what the plan actually serves, and an honest account of what it will not

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,0 +1,221 @@
+// app/admin/analytics/page.tsx
+// A development-only view of the traffic this site actually receives.
+//
+// GATE. `assertDevOnly()` 404s this route in production, and it is called here as well
+// as in the admin layout rather than trusted from the layout alone — a layout is a file
+// someone else can restructure, and the failure mode of getting this wrong is a public
+// admin page over a team-wide API token. The helper fails closed on either VERCEL_ENV or
+// NODE_ENV, and `tests/unit/discovery-admin-gate.test.ts` enumerates this directory, so
+// this page is picked up by that guard automatically.
+//
+// The token is read in lib/analytics/vercelApi.ts, on the server, and only aggregate
+// numbers are passed down as props. Nothing credential-shaped crosses into the client.
+
+import type { Metadata } from "next";
+import { Panel, FailureNotice, EmptyNotice } from "@/components/admin/analytics/Panel";
+import { TrafficOverTime } from "@/components/admin/analytics/TrafficOverTime";
+import { DimensionTable } from "@/components/admin/analytics/DimensionTable";
+import { Limitations } from "@/components/admin/analytics/Limitations";
+import { dailySeries, loadDashboard, PANEL_LIMITS } from "@/lib/analytics/dashboard";
+import { assertDevOnly } from "@/lib/discovery/devOnly";
+import { totals as sumDaily } from "@/lib/analytics/window";
+import type { AggregateRow, AnalyticsResult } from "@/lib/analytics/vercelApi";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Traffic — development only",
+  robots: { index: false, follow: false },
+};
+
+function Grouped({
+  result,
+  dimension,
+  valueHeading,
+  emptyLabel,
+  limit,
+  what,
+  since,
+  until,
+}: {
+  result: AnalyticsResult<AggregateRow[]>;
+  dimension: string;
+  valueHeading: string;
+  emptyLabel?: string;
+  limit: number;
+  what: string;
+  since: string;
+  until: string;
+}) {
+  if (!result.ok) return <FailureNotice failure={result.failure} />;
+  if (result.data.length === 0) return <EmptyNotice what={what} since={since} until={until} />;
+  return (
+    <DimensionTable
+      rows={result.data}
+      dimension={dimension}
+      valueHeading={valueHeading}
+      emptyLabel={emptyLabel}
+      limit={limit}
+    />
+  );
+}
+
+export default async function AnalyticsPage() {
+  assertDevOnly();
+
+  const now = new Date();
+  const d = await loadDashboard(now);
+  const sinceLabel = d.since.toISOString().slice(0, 10);
+  const untilLabel = d.until.toISOString().slice(0, 10);
+
+  const series = d.daily.ok ? dailySeries(d.daily.data, d.since, d.until) : [];
+  const seriesTotals = sumDaily(series);
+  const uniqueVisitors = d.totals.ok ? d.totals.data.visitors : null;
+  const cameraPageCount = d.cameraPaths.ok
+    ? d.cameraPaths.data.filter((r) => r.requestPath !== "Others").length
+    : null;
+
+  return (
+    <>
+      <h1 className="adm-h1">Traffic</h1>
+      <p className="adm-lede">
+        What the site actually received, read back from Vercel Web Analytics: {sinceLabel} to{" "}
+        {untilLabel}, a rolling {d.windowDays}-day window that is the whole of what this plan
+        retains. Every panel below states which of its numbers were measured and which were never
+        available, because on a dashboard an unexplained empty panel reads as a zero.
+      </p>
+
+      <Panel
+        title="1 · Traffic over time"
+        subtitle="Visitors and pageviews per day, with the retention edge drawn rather than described"
+      >
+        {d.daily.ok ? (
+          series.length === 0 ? (
+            <EmptyNotice what="pageviews" since={sinceLabel} until={untilLabel} />
+          ) : (
+            <TrafficOverTime
+              points={series}
+              windowDays={d.windowDays}
+              uniqueVisitors={uniqueVisitors}
+              totalPageviews={seriesTotals.pageviews}
+            />
+          )
+        ) : (
+          <FailureNotice failure={d.daily.failure} />
+        )}
+      </Panel>
+
+      <Panel title="2 · Where they land" subtitle="Top routes by pageviews">
+        <Grouped
+          result={d.routes}
+          dimension="route"
+          valueHeading="Route"
+          limit={PANEL_LIMITS.routes}
+          what="routes"
+          since={sinceLabel}
+          until={untilLabel}
+        />
+      </Panel>
+
+      <Panel
+        title="2b · Did the generated camera pages get visited?"
+        subtitle="Individual paths under the /camera/[id] route"
+      >
+        {cameraPageCount != null && (
+          <p style={{ fontSize: 13, marginTop: 0 }}>
+            <strong>{cameraPageCount.toLocaleString("en-GB")}</strong> distinct camera pages
+            recorded at least one visit in this window.{" "}
+            <span style={{ color: "var(--adm-ink-faint)" }}>
+              This is a floor: the query asks for the top {PANEL_LIMITS.cameraPaths} distinct paths
+              and Vercel buckets the rest, so the true number can only be higher. It is not
+              comparable to the total number of camera pages the site generates, which is a
+              different measurement and is not made here.
+            </span>
+          </p>
+        )}
+        <Grouped
+          result={d.cameraPaths}
+          dimension="requestPath"
+          valueHeading="Path"
+          limit={PANEL_LIMITS.cameraPaths}
+          what="camera-page visits"
+          since={sinceLabel}
+          until={untilLabel}
+        />
+      </Panel>
+
+      <Panel title="3 · Where they came from" subtitle="Referring hostname, as reported by the browser">
+        <Grouped
+          result={d.referrers}
+          dimension="referrerHostname"
+          valueHeading="Referrer"
+          emptyLabel="(direct — typed, bookmarked, or an app that sends no referrer)"
+          limit={PANEL_LIMITS.referrers}
+          what="referrers"
+          since={sinceLabel}
+          until={untilLabel}
+        />
+      </Panel>
+
+      <Panel
+        title="3b · Campaign attribution (UTM)"
+        subtitle="Requested live on every load, so the answer below is the current one rather than a remembered one"
+      >
+        <Grouped
+          result={d.utm}
+          dimension="utmSource"
+          valueHeading="utm_source"
+          limit={PANEL_LIMITS.referrers}
+          what="tagged campaign visits"
+          since={sinceLabel}
+          until={untilLabel}
+        />
+      </Panel>
+
+      <Panel title="4 · Who" subtitle="Country, device and browser">
+        <div style={{ display: "grid", gap: 18 }}>
+          <div>
+            <h3 style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", margin: "0 0 4px", fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.06em" }}>Country</h3>
+            <Grouped
+              result={d.countries}
+              dimension="country"
+              valueHeading="Country"
+              limit={PANEL_LIMITS.countries}
+              what="countries"
+              since={sinceLabel}
+              until={untilLabel}
+            />
+          </div>
+          <div>
+            <h3 style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", margin: "0 0 4px", fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.06em" }}>Device</h3>
+            <Grouped
+              result={d.devices}
+              dimension="deviceType"
+              valueHeading="Device"
+              limit={PANEL_LIMITS.devices}
+              what="device types"
+              since={sinceLabel}
+              until={untilLabel}
+            />
+          </div>
+          <div>
+            <h3 style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", margin: "0 0 4px", fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.06em" }}>Browser</h3>
+            <Grouped
+              result={d.browsers}
+              dimension="browserName"
+              valueHeading="Browser"
+              limit={PANEL_LIMITS.browsers}
+              what="browsers"
+              since={sinceLabel}
+              until={untilLabel}
+            />
+          </div>
+        </div>
+      </Panel>
+
+      <Panel title="5 · What this cannot tell you">
+        <Limitations windowDays={d.windowDays} />
+      </Panel>
+    </>
+  );
+}

--- a/components/admin/analytics/DimensionTable.tsx
+++ b/components/admin/analytics/DimensionTable.tsx
@@ -1,0 +1,76 @@
+// components/admin/analytics/DimensionTable.tsx
+// A grouped-by-dimension table: routes, referrers, countries, devices, browsers.
+//
+// Two values in these responses mean something other than what they look like, and
+// both were observed live on 2026-08-19:
+//   ""       on referrerHostname is a visit with no referrer at all — a typed URL, a
+//            bookmark, an app. It is not an unnamed website.
+//   "Others" is the API's own overflow bucket for everything past `limit`. It is not
+//            a country called Others. Rendering it as an ordinary row would invent a
+//            category and, worse, make the long tail look like a single large source.
+// Both are labelled here rather than in a caption, because a row read on its own is
+// exactly how a wrong number escapes into a slide.
+
+import { dimensionLabel, isOthersBucket, type AggregateRow } from "@/lib/analytics/vercelApi";
+
+export function DimensionTable({
+  rows,
+  dimension,
+  valueHeading,
+  emptyLabel,
+  limit,
+}: {
+  rows: AggregateRow[];
+  /** The `by` key these rows were grouped on. */
+  dimension: string;
+  valueHeading: string;
+  /** What an empty-string value means for THIS dimension. */
+  emptyLabel?: string;
+  /** The distinct-value cap that was sent, so the table can say when it may be truncated. */
+  limit: number;
+}) {
+  const sorted = [...rows].sort((a, b) => b.pageviews - a.pageviews);
+  const truncated = rows.some((r) => isOthersBucket(r, dimension));
+
+  return (
+    <div>
+      <table className="adm-table">
+        <thead>
+          <tr>
+            <th>{valueHeading}</th>
+            <th style={{ textAlign: "right", width: 110 }}>Visitors</th>
+            <th style={{ textAlign: "right", width: 110 }}>Pageviews</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((row, i) => {
+            const others = isOthersBucket(row, dimension);
+            const raw = dimensionLabel(row, dimension);
+            const label = raw === "(none)" ? (emptyLabel ?? "(no value)") : raw;
+            return (
+              <tr key={`${label}-${i}`}>
+                <td style={{ overflowWrap: "anywhere" }}>
+                  {others ? (
+                    <span style={{ color: "var(--adm-ink-faint)", fontStyle: "italic" }}>
+                      everything past the top {limit}, bucketed by Vercel
+                    </span>
+                  ) : (
+                    label
+                  )}
+                </td>
+                <td className="adm-num">{row.visitors.toLocaleString("en-GB")}</td>
+                <td className="adm-num">{row.pageviews.toLocaleString("en-GB")}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {truncated && (
+        <p style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", marginTop: 8, marginBottom: 0 }}>
+          This query asked for the top {limit} distinct values and Vercel folded the rest into one
+          bucket, so the number of distinct values here is a floor, not a total.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/admin/analytics/Limitations.tsx
+++ b/components/admin/analytics/Limitations.tsx
@@ -1,0 +1,87 @@
+// components/admin/analytics/Limitations.tsx
+// Section 5: what this dashboard cannot tell you, and what it would cost to change.
+//
+// Everything here is either a refusal we received verbatim or a line transcribed from
+// Vercel's published pricing table. No inference, no recommendation: the reader is
+// the one paying, and the only useful thing this panel can do is put the boundary and
+// the price in the same place and then stop talking.
+
+import { MEASURED_REFUSALS, PLAN_TABLE, PRO_PRICE_NOTE, SHARED_ALLOWANCE_NOTE } from "@/lib/analytics/limits";
+
+export function Limitations({ windowDays }: { windowDays: number }) {
+  return (
+    <div style={{ fontSize: 13.5, lineHeight: 1.6 }}>
+      <p style={{ marginTop: 0, maxWidth: "78ch", color: "var(--adm-ink-dim)" }}>
+        This page shows pageviews, routes, referrers, countries, devices and browsers, over a
+        rolling {windowDays}-day window. That is the whole of it. It cannot tell you what anyone
+        <em> did</em> once they arrived — not a layer toggled, a camera opened, a board switched or
+        a tour abandoned — because none of that is collected. Custom events are the mechanism for
+        it, and this plan does not include them.
+      </p>
+
+      <h3 style={{ fontSize: 12.5, margin: "18px 0 4px", textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--adm-ink-faint)" }}>
+        What we asked for and were refused
+      </h3>
+      <p style={{ fontSize: 12, color: "var(--adm-ink-faint)", margin: "0 0 8px" }}>
+        Measured against the live API, quoted exactly as it answered.
+      </p>
+      <table className="adm-table">
+        <thead>
+          <tr>
+            <th style={{ width: "32%" }}>Asked for</th>
+            <th style={{ width: 60 }}>Status</th>
+            <th>Vercel&apos;s answer</th>
+          </tr>
+        </thead>
+        <tbody>
+          {MEASURED_REFUSALS.map((r) => (
+            <tr key={r.asked}>
+              <td>{r.asked}</td>
+              <td className="adm-num">{r.status}</td>
+              <td>
+                <span style={{ fontStyle: "italic", color: "var(--adm-ink-dim)" }}>
+                  &ldquo;{r.message}&rdquo;
+                </span>
+                <span style={{ color: "var(--adm-ink-faint)", fontSize: 12 }}> — measured {r.measuredOn}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3 style={{ fontSize: 12.5, margin: "24px 0 4px", textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--adm-ink-faint)" }}>
+        What a paid plan would add
+      </h3>
+      <table className="adm-table">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Hobby (current)</th>
+            <th>Pro</th>
+            <th>Pro + Analytics Plus</th>
+          </tr>
+        </thead>
+        <tbody>
+          {PLAN_TABLE.map((row) => (
+            <tr key={row.feature}>
+              <td>{row.feature}</td>
+              <td style={{ color: "var(--adm-ink-faint)" }}>{row.hobby}</td>
+              <td>{row.pro}</td>
+              <td>{row.proPlus}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="adm-note" style={{ marginTop: 14 }}>
+        {PRO_PRICE_NOTE}
+        <div style={{ marginTop: 6 }}>{SHARED_ALLOWANCE_NOTE}</div>
+      </div>
+
+      <p style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", marginTop: 10, marginBottom: 0 }}>
+        Plan table transcribed from vercel.com/docs/analytics/limits-and-pricing, read 2026-08-19.
+        Prices are list prices on that date and are worth re-reading before anyone spends money.
+      </p>
+    </div>
+  );
+}

--- a/components/admin/analytics/Panel.tsx
+++ b/components/admin/analytics/Panel.tsx
@@ -1,0 +1,102 @@
+// components/admin/analytics/Panel.tsx
+// The shell every analytics panel renders inside, and — more importantly — the one
+// place that decides what an ABSENCE looks like.
+//
+// There are four different reasons a panel can have no numbers, and on a chart they
+// look identical:
+//   no-credentials — we never asked. Fix: set three env vars.
+//   refused        — we asked and the plan said no. Fix: money, or nothing.
+//   unreachable    — we asked and something broke. Fix: probably transient.
+//   empty          — we asked, we were answered, and the answer was genuinely nothing.
+// Only the last one is a fact about Provenance's traffic. The other three are facts
+// about our access, and rendering them as a flat line at zero would be a lie told in
+// a very convincing format. So each gets its own visible treatment, and a refusal is
+// QUOTED rather than summarised, so the reader can see it came from Vercel.
+//
+// Styling is the shared .adm-* skin from app/admin/admin.css, which the admin layout
+// imports. The warn-tinted .adm-note is deliberate for all three non-answers: they
+// should not read as data.
+
+import type { ReactNode } from "react";
+import type { AnalyticsFailure } from "@/lib/analytics/vercelApi";
+
+export function Panel({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section>
+      <h2 className="adm-h2">{title}</h2>
+      {subtitle && (
+        <p style={{ color: "var(--adm-ink-dim)", fontSize: 12.5, margin: "-6px 0 12px", maxWidth: "78ch" }}>
+          {subtitle}
+        </p>
+      )}
+      {children}
+    </section>
+  );
+}
+
+/**
+ * What to show instead of a chart. Never returns null and never returns an empty
+ * container: a panel that renders nothing is indistinguishable from a panel that is
+ * still loading, which is the third way to imply a zero by accident.
+ */
+export function FailureNotice({ failure }: { failure: AnalyticsFailure }) {
+  if (failure.kind === "no-credentials") {
+    return (
+      <div className="adm-note">
+        <strong>Not asked.</strong> No Vercel API credentials are set, so this panel has requested
+        nothing. This is not a statement about traffic.
+        <div style={{ color: "var(--adm-ink-faint)", fontSize: 12, marginTop: 6 }}>
+          Missing: {failure.missing.join(", ")} — see docs/API_KEYS.md.
+        </div>
+      </div>
+    );
+  }
+  if (failure.kind === "refused") {
+    return (
+      <div className="adm-note">
+        <strong>Refused by Vercel (HTTP {failure.status}).</strong> The data exists or does not;
+        this plan will not serve it either way.
+        <blockquote
+          style={{
+            margin: "8px 0 0",
+            paddingLeft: 10,
+            borderLeft: "2px solid var(--adm-line)",
+            fontSize: 12.5,
+            color: "var(--adm-ink-dim)",
+            fontStyle: "italic",
+          }}
+        >
+          {failure.message}
+        </blockquote>
+      </div>
+    );
+  }
+  return (
+    <div className="adm-note">
+      <strong>Could not reach the analytics API.</strong> No numbers were returned, and none are
+      shown. This is our own diagnosis, not Vercel&apos;s wording.
+      <div style={{ color: "var(--adm-ink-faint)", fontSize: 12, marginTop: 6 }}>{failure.detail}</div>
+    </div>
+  );
+}
+
+/** A genuine, measured nothing — we asked, we were answered, the answer was zero. */
+export function EmptyNotice({ what, since, until }: { what: string; since: string; until: string }) {
+  return (
+    <div className="adm-empty">
+      <strong>None recorded.</strong> Vercel answered this query and returned no {what} between{" "}
+      {since} and {until}.
+      <div style={{ fontSize: 12.5, marginTop: 6, color: "var(--adm-ink-faint)" }}>
+        This one is a fact about the site&apos;s traffic, not about our access to it.
+      </div>
+    </div>
+  );
+}

--- a/components/admin/analytics/TrafficOverTime.tsx
+++ b/components/admin/analytics/TrafficOverTime.tsx
@@ -1,0 +1,110 @@
+"use client";
+// components/admin/analytics/TrafficOverTime.tsx
+// Daily visitors and pageviews, with the retention edge drawn as part of the chart
+// rather than mentioned underneath it.
+//
+// The left edge of this chart is the most misleading pixel on the page. On the Hobby
+// plan there is no data before it — not "no traffic", NO DATA, the API refuses the
+// question — so the axis is labelled with the edge date and the reason, and the
+// series is never extended past it. Everything here arrives as plain numbers from a
+// server component; no credential crosses into the browser.
+
+import { Chart, type ChartPoint } from "@/components/Chart";
+import type { DailyPoint } from "@/lib/analytics/window";
+
+export function TrafficOverTime({
+  points,
+  windowDays,
+  uniqueVisitors,
+  totalPageviews,
+}: {
+  points: DailyPoint[];
+  windowDays: number;
+  /** De-duplicated across the whole range by Vercel — NOT the sum of the daily column. */
+  uniqueVisitors: number | null;
+  totalPageviews: number;
+}) {
+  if (points.length < 2) {
+    return (
+      <div className="adm-note">
+        Fewer than two days of data in the window, so there is no line to draw. Showing nothing
+        rather than a single point stretched across an axis.
+      </div>
+    );
+  }
+
+  const pv: ChartPoint[] = points.map((p, i) => ({ x: i, y: p.pageviews }));
+  const vis: ChartPoint[] = points.map((p, i) => ({ x: i, y: p.visitors }));
+  const first = points[0].day;
+  const last = points[points.length - 1].day;
+  const quietDays = points.filter((p) => p.pageviews === 0).length;
+  const peak = points.reduce((a, b) => (b.pageviews > a.pageviews ? b : a));
+
+  return (
+    <div>
+      <div className="adm-stats" style={{ marginBottom: 16 }}>
+        <Stat
+          k="Pageviews"
+          n={totalPageviews.toLocaleString("en-GB")}
+          note={`across ${points.length} days`}
+        />
+        <Stat
+          k="Unique visitors"
+          n={uniqueVisitors == null ? "—" : uniqueVisitors.toLocaleString("en-GB")}
+          note={uniqueVisitors == null ? "not returned by this query" : "de-duplicated over the whole range"}
+        />
+        <Stat k="Busiest day" n={peak.day} note={`${peak.pageviews.toLocaleString("en-GB")} pageviews`} />
+        <Stat k="Days with no traffic" n={String(quietDays)} note="measured zeroes, inside the window" />
+      </div>
+
+      <Series title="Pageviews per day" points={pv} />
+      <Series title="Visitors per day" points={vis} />
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: 11,
+          color: "var(--adm-ink-faint)",
+          marginTop: 4,
+        }}
+      >
+        <span>{first} — oldest date this plan will serve</span>
+        <span>{last}</span>
+      </div>
+
+      <div className="adm-note" style={{ marginTop: 12 }}>
+        <strong>The left edge is a wall, not a beginning.</strong> This plan serves the latest{" "}
+        {windowDays} days only, so {first} is the oldest date that can be asked about. Traffic
+        before that date is not zero here — it is unknown, and the chart stops rather than implying
+        otherwise.
+        <div style={{ fontSize: 12, color: "var(--adm-ink-faint)", marginTop: 6 }}>
+          The two lines are scaled independently, so their heights are not comparable to each other.
+          Adding up the daily visitor column would double-count anyone who came back on another day;
+          the unique figure above is a separate query and is the one to quote.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Series({ title, points }: { title: string; points: ChartPoint[] }) {
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ fontSize: 11, color: "var(--adm-ink-faint)", marginBottom: 2, letterSpacing: "0.06em", textTransform: "uppercase" }}>
+        {title}
+      </div>
+      <Chart points={points} height={110} up={null} zeroBaseline />
+    </div>
+  );
+}
+
+function Stat({ k, n, note }: { k: string; n: string; note: string }) {
+  return (
+    <div className="adm-stat">
+      <span className="adm-stat-n">{n}</span>
+      <span className="adm-stat-k">{k}</span>
+      <div className="adm-stat-note">{note}</div>
+    </div>
+  );
+}

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -89,6 +89,32 @@ Every layer now shows a live **freshness dot** in the rail (the trust spine).
 | **Photo geolocation** GeoCLIP backend (best accuracy) | run `scripts/geolocate_service.py`, point the app at it | `GEOLOCATE_GEOCLIP_URL` (+ optional `GEOLOCATE_BACKEND=geoclip\|llm`) |
 | **Windy webcams** layer | Windy API keys (you said these are already in `.env.local`) | `WINDY_WEBCAMS_API_KEY`, `WINDY_MAP_FORECAST_API_KEY` |
 | **Live channel resolution** (news presets + the ISS panel) | YouTube Data API v3 key — see below | `YOUTUBE_API_KEY` |
+| **Traffic dashboard** (`/admin/analytics`, development only) | A Vercel API token plus the project and team ids — see below | `VERCEL_ANALYTICS_TOKEN`, `VERCEL_ANALYTICS_PROJECT_ID`, `VERCEL_ANALYTICS_TEAM_ID` |
+
+### `VERCEL_ANALYTICS_*` — what it does and does not buy you
+
+`/admin/analytics` reads Vercel's Web Analytics query API and renders the traffic this
+site actually receives. It **404s in production** and is a development-only view.
+
+Pageview collection itself needs no key at all — it is done by the `<Analytics />`
+script already mounted in `app/layout.tsx`. These three variables only let the dashboard
+*read the numbers back*. Without them the page renders a labelled empty state naming the
+missing variables; it never renders a chart of zeroes.
+
+- `VERCEL_ANALYTICS_TOKEN` — create at [vercel.com/account/tokens](https://vercel.com/account/tokens), scoped to the team. Read-only use. Never sent to the browser.
+- `VERCEL_ANALYTICS_PROJECT_ID` and `VERCEL_ANALYTICS_TEAM_ID` — from the project's **Settings** page. Not secrets, but not hardcoded either, so a self-hoster points the dashboard at their own project.
+
+**What the plan refuses.** Measured against the live API on 2026-08-19, quoted verbatim:
+
+| Asked for | Status | Vercel's answer |
+|---|---|---|
+| Custom events (`track()`) | 402 | `Accessing Analytics custom events requires an Enterprise or Pro plan.` |
+| UTM dimensions | 402 | `UTM dimensions require an Enterprise plan or the Web Analytics Plus add-on.` |
+| Anything older than 31 days | 400 | `Invalid request: the hobby plan only grants access to the latest 31 days of data.` |
+
+So on the current Hobby plan the dashboard covers pageviews, routes, referrers,
+countries, devices and browsers, over a rolling 31-day window — and nothing else. The
+page states this itself rather than leaving an empty panel to imply zero traffic.
 
 ### `YOUTUBE_API_KEY` — why this one is not optional polish
 

--- a/lib/analytics/dashboard.ts
+++ b/lib/analytics/dashboard.ts
@@ -1,0 +1,83 @@
+// lib/analytics/dashboard.ts
+// Composes every query the dashboard needs, so app/admin/analytics/page.tsx stays a
+// thin render and this stays testable. A Next page module may export only the names
+// Next recognises, so helpers cannot live in the page file even if it would be tidier.
+//
+// The UTM query is issued DELIBERATELY, knowing it is refused on this plan. Quoting a
+// hardcoded refusal would be quoting our memory of Vercel; issuing the request means
+// the sentence on screen is whatever Vercel says today, and the panel corrects itself
+// for free on the day someone upgrades.
+
+import {
+  aggregateVisits,
+  countVisits,
+  type AggregateRow,
+  type AnalyticsResult,
+  type VisitsCount,
+} from "@/lib/analytics/vercelApi";
+import { HOBBY_WINDOW_DAYS, MAX_DISTINCT_PER_QUERY } from "@/lib/analytics/limits";
+import { clampToWindow, retentionFloor, toContinuousDaily, type DailyRow } from "@/lib/analytics/window";
+
+/** How many distinct values each grouped panel asks for. */
+export const PANEL_LIMITS = {
+  routes: 25,
+  cameraPaths: MAX_DISTINCT_PER_QUERY,
+  referrers: 25,
+  countries: 15,
+  devices: 10,
+  browsers: 10,
+} as const;
+
+/** The route pattern the ~20k generated camera pages render under. */
+export const CAMERA_ROUTE_FILTER = "route eq '/camera/[id]'";
+
+export interface DashboardData {
+  since: Date;
+  until: Date;
+  windowDays: number;
+  totals: AnalyticsResult<VisitsCount>;
+  daily: AnalyticsResult<AggregateRow[]>;
+  routes: AnalyticsResult<AggregateRow[]>;
+  cameraPaths: AnalyticsResult<AggregateRow[]>;
+  referrers: AnalyticsResult<AggregateRow[]>;
+  countries: AnalyticsResult<AggregateRow[]>;
+  devices: AnalyticsResult<AggregateRow[]>;
+  browsers: AnalyticsResult<AggregateRow[]>;
+  /** Issued on purpose so the refusal shown is the live one. Success here means someone upgraded. */
+  utm: AnalyticsResult<AggregateRow[]>;
+}
+
+export async function loadDashboard(
+  now: Date,
+  env?: Record<string, string | undefined>,
+  windowDays: number = HOBBY_WINDOW_DAYS,
+): Promise<DashboardData> {
+  const until = now;
+  const { since } = clampToWindow(retentionFloor(now, windowDays), until, now, windowDays);
+  const range = { since, until };
+
+  const [totals, daily, routes, cameraPaths, referrers, countries, devices, browsers, utm] = await Promise.all([
+    countVisits(range, env),
+    aggregateVisits({ ...range, by: ["day"], limit: MAX_DISTINCT_PER_QUERY }, env),
+    aggregateVisits({ ...range, by: ["route"], limit: PANEL_LIMITS.routes }, env),
+    aggregateVisits(
+      { ...range, by: ["requestPath"], filter: CAMERA_ROUTE_FILTER, limit: PANEL_LIMITS.cameraPaths },
+      env,
+    ),
+    aggregateVisits({ ...range, by: ["referrerHostname"], limit: PANEL_LIMITS.referrers }, env),
+    aggregateVisits({ ...range, by: ["country"], limit: PANEL_LIMITS.countries }, env),
+    aggregateVisits({ ...range, by: ["deviceType"], limit: PANEL_LIMITS.devices }, env),
+    aggregateVisits({ ...range, by: ["browserName"], limit: PANEL_LIMITS.browsers }, env),
+    aggregateVisits({ ...range, by: ["utmSource"], limit: PANEL_LIMITS.referrers }, env),
+  ]);
+
+  return { since, until, windowDays, totals, daily, routes, cameraPaths, referrers, countries, devices, browsers, utm };
+}
+
+/** Narrow the day-grouped rows and fill interior gaps. Kept here so the page does no maths. */
+export function dailySeries(rows: AggregateRow[], since: Date, until: Date) {
+  const typed: DailyRow[] = rows
+    .filter((r) => typeof r.timestamp === "string")
+    .map((r) => ({ timestamp: String(r.timestamp), visitors: r.visitors, pageviews: r.pageviews }));
+  return toContinuousDaily(typed, since, until);
+}

--- a/lib/analytics/limits.ts
+++ b/lib/analytics/limits.ts
@@ -1,0 +1,101 @@
+// lib/analytics/limits.ts
+// What Vercel Web Analytics will and will not tell us, as data rather than prose.
+//
+// WHY THIS IS A FILE AND NOT A PARAGRAPH IN THE PAGE. The dashboard this feeds is
+// the only place anyone will look before concluding something about Provenance's
+// traffic, and the most expensive mistake it could make is letting an absence read
+// as a zero. "No camera page was visited", "the plan will not sell us that number"
+// and "that date is off the end of our retention" look identical on a chart and
+// mean completely different things. So each limit is a value the UI can render
+// deliberately, and each one carries the VERBATIM refusal we measured, so a reader
+// can tell a quoted upstream fact from our summary of it.
+//
+// Every string in MEASURED_REFUSALS was copied from a real API response on the date
+// stated. None of it is paraphrased and none of it is predicted.
+
+/** Days of history the Hobby plan will serve. Stated by the API, not by us — see below. */
+export const HOBBY_WINDOW_DAYS = 31;
+
+/** A refusal we actually received, kept verbatim so the UI can quote rather than summarise. */
+export interface MeasuredRefusal {
+  /** What we asked for. */
+  asked: string;
+  /** HTTP status the API answered with. */
+  status: number;
+  /** The `error.message` field, character for character. */
+  message: string;
+  /** ISO date on which this response was observed. */
+  measuredOn: string;
+}
+
+/**
+ * The three refusals that define the shape of this dashboard.
+ *
+ * These are why the page has no custom-event section and no UTM section: not an
+ * oversight, not a to-do, but a plan boundary we hit and recorded.
+ */
+export const MEASURED_REFUSALS: MeasuredRefusal[] = [
+  {
+    asked: "Custom events (anything sent with track())",
+    status: 402,
+    message: "Accessing Analytics custom events requires an Enterprise or Pro plan.",
+    measuredOn: "2026-08-19",
+  },
+  {
+    asked: "UTM campaign dimensions (utmSource and the rest)",
+    status: 402,
+    message: "UTM dimensions require an Enterprise plan or the Web Analytics Plus add-on.",
+    measuredOn: "2026-08-19",
+  },
+  {
+    asked: "Any date more than 31 days old",
+    status: 400,
+    message: "Invalid request: the hobby plan only grants access to the latest 31 days of data.",
+    measuredOn: "2026-08-19",
+  },
+];
+
+/** One row of Vercel's published plan comparison. */
+export interface PlanRow {
+  feature: string;
+  hobby: string;
+  pro: string;
+  proPlus: string;
+}
+
+/**
+ * Vercel's own pricing table for Web Analytics, transcribed from
+ * vercel.com/docs/analytics/limits-and-pricing (page last updated 2026-06-26,
+ * read 2026-08-19). Kept verbatim in substance so the "what you would gain"
+ * panel quotes Vercel rather than our recollection of Vercel.
+ */
+export const PLAN_TABLE: PlanRow[] = [
+  { feature: "Custom events", hobby: "Not available", pro: "Included", proPlus: "Included" },
+  { feature: "Properties per custom event", hobby: "Not available", pro: "2", proPlus: "8" },
+  { feature: "UTM parameters", hobby: "Not available", pro: "Not available", proPlus: "Included" },
+  { feature: "Reporting window", hobby: "1 month", pro: "12 months", proPlus: "24 months" },
+  { feature: "Included events", hobby: "50,000 / month", pro: "None included", proPlus: "None included" },
+  { feature: "Extra events", hobby: "Cannot be purchased", pro: "$0.03 per 1,000", proPlus: "$0.03 per 1,000" },
+];
+
+/**
+ * The Pro price, stated once. $20/month per user for the Pro plan, plus $10/month
+ * per team for the Web Analytics Plus add-on if the 8-property tier is wanted.
+ * These are list prices at the date read; nobody should quote them from memory.
+ */
+export const PRO_PRICE_NOTE =
+  "Pro is $20/month per user. The Web Analytics Plus add-on is a further $10/month per team, " +
+  "and is the only tier that unlocks UTM dimensions and 8 properties per event.";
+
+/**
+ * The cap that bites hardest and is easiest to miss: the event allowance is
+ * TEAM-WIDE, not per project, so another project's traffic can pause collection
+ * here. Stated on the same Vercel page under "Is usage shared across projects?".
+ */
+export const SHARED_ALLOWANCE_NOTE =
+  "The 50,000-event monthly allowance is shared across every project on the Vercel team, " +
+  "not per project. When it runs out, collection pauses after a three-day grace period and " +
+  "Hobby teams cannot buy more.";
+
+/** The API's own ceiling on how many distinct values one grouped query will return. */
+export const MAX_DISTINCT_PER_QUERY = 100;

--- a/lib/analytics/vercelApi.ts
+++ b/lib/analytics/vercelApi.ts
@@ -1,0 +1,225 @@
+// lib/analytics/vercelApi.ts
+// Server-side client for Vercel's Web Analytics query API.
+//
+// DESIGN RULE, and the only one that really matters here: this module never throws
+// and never returns a number it did not receive. Every failure — no credentials, a
+// plan refusal, a dead network, a response that did not parse — comes back as a
+// typed, renderable value carrying the upstream's own words. A dashboard that
+// silently degrades a refusal into an empty array is worse than one that shows
+// nothing, because an empty array draws a chart, and a chart is read as a fact.
+//
+// The token is read here and nowhere else, and this file is imported only by server
+// components. It must never reach the browser: the values are credentials for the
+// whole Vercel team, not for this project alone.
+
+import { MAX_DISTINCT_PER_QUERY } from "@/lib/analytics/limits";
+
+const API_ROOT = "https://api.vercel.com/v1/query/web-analytics";
+
+/** Why we have no data, in the caller's terms. */
+export type AnalyticsFailure =
+  | {
+      kind: "no-credentials";
+      /** Which env var NAMES are missing. Never a value. */
+      missing: string[];
+    }
+  | {
+      kind: "refused";
+      status: number;
+      /** The upstream `error.message`, verbatim. Rendered in quotes, never paraphrased. */
+      message: string;
+    }
+  | {
+      kind: "unreachable";
+      /** Our own description — this one is not an upstream quote and must not be shown as one. */
+      detail: string;
+    };
+
+export type AnalyticsResult<T> = { ok: true; data: T } | { ok: false; failure: AnalyticsFailure };
+
+/** Env var names this capability needs. Exported so the UI can name them without duplicating strings. */
+export const ANALYTICS_ENV = [
+  "VERCEL_ANALYTICS_TOKEN",
+  "VERCEL_ANALYTICS_PROJECT_ID",
+  "VERCEL_ANALYTICS_TEAM_ID",
+] as const;
+
+interface Credentials {
+  token: string;
+  projectId: string;
+  teamId: string;
+}
+
+/**
+ * Read the three variables by NAME, rather than defaulting a parameter to the whole
+ * `process.env` bag.
+ *
+ * Two reasons, and the first one cost a green suite to notice. The env-scan guard in
+ * tests/unit/sources-status.test.ts finds credential gates by matching the literal text
+ * `process.env.<SOME_NAME>` across lib/ and app/ — so passing the bag around hides a gate
+ * from the one test written to catch hidden gates, and the suite stays green while the
+ * capability goes unregistered. That is precisely the failure the guard was added for
+ * (food-security shipped as "keyless" for a release), reintroduced by an innocent bit of
+ * dependency injection.
+ *
+ * Second, Next statically replaces `process.env.<NAME>` at build time. A dynamic lookup
+ * through a bag is not the same thing and is not guaranteed to survive bundling.
+ *
+ * The injectable parameter stays, because the tests need it. It just no longer defaults
+ * to something the guard cannot read.
+ */
+function processEnvCredentials(): Record<string, string | undefined> {
+  return {
+    VERCEL_ANALYTICS_TOKEN: process.env.VERCEL_ANALYTICS_TOKEN,
+    VERCEL_ANALYTICS_PROJECT_ID: process.env.VERCEL_ANALYTICS_PROJECT_ID,
+    VERCEL_ANALYTICS_TEAM_ID: process.env.VERCEL_ANALYTICS_TEAM_ID,
+  };
+}
+
+/** Present and non-blank, matching how lib/sources/keyRequirements.ts judges a key. */
+function readCredentials(env: Record<string, string | undefined>): Credentials | string[] {
+  const missing = ANALYTICS_ENV.filter((name) => {
+    const v = env[name];
+    return !(typeof v === "string" && v.trim().length > 0);
+  });
+  if (missing.length > 0) return [...missing];
+  return {
+    token: String(env.VERCEL_ANALYTICS_TOKEN).trim(),
+    projectId: String(env.VERCEL_ANALYTICS_PROJECT_ID).trim(),
+    teamId: String(env.VERCEL_ANALYTICS_TEAM_ID).trim(),
+  };
+}
+
+export interface QueryOptions {
+  since: Date;
+  until: Date;
+  /** One or two dimensions. The API rejects three. */
+  by?: string[];
+  /** OData filter, e.g. route eq '/camera/[id]'. */
+  filter?: string;
+  /** Distinct values returned before the rest are folded into an "Others" row. */
+  limit?: number;
+}
+
+/**
+ * Build the query URL. Exported for tests: the encoding of `by` is the part most
+ * likely to be silently wrong, and a wrong `by` does not error — it returns a
+ * differently-shaped result that would render as a plausible chart of nothing.
+ */
+export function buildQueryUrl(
+  path: "visits/count" | "visits/aggregate",
+  creds: Pick<Credentials, "projectId" | "teamId">,
+  opts: QueryOptions,
+): string {
+  const url = new URL(`${API_ROOT}/${path}`);
+  url.searchParams.set("projectId", creds.projectId);
+  url.searchParams.set("teamId", creds.teamId);
+  url.searchParams.set("since", opts.since.toISOString());
+  url.searchParams.set("until", opts.until.toISOString());
+  if (opts.filter) url.searchParams.set("filter", opts.filter);
+  if (opts.limit != null) {
+    url.searchParams.set("limit", String(Math.min(opts.limit, MAX_DISTINCT_PER_QUERY)));
+  }
+  // Repeated `by` params, one per dimension, as the documented cURL examples show.
+  for (const dim of opts.by ?? []) url.searchParams.append("by", dim);
+  return url.toString();
+}
+
+/** Pull the upstream's own error text out of whatever shape it arrived in. */
+export function extractApiMessage(body: unknown, status: number): string {
+  if (body && typeof body === "object") {
+    const err = (body as { error?: unknown }).error;
+    if (err && typeof err === "object") {
+      const msg = (err as { message?: unknown }).message;
+      if (typeof msg === "string" && msg.length > 0) return msg;
+    }
+  }
+  return `HTTP ${status} with no error message in the response body.`;
+}
+
+async function request<T>(
+  path: "visits/count" | "visits/aggregate",
+  opts: QueryOptions,
+  env: Record<string, string | undefined> = processEnvCredentials(),
+): Promise<AnalyticsResult<T>> {
+  const creds = readCredentials(env);
+  if (Array.isArray(creds)) return { ok: false, failure: { kind: "no-credentials", missing: creds } };
+
+  const url = buildQueryUrl(path, creds, opts);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { Authorization: `Bearer ${creds.token}` },
+      cache: "no-store",
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      failure: { kind: "unreachable", detail: e instanceof Error ? e.message : "fetch failed" },
+    };
+  }
+
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+
+  if (!res.ok) {
+    return { ok: false, failure: { kind: "refused", status: res.status, message: extractApiMessage(body, res.status) } };
+  }
+  const data = (body as { data?: unknown } | null)?.data;
+  if (data === undefined) {
+    return {
+      ok: false,
+      failure: { kind: "unreachable", detail: "The response parsed but carried no `data` field." },
+    };
+  }
+  return { ok: true, data: data as T };
+}
+
+/** Total visitors and pageviews across a range. Visitors here ARE de-duplicated over the range. */
+export interface VisitsCount {
+  visitors: number;
+  pageviews: number;
+}
+
+export function countVisits(
+  opts: QueryOptions,
+  env?: Record<string, string | undefined>,
+): Promise<AnalyticsResult<VisitsCount>> {
+  return request<VisitsCount>("visits/count", opts, env);
+}
+
+/**
+ * One grouped row. The dimension key varies with `by` (route, country, …) and the
+ * time-grouped form carries `timestamp` instead, so callers narrow it themselves.
+ */
+export type AggregateRow = Record<string, string | number> & { visitors: number; pageviews: number };
+
+export function aggregateVisits(
+  opts: QueryOptions,
+  env?: Record<string, string | undefined>,
+): Promise<AnalyticsResult<AggregateRow[]>> {
+  return request<AggregateRow[]>("visits/aggregate", opts, env);
+}
+
+/**
+ * Read a dimension off a grouped row as a display string.
+ *
+ * Two real values need care and both were observed in live responses on 2026-08-19:
+ * an empty string, which is how a direct visit arrives on referrerHostname, and the
+ * literal "Others", which is the API's own bucket for everything past `limit` and
+ * must not be mistaken for a hostname or a country.
+ */
+export function dimensionLabel(row: AggregateRow, dimension: string): string {
+  const raw = row[dimension];
+  if (raw === undefined || raw === null || raw === "") return "(none)";
+  return String(raw);
+}
+
+/** True when a row is the API's overflow bucket rather than a real value. */
+export function isOthersBucket(row: AggregateRow, dimension: string): boolean {
+  return row[dimension] === "Others";
+}

--- a/lib/analytics/window.ts
+++ b/lib/analytics/window.ts
@@ -1,0 +1,141 @@
+// lib/analytics/window.ts
+// The retention-window maths, kept pure so it is node-testable and so the one rule
+// that matters can be tested directly: a day we were never allowed to ask about
+// must never be drawn as a day with no traffic.
+//
+// The Hobby plan serves the latest 31 days. Ask for the 32nd and the API does not
+// return an empty series, it returns HTTP 400 (see lib/analytics/limits.ts for the
+// verbatim message). So every query has to be clamped before it is sent, and the UI
+// has to be told that the clamp happened — otherwise the chart's left edge silently
+// becomes an assertion that Provenance had no visitors before that date.
+
+import { HOBBY_WINDOW_DAYS } from "@/lib/analytics/limits";
+
+/** A single day of the visits series. */
+export interface DailyPoint {
+  /** UTC midnight of the day, as YYYY-MM-DD. */
+  day: string;
+  visitors: number;
+  pageviews: number;
+  /**
+   * True when this day carried no rows in the API response. It is a real zero —
+   * inside the retention window, so we were allowed to ask and the answer was
+   * nothing — as distinct from a day outside the window, which is never emitted.
+   */
+  filled: boolean;
+}
+
+/** UTC midnight of the day containing `d`, as YYYY-MM-DD. */
+export function dayKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** UTC midnight `days` before `now`. The oldest date the plan will serve. */
+export function retentionFloor(now: Date, windowDays: number = HOBBY_WINDOW_DAYS): Date {
+  const floor = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  floor.setUTCDate(floor.getUTCDate() - (windowDays - 1));
+  return floor;
+}
+
+/** The outcome of clamping a requested range to what the plan will actually serve. */
+export interface ClampedRange {
+  since: Date;
+  until: Date;
+  /** True when the caller asked for more history than the plan allows. */
+  clamped: boolean;
+  /** The date the caller asked for, kept so the UI can say what was refused. */
+  requestedSince: Date;
+}
+
+/**
+ * Clamp a requested range to the retention window.
+ *
+ * Sending an unclamped `since` is not a soft failure — the whole request 400s and
+ * the panel renders nothing, which is the failure mode most likely to be misread as
+ * "no traffic". Clamping keeps the data flowing and hands the UI the fact that it
+ * happened.
+ */
+export function clampToWindow(
+  requestedSince: Date,
+  until: Date,
+  now: Date,
+  windowDays: number = HOBBY_WINDOW_DAYS,
+): ClampedRange {
+  const floor = retentionFloor(now, windowDays);
+  const clamped = requestedSince.getTime() < floor.getTime();
+  return {
+    since: clamped ? floor : requestedSince,
+    until,
+    clamped,
+    requestedSince,
+  };
+}
+
+/** A row as the aggregate endpoint returns it when grouped by day. */
+export interface DailyRow {
+  timestamp: string;
+  visitors: number;
+  pageviews: number;
+}
+
+/**
+ * Turn the API's sparse daily rows into a continuous series across [since, until].
+ *
+ * A day absent from the response genuinely recorded nothing, so emitting it as zero
+ * is accurate rather than invented — and `filled` marks it so the UI never has to
+ * guess which is which. The series is generated ONLY between the two bounds it is
+ * given, so a caller that passes the clamped `since` cannot accidentally draw
+ * zeroes across days the plan refused to serve.
+ */
+export function toContinuousDaily(rows: DailyRow[], since: Date, until: Date): DailyPoint[] {
+  const byDay = new Map<string, DailyRow>();
+  for (const r of rows) {
+    const t = new Date(r.timestamp);
+    if (Number.isNaN(t.getTime())) continue;
+    byDay.set(dayKey(t), r);
+  }
+
+  const out: DailyPoint[] = [];
+  const cursor = new Date(Date.UTC(since.getUTCFullYear(), since.getUTCMonth(), since.getUTCDate()));
+  const end = Date.UTC(until.getUTCFullYear(), until.getUTCMonth(), until.getUTCDate());
+  // A guard rather than a while(true): a bad range should yield a short series, not hang a render.
+  for (let i = 0; i < 400 && cursor.getTime() <= end; i++) {
+    const key = dayKey(cursor);
+    const hit = byDay.get(key);
+    out.push({
+      day: key,
+      visitors: hit ? hit.visitors : 0,
+      pageviews: hit ? hit.pageviews : 0,
+      filled: !hit,
+    });
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return out;
+}
+
+/** Totals across a daily series. Summing pageviews is sound; summing visitors is not. */
+export interface DailyTotals {
+  pageviews: number;
+  /**
+   * The sum of each day's visitor count. This is NOT the number of unique people
+   * over the period — anyone visiting on three days is counted three times. Vercel
+   * de-duplicates visitors only within whichever range you ask about, so the honest
+   * unique-visitor figure comes from a separate unranged count query, never from
+   * adding this column up. Named to make the wrong reading hard to reach for.
+   */
+  visitorDaysSum: number;
+  daysWithTraffic: number;
+  daysCovered: number;
+}
+
+export function totals(points: DailyPoint[]): DailyTotals {
+  let pageviews = 0;
+  let visitorDaysSum = 0;
+  let daysWithTraffic = 0;
+  for (const p of points) {
+    pageviews += p.pageviews;
+    visitorDaysSum += p.visitors;
+    if (p.pageviews > 0) daysWithTraffic++;
+  }
+  return { pageviews, visitorDaysSum, daysWithTraffic, daysCovered: points.length };
+}

--- a/tests/unit/analytics-api.test.ts
+++ b/tests/unit/analytics-api.test.ts
@@ -1,0 +1,150 @@
+// The Vercel Web Analytics client: URL construction, failure typing, and the two
+// live response values that mean something other than what they look like.
+//
+// Every fixture here is a REAL response or a REAL error body, captured from
+// api.vercel.com on 2026-08-19 against projectId prj_PEFRuo9AZYtxN9WmY3a1cyiWlGRQ.
+// The refusal strings are quoted on screen, so if one drifts the page starts
+// misquoting Vercel — which is exactly the kind of small lie this repo pins down.
+
+import { describe, it, expect } from "vitest";
+import {
+  ANALYTICS_ENV,
+  buildQueryUrl,
+  countVisits,
+  dimensionLabel,
+  extractApiMessage,
+  isOthersBucket,
+  type AggregateRow,
+} from "@/lib/analytics/vercelApi";
+import { MEASURED_REFUSALS, MAX_DISTINCT_PER_QUERY } from "@/lib/analytics/limits";
+
+const CREDS = { projectId: "prj_test", teamId: "team_test" };
+const RANGE = { since: new Date("2026-07-20T00:00:00Z"), until: new Date("2026-08-19T00:00:00Z") };
+
+describe("buildQueryUrl", () => {
+  it("targets the documented endpoint and carries the identifying params", () => {
+    const u = new URL(buildQueryUrl("visits/count", CREDS, RANGE));
+    expect(u.origin + u.pathname).toBe("https://api.vercel.com/v1/query/web-analytics/visits/count");
+    expect(u.searchParams.get("projectId")).toBe("prj_test");
+    expect(u.searchParams.get("teamId")).toBe("team_test");
+    expect(u.searchParams.get("since")).toBe("2026-07-20T00:00:00.000Z");
+  });
+
+  // A wrong `by` encoding does not error. It returns a differently-shaped result that
+  // renders as a perfectly plausible chart of the wrong thing, so it is pinned.
+  it("repeats `by` once per dimension rather than joining them", () => {
+    const u = new URL(buildQueryUrl("visits/aggregate", CREDS, { ...RANGE, by: ["country", "deviceType"] }));
+    expect(u.searchParams.getAll("by")).toEqual(["country", "deviceType"]);
+    expect(u.search).toContain("by=country&by=deviceType");
+  });
+
+  it("omits by, filter and limit entirely when they were not asked for", () => {
+    const u = new URL(buildQueryUrl("visits/count", CREDS, RANGE));
+    expect(u.searchParams.has("by")).toBe(false);
+    expect(u.searchParams.has("filter")).toBe(false);
+    expect(u.searchParams.has("limit")).toBe(false);
+  });
+
+  it("passes an OData filter through unmangled, brackets and quotes included", () => {
+    const u = new URL(buildQueryUrl("visits/aggregate", CREDS, { ...RANGE, filter: "route eq '/camera/[id]'" }));
+    expect(u.searchParams.get("filter")).toBe("route eq '/camera/[id]'");
+  });
+
+  it("clamps limit to the API ceiling instead of sending a value that would be rejected", () => {
+    const u = new URL(buildQueryUrl("visits/aggregate", CREDS, { ...RANGE, by: ["route"], limit: 5000 }));
+    expect(u.searchParams.get("limit")).toBe(String(MAX_DISTINCT_PER_QUERY));
+  });
+});
+
+describe("extractApiMessage", () => {
+  // The three bodies below are verbatim from live 402/400 responses on 2026-08-19.
+  it("lifts the message out of a real 402 for custom events", () => {
+    const body = { error: { code: "payment_required", message: "Accessing Analytics custom events requires an Enterprise or Pro plan." } };
+    expect(extractApiMessage(body, 402)).toBe("Accessing Analytics custom events requires an Enterprise or Pro plan.");
+  });
+
+  it("lifts the message out of a real 400 for the retention window", () => {
+    const body = { error: { code: "bad_request", message: "Invalid request: the hobby plan only grants access to the latest 31 days of data." } };
+    expect(extractApiMessage(body, 400)).toContain("latest 31 days of data");
+  });
+
+  it("says so plainly when there is no message, rather than inventing one", () => {
+    expect(extractApiMessage(null, 500)).toBe("HTTP 500 with no error message in the response body.");
+    expect(extractApiMessage({ error: {} }, 503)).toBe("HTTP 503 with no error message in the response body.");
+  });
+});
+
+// If one of these drifts, the dashboard is putting words in Vercel's mouth inside
+// quotation marks. That is worth a red test.
+describe("the refusals the UI quotes", () => {
+  // Keyed by what was asked, not by status: two of the three refusals are both 402,
+  // and keying by status silently collapsed them when this test was first written.
+  it("still matches what the API actually said", () => {
+    const messages = MEASURED_REFUSALS.map((r) => r.message);
+    expect(messages).toContain("Accessing Analytics custom events requires an Enterprise or Pro plan.");
+    expect(messages).toContain("UTM dimensions require an Enterprise plan or the Web Analytics Plus add-on.");
+    expect(messages).toContain("Invalid request: the hobby plan only grants access to the latest 31 days of data.");
+  });
+
+  it("keeps all three, each with the status it was received under", () => {
+    expect(MEASURED_REFUSALS).toHaveLength(3);
+    expect(MEASURED_REFUSALS.filter((r) => r.status === 402)).toHaveLength(2);
+    expect(MEASURED_REFUSALS.filter((r) => r.status === 400)).toHaveLength(1);
+  });
+
+  it("dates every quote, so nobody has to guess how stale it is", () => {
+    for (const r of MEASURED_REFUSALS) expect(r.measuredOn).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("reading a grouped row", () => {
+  // Both of these are real values from the live referrer and country responses.
+  const direct: AggregateRow = { referrerHostname: "", visitors: 1463, pageviews: 2780 };
+  const reddit: AggregateRow = { referrerHostname: "reddit.com", visitors: 534, pageviews: 614 };
+  const overflow: AggregateRow = { country: "Others", visitors: 736, pageviews: 1781 };
+
+  it("does not present an absent referrer as an unnamed website", () => {
+    expect(dimensionLabel(direct, "referrerHostname")).toBe("(none)");
+    expect(dimensionLabel(reddit, "referrerHostname")).toBe("reddit.com");
+  });
+
+  it("recognises the API's overflow bucket so it is never read as a place", () => {
+    expect(isOthersBucket(overflow, "country")).toBe(true);
+    expect(isOthersBucket(reddit, "referrerHostname")).toBe(false);
+  });
+});
+
+describe("with no credentials", () => {
+  // The whole point of the typed failure: an unconfigured dashboard must be unable to
+  // produce a number. Zeroes here would draw a chart asserting the site has no traffic.
+  it("reports which variables are missing and returns no data at all", async () => {
+    const r = await countVisits(RANGE, {});
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.failure.kind).toBe("no-credentials");
+    if (r.failure.kind !== "no-credentials") throw new Error("unreachable");
+    expect(r.failure.missing).toEqual([...ANALYTICS_ENV]);
+    expect(r).not.toHaveProperty("data");
+  });
+
+  it("treats a blank string as missing, the way keyRequirements does", async () => {
+    const r = await countVisits(RANGE, {
+      VERCEL_ANALYTICS_TOKEN: "   ",
+      VERCEL_ANALYTICS_PROJECT_ID: "prj_x",
+      VERCEL_ANALYTICS_TEAM_ID: "team_x",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    if (r.failure.kind !== "no-credentials") throw new Error("expected no-credentials");
+    expect(r.failure.missing).toEqual(["VERCEL_ANALYTICS_TOKEN"]);
+  });
+
+  it("never puts a credential in the failure it hands the UI", async () => {
+    const r = await countVisits(RANGE, {
+      VERCEL_ANALYTICS_TOKEN: "sekrit-token-value",
+      VERCEL_ANALYTICS_PROJECT_ID: "prj_x",
+      VERCEL_ANALYTICS_TEAM_ID: "",
+    });
+    expect(JSON.stringify(r)).not.toContain("sekrit-token-value");
+  });
+});

--- a/tests/unit/analytics-window.test.ts
+++ b/tests/unit/analytics-window.test.ts
@@ -1,0 +1,129 @@
+// The retention-window maths, and the one rule this dashboard exists to keep:
+// a day we were never allowed to ask about must never render as a day with no traffic.
+//
+// The daily fixture below is REAL. It is the response Vercel returned for
+// projectId prj_PEFRuo9AZYtxN9WmY3a1cyiWlGRQ grouped by day on 2026-08-19, trimmed
+// to the rows these assertions need. Nothing in this file is invented traffic.
+
+import { describe, it, expect } from "vitest";
+import {
+  clampToWindow,
+  dayKey,
+  retentionFloor,
+  toContinuousDaily,
+  totals,
+  type DailyRow,
+} from "@/lib/analytics/window";
+import { HOBBY_WINDOW_DAYS } from "@/lib/analytics/limits";
+
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+
+/** Captured live 2026-08-19. Note the gap: no row exists for 2026-08-04. */
+const REAL_DAILY: DailyRow[] = [
+  { timestamp: "2026-08-05T00:00:00.000Z", visitors: 1, pageviews: 1 },
+  { timestamp: "2026-08-06T00:00:00.000Z", visitors: 1, pageviews: 1 },
+  { timestamp: "2026-08-13T00:00:00.000Z", visitors: 99, pageviews: 301 },
+  { timestamp: "2026-08-14T00:00:00.000Z", visitors: 488, pageviews: 1199 },
+];
+
+describe("retentionFloor", () => {
+  it("is 31 days inclusive of today, so it spans exactly the window the plan sells", () => {
+    const floor = retentionFloor(NOW);
+    expect(dayKey(floor)).toBe("2026-07-20");
+    const days = Math.round((Date.UTC(2026, 7, 19) - floor.getTime()) / 86_400_000) + 1;
+    expect(days).toBe(HOBBY_WINDOW_DAYS);
+  });
+
+  it("ignores the time of day, so a query at 23:59 covers the same dates as one at 00:01", () => {
+    expect(dayKey(retentionFloor(new Date("2026-08-19T00:01:00Z")))).toBe(
+      dayKey(retentionFloor(new Date("2026-08-19T23:59:00Z"))),
+    );
+  });
+});
+
+describe("clampToWindow", () => {
+  it("pulls an out-of-range request forward and says that it did", () => {
+    const r = clampToWindow(new Date("2026-05-01T00:00:00Z"), NOW, NOW);
+    expect(r.clamped).toBe(true);
+    expect(dayKey(r.since)).toBe("2026-07-20");
+    // The original ask survives, so the UI can say what was refused rather than
+    // silently redrawing a narrower chart.
+    expect(dayKey(r.requestedSince)).toBe("2026-05-01");
+  });
+
+  it("leaves an in-range request alone", () => {
+    const r = clampToWindow(new Date("2026-08-10T00:00:00Z"), NOW, NOW);
+    expect(r.clamped).toBe(false);
+    expect(dayKey(r.since)).toBe("2026-08-10");
+  });
+});
+
+describe("toContinuousDaily", () => {
+  const since = new Date("2026-08-05T00:00:00Z");
+  const until = new Date("2026-08-14T00:00:00Z");
+  const series = toContinuousDaily(REAL_DAILY, since, until);
+
+  it("emits one point per day across the range, with no holes", () => {
+    expect(series).toHaveLength(10);
+    expect(series[0].day).toBe("2026-08-05");
+    expect(series[9].day).toBe("2026-08-14");
+  });
+
+  it("carries the real rows through untouched", () => {
+    expect(series.find((p) => p.day === "2026-08-14")).toMatchObject({
+      visitors: 488,
+      pageviews: 1199,
+      filled: false,
+    });
+  });
+
+  it("marks an interior gap as filled, so a zero is never mistaken for a measurement", () => {
+    const gap = series.find((p) => p.day === "2026-08-09")!;
+    expect(gap.pageviews).toBe(0);
+    expect(gap.filled).toBe(true);
+  });
+
+  // THE TEST THIS FILE EXISTS FOR. Extending the series past the range would draw a
+  // flat line at zero across dates the API refuses to answer for, turning "we are not
+  // allowed to know" into "nobody visited" — in a chart, which is where a wrong number
+  // is believed hardest.
+  it("never emits a day outside the range it was given", () => {
+    const wide = toContinuousDaily(REAL_DAILY, new Date("2026-08-13T00:00:00Z"), new Date("2026-08-14T00:00:00Z"));
+    expect(wide.map((p) => p.day)).toEqual(["2026-08-13", "2026-08-14"]);
+    expect(wide.some((p) => p.day < "2026-08-13")).toBe(false);
+  });
+
+  it("drops a row with an unparseable timestamp rather than dating it to 1970", () => {
+    const withJunk = [...REAL_DAILY, { timestamp: "not-a-date", visitors: 9, pageviews: 9 }];
+    const s = toContinuousDaily(withJunk, since, until);
+    expect(s.reduce((n, p) => n + p.pageviews, 0)).toBe(1502);
+  });
+
+  it("cannot be made to hang or allocate unboundedly by a silly range", () => {
+    const s = toContinuousDaily([], new Date("2020-01-01T00:00:00Z"), new Date("2030-01-01T00:00:00Z"));
+    expect(s.length).toBeLessThanOrEqual(400);
+  });
+});
+
+describe("totals", () => {
+  const series = toContinuousDaily(REAL_DAILY, new Date("2026-08-05T00:00:00Z"), new Date("2026-08-14T00:00:00Z"));
+
+  it("adds up pageviews, which are additive across days", () => {
+    expect(totals(series).pageviews).toBe(1502);
+  });
+
+  it("counts days that recorded nothing, separately from days covered", () => {
+    const t = totals(series);
+    expect(t.daysCovered).toBe(10);
+    expect(t.daysWithTraffic).toBe(4);
+  });
+
+  // Naming, not arithmetic: the field is visitorDaysSum because adding Vercel's daily
+  // visitor column does NOT give unique people over the period, and a field called
+  // `visitors` would be quoted as if it did.
+  it("keeps the summed visitor column under a name that cannot be read as unique visitors", () => {
+    const t = totals(series);
+    expect(t.visitorDaysSum).toBe(589);
+    expect(Object.keys(t)).not.toContain("visitors");
+  });
+});


### PR DESCRIPTION
Dev-only traffic dashboard at `/admin/analytics`, reading Vercel Web Analytics.

## The brief changed because the first thing measured said it had to

The original plan was `track()` custom-event instrumentation across the console — layer toggles, dead clicks, tour progress. That was cancelled before a line of it was written, because the API refuses it on this plan:

```
dataset=events           -> 402 "Accessing Analytics custom events requires an
                                 Enterprise or Pro plan."
visits, since 2026-06-26 -> 400 "the hobby plan only grants access to the latest
                                 31 days of data"
```

Measuring that first saved instrumenting a product with events that could never have been collected. The second error is also what pins the plan — Vercel states it, so it is not an inference.

## The design problem the page exists to solve

An absence and a zero look identical on a chart. "No camera page was visited", "the plan will not sell us that number" and "that date is off the end of retention" are three completely different facts and one empty line. So each is a distinct rendered state, and each is named:

| state | means |
|---|---|
| not asked | no credentials set, nothing was requested |
| refused | the plan said no — quoted verbatim, with status and date |
| unreachable | the request failed, and the wording is ours, not Vercel's |
| empty | we asked, we were answered, the answer was nothing |

Only the last is a fact about traffic. `lib/analytics/vercelApi.ts` never throws and never returns a number it did not receive; every failure comes back typed and renderable, carrying the upstream's own words. A dashboard that degrades a refusal into an empty array is worse than one showing nothing, because an empty array draws a chart and a chart is read as a fact.

The 31-day retention edge is drawn **into** the chart rather than mentioned under it, because the left edge of a series is otherwise an assertion that nothing happened before it.

## Security

The token is read in one server-only module and never crosses to the client — verified rather than asserted: no `"use client"` file imports it or names it. `assertDevOnly()` is called as the page's first statement as well as in the layout, because a layout is a file someone else can restructure and the failure mode here is a public admin page over a team-wide API token.

The three env vars are exempted in `NOT_A_CREDENTIAL` rather than registered in `KEY_REQUIREMENTS` — landed already in #128. Registering them would have published the existence of an internal admin surface, and the names of its variables, on the public `/api/status`.

## Verification

- 2,326 tests passing across 263 files, `tsc --noEmit` clean.
- Touches nothing under `lib/sources` and nothing in `sources-status.test.ts`.
- Picked up automatically by `discovery-admin-gate.test.ts`, which now enumerates 10 route files and finds all 10 guarded.