### PR TITLE
Give the board back its last 20px, and stop the export buttons wearing a chip nobody else wears

### DIFF
--- a/app/(console)/app/page.tsx
+++ b/app/(console)/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import ConsoleShell from "@/components/shell/ConsoleShell";
 import { viewToShareMeta } from "@/lib/share/shareMeta";
 import { BRAND } from "@/lib/brand";
+import { CAMERA_FEED_COUNT } from "@/lib/sources/registry";
 
 // The board id (?v=…) is the only shared param the social card derives from, so we
 // parse it inline rather than importing the client-oriented deep-link codec
@@ -48,10 +49,34 @@ export async function generateMetadata({
 
 // The map lives in the console's centre stage (StageHost), so the page just mounts
 // the shell; the heavy client-only canvas is dynamically imported there.
+//
+// CAMERA_FEED_COUNT IS READ HERE, ON THE SERVER, AND PASSED DOWN. ConsoleShell is
+// the "use client" boundary, so importing the registry from inside it puts every
+// camera adapter — and everything they import — into the BROWSER bundle, for the
+// sake of one integer on the boot screen. That is not a size worry in the abstract:
+// it is what broke the build. `lib/sources/actpr.ts` needs `node:http2` to talk to
+// Puerto Rico's HTTP/2-only host, `node:http2` has no browser resolution, and
+// production stopped deploying with "Module not found: Can't resolve 'http2'" and
+// an import trace ending at ConsoleShell.tsx. Prod served a stale build for two
+// merges before anyone noticed, because `tsc --noEmit` and the whole vitest suite
+// pass — vitest runs in a node environment, where node:http2 resolves fine. Only
+// `next build` sees it.
+//
+// The same rule is already applied twice elsewhere and written down both times:
+// CLAUDE.md states it for the hero globe ("read from SOURCE_CATALOG in the server
+// component and passed down as a prop — never imported into the client, or all ~39
+// adapters land in the browser bundle"), and components/console/SourceCatalog.tsx
+// derives its own count from CAMERA_REGIONS for exactly this reason.
+//
+// It stays DERIVED. CAMERA_FEED_COUNT is SOURCES.length, and the two pinning tests
+// (readme-counts, claude-md-counts) read the code rather than restating it — so a
+// hand-typed literal here would satisfy every test today and rot the moment a feed
+// is added. `feeds` is a required prop with no default precisely so the number can
+// only come from the constant that is already in scope on this line.
 export default function Home() {
   return (
     <main className="tn-shell-main">
-      <ConsoleShell />
+      <ConsoleShell feeds={CAMERA_FEED_COUNT} />
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4400,7 +4400,20 @@ body:has(.tn-terminal[data-tnx-skin="light"]) { background: #eef1f5; color: #101
   color: var(--tnx-accent); line-height: 1.35;
 }
 
-.tn-terminal .tn-export { display: flex; align-items: stretch; }
+/* The terminal override has to UNDO the chip, not just re-flex it.
+   `.tn-export` outside this scope is a rounded pill — `background:var(--tn-chip-bg);
+   border-radius:9px; padding:2px; gap:2px` — which is right in the old control
+   cluster and wrong here. Overriding only `display` and `align-items` left the
+   background, the radius, the padding and the gap in force, so REPORT and IMAGE
+   rendered as a grey rounded pill inset in a bar of flush square segments, and
+   the 2px padding made them 17px tall against their neighbours' 21px, so their
+   divider rules stopped short of the bar's edges. Every property the chip sets is
+   reset here rather than left to the cascade: a partial override is what caused
+   this in the first place. */
+.tn-terminal .tn-export {
+  display: flex; align-items: stretch;
+  background: none; border-radius: 0; padding: 0; gap: 0;
+}
 .tn-terminal .tn-export-btn {
   border: 0; background: none; padding: 0 10px; cursor: pointer; font: inherit;
   font-size: 9px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
@@ -4409,6 +4422,10 @@ body:has(.tn-terminal[data-tnx-skin="light"]) { background: #eef1f5; color: #101
 }
 .tn-terminal .tn-export-btn:hover:not(:disabled) { color: var(--tnx-ink); }
 .tn-terminal .tn-export-btn:disabled { opacity: 0.45; cursor: progress; }
+/* Export is the last cluster on the row, so its final divider would be a rule
+   drawn against the window edge. `:last-of-type` and not `:last-child` — the live
+   region span is the last child and is a sibling of these buttons. */
+.tn-terminal .tnx-view-controls .tn-export-btn:last-of-type { border-right: 0; }
 /* Empty until something happens, and it must not reserve width while empty or the
    bar reflows every time a message appears and expires. */
 .tn-terminal .tn-export-note:not(:empty) {

--- a/components/console/ConsoleWorkspace.tsx
+++ b/components/console/ConsoleWorkspace.tsx
@@ -14,7 +14,7 @@ import WatchlistPanel from "@/components/shell/WatchlistPanel";
 import { getWidgetType } from "@/lib/console/registry";
 import { stageRegionLabel } from "@/components/shell/a11y";
 import { SKIP_TARGET_ID } from "@/components/shell/SkipLink";
-import { readingOrder, COLS, ROW_PX, GAP_PX } from "@/lib/terminal/layoutGrid";
+import { readingOrder, rowsUsed, COLS, ROW_PX, GAP_PX } from "@/lib/terminal/layoutGrid";
 import { useStageSolo } from "@/lib/terminal/solo";
 import { useGridDrag, gridArea, type ResizeDir } from "@/lib/terminal/useGridDrag";
 import { useTerminalSkin } from "@/lib/terminal/skin";
@@ -117,8 +117,49 @@ export default function ConsoleWorkspace() {
     return [...held, ...ordered.filter((w) => !heldIds.has(w.id))];
   }, [ordered, drag.activeId]);
 
+  /**
+   * How many rows the board actually occupies — its lowest bottom edge.
+   *
+   * Solo counts the stage alone: the widgets are `hidden`, which is `display:none`,
+   * so they hold no tracks and a board sized to include them would leave the exact
+   * dead strip this is here to remove.
+   */
+  const boardRows = useMemo(() => {
+    const rects: GridRect[] = [stageRect];
+    if (!solo) for (const w of ordered) if (w.rect) rects.push(w.rect);
+    return Math.max(1, rowsUsed(rects));
+  }, [solo, stageRect, ordered]);
+
   const gridStyle = {
     gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))`,
+    // THE LAST ROW ABSORBS THE REMAINDER, and that is the whole reason this is a
+    // template rather than `gridAutoRows` alone.
+    //
+    // Rows are a fixed 24px on a 1px gap — a 25px pitch — and `alignContent:start`
+    // pins them to the top. A band whose height is not an exact multiple of 25 is
+    // therefore left with 0-24px of unused track at the bottom, and `.tn-seg`'s
+    // background is `var(--tnx-line)`: the hairline colour, chosen so the 1px
+    // gutters between panels ARE the rules. Leftover track paints in that colour,
+    // full width, so it reads as a grey bar sitting under the board rather than as
+    // slack. Measured in the running app at 1600x900: band 844px, 33 rows x 25px =
+    // 824px, 20px of bar. Sampo circled it and asked what it was for. Nothing.
+    //
+    // So the last row is `minmax(ROW_PX, 1fr)` and eats the remainder: the map and
+    // the bottom-most cards get those pixels instead. It is not a repaint — there
+    // is no leftover track left to colour.
+    //
+    // WHY THE FLOOR MATTERS. When the board is TALLER than the band there is no
+    // free space, `1fr` collapses to its minimum, the tracks overflow and the
+    // grid's own `overflow:auto` scrolls — which is the behaviour the removed
+    // `min-height` note below exists to protect. Without the `minmax` floor the
+    // final row would flatten to nothing on exactly those tall boards.
+    //
+    // `gridAutoRows` STAYS, and is not redundant: a drag can put a card past the
+    // template's last row mid-gesture, and those implicit rows still need a height.
+    gridTemplateRows:
+      boardRows > 1
+        ? `repeat(${boardRows - 1}, ${ROW_PX}px) minmax(${ROW_PX}px, 1fr)`
+        : `minmax(${ROW_PX}px, 1fr)`,
     gridAutoRows: `${ROW_PX}px`,
     gap: `${GAP_PX}px`,
     alignContent: "start",

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -24,7 +24,6 @@ import TerminalHeader from "@/components/terminal/TerminalHeader";
 import BootSequence from "@/components/terminal/BootSequence";
 import { BOOT_MS, bootOverrideFromSearch, loadBootSeen, shouldPlayBoot } from "@/lib/terminal/boot";
 import { SIGNALS } from "@/lib/signals/registry";
-import { CAMERA_FEED_COUNT } from "@/lib/sources/registry";
 import FeedHealthStrip from "@/components/terminal/FeedHealthStrip";
 import { focusStageSearch } from "@/components/terminal/StageBar";
 import SelectionAnnouncer from "@/components/terminal/SelectionAnnouncer";
@@ -56,7 +55,27 @@ import { applyPreset, DEFAULT_PRESET_ID } from "@/lib/console/presets";
 import { decodeLayout } from "@/lib/console/share";
 import "@/lib/console/widgets";
 
-export default function ConsoleShell() {
+/**
+ * `feeds` — how many camera feeds the registry holds, for the boot screen's one
+ * line of copy.
+ *
+ * IT IS A PROP RATHER THAN AN IMPORT, AND THAT IS LOAD-BEARING. This file is the
+ * "use client" boundary, so `import { CAMERA_FEED_COUNT } from "@/lib/sources/
+ * registry"` — which is what used to be here — pulls every camera adapter into the
+ * BROWSER bundle. On 2026-08-21 that stopped being a size problem and became a
+ * broken build: `lib/sources/actpr.ts` imports `node:http2`, which has no browser
+ * resolution, so `next build` failed with "Module not found: Can't resolve 'http2'"
+ * and an import trace ending here. Production quietly served a two-merges-old build
+ * until someone read the deployment list — `tsc --noEmit` was clean and all 2,445
+ * unit tests passed, because vitest runs in a node environment where node:http2
+ * resolves fine. No test in a node-environment suite can see this class of failure.
+ *
+ * Required, with no default: the only caller is the server component that renders
+ * this shell (app/(console)/app/page.tsx), where the derived constant is already in
+ * scope. A default would invite a hand-typed number that every pinning test would
+ * happily accept and that would rot the next time a feed is added.
+ */
+export default function ConsoleShell({ feeds }: { feeds: number }) {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const skin = useTerminalSkin();
@@ -253,7 +272,7 @@ export default function ConsoleShell() {
           time-to-interactive. Gate the shell on it and a decoration becomes a
           load-time regression. Counts are read from the registries rather than
           typed, so the line cannot drift from the product. */}
-      <BootSequence layers={SIGNALS.length} feeds={CAMERA_FEED_COUNT} />
+      <BootSequence layers={SIGNALS.length} feeds={feeds} />
 
       <SkipLink />
       {/* Replaces StatusBar outright rather than sitting beside it: it carries the

--- a/tests/unit/client-bundle-node-builtins.test.ts
+++ b/tests/unit/client-bundle-node-builtins.test.ts
@@ -1,0 +1,195 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * NO CLIENT COMPONENT MAY REACH A `node:` BUILTIN.
+ *
+ * WHY THIS EXISTS. On 2026-08-21 production silently stopped deploying. Three merges
+ * went in, three Vercel builds ERRORed, and the live site quietly carried on serving a
+ * build from two merges earlier — `/api/coverage` still answering with 14 feeds while
+ * `main` held 17. The break:
+ *
+ *     components/shell/ConsoleShell.tsx   "use client"
+ *       → lib/sources/registry.ts
+ *         → lib/sources/actpr.ts          (added by #136)
+ *           → lib/http/h2.ts              import http2 from "node:http2"
+ *
+ * `ConsoleShell` imported ONE INTEGER (`CAMERA_FEED_COUNT`) from the adapter registry,
+ * which drags every camera adapter into the browser bundle. That was survivable while
+ * adapters were fetch-only. The moment one of them imported a Node builtin it became a
+ * fatal webpack resolution error — `next.config.ts` strips the `node:` scheme for the
+ * client, so `node:http2` becomes `http2`, which is not in `resolve.fallback`.
+ *
+ * WHY THE REST OF THE SUITE CANNOT SEE IT. Vitest runs in a NODE environment, so
+ * `node:http2` resolves perfectly here. `tsc --noEmit` passes too — the types are fine.
+ * Only `next build` fails, and its only outward symptom is that production stops
+ * updating. 2,445 tests were green through the entire outage. This test is the suite
+ * learning to see what it structurally could not.
+ *
+ * WHY IT IS SHAPED THIS WAY. The rule that holds is "no client component may reach a
+ * `node:` builtin", not "nobody may import registry.ts" — the registry is only today's
+ * path to one. A string match on `lib/sources/registry` would pass the moment somebody
+ * wrote it as a relative path, a re-export or a barrel. So this walks the real import
+ * graph and reports the chain, the way webpack does.
+ *
+ * WHAT IT DOES NOT CATCH, stated rather than implied:
+ *   - Imports it cannot see statically: `await import(someVariable)`, `require(expr)`.
+ *   - Node builtins imported WITHOUT the `node:` prefix (`import fs from "fs"`). Those
+ *     are already stubbed to `false` in `next.config.ts`'s `resolve.fallback`, so they
+ *     fail loudly in a different way; the `node:` form is the one that slips past.
+ *   - Anything reached through a third-party package. Only first-party files (`@/…`
+ *     and relative paths) are followed; `node_modules` is not walked.
+ * A guard that quietly checks less than it claims is worse than a narrow one that says
+ * so, so the limits are listed here rather than discovered later.
+ */
+
+const ROOT = resolve(__dirname, "..", "..");
+const SEARCH_DIRS = ["components", "app", "lib"];
+const EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+
+/** Every source file under the directories a bundle can be rooted in. */
+function sourceFiles(dir: string): string[] {
+  const abs = join(ROOT, dir);
+  if (!existsSync(abs)) return [];
+  const out: string[] = [];
+  const walk = (d: string) => {
+    for (const entry of readdirSync(d)) {
+      if (entry === "node_modules" || entry === ".next") continue;
+      const p = join(d, entry);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (EXTENSIONS.some((e) => p.endsWith(e))) out.push(p);
+    }
+  };
+  walk(abs);
+  return out;
+}
+
+/**
+ * Resolve a first-party specifier to a file on disk. Returns undefined for bare
+ * package names — `node_modules` is deliberately not walked.
+ */
+function resolveSpecifier(spec: string, fromFile: string): string | undefined {
+  let base: string;
+  if (spec.startsWith("@/")) base = join(ROOT, spec.slice(2));
+  else if (spec.startsWith(".")) base = resolve(dirname(fromFile), spec);
+  else return undefined;
+
+  for (const ext of EXTENSIONS) {
+    if (existsSync(base + ext)) return base + ext;
+  }
+  if (existsSync(base) && statSync(base).isDirectory()) {
+    for (const ext of EXTENSIONS) {
+      const idx = join(base, "index" + ext);
+      if (existsSync(idx)) return idx;
+    }
+  }
+  return existsSync(base) && statSync(base).isFile() ? base : undefined;
+}
+
+/** Static `import`/`export from`/dynamic-import specifiers, with comments stripped. */
+function specifiersOf(source: string): string[] {
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  const out: string[] = [];
+  const patterns = [
+    /(?:^|\s)import\s[^;]*?from\s*["']([^"']+)["']/g,
+    /(?:^|\s)import\s*["']([^"']+)["']/g,
+    /(?:^|\s)export\s[^;]*?from\s*["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+  for (const re of patterns) {
+    for (const m of code.matchAll(re)) out.push(m[1]);
+  }
+  return out;
+}
+
+/** The `node:` builtins a file imports directly. */
+function nodeBuiltinsOf(source: string): string[] {
+  return specifiersOf(source).filter((s) => s.startsWith("node:"));
+}
+
+function isClientComponent(file: string): boolean {
+  const head = readFileSync(file, "utf8").slice(0, 400);
+  return /^\s*(?:\/\/[^\n]*\n|\/\*[\s\S]*?\*\/\s*)*["']use client["']/.test(head);
+}
+
+/**
+ * The chain from `file` to the first `node:` builtin it can reach, or null if clean.
+ *
+ * MEMOISED, and that is not a micro-optimisation. Forty-odd client entry points share
+ * most of their import graph, so the naive walk re-reads the same files once per entry
+ * and the test costs ~14s on a 27s suite. A guard that slow is a guard somebody
+ * eventually skips. The answer for a file does not depend on who imported it, so it
+ * caches cleanly.
+ */
+const reachCache = new Map<string, { builtins: string[]; chain: string[] } | null>();
+
+function firstBuiltinChain(
+  file: string,
+  visiting: Set<string>,
+): { builtins: string[]; chain: string[] } | null {
+  const cached = reachCache.get(file);
+  if (cached !== undefined) return cached;
+  // A cycle: this branch contributes nothing. Not cached — the answer here is "unknown
+  // on this path", not "clean", and caching it would poison the entry that asked.
+  if (visiting.has(file)) return null;
+
+  visiting.add(file);
+  const source = readFileSync(file, "utf8");
+
+  let result: { builtins: string[]; chain: string[] } | null = null;
+  const builtins = nodeBuiltinsOf(source);
+  if (builtins.length) {
+    result = { builtins, chain: [file] };
+  } else {
+    for (const spec of specifiersOf(source)) {
+      const next = resolveSpecifier(spec, file);
+      if (!next) continue;
+      const found = firstBuiltinChain(next, visiting);
+      if (found) {
+        result = { builtins: found.builtins, chain: [file, ...found.chain] };
+        break;
+      }
+    }
+  }
+
+  visiting.delete(file);
+  reachCache.set(file, result);
+  return result;
+}
+
+/** An import trace in webpack's shape, or undefined when the graph is clean. */
+function findNodeBuiltinReach(entry: string): string | undefined {
+  const found = firstBuiltinChain(entry, new Set());
+  if (!found) return undefined;
+  const trace = found.chain.map((f) => "  " + relative(ROOT, f).replace(/\\/g, "/")).join("\n");
+  return `imports ${found.builtins.join(", ")}\nImport trace:\n${trace}`;
+}
+
+describe("client bundle", () => {
+  const clientEntries = SEARCH_DIRS.flatMap(sourceFiles).filter(isClientComponent);
+
+  it("finds the client components to check", () => {
+    // If this drops to zero the walk below is vacuously green, which would be worse
+    // than no test at all.
+    expect(clientEntries.length).toBeGreaterThan(10);
+  });
+
+  it("no client component reaches a node: builtin", () => {
+    const offenders: string[] = [];
+    for (const entry of clientEntries) {
+      const reach = findNodeBuiltinReach(entry);
+      if (reach) offenders.push(`${relative(ROOT, entry).replace(/\\/g, "/")} ${reach}`);
+    }
+
+    expect(
+      offenders.join("\n\n"),
+      "A client component reaches a Node builtin. It will be bundled for the browser, " +
+        "and `next build` fails with \"Module not found\" — while tsc and the rest of " +
+        "this suite stay green and production silently stops deploying. Read the value " +
+        "the client actually needs in a SERVER component and pass it down as a prop; " +
+        "components/shell/SourceCatalog.tsx is the in-repo precedent.",
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
Two things Sampo circled on the console, plus the causal fix for this afternoon's
outage and the guard that would have caught it at PR time.

## The two visual fixes (35f748b)

**REPORT / IMAGE looked foreign in the FEED HEALTH row.** Outside the terminal skin
`.tn-export` is deliberately a rounded chip: `background`, `border-radius: 9px`,
`padding: 2px`, `gap: 2px`. When those buttons moved into that row in #135 the terminal
override only restated `display` and `align-items`, so everything else stayed in force.
They rendered as a grey pill inset in a bar of flush square segments, and the 2px padding
made them 17.4px tall against their neighbours' 21.4px, which is why their divider rules
stopped short of the bar's edges. Every property the chip sets is now reset explicitly
rather than left to the cascade; a partial override is what caused this. Measured after:
21.4px against the basemap buttons' 21.4px. The last button's trailing rule is dropped
too, since it was being drawn against the window edge.

**The grey strip along the bottom of the window is leftover grid track.** Nothing draws
it. `.tn-seg` lays the board out on fixed 24px rows over a 1px gap, a 25px pitch, with
`alignContent: start` pinning the tracks to the top, and its background is
`var(--tnx-line)`: the hairline colour, chosen so the 1px gutters between panels *are*
the rules and no panel needs a border. Any band height that is not an exact multiple of
25 therefore ends with up to 24px of unused track painted in that colour, full width.
Measured at 1600x900: band 844px, 33 rows x 25px = 824px, 20px of bar.

The last row is now `minmax(ROW_PX, 1fr)` and eats the remainder, so the map and the
bottom cards get those pixels. Not a repaint: there is no leftover track left to colour.

| | before | after |
|---|---|---|
| unused track at the bottom | 20px | 0px |
| stage bottom vs window bottom | 880 / 900 | 900 / 900 |

Verified at four window heights, in both skins, and in solo: leftover 0px every time.

The `minmax` floor is load-bearing. On a board taller than the band there is no free
space, `1fr` collapses to 24px, the tracks overflow and the grid's own `overflow: auto`
scrolls, which is the behaviour the deleted `min-height` note in that file exists to
protect. Checked rather than assumed: at 1280x560 the grid reports scrollHeight 824
against clientHeight 504, and `scrollTop` takes effect and clamps at 320.

**One honest limit.** Boards are fitted to the window at preset-apply time and never
re-fitted on resize, because re-fitting would move cards the user placed by hand. So a
window dragged much taller than the board was fitted for gives its last row all of the
slack: at 1600x1300 that is a 444px last row. Not free of consequence, but the
alternative on that same window was 420px of dead grey, and it corrects itself the moment
the board is re-arranged. Freshly seeded at 2400x1290 the last row grows by 10px.

## The causal fix for the outage (2b625ea)

`/app` would not build locally at all, which is what sent me looking. Production had been
serving a build from two merges back since 15:12: #136 and #137 both merged, both deploys
ERROR, and the site kept serving #135 so it looked healthy.

```
./lib/http/h2.ts
Module not found: Can't resolve 'http2'
Import trace for requested module:
  ./lib/sources/actpr.ts
  ./lib/sources/registry.ts
  ./components/shell/ConsoleShell.tsx
```

`ConsoleShell` is the `"use client"` boundary and it imported `CAMERA_FEED_COUNT` from
the adapter registry, one integer for one line of copy on the boot screen, which puts
every camera adapter and everything they import into the browser bundle. Survivable while
every adapter was fetch-only. #136 added `lib/http/h2.ts` for Puerto Rico's HTTP/2-only
host, `node:http2` has no browser resolution, and the client bundle stopped resolving.

The count is now read in the server component that renders the shell and passed down, and
`feeds` is a required prop with no default. It stays derived from `SOURCES.length`, so
`readme-counts` and `claude-md-counts` still bite; a hand-typed literal would satisfy
every test today and rot the next time a feed is added.

The rule is not new and it is written down twice already: CLAUDE.md states it for the hero
globe ("never imported into the client, or all ~39 adapters land in the browser bundle"),
and `SourceCatalog.tsx` derives its own count from `CAMERA_REGIONS` with a comment naming
this exact hazard.

**This is what makes #138's `http2: false` stub redundant rather than load-bearing.** That
stub shipped first and unblocked production, and its comment correctly says it is a guard
and not the fix. With the registry out of the client graph the stub is now doing nothing,
which is the state a guard should be in. Verified causally rather than by a green build:
before rebasing onto #138 I reverted the stub locally, so `next.config.ts` was
byte-identical to b75864d with no `http2` entry, and `/app` rendered and ran live data.

## The guard (3a27813)

Walks the real import graph out of every `"use client"` file and fails if any can reach a
`node:` builtin, printing the chain webpack-style. Not a string match on `registry.ts`.

Nothing in this repo's suite could see the original failure: `tsc --noEmit` was clean and
all 2,441 tests passed, because vitest runs in a node environment where `node:http2`
resolves fine. Only `next build` can see a client-bundle resolution failure, and its only
outward symptom is that production quietly stops deploying.

Watched go red against the real defect, not a synthetic one: re-injecting the import into
`ConsoleShell` reproduces Vercel's trace file for file, and removing it turns the test
green. `ConsoleShell.tsx` restored byte-for-byte afterwards.

## Gate

`npx tsc --noEmit` clean. 2,449 tests across 274 files pass on this branch, rebased onto
75dd8c0.

`README.md`, `CLAUDE.md` and the two count-pinning tests are untouched. No stated figure
moves.
