### PR TITLE
Pick cameras off the map, name the wall they land in, and let a downward drag actually land

### DIFF
--- a/app/console-chrome.css
+++ b/app/console-chrome.css
@@ -1,0 +1,108 @@
+/* ===========================================================================
+   Console board chrome — the affordances that let a board be rebuilt.
+
+   Owned by the grid/card-chrome lane and kept OUT of globals.css deliberately:
+   three agents were appending to that file's tail at once and every one of them
+   was diffing the others. Everything here is scoped under .tn-terminal so it
+   inherits the skin's --tnx-* tokens and follows the light/dark toggle without
+   restating a single colour.
+   =========================================================================== */
+
+/* ── The ghost "add" tile ────────────────────────────────────────────────────
+   Drawn in the cell the next wall will really occupy, so it reads as a place
+   rather than a button that lives nowhere. Dashed, never filled: a solid card
+   here would be counted as content by anyone scanning the wall. */
+.tn-terminal .tn-cw-add {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 0;
+  border: 1px dashed var(--tnx-ink-ghost, rgba(127, 140, 158, 0.4));
+  border-radius: 4px;
+  background: transparent;
+  color: var(--tnx-ink-faint);
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.tn-terminal .tn-cw-add:hover,
+.tn-terminal .tn-cw-add:focus-visible {
+  border-color: var(--tnx-accent);
+  color: var(--tnx-accent);
+  background: var(--tnx-accent-soft, transparent);
+}
+
+.tn-terminal .tn-cw-add-plus {
+  font-size: 22px;
+  line-height: 1;
+  font-family: var(--tnx-font-mono, ui-monospace, monospace);
+}
+
+.tn-terminal .tn-cw-add-l {
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-align: center;
+  padding: 0 8px;
+}
+
+/* ── The empty-board rescue panel ────────────────────────────────────────────
+   Shown only when the board holds no widgets at all. This is a dead end
+   otherwise: removing the last wall leaves an empty grid, and the stage bar's
+   control answers it only while the map stage is on screen. */
+.tn-terminal .tn-cw-rescue {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-width: 0;
+  min-height: 0;
+  padding: 16px;
+  border: 1px dashed var(--tnx-ink-ghost, rgba(127, 140, 158, 0.4));
+  border-radius: 4px;
+  background: var(--tnx-panel);
+  text-align: center;
+}
+
+.tn-terminal .tn-cw-rescue-t {
+  margin: 0;
+  color: var(--tnx-ink);
+  font-size: 13px;
+  font-family: var(--tnx-font-title, inherit);
+}
+
+.tn-terminal .tn-cw-rescue-b {
+  margin: 0;
+  max-width: 32ch;
+  color: var(--tnx-ink-dim);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.tn-terminal .tn-cw-rescue-btn {
+  margin-top: 2px;
+  padding: 7px 14px;
+  border: 1px solid var(--tnx-accent);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--tnx-accent);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.tn-terminal .tn-cw-rescue-btn:hover,
+.tn-terminal .tn-cw-rescue-btn:focus-visible {
+  background: var(--tnx-accent);
+  color: var(--tnx-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tn-terminal .tn-cw-add,
+  .tn-terminal .tn-cw-rescue-btn { transition: none; }
+}

--- a/app/console-chrome.css
+++ b/app/console-chrome.css
@@ -106,3 +106,29 @@
   .tn-terminal .tn-cw-add,
   .tn-terminal .tn-cw-rescue-btn { transition: none; }
 }
+
+/* ── Remove, on the card itself ──────────────────────────────────────────────
+   The ⋯ menu still carries Remove, but there it is the last of nineteen entries
+   in a scrolling panel and on a short card it falls below an internal scroll.
+   Kept visually quieter than its neighbours until hovered: it is the only
+   destructive control in the header and should not compete for the eye with
+   expand or notifications. */
+.tn-terminal .tn-cw-close {
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--tnx-ink-ghost, var(--tn-text-faint));
+  font-size: 13px;
+  line-height: 1;
+  padding: 0 1px;
+  transition: color 120ms ease;
+}
+
+.tn-terminal .tn-cw-close:hover,
+.tn-terminal .tn-cw-close:focus-visible {
+  color: var(--tnx-alert-critical, #d4523e);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tn-terminal .tn-cw-close { transition: none; }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,5 @@
+@import "./console-chrome.css";
+
 /* ====================================================================   TrafficNerd v2 — calm light console shell.
    Light is the default identity; dark survives as an optional [data-theme]
    toggle. Real typography for text; monospace (.tn-num) reserved for numerics.

--- a/app/globals.css
+++ b/app/globals.css
@@ -4939,11 +4939,11 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
   70%  { box-shadow: inset 0 0 0 2px var(--tn-accent); }
   100% { box-shadow: inset 0 0 0 2px transparent; }
 }
-[data-grid-id].is-just-added { animation: tn-just-added 1.4s ease-out 1; }
+[data-grid-id][data-just-added] { animation: tn-just-added 1.4s ease-out 1; }
 @media (prefers-reduced-motion: reduce) {
   /* No pulse, but the ring still has to appear or the reveal says nothing at
      all to someone who asked for less motion. It simply does not fade. */
-  [data-grid-id].is-just-added { animation: none; box-shadow: inset 0 0 0 2px var(--tn-accent); }
+  [data-grid-id][data-just-added] { animation: none; box-shadow: inset 0 0 0 2px var(--tn-accent); }
 }
 
 /* ── The camera tray ─────────────────────────────────────────────────────────

--- a/app/globals.css
+++ b/app/globals.css
@@ -4828,10 +4828,10 @@ body:has(.tn-terminal[data-tnx-skin="light"]) { background: #eef1f5; color: #101
    would stack them. The ring is on ::after with pointer-events:none because
    .world-map is the click surface — a real border would move the canvas by 2px and
    re-project every pin. */
-.world-map.tn-armed::after{content:"";position:absolute;inset:0;z-index:20;pointer-events:none;
+.world-map.tn-picking::after{content:"";position:absolute;inset:0;z-index:20;pointer-events:none;
 border-radius:10px;box-shadow:inset 0 0 0 2px var(--tn-accent)}
-.world-map.tn-armed .maplibregl-canvas-container,
-.world-map.tn-armed .maplibregl-canvas{cursor:crosshair}
+.world-map.tn-picking .maplibregl-canvas-container,
+.world-map.tn-picking .maplibregl-canvas{cursor:crosshair}
 .tn-arm-hint{position:absolute;left:50%;transform:translateX(-50%);top:12px;z-index:30;
 display:flex;align-items:center;gap:8px;max-width:min(560px,calc(100% - 32px));
 padding:6px 14px;border-radius:999px;border:1px solid var(--tn-accent);
@@ -4854,7 +4854,6 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
   .tn-cs { height: auto; }
   .tn-cs-stage { aspect-ratio: 16 / 9; min-height: 0; flex: none; }
 }
-.tn-cs-arm.is-on { border-color: var(--tn-accent); background: var(--tn-accent-soft); color: var(--tn-accent-strong); font-weight: 700; }
 
 /* ── Feedback prompt ────────────────────────────────────────────────────────
    A centred card over a dimmed console, shown once to a sampled third of the
@@ -4945,4 +4944,157 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
   /* No pulse, but the ring still has to appear or the reveal says nothing at
      all to someone who asked for less motion. It simply does not fade. */
   [data-grid-id].is-just-added { animation: none; box-shadow: inset 0 0 0 2px var(--tn-accent); }
+}
+
+/* ── The camera tray ─────────────────────────────────────────────────────────
+   The basket, drawn over the foot of the MAP STAGE — not the viewport. It is the
+   receipt for a gesture that happens on the map, so it is positioned against the
+   map's box: a child of the (position:relative) stage container, pinned
+   left/right/bottom. A fixed bar across the window would float over whichever
+   widget happened to be at the foot of the board and would read as belonging to
+   the whole console, which it does not.
+
+   Everything below is written in --tn-* tokens rather than --tnx-*, so the
+   terminal skin picks it up through its own remap (see the .tn-terminal block
+   near line 3160) and there is no second copy of these rules to keep in step.
+
+   z-index 25 sits above the map canvas and its overlays and below .tn-arm-hint's
+   30, so a hint and the tray can never fight for the same pixels. */
+.tn-tray {
+  position: absolute; left: 0; right: 0; bottom: 0; z-index: 25;
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 7px 9px;
+  background: var(--tn-surface); color: var(--tn-text);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--tn-border-strong);
+  border-radius: 0 0 10px 10px;
+  box-shadow: 0 -6px 20px rgba(15, 23, 42, .10);
+}
+.tn-tray-row { display: flex; align-items: center; gap: 10px; min-width: 0; }
+
+/* Mono + caps, matching the console's other status labels. `flex: none` because
+   this is the line a screen reader is read on a change and it must never be the
+   thing that gets squeezed. */
+.tn-tray-count {
+  flex: none;
+  font-family: var(--tn-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--tn-text-muted); white-space: nowrap;
+}
+
+/* THE STRIP SCROLLS INSIDE ITSELF. `min-width: 0` is the load-bearing half of
+   that: without it a flex child sizes to its content, sixty chips push the row
+   wider than the stage, and the horizontal scrollbar appears on the PAGE instead
+   of on the strip. */
+.tn-tray-strip {
+  flex: 1 1 auto; min-width: 0;
+  display: flex; align-items: center; gap: 4px;
+  margin: 0; padding: 2px 0; list-style: none;
+  overflow-x: auto; overflow-y: hidden;
+  scrollbar-width: thin;
+  overscroll-behavior-x: contain;
+}
+.tn-tray-chip {
+  flex: none; display: inline-flex; align-items: center; gap: 5px;
+  max-width: 200px; padding: 3px 4px 3px 8px;
+  border: 1px solid var(--tn-border); border-radius: 3px;
+  background: var(--tn-chip-bg); color: var(--tn-text);
+}
+.tn-tray-chip-label {
+  font-size: 11.5px; line-height: 1.3; max-width: 130px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* Which network it came from. A road camera and a Windy webcam behave differently
+   once they are on a wall, and this is the last point at which the user can tell
+   them apart before committing. */
+.tn-tray-chip-src {
+  flex: none;
+  font-family: var(--tn-mono); font-size: 9px; letter-spacing: 0.04em;
+  text-transform: uppercase; color: var(--tn-text-faint); white-space: nowrap;
+}
+.tn-tray-chip-x {
+  flex: none; width: 17px; height: 17px; padding: 0;
+  display: grid; place-items: center;
+  border: 0; border-radius: 3px; background: none;
+  color: var(--tn-text-faint); font: inherit; font-size: 13px; line-height: 1;
+  cursor: pointer;
+  transition: color 120ms, background 120ms;
+}
+.tn-tray-chip-x:hover { color: var(--tn-down-ink); background: var(--tn-surface-2); }
+.tn-tray-chip-x:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: 1px; }
+
+.tn-tray-actions { flex: none; display: flex; align-items: center; gap: 6px; }
+.tn-tray-menu-wrap { position: relative; }
+.tn-tray-btn {
+  font: inherit; font-size: 11.5px; font-weight: 600; white-space: nowrap;
+  padding: 5px 10px; cursor: pointer;
+  border: 1px solid var(--tn-border-strong); border-radius: 4px;
+  background: var(--tn-surface-solid); color: var(--tn-text);
+}
+.tn-tray-btn:hover:not(:disabled) { border-color: var(--tn-accent); color: var(--tn-accent-strong); }
+.tn-tray-btn:disabled { opacity: .5; cursor: default; }
+.tn-tray-btn:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: 2px; }
+.tn-tray-btn.is-primary { border-color: var(--tn-accent); background: var(--tn-accent-soft); color: var(--tn-accent-strong); }
+
+/* Opens UPWARDS. The trigger is a few pixels off the bottom of the stage, so a
+   menu below it would be drawn outside the map entirely — or clipped by it. */
+.tn-tray-menu {
+  position: absolute; bottom: calc(100% + 6px); right: 0; z-index: 2;
+  min-width: 216px; max-width: min(320px, 70vw);
+  max-height: 46vh; overflow-y: auto;
+  display: flex; flex-direction: column; padding: 4px;
+  background: var(--tn-surface-solid); color: var(--tn-text);
+  border: 1px solid var(--tn-border-strong); border-radius: 6px;
+  box-shadow: var(--tn-shadow);
+}
+.tn-tray-menu-item {
+  display: flex; align-items: baseline; gap: 8px; width: 100%;
+  padding: 6px 8px; text-align: left; cursor: pointer;
+  font: inherit; font-size: 12px;
+  border: 0; border-radius: 4px; background: none; color: var(--tn-text);
+}
+.tn-tray-menu-item:hover { background: var(--tn-accent-soft); color: var(--tn-accent-strong); }
+.tn-tray-menu-item:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: -2px; }
+.tn-tray-menu-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-tray-menu-count {
+  flex: none;
+  font-family: var(--tn-mono); font-variant-numeric: tabular-nums;
+  font-size: 10px; color: var(--tn-text-faint);
+}
+.tn-tray-menu-sep { height: 1px; margin: 4px 2px; background: var(--tn-border); }
+
+/* The honest line. Amber ink rather than red: the area holding more cameras than a
+   wall can take is a fact about the area, not a failure — the same colour
+   .tn-cs-note uses for a slot reporting what it could not show. */
+.tn-tray-note {
+  margin: 0; padding: 0 1px;
+  font-size: 10.5px; line-height: 1.35; color: var(--tn-lagging-ink);
+}
+
+/* Below 900px the stage is short and a chip strip plus two buttons will not sit on
+   one line. The count and the actions stay together on the first row; the strip
+   takes the whole of the second and still scrolls inside itself. */
+@media (max-width: 900px) {
+  .tn-tray-row { flex-wrap: wrap; }
+  .tn-tray-strip { order: 3; flex-basis: 100%; }
+  .tn-tray-actions { margin-left: auto; }
+  .tn-tray-btn { min-height: 32px; }
+  .tn-tray-chip-x { width: 24px; height: 24px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tn-tray-chip-x { transition: none; }
+}
+
+/* THE CLOCK STRIP IS ALREADY AT bottom:0 OF THIS SAME BOX. `.tnx-stage-foot` is a
+   24px absolutely-positioned ribbon pinned to the foot of the stage, so a tray at
+   bottom:0 lands on top of it and hides the world clock for as long as anything is
+   picked. Stack on it instead of over it. The bottom radius goes with the offset —
+   it was there to meet the stage's rounded corner, and the tray no longer touches
+   one. */
+.tn-terminal .tn-tray { bottom: 24px; border-radius: 0; }
+@media (max-width: 900px) {
+  /* The clock strip is display:none below this width (globals.css:4607), so the
+     24px it was standing on has gone with it. */
+  .tn-terminal .tn-tray { bottom: 0; }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5098,3 +5098,33 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
      24px it was standing on has gone with it. */
   .tn-terminal .tn-tray { bottom: 0; }
 }
+
+/* ── Stage chrome on a narrow stage ──────────────────────────────────────────
+   The search box is centred and 420px wide; the right-hand stack is 200px and
+   pinned to the right edge. Together they need 628px. The STREETS board gives
+   the map four of twelve columns, so the stage is 471px — and the two were
+   painted on top of each other: measured on the live board, 182px of horizontal
+   overlap and 25px of vertical, the geocoder input running underneath the layer
+   key.
+
+   There is already an un-centring rule for this, and it does not fire here: it
+   is a VIEWPORT media query, and Streets has a narrow stage inside a wide
+   window. That is the whole bug — the constraint is the stage's width, so the
+   query has to be about the stage. Hence a container query on `.tn-cw-stage`,
+   which is already the positioned ancestor both children resolve against.
+
+   Un-centring rather than narrowing, because narrowing cannot work: a CENTRED
+   box of width W on a 471px stage reaches (471+W)/2, so keeping it clear of a
+   stack that starts at 263 would cap it at 55px. Below the threshold the search
+   spans the space to the LEFT of the stack instead. */
+.tn-terminal .tn-cw-stage { container-type: inline-size; container-name: tnstage; }
+
+@container tnstage (max-width: 640px) {
+  .tn-terminal .tnx-stage-search {
+    left: 8px;
+    /* 200px stack + 8px its right inset + 8px gutter. */
+    right: 216px;
+    width: auto;
+    transform: none;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4927,3 +4927,22 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
 .tn-fb-btn.is-ghost { background: none; border-color: transparent; color: var(--tn-text-faint); font-weight: 400; }
 .tn-fb-btn.is-ghost:hover:not(:disabled) { color: var(--tn-text); background: var(--tn-surface-2); }
 @media (prefers-reduced-motion: reduce) { .tn-fb-card { animation: none; } }
+
+/* ── A widget that has just been added ───────────────────────────────────────
+   Adding a camera wall to a full board places it below the fold (the wall is
+   tiled to cover every column, so findFreeSpot falls through to the row under
+   the board). revealWidget() scrolls to it; this is how it says "here, this
+   one" once it arrives. Deliberately a fading ring rather than a lasting
+   style — a permanent marker on a new card would become part of how a new card
+   looks, and then it stops meaning anything. */
+@keyframes tn-just-added {
+  0%   { box-shadow: inset 0 0 0 2px var(--tn-accent); }
+  70%  { box-shadow: inset 0 0 0 2px var(--tn-accent); }
+  100% { box-shadow: inset 0 0 0 2px transparent; }
+}
+[data-grid-id].is-just-added { animation: tn-just-added 1.4s ease-out 1; }
+@media (prefers-reduced-motion: reduce) {
+  /* No pulse, but the ring still has to appear or the reveal says nothing at
+     all to someone who asked for less motion. It simply does not fade. */
+  [data-grid-id].is-just-added { animation: none; box-shadow: inset 0 0 0 2px var(--tn-accent); }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4942,9 +4942,9 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
   70%  { box-shadow: inset 0 0 0 2px var(--tn-accent); }
   100% { box-shadow: inset 0 0 0 2px transparent; }
 }
-[data-grid-id].is-just-added { animation: tn-just-added 1.4s ease-out 1; }
+[data-grid-id][data-just-added] { animation: tn-just-added 1.4s ease-out 1; }
 @media (prefers-reduced-motion: reduce) {
   /* No pulse, but the ring still has to appear or the reveal says nothing at
      all to someone who asked for less motion. It simply does not fade. */
-  [data-grid-id].is-just-added { animation: none; box-shadow: inset 0 0 0 2px var(--tn-accent); }
+  [data-grid-id][data-just-added] { animation: none; box-shadow: inset 0 0 0 2px var(--tn-accent); }
 }

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -19,6 +19,7 @@ import { overlay } from "@/lib/overlay";
 import { cinematic } from "@/lib/cinematic/store";
 import { computeDive } from "@/lib/cinematic/dive";
 import { loadedCamerasStore } from "@/lib/cameras/loaded";
+import { loadedWebcamsStore } from "@/lib/webcams/loaded";
 import { useSatellites } from "@/lib/satellites/useSatellites";
 import { usePlanes, type PlaneTrail, type PlanesLayer } from "@/lib/planes/usePlanes";
 import { trackStore, useTrack, type TrackState } from "@/lib/planes/track";
@@ -63,20 +64,22 @@ import {
   expandCluster,
 } from "@/lib/map/cluster";
 import { createThumbnailManager } from "@/lib/map/liveThumbnails";
-// Map arming. Every rule lives in camslot.arm; this file supplies geometry and
-// side effects and decides nothing. See the block above appendToArmedSlot for why
-// none of it may be closed over.
+// Map picking. Every rule lives in camslot.pick and camslot.arm; this file supplies
+// geometry and side effects and decides nothing. See the block above addPicks for
+// why none of it may be closed over.
 import {
-  armStore,
-  useArmedSlot,
+  pickStore,
+  usePicks,
+  describePicked,
+  camerasInRing,
+  pickKey,
+  type PickedCamera,
+} from "@/lib/console/widgets/camslot.pick";
+import {
   camerasInBounds,
   normalizeBounds,
   orderByDistanceFrom,
-  cadenceCap,
-  planAppend,
-  describeAppend,
   webcamRef,
-  FALLBACK_REFRESH_SECONDS,
   type LatLon,
 } from "@/lib/console/widgets/camslot.arm";
 import { sanitizeCamslotConfig, type StreamRef } from "@/lib/console/widgets/camslot.model";
@@ -293,10 +296,14 @@ function whenStyleReady(map: maplibregl.Map, fn: () => void): void {
 // what an armed click means would disagree for 24 cameras out of 97, side by side,
 // at the same zoom — a bug no manual click-test would reliably find.
 
-interface ArmCandidate extends LatLon {
+interface PickCandidate extends LatLon {
   ref: StreamRef;
+  /** What the tray calls it. Resolved here because this is the only place that
+   *  holds both the map feature and the loaded camera row. */
+  label: string;
   refreshSeconds?: number;
   available?: boolean;
+  source?: string;
 }
 
 function toast(message: string): void {
@@ -308,83 +315,68 @@ function toast(message: string): void {
  *  /api/webcam-image is bounded by that. */
 const WEBCAM_REFRESH_SECONDS = 600;
 
-
-/** The cadence of a stream already in the slot. Road cameras are the only kind that
- *  varies, and loadedCamerasStore is the only place the client holds it. */
-function refreshForRef(ref: StreamRef): number | undefined {
-  if (ref.k === "webcam") return WEBCAM_REFRESH_SECONDS;
-  if (ref.k === "yt") return undefined; // an embed is not polled; it has no cadence
-  return loadedCamerasStore.get().find((c) => c.id === ref.id)?.refreshSeconds;
+function toPicked(c: PickCandidate): PickedCamera {
+  return {
+    ref: c.ref,
+    key: pickKey(c.ref),
+    label: c.label,
+    lat: c.lat,
+    lon: c.lon,
+    refreshSeconds: c.refreshSeconds,
+    source: c.source,
+  };
 }
 
 /**
- * Append candidates to the armed slot, if one is armed.
+ * Put candidates in the basket, if picking is on.
  *
  * Returns TRUE when the gesture was consumed, so every caller can bail before
- * doing its normal job. Consumption is decided synchronously and does not depend
- * on whether anything was actually added: an armed click on a camera already in
- * the slot still belongs to arming, and still owes the user a visible answer
+ * doing its normal job. Consumption is decided synchronously and does NOT depend
+ * on whether anything was actually added: a pick-mode click on a camera already in
+ * the basket still belongs to picking, and still owes the user a visible answer
  * rather than a silent nothing or a surprise dossier.
  *
- * The write is async because the layout store is imported lazily — the same shape
- * camslot.picker.tsx:165-169 uses, and for the same reason: it keeps the console
- * store out of the map's import graph.
+ * WHAT CHANGED FROM ARMING, and why this function is now short. Arming had to
+ * resolve a destination widget, read its playlist out of the layout store, work out
+ * a cadence cap from the streams already in it, and plan an append — all inside a
+ * lazily-imported promise, on every click. None of that belongs at click time any
+ * more: the destination is not chosen until the user presses Send, so the cap and
+ * the plan are computed once, there, against the slot they actually pick. This
+ * leaves the map doing what the map is for — turning a gesture into a list of
+ * cameras — and it is why the console store is no longer in this path at all.
  */
-function appendToArmedSlot(candidates: ArmCandidate[], centre: LatLon): boolean {
-  const instanceId = armStore.get();
-  if (!instanceId) return false;
+function addPicks(candidates: PickCandidate[], centre: LatLon, opts: { fromArea?: boolean } = {}): boolean {
+  if (pickStore.get().mode !== "picking") return false;
 
-  void import("@/lib/console/store").then(({ shellLayoutStore }) => {
-    const widget = shellLayoutStore.get().widgets.find((w) => w.id === instanceId);
-    if (!widget) {
-      // The armed slot was removed from the board while the mode was on.
-      armStore.disarm();
-      toast("That slot is gone — arming turned off.");
-      return;
-    }
-    // Read the playlist from the STORE, never from a value captured when the mode
-    // was armed: between arming and clicking, the picker or another append may have
-    // changed it, and writing a stale array would silently drop those streams.
-    const cfg = sanitizeCamslotConfig(widget.config);
-
-    const ordered = orderByDistanceFrom(candidates, centre);
-    // The cap is set by the FASTEST-refreshing member of the resulting playlist, so
-    // the streams already in the slot count too — appending a 60s camera to a slot of
-    // 300s ones is exactly the case that moves it, and ignoring the existing members
-    // would let the cap drift up every time the user clicked.
-    const cadences = [
-      ...cfg.streams.map(refreshForRef),
-      ...ordered.map((c) => c.refreshSeconds),
-    ];
-    const cap = cadenceCap(cadences, cfg.intervalMs);
-    const plan = planAppend(cfg.streams, ordered.map((c) => c.ref), cap);
-    const resolved = cadences.map((s) =>
-      typeof s === "number" && s > 0 ? s : FALLBACK_REFRESH_SECONDS,
-    );
-    const capSetBySeconds = Math.min(...resolved, FALLBACK_REFRESH_SECONDS);
-    const capMixed = new Set(resolved).size > 1;
-
-    if (plan.next) shellLayoutStore.configure(instanceId, { streams: plan.next });
-    toast(
-      describeAppend(plan, {
-        available: candidates.filter((c) => c.available !== false).length,
-        cap,
-        capSetBySeconds,
-        capMixed,
-      }),
-    );
-  });
-
+  // Nearest-first, so a cap that bites drops the far edge of what the user framed
+  // rather than an arbitrary slice of whatever order the feed arrived in.
+  const ordered = orderByDistanceFrom(candidates, centre);
+  const res = pickStore.add(ordered.map(toPicked));
+  toast(describePicked(res, { fromArea: opts.fromArea }));
   return true;
 }
 
+/** A road camera's own name, for the tray. Falls back to the id rather than to a
+ *  blank — an unlabelled chip is worse than an ugly one. */
+function camLabel(id: string, fallback?: string): string {
+  const row = loadedCamerasStore.get().find((c) => c.id === id);
+  return row?.name || fallback || id;
+}
+
 /** One road camera, from either the layer click or a live-thumbnail button. */
-function armedPickCamera(id: string, lat: number, lon: number): boolean {
-  if (!armStore.get()) return false;
+function pickOneCamera(id: string, lat: number, lon: number, name?: string): boolean {
+  if (pickStore.get().mode !== "picking") return false;
   // The store row is the only place a per-camera cadence exists on the client.
   const row = loadedCamerasStore.get().find((c) => c.id === id);
-  return appendToArmedSlot(
-    [{ ref: { k: "cam", id }, lat, lon, refreshSeconds: row?.refreshSeconds, available: row?.available }],
+  return addPicks(
+    [{
+      ref: { k: "cam", id },
+      label: row?.name || name || id,
+      lat, lon,
+      refreshSeconds: row?.refreshSeconds,
+      available: row?.available,
+      source: row?.source,
+    }],
     { lat, lon },
   );
 }
@@ -398,7 +390,7 @@ function armedPickCamera(id: string, lat: number, lon: number): boolean {
  * produced no visible consequence is the one outcome this interception exists to
  * prevent, and "the map moved a bit" does not count as one.
  */
-async function appendClusterLeaves(
+async function pickClusterLeaves(
   map: maplibregl.Map,
   sourceId: string,
   clusterId: number,
@@ -421,7 +413,7 @@ async function appendClusterLeaves(
 
   const isWebcam = sourceId === WEBCAM_SRC;
   const rows = loadedCamerasStore.get();
-  const candidates: ArmCandidate[] = [];
+  const candidates: PickCandidate[] = [];
   for (const leaf of leaves) {
     if (leaf.geometry?.type !== "Point") continue;
     const props = leaf.properties as { id?: string; name?: string } | null;
@@ -432,18 +424,22 @@ async function appendClusterLeaves(
       // toWebcamFC puts the title in `name` (features.ts:82).
       candidates.push({
         ref: webcamRef(id, props?.name),
+        label: props?.name || id,
         lat,
         lon,
         refreshSeconds: WEBCAM_REFRESH_SECONDS,
+        source: "Windy",
       });
     } else {
       const row = rows.find((c) => c.id === id);
       candidates.push({
         ref: { k: "cam", id },
+        label: row?.name || props?.name || id,
         lat,
         lon,
         refreshSeconds: row?.refreshSeconds,
         available: row?.available,
+        source: row?.source,
       });
     }
   }
@@ -452,7 +448,7 @@ async function appendClusterLeaves(
     toast("That group is empty now — nothing to add.");
     return;
   }
-  appendToArmedSlot(candidates, { lat: centre[1], lon: centre[0] });
+  addPicks(candidates, { lat: centre[1], lon: centre[0] });
 }
 
 /**
@@ -465,7 +461,7 @@ async function appendClusterLeaves(
  * a drag-triggered fan-out is precisely the "going wide" that risk is about. The note
  * says what was covered instead of quietly covering less.
  */
-function appendBoxSelection(bounds: ReturnType<typeof normalizeBounds>, webcams: WorldObject[]): void {
+function pickBoxSelection(bounds: ReturnType<typeof normalizeBounds>, webcams: WorldObject[]): void {
   const rows = loadedCamerasStore.get();
   const cams = camerasInBounds(rows, bounds);
   const cover = camerasInBounds(webcams, bounds);
@@ -481,23 +477,27 @@ function appendBoxSelection(bounds: ReturnType<typeof normalizeBounds>, webcams:
     return;
   }
 
-  const candidates: ArmCandidate[] = [
+  const candidates: PickCandidate[] = [
     ...cams.map((c) => ({
       ref: { k: "cam", id: c.id } as StreamRef,
+      label: c.name || c.id,
       lat: c.lat,
       lon: c.lon,
       refreshSeconds: c.refreshSeconds,
       available: c.available,
+      source: c.source,
     })),
     ...cover.map((w) => ({
       ref: webcamRef(w.id, w.label),
+      label: w.label || w.id,
       lat: w.lat,
       lon: w.lon,
       refreshSeconds: WEBCAM_REFRESH_SECONDS,
+      source: "Windy",
     })),
   ];
 
-  appendToArmedSlot(candidates, {
+  addPicks(candidates, {
     lat: (bounds.north + bounds.south) / 2,
     lon: (bounds.east + bounds.west) / 2,
   });
@@ -572,8 +572,8 @@ export default function WorldMap() {
   selectionRef.current = selection;
   // Which slot the map is currently filling, or null. Read as a HOOK here because
   // this is the render path — the ring, the cursor and the hint are React's job. The
-  // event handlers deliberately do not use this value; they call armStore.get().
-  const armedSlot = useArmedSlot();
+  // event handlers deliberately do not use this value; they call pickStore.get().
+  const picking = usePicks().mode === "picking";
   const camFilter = useCameraFilter();
   const signalsState = useSignals();
   // Global time-window filter (M-final): trims time-stamped signals by recency.
@@ -1357,10 +1357,10 @@ export default function WorldMap() {
       // INTERCEPTION 1. A road pin does not open a dossier — it flies the map and
       // lands a full-screen hero card, so an armed click that fell through here
       // would be loudly wrong rather than merely inert. Bail before the dive.
-      if (armStore.get()) {
+      if (pickStore.get().mode === "picking") {
         if (e.originalEvent === lastCamEvent) return; // second layer delivery
         lastCamEvent = e.originalEvent;
-        armedPickCamera(p.id, lat, lon);
+        pickOneCamera(p.id, lat, lon, p.name);
         return;
       }
       cinematic.dive({
@@ -1415,16 +1415,18 @@ export default function WorldMap() {
       // written separately rather than folded in with camClick. The id is the same
       // "windy:NNN" key /api/webcam-image re-resolves server-side (WebcamsFeed:2016),
       // so the ref is valid without any translation.
-      if (armStore.get()) {
+      if (pickStore.get().mode === "picking") {
         if (e.originalEvent === lastWebcamEvent) return; // second layer delivery
         lastWebcamEvent = e.originalEvent;
-        appendToArmedSlot(
+        addPicks(
           [
             {
               ref: webcamRef(cam.id, cam.label),
+              label: cam.label || cam.id,
               lat: cam.lat,
               lon: cam.lon,
               refreshSeconds: WEBCAM_REFRESH_SECONDS,
+              source: "Windy",
             },
           ],
           { lat: cam.lat, lon: cam.lon },
@@ -1557,8 +1559,8 @@ export default function WorldMap() {
       if (clusterId == null || f?.geometry.type !== "Point") return;
       const centre = f.geometry.coordinates as [number, number];
 
-      if (armStore.get()) {
-        void appendClusterLeaves(map, sourceId, clusterId, centre, props?.point_count ?? 0);
+      if (pickStore.get().mode === "picking") {
+        void pickClusterLeaves(map, sourceId, clusterId, centre, props?.point_count ?? 0);
         return;
       }
       void expandCluster(map, sourceId, clusterId, centre);
@@ -1732,7 +1734,7 @@ export default function WorldMap() {
     // stopPropagation — so "I clicked a pin and it armed" is true 75% of the time
     // whether or not interception 2 works. A handle is the only way to aim a test at
     // a NAMED camera on a chosen path.
-    (window as unknown as { __arm?: typeof armStore }).__arm = armStore;
+    (window as unknown as { __pick?: typeof pickStore }).__pick = pickStore;
 
     map.addControl(new maplibregl.AttributionControl({ compact: true }), "bottom-right");
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "bottom-right");
@@ -1763,7 +1765,7 @@ export default function WorldMap() {
       // depends on MAX_THUMBS and on `available`. If arming were patched into camClick
       // alone it would fail for those 24 while working for the 73 beside them.
       onPick: (c) => {
-        if (armedPickCamera(c.id, c.lat, c.lon)) return;
+        if (pickOneCamera(c.id, c.lat, c.lon, c.name)) return;
         cinematic.dive({ kind: "camera", id: c.id, lat: c.lat, lon: c.lon, label: c.name, meta: { available: true } });
       },
     });
@@ -2110,7 +2112,7 @@ export default function WorldMap() {
   // explain it — a silent, sitewide regression from a feature nobody was using.
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !armedSlot) return;
+    if (!map || !picking) return;
 
     map.boxZoom.disable();
     const canvas = map.getCanvasContainer();
@@ -2161,7 +2163,7 @@ export default function WorldMap() {
       const rect = canvas.getBoundingClientRect();
       const a = map.unproject([from.x - rect.left, from.y - rect.top]);
       const b = map.unproject([ev.clientX - rect.left, ev.clientY - rect.top]);
-      appendBoxSelection(
+      pickBoxSelection(
         normalizeBounds({ lat: a.lat, lon: a.lng }, { lat: b.lat, lon: b.lng }),
         webcamsRef.current,
       );
@@ -2180,7 +2182,7 @@ export default function WorldMap() {
       clearBox();
       map.boxZoom.enable();
     };
-  }, [armedSlot]);
+  }, [picking]);
 
   const trackedFound = track.id ? planesLayer.objects.some((o) => o.id === track.id) : false;
 
@@ -2197,17 +2199,18 @@ export default function WorldMap() {
   }, []);
 
   return (
-    <div className={armedSlot ? "world-map tn-armed" : "world-map"}>
+    <div className={picking ? "world-map tn-picking" : "world-map"}>
       <div ref={containerRef} className="map-canvas" />
 
       {/* INTERCEPTION 7, the visible half. A global mode on a map that has no other
           mode has to say it is on and say how to leave, or the next click is a
           surprise. Rendered from the hook, so it survives the fact that the click
           handlers themselves are frozen closures. */}
-      {armedSlot && (
+      {picking && (
         <div className="tn-arm-hint" role="status" aria-live="polite">
           <span>
-            Filling a slot — click a pin, or shift-drag a box. <kbd>Esc</kbd> to stop.
+            Picking cameras — click a pin, shift-drag a box, or draw an area.{" "}
+            <kbd>Esc</kbd> to stop.
           </span>
         </div>
       )}
@@ -2448,11 +2451,15 @@ function WebcamsFeed({ onData }: { onData: (webcams: WorldObject[]) => void }) {
           },
         }));
         onData(objects);
+        // Publish alongside onData so anything outside the map — the area picker on
+        // the stage bar, in particular — can read what is drawn without a refetch.
+        loadedWebcamsStore.set(objects.map((o) => ({ id: o.id, label: o.label, lat: o.lat, lon: o.lon })));
         freshnessStore.record("webcams", { count: objects.length, ok: true });
       })
       .catch(() => {
         if (!alive) return;
         onData([]);
+        loadedWebcamsStore.set([]);
         freshnessStore.record("webcams", { count: 0, ok: false });
       });
     return () => {

--- a/components/console/AoiControl.tsx
+++ b/components/console/AoiControl.tsx
@@ -20,7 +20,7 @@
 // finish gesture is invisible otherwise — a user who has placed two points needs
 // to know why Enter is not closing the ring.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { useScope } from "@/lib/shell/scope";
 import {
   MIN_VERTICES,
@@ -30,10 +30,14 @@ import {
   useAoiDraw,
 } from "@/lib/map/aoi";
 import { getMapInstance } from "@/lib/map/instance";
+import { areaPickStore } from "@/lib/console/widgets/camslot.area";
 
 export default function AoiControl() {
   const scope = useScope();
   const drawing = useAoiDraw();
+  // The camera picker borrows the same draw tool. While it owns the gesture this
+  // control stays out of the way rather than narrating someone else's ring.
+  const theirs = useSyncExternalStore(areaPickStore.subscribe, areaPickStore.get, () => false);
   const [note, setNote] = useState<string | null>(null);
 
   useEffect(() => {
@@ -48,7 +52,7 @@ export default function AoiControl() {
     if (!startDraw(map)) setNote("The map is still loading.");
   }, []);
 
-  if (drawing.active) {
+  if (drawing.active && !theirs) {
     const n = drawing.vertices.length;
     const ready = n >= MIN_VERTICES;
     return (

--- a/components/console/CameraPickControl.tsx
+++ b/components/console/CameraPickControl.tsx
@@ -1,0 +1,118 @@
+"use client";
+// PICK CAMERAS FOR A WALL — the map-side entry point to building a camera wall.
+//
+// It replaces a `⊕` that lived inside one widget's hover-only control bar. That
+// button had three problems and this control exists to answer each one:
+//
+//   1. You had to find it. It appeared on hover, inside a card, next to four other
+//      glyphs. Here the control is on the stage bar beside "Restrict results to
+//      area", permanently, in words.
+//   2. It chose the DESTINATION first, so you had to know which of four identically
+//      titled "CAMERA WALL" cards you meant before you had picked anything. Picking
+//      chooses the destination last, in the tray, when there is something to place.
+//   3. It had no answer for an area. "Draw an area" is now the same gesture as
+//      "click a pin" — both fill the same basket.
+//
+// It sits UNDER AoiControl on purpose. The two are neighbours in a reader's mind
+// and opposites in effect: one narrows what the feeds answer with, the other
+// gathers cameras out of the map. Putting them together is also what makes the
+// difference legible — "Restrict results to area" filters, "Draw an area" collects.
+
+import { useCallback, useEffect, useState } from "react";
+import { MIN_VERTICES, cancelDraw, useAoiDraw } from "@/lib/map/aoi";
+import { pickStore, usePicks } from "@/lib/console/widgets/camslot.pick";
+import { startAreaPick } from "@/lib/console/widgets/camslot.area";
+import { createCamslot } from "@/lib/console/widgets/camslot.create";
+
+export default function CameraPickControl() {
+  const { mode, picks } = usePicks();
+  const drawing = useAoiDraw();
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!note) return;
+    const t = setTimeout(() => setNote(null), 3500);
+    return () => clearTimeout(t);
+  }, [note]);
+
+  const onNewWall = useCallback(() => {
+    const r = createCamslot();
+    // createCamslot scrolls to and flashes the card it made, so a success needs no
+    // note of its own — saying "added" beside a card that has just lit up is noise.
+    if (!r.ok) setNote(r.reason ?? "Could not add a camera wall.");
+  }, []);
+
+  const onArea = useCallback(() => {
+    const r = startAreaPick();
+    if (r.kind === "no-map") setNote("No map on the stage to draw on.");
+    else if (r.kind === "not-ready") setNote("The map is still loading.");
+  }, []);
+
+  // A draw in progress owns the control: the finish gesture (Enter, or a
+  // double-click) is invisible, so a user who has placed two points needs to be
+  // told why the ring will not close. Copy deliberately mirrors AoiControl's, since
+  // the gesture is literally the same one.
+  if (drawing.active) {
+    const n = drawing.vertices.length;
+    const ready = n >= MIN_VERTICES;
+    return (
+      <div className="tn-aoi tn-campick" role="group" aria-label="Drawing an area to pick cameras from">
+        <span className="tn-aoi-live" role="status" aria-live="polite">
+          {ready ? `${n} points - Enter for the cameras inside` : `${n}/${MIN_VERTICES} points`}
+        </span>
+        <button type="button" className="tn-aoi-btn" onClick={cancelDraw} title="Abandon this area (Esc)">
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  const picking = mode === "picking";
+
+  return (
+    <div className="tn-aoi tn-campick" role="group" aria-label="Camera walls">
+      <button
+        type="button"
+        className={picking ? "tn-aoi-btn is-on" : "tn-aoi-btn"}
+        aria-pressed={picking}
+        onClick={() => pickStore.setMode(picking ? "off" : "picking")}
+        title={
+          picking
+            ? "Stop picking. What you have already picked stays in the tray."
+            : "Click camera pins, or shift-drag a box, to collect them for a wall"
+        }
+      >
+        {picking ? "◉ Picking cameras" : "◎ Pick cameras"}
+      </button>
+
+      <button
+        type="button"
+        className="tn-aoi-btn"
+        onClick={onArea}
+        title="Draw a shape; every camera inside it is picked"
+      >
+        Draw an area
+      </button>
+
+      {/* The always-available way to get an empty wall, so removing the last one is
+          never a dead end. Sam's report: "after doing this I then can't add a
+          camera as there isn't a widget to add it to." */}
+      <button
+        type="button"
+        className="tn-aoi-btn"
+        onClick={onNewWall}
+        title="Add an empty camera wall to this board"
+      >
+        ＋ New wall
+      </button>
+
+      {picks.length > 0 && (
+        <span className="tn-aoi-live" role="status" aria-live="polite">
+          {picks.length} picked
+        </span>
+      )}
+
+      {note && <span className="tn-aoi-note" role="status">{note}</span>}
+    </div>
+  );
+}

--- a/components/console/CameraPickControl.tsx
+++ b/components/console/CameraPickControl.tsx
@@ -18,15 +18,19 @@
 // gathers cameras out of the map. Putting them together is also what makes the
 // difference legible — "Restrict results to area" filters, "Draw an area" collects.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { MIN_VERTICES, cancelDraw, useAoiDraw } from "@/lib/map/aoi";
 import { pickStore, usePicks } from "@/lib/console/widgets/camslot.pick";
-import { startAreaPick } from "@/lib/console/widgets/camslot.area";
+import { areaPickStore, startAreaPick } from "@/lib/console/widgets/camslot.area";
 import { createCamslot } from "@/lib/console/widgets/camslot.create";
 
 export default function CameraPickControl() {
   const { mode, picks } = usePicks();
   const drawing = useAoiDraw();
+  // A draw started by "Restrict results to area" is not ours: both controls would
+  // otherwise render a vertex counter and a Cancel button at the same time, and one
+  // of the two would be describing a gesture the user never asked for.
+  const oursToDraw = useSyncExternalStore(areaPickStore.subscribe, areaPickStore.get, () => false);
   const [note, setNote] = useState<string | null>(null);
 
   useEffect(() => {
@@ -52,7 +56,7 @@ export default function CameraPickControl() {
   // double-click) is invisible, so a user who has placed two points needs to be
   // told why the ring will not close. Copy deliberately mirrors AoiControl's, since
   // the gesture is literally the same one.
-  if (drawing.active) {
+  if (drawing.active && oursToDraw) {
     const n = drawing.vertices.length;
     const ready = n >= MIN_VERTICES;
     return (

--- a/components/console/CameraTray.tsx
+++ b/components/console/CameraTray.tsx
@@ -1,0 +1,182 @@
+"use client";
+// ── The camera tray ──────────────────────────────────────────────────────────
+//
+// The basket, made visible. It is the half of picking that arming never had: a
+// standing, on-screen answer to "what have I chosen, and where is it going?".
+//
+// WHY IT SITS ON THE STAGE AND NOT THE VIEWPORT. Picking happens on the map, and the
+// tray is the receipt for it. A fixed bar across the bottom of the window would float
+// over whichever widget happened to be at the foot of the board and would claim to
+// belong to the whole console, when it belongs to one gesture on one surface. It is
+// rendered as a child of the stage container and positioned against that box, so it
+// covers the map it is describing and nothing else.
+//
+// WHY IT DISAPPEARS. Visible only while the basket has something in it or picking is
+// switched on. A tray that is always there is chrome; a tray that appears when you
+// start choosing and leaves when you are done is feedback.
+//
+// THE AREA TOTAL IS NEVER `picks.length`. When a drawn area held more cameras than a
+// wall can take, the tray says so in the area's own numbers. Printing the basket size
+// as the area's total would turn a cap into a coverage claim — "Soho has 60 cameras"
+// — which is the one thing this product must not say.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MAX_PICKS, pickStore, usePicks } from "@/lib/console/widgets/camslot.pick";
+import { camslotTargets, sendPicksToWall, type CamslotTarget } from "@/lib/console/widgets/camslot.send";
+
+/** The console's one notification channel — ConsoleShell listens for this and
+ *  renders it into the single `.tn-toast` live region. A second mechanism here
+ *  would mean two things on screen claiming to be the app talking. */
+function toast(message: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent("tn-toast", { detail: message }));
+}
+
+export default function CameraTray() {
+  const { mode, picks, foundInArea } = usePicks();
+  const [menuOpen, setMenuOpen] = useState(false);
+  // Snapshotted when the menu OPENS rather than subscribed to. The list is only ever
+  // read while it is on screen, and taking it at open time means a wall added by
+  // another surface mid-menu cannot renumber the rows under the user's cursor.
+  const [targets, setTargets] = useState<CamslotTarget[]>([]);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const closeMenu = useCallback((refocus: boolean) => {
+    setMenuOpen(false);
+    if (refocus) triggerRef.current?.focus();
+  }, []);
+
+  // Escape closes from anywhere inside the tray, and hands focus back to the button
+  // that opened it — a keyboard user who dismisses a menu and lands at the top of the
+  // document has been punished for using the keyboard.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        closeMenu(true);
+      }
+    };
+    const onDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (menuRef.current?.contains(t ?? null)) return;
+      if (triggerRef.current?.contains(t ?? null)) return;
+      closeMenu(false);
+    };
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("pointerdown", onDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("pointerdown", onDown, true);
+    };
+  }, [menuOpen, closeMenu]);
+
+  // A menu left open over a board that has changed underneath it is a menu that sends
+  // somewhere the user did not choose, so it closes with the tray.
+  useEffect(() => {
+    if (picks.length === 0 && menuOpen) closeMenu(false);
+  }, [picks.length, menuOpen, closeMenu]);
+
+  const openMenu = useCallback(() => {
+    setTargets(camslotTargets());
+    setMenuOpen(true);
+  }, []);
+
+  const send = useCallback((target: string) => {
+    closeMenu(true);
+    toast(sendPicksToWall(target).message);
+  }, [closeMenu]);
+
+  // Nothing chosen and not picking: the tray has nothing to say, so it says nothing.
+  if (picks.length === 0 && mode !== "picking") return null;
+
+  const empty = picks.length === 0;
+
+  return (
+    <div className="tn-tray" role="region" aria-label="Picked cameras">
+      <div className="tn-tray-row">
+        <span className="tn-tray-count" role="status" aria-live="polite">
+          {empty ? "PICKING — click cameras on the map" : `SELECTED ${picks.length}`}
+        </span>
+
+        {picks.length > 0 && (
+          <ul className="tn-tray-strip" aria-label="Cameras in the tray">
+            {picks.map((p) => (
+              <li key={p.key} className="tn-tray-chip">
+                <span className="tn-tray-chip-label" title={p.label}>{p.label}</span>
+                {p.source ? <span className="tn-tray-chip-src">{p.source}</span> : null}
+                <button
+                  type="button"
+                  className="tn-tray-chip-x"
+                  aria-label={`Remove ${p.label}`}
+                  onClick={() => pickStore.remove(p.key)}
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="tn-tray-actions">
+          <div className="tn-tray-menu-wrap">
+            <button
+              type="button"
+              ref={triggerRef}
+              className="tn-tray-btn is-primary"
+              disabled={empty}
+              aria-expanded={menuOpen}
+              aria-haspopup="true"
+              onClick={() => (menuOpen ? closeMenu(true) : openMenu())}
+            >
+              Send to wall ▾
+            </button>
+
+            {menuOpen && (
+              // A labelled group of ordinary buttons rather than role="menu". A menu
+              // promises arrow-key roving that this does not implement, and Tab
+              // through real buttons already works; claiming the role and not
+              // honouring it is worse for a screen-reader user than not claiming it.
+              <div className="tn-tray-menu" ref={menuRef} role="group" aria-label="Send picked cameras to">
+                <button type="button" className="tn-tray-menu-item" onClick={() => send("new")}>
+                  New camera wall
+                </button>
+                {targets.length > 0 && <div className="tn-tray-menu-sep" />}
+                {targets.map((t) => (
+                  <button
+                    key={t.id}
+                    type="button"
+                    className="tn-tray-menu-item"
+                    onClick={() => send(t.id)}
+                  >
+                    <span className="tn-tray-menu-name">{t.name}</span>
+                    <span className="tn-tray-menu-count">({t.count})</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Always does something visible. With a basket it empties it; with an
+              empty basket the only sensible reading of "clear" is "stop", and a
+              tray with no way out of picking is the dead end this overhaul exists
+              to remove. */}
+          <button
+            type="button"
+            className="tn-tray-btn"
+            onClick={() => (empty ? pickStore.setMode("off") : pickStore.clear())}
+          >
+            {empty ? "Stop picking" : "Clear"}
+          </button>
+        </div>
+      </div>
+
+      {foundInArea > picks.length && (
+        <p className="tn-tray-note">
+          this area has {foundInArea} cameras — a wall holds {MAX_PICKS}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/console/ConsoleWorkspace.tsx
+++ b/components/console/ConsoleWorkspace.tsx
@@ -14,7 +14,8 @@ import WatchlistPanel from "@/components/shell/WatchlistPanel";
 import { getWidgetType } from "@/lib/console/registry";
 import { stageRegionLabel } from "@/components/shell/a11y";
 import { SKIP_TARGET_ID } from "@/components/shell/SkipLink";
-import { readingOrder, rowsUsed, COLS, ROW_PX, GAP_PX } from "@/lib/terminal/layoutGrid";
+import { readingOrder, rowsUsed, findFreeSpot, COLS, ROW_PX, GAP_PX } from "@/lib/terminal/layoutGrid";
+import { createCamslot, CAMSLOT_SIZE } from "@/lib/console/widgets/camslot.create";
 import { useStageSolo } from "@/lib/terminal/solo";
 import { useGridDrag, gridArea, type ResizeDir } from "@/lib/terminal/useGridDrag";
 import { useTerminalSkin } from "@/lib/terminal/skin";
@@ -129,6 +130,34 @@ export default function ConsoleWorkspace() {
     if (!solo) for (const w of ordered) if (w.rect) rects.push(w.rect);
     return Math.max(1, rowsUsed(rects));
   }, [solo, stageRect, ordered]);
+
+  /**
+   * Where the next camera wall would land, or null when there is nowhere obvious.
+   *
+   * findFreeSpot is the SAME scan the store runs when a card is actually added, so
+   * the ghost tile marks the real destination rather than a guess. Withheld once the
+   * spot falls past the rows the board already occupies: drawing it there would add a
+   * permanent empty row to a surface whose whole argument is that it has no dead
+   * strips, and the board would grow a row taller the moment you stopped using it.
+   */
+  const addSpot = useMemo(() => {
+    if (solo) return null;
+    const rects: GridRect[] = [stageRect];
+    for (const w of ordered) if (w.rect) rects.push(w.rect);
+    const { x, y } = findFreeSpot(rects, CAMSLOT_SIZE.w, CAMSLOT_SIZE.h);
+    if (y + CAMSLOT_SIZE.h > boardRows) return null;
+    return { x, y, w: CAMSLOT_SIZE.w, h: CAMSLOT_SIZE.h } as GridRect;
+  }, [solo, stageRect, ordered, boardRows]);
+
+  /** True when the board carries no widgets at all — the dead end this rescues. */
+  const boardIsEmpty = !solo && ordered.length === 0;
+
+  const addWall = () => {
+    const r = createCamslot();
+    if (!r.ok && r.reason) {
+      window.dispatchEvent(new CustomEvent("tn-toast", { detail: r.reason }));
+    }
+  };
 
   const gridStyle = {
     gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))`,
@@ -328,6 +357,35 @@ export default function ConsoleWorkspace() {
             {handlesFor(w.id, w.rect)}
           </div>
         ))}
+
+        {/* THE DEAD END THIS FIXES: remove the last camera wall and the board is an
+            empty grid with no way back. The stage bar's control only answers it while
+            the map is on screen, so the rescue lives on the board itself. */}
+        {boardIsEmpty && (
+          <div className="tn-cw-rescue" style={addSpot ? gridArea(addSpot) : undefined}>
+            <p className="tn-cw-rescue-t">This board has no camera walls</p>
+            <p className="tn-cw-rescue-b">A wall shows live pictures side by side. Add one, then pick cameras on the map to fill it.</p>
+            <button type="button" className="tn-cw-rescue-btn" onClick={addWall}>
+              Add a camera wall
+            </button>
+          </div>
+        )}
+
+        {/* The ghost tile sits in the cell the next wall will actually occupy. Hidden
+            during a gesture: it is not a drop target, and a phantom card appearing
+            beside the one you are holding reads as the board reflowing under you. */}
+        {!boardIsEmpty && addSpot && !drag.activeId && (
+          <button
+            type="button"
+            className="tn-cw-add"
+            style={gridArea(addSpot)}
+            onClick={addWall}
+            title="Add a camera wall here"
+          >
+            <span className="tn-cw-add-plus" aria-hidden="true">+</span>
+            <span className="tn-cw-add-l">Add camera wall</span>
+          </button>
+        )}
       </div>
 
       {/* The variant's persistent chrome — the Source Catalog rail, and the ONLY

--- a/components/console/WidgetFrame.tsx
+++ b/components/console/WidgetFrame.tsx
@@ -65,6 +65,14 @@ export default function WidgetFrame({
   const helpBtnRef = useRef<HTMLButtonElement>(null);
   const onReport = useCallback((r: Report) => setReport(r), []);
 
+  // What this CARD is called, which is not always what its TYPE is called. A widget
+  // that can appear several times on one board and be pointed at individually — a
+  // camera wall, four of them on Streets — has to say WHICH one it is, or every
+  // control that targets one by name is aiming at an unlabelled row of identical
+  // headers. Falls back to the type title, which is the right answer for the ~70
+  // widgets that are only ever on a board once.
+  const frameTitle = type?.titleOf?.(instance.config) || type?.title || instance.type;
+
   // Per-widget notification rule (keyed by TYPE) + the creds that gate each channel.
   const rule = useRule(instance.type);
   const notif = useNotifications();
@@ -165,7 +173,7 @@ export default function WidgetFrame({
         <button
           type="button"
           className="tn-cw-grip"
-          aria-label={`Move ${type.title}. Arrow keys move, shift with arrow keys resizes.`}
+          aria-label={`Move ${frameTitle}. Arrow keys move, shift with arrow keys resizes.`}
           title="Drag to move · arrows to nudge · shift+arrows to resize"
           onPointerDown={onGrab}
           onKeyDown={onNudgeKey}
@@ -190,7 +198,7 @@ export default function WidgetFrame({
             accessible description that merely repeats the accessible name is
             suppressed by screen readers rather than announced twice, which is the
             trap f79b004 fixed and this must not reintroduce. */}
-        <h3 className="tn-cw-title" style={{ margin: 0, fontSize: "inherit" }} title={type.title}>{type.title}</h3>
+        <h3 className="tn-cw-title" style={{ margin: 0, fontSize: "inherit" }} title={frameTitle}>{frameTitle}</h3>
         {report.count != null && <span className="tn-cw-count">{report.count}</span>}
         <span className="tn-cw-sp" />
         {report.alerts.length > 0 && <span className={`tn-cw-badge tn-sev-${sev}`}>{report.alerts.length}</span>}
@@ -215,7 +223,7 @@ export default function WidgetFrame({
             but not clickable — Playwright caught the handle swallowing the
             click. Raising this above the handle instead would take the corner
             away from resizing, which is a real control, not dead space. */}
-        <button className="tn-cw-close" aria-label={`Remove ${type.title}`} title="Remove from board"
+        <button className="tn-cw-close" aria-label={`Remove ${frameTitle}`} title="Remove from board"
           onClick={() => shellLayoutStore.remove(instance.id)}>✕</button>
         <button className="tn-cw-menu" aria-label="Widget menu" onClick={() => { setMenuOpen((o) => !o); setBellOpen(false); setHelpOpen(false); }}>⋯</button>
       </header>
@@ -279,7 +287,7 @@ export default function WidgetFrame({
         // toggles (the size chips carry aria-pressed), and a pressed menuitem is
         // a contradiction most screen readers announce badly. A labelled group of
         // ordinary buttons describes what this actually is.
-        <div className="tn-cw-menu-pop" role="group" aria-label={`${type.title} options`}>
+        <div className="tn-cw-menu-pop" role="group" aria-label={`${frameTitle} options`}>
           {/* MOVE — the drag, as buttons. One click, no aim, keyboard-reachable. */}
           <div className="tn-cw-menu-sec">Move</div>
           <div className="tn-cw-menu-row">

--- a/components/console/WidgetFrame.tsx
+++ b/components/console/WidgetFrame.tsx
@@ -9,6 +9,7 @@ import {
   HEIGHT_PRESET_TOLERANCE_PX,
   WIDTH_PRESETS,
 } from "@/lib/console/resize";
+import { ROW_PX, GAP_PX } from "@/lib/terminal/layoutGrid";
 import { getWidgetType } from "@/lib/console/registry";
 import { resolveWidgetHelp } from "@/lib/console/help";
 import { topSeverity, type Alert } from "@/lib/console/alerts";
@@ -135,7 +136,18 @@ export default function WidgetFrame({
   const rect = instance.rect;
   const nudgeBy = (d: { dx?: number; dy?: number; dw?: number; dh?: number }) => onNudge?.(d);
   const activeWidth = activePreset(WIDTH_PRESETS, rect?.w ?? instance.width);
-  const activeHeight = activePreset(HEIGHT_PRESETS, instance.height, HEIGHT_PRESET_TOLERANCE_PX);
+  // Height, like width, has to come off the GRID RECT when there is one.
+  // `instance.height` is the legacy px field: the preset buttons write it, but a
+  // drag-resize writes rect.h and never touches it, so reading it alone left the
+  // S/M/L/XL chips showing whatever was last chosen from this menu no matter how
+  // far the card had since been dragged. Width was already correct because it
+  // reads rect.w first; this is the same rule applied to the other axis.
+  // Rows convert at the grid's own pitch rather than a retyped 25.
+  const activeHeight = activePreset(
+    HEIGHT_PRESETS,
+    rect ? rect.h * (ROW_PX + GAP_PX) : instance.height,
+    HEIGHT_PRESET_TOLERANCE_PX,
+  );
 
   return (
     <div className="tn-cw" data-widget-type={instance.type} style={{ maxHeight: instance.collapsed ? undefined : instance.height }}>
@@ -272,8 +284,8 @@ export default function WidgetFrame({
           <div className="tn-cw-menu-sec">Move</div>
           <div className="tn-cw-menu-row">
             <button className="tn-cw-chip" title="Move one column left" onClick={() => nudgeBy({ dx: -1 })}>◀</button>
-            <button className="tn-cw-chip" title="Move one row up" onClick={() => nudgeBy({ dy: -1 })}>▲</button>
-            <button className="tn-cw-chip" title="Move one row down" onClick={() => nudgeBy({ dy: 1 })}>▼</button>
+            <button className="tn-cw-chip" title="Move up past the card above" onClick={() => nudgeBy({ dy: -1 })}>▲</button>
+            <button className="tn-cw-chip" title="Move down past the card below" onClick={() => nudgeBy({ dy: 1 })}>▼</button>
             <button className="tn-cw-chip" title="Move one column right" onClick={() => nudgeBy({ dx: 1 })}>▶</button>
           </div>
           <div className="tn-cw-menu-sec">Grow / shrink</div>

--- a/components/console/WidgetFrame.tsx
+++ b/components/console/WidgetFrame.tsx
@@ -21,6 +21,7 @@ import { useTelegram, isTelegramConfigured } from "@/lib/shell/telegram";
 import FreshChip from "@/components/console/FreshChip";
 import LayerExplainerCard from "@/components/LayerExplainerCard";
 import type { FreshObservation } from "@/lib/console/freshChip";
+import { WIDGET_LIMIT_MESSAGE } from "@/lib/console/types";
 
 interface Report {
   alerts: Alert[];
@@ -302,7 +303,7 @@ export default function WidgetFrame({
           </div>
 
           <div className="tn-cw-menu-sep" />
-          <button onClick={() => { const r = shellLayoutStore.add(instance.type, { config: { ...cfg } }); if (!r.ok) window.dispatchEvent(new CustomEvent("tn-toast", { detail: "50-widget limit — remove one to add another" })); setMenuOpen(false); }}>⧉ Duplicate</button>
+          <button onClick={() => { const r = shellLayoutStore.add(instance.type, { config: { ...cfg } }); if (!r.ok) window.dispatchEvent(new CustomEvent("tn-toast", { detail: WIDGET_LIMIT_MESSAGE })); setMenuOpen(false); }}>⧉ Duplicate</button>
           <button onClick={() => { shellLayoutStore.configure(instance.id, { alertStyle: alertStyle === "top" ? "feed" : "top" }); setMenuOpen(false); }}>
             ⚡ Alerts: {alertStyle === "top" ? "on top" : "in feed"}
           </button>

--- a/components/console/WidgetFrame.tsx
+++ b/components/console/WidgetFrame.tsx
@@ -191,6 +191,20 @@ export default function WidgetFrame({
         <button className={`tn-cw-bell${rule.enabled ? " is-on" : ""}`} aria-label="Notifications" aria-pressed={rule.enabled}
           title={rule.enabled ? "Notifications on" : "Notify me"} onClick={() => { setBellOpen((o) => !o); setMenuOpen(false); setHelpOpen(false); }}>🔔</button>
         <button className="tn-cw-expand" aria-label="Expand widget" title="Expand to main window" onClick={() => shellLayoutStore.focus(instance.id)}>⤢</button>
+        {/* Remove is on the card, not only in the ⋯ menu. In the menu it is the
+            LAST of nineteen entries in a scrolling panel, so on a short card it
+            sits below an internal scroll — a control you have to already know is
+            there. The menu entry stays: this is a second route, not a move, and
+            the menu also holds the nudge buttons that let the 10px resize handles
+            claim the WCAG 2.5.8 equivalent-alternative exemption. */}
+        {/* Sits INBOARD of the menu button on purpose. The 16x16 .tn-rz-ne
+            resize handle is pinned to the card corner at z-index 20 and covers
+            the top-right of the header, so a control placed last here is drawn
+            but not clickable — Playwright caught the handle swallowing the
+            click. Raising this above the handle instead would take the corner
+            away from resizing, which is a real control, not dead space. */}
+        <button className="tn-cw-close" aria-label={`Remove ${type.title}`} title="Remove from board"
+          onClick={() => shellLayoutStore.remove(instance.id)}>✕</button>
         <button className="tn-cw-menu" aria-label="Widget menu" onClick={() => { setMenuOpen((o) => !o); setBellOpen(false); setHelpOpen(false); }}>⋯</button>
       </header>
 

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -131,12 +131,31 @@ function buildCommands(close: () => void): Command[] {
 
   // ── Open widgets: jump focus to a card that's already on the workspace ──
   const openWidgets = shellLayoutStore.get().widgets;
-  const typeSeen = new Map<string, number>();
+  // A card is called what the CARD is called, using the same precedence the frame
+  // uses (WidgetFrame's frameTitle): the instance's own name first, the type's name
+  // second. Reading the type title here while the board reads the instance one is
+  // worse than both being anonymous — a user who can finally see "London" on a card
+  // would search the palette for "London" and find four rows called
+  // "Focus Camera wall #1..#4", numbered against nothing on screen.
+  const titleFor = (w: { type: string; config?: Record<string, unknown> }) => {
+    const t = getWidgetType(w.type);
+    return t?.titleOf?.(w.config ?? {}) || t?.title || w.type;
+  };
+  // The #n disambiguator is keyed on the RESOLVED title, not the type: three named
+  // walls need no numbering at all, and numbering them would re-introduce exactly
+  // the anonymity the names just removed. Two walls that genuinely share a name
+  // still get numbered, because then the number is the only thing telling them apart.
+  const titleTotals = new Map<string, number>();
   for (const w of openWidgets) {
-    const title = getWidgetType(w.type)?.title ?? w.type;
-    const total = openWidgets.filter((x) => x.type === w.type).length;
-    const n = (typeSeen.get(w.type) ?? 0) + 1;
-    typeSeen.set(w.type, n);
+    const t = titleFor(w);
+    titleTotals.set(t, (titleTotals.get(t) ?? 0) + 1);
+  }
+  const titleSeen = new Map<string, number>();
+  for (const w of openWidgets) {
+    const title = titleFor(w);
+    const total = titleTotals.get(title) ?? 1;
+    const n = (titleSeen.get(title) ?? 0) + 1;
+    titleSeen.set(title, n);
     cmds.push({
       id: `focus-${w.id}`,
       label: `Focus ${title}${total > 1 ? ` #${n}` : ""}`,

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -35,6 +35,7 @@ import {
   type PaletteSnapshot,
 } from "@/lib/console/paletteGroups";
 import type { GeocodeResult } from "@/lib/geo/geocode";
+import { WIDGET_LIMIT_MESSAGE } from "@/lib/console/types";
 
 // Pick a fly-to zoom from a geocode result's extent (wider areas frame out).
 function zoomForResult(r: GeocodeResult): number {
@@ -59,7 +60,7 @@ const LAYER_NAMES: Record<LayerKey, string> = {
 };
 
 function alertCapacity() {
-  if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent("tn-toast", { detail: "50-widget limit — remove one to add another" }));
+  if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent("tn-toast", { detail: WIDGET_LIMIT_MESSAGE }));
 }
 
 function buildCommands(close: () => void): Command[] {

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -30,7 +30,7 @@ import SelectionAnnouncer from "@/components/terminal/SelectionAnnouncer";
 import { basemapForSkin, terminalSkinStore, useTerminalSkin } from "@/lib/terminal/skin";
 import { mapViewStore } from "@/lib/mapView";
 import { selectionStore } from "@/lib/terminal/selection";
-import { armStore } from "@/lib/console/widgets/camslot.arm";
+import { pickStore } from "@/lib/console/widgets/camslot.pick";
 import SkipLink from "@/components/shell/SkipLink";
 import CommandPalette from "@/components/shell/CommandPalette";
 import TourOverlay from "@/components/shell/TourOverlay";
@@ -197,14 +197,19 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
           if (focusStageSearch()) e.preventDefault();
           break;
         case "Escape":
-          // Escape leaves the innermost thing first, and a map armed to fill a slot
-          // is inner to a selection. Sequenced HERE rather than from a second
+          // Escape leaves the innermost thing first, and a map in camera-picking
+          // mode is inner to a selection. Sequenced HERE rather than from a second
           // listener, because two listeners would both fire on the same keydown and
-          // one press would end arming AND silently clear the user's selection —
-          // work they never asked to lose. Armed: end the mode, nothing else. A
+          // one press would end picking AND silently clear the user's selection —
+          // work they never asked to lose. Picking: leave the mode, nothing else. A
           // second Escape then clears the selection as it always did.
-          if (armStore.get()) {
-            armStore.disarm();
+          //
+          // Leaving the mode does NOT empty the basket. Escape is how you stop the
+          // map intercepting clicks, and a user who presses it to pan around before
+          // sending would otherwise lose every camera they had chosen. `clear()` on
+          // the tray is the only thing that throws picks away.
+          if (pickStore.get().mode === "picking") {
+            pickStore.setMode("off");
             break;
           }
           selectionStore.clear();
@@ -234,13 +239,16 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
       const now = shellLayoutStore.get().focusedWidgetId;
       if (now === lastFocus) return;
       lastFocus = now;
-      if (now) armStore.disarm(); // entering focus, not leaving it
+      if (now) pickStore.setMode("off"); // entering focus, not leaving it
     });
     const offPreset = activePresetStore.subscribe(() => {
       const now = activePresetStore.get();
       if (now === lastPreset) return;
       lastPreset = now;
-      armStore.disarm();
+      // A board change is the one case that empties the basket: picks belong to
+      // the wall you were building, and carrying them to another board would
+      // offer to send cameras to slots that are not there any more.
+      pickStore.reset();
     });
     return () => {
       offLayout();

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -248,7 +248,7 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
     };
   }, []);
 
-  // The ⌘K palette dispatches a `tn-toast` CustomEvent (e.g. the 50-widget cap).
+  // The ⌘K palette dispatches a `tn-toast` CustomEvent (e.g. the widget cap).
   // This always-mounted shell is the host that surfaces it as a calm pill.
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;

--- a/components/terminal/StageBar.tsx
+++ b/components/terminal/StageBar.tsx
@@ -112,6 +112,8 @@ import {
   WEBCAM_COLOR,
 } from "@/lib/icons/svg";
 import AoiControl from "@/components/console/AoiControl";
+import CameraPickControl from "@/components/console/CameraPickControl";
+import CameraTray from "@/components/console/CameraTray";
 import MapSearch from "@/components/console/MapSearch";
 import WorldClock from "@/components/console/WorldClock";
 
@@ -290,7 +292,14 @@ export default function StageBar() {
       <div className="tnx-stage-right">
         <StageLegend />
         <AoiControl />
+        <CameraPickControl />
       </div>
+
+      {/* The tray. Bottom of the STAGE, not of the viewport — it is about the map,
+          and a bar pinned to the window would sit over whichever widget happened to
+          be at the foot of the board. It renders nothing at all when the basket is
+          empty and picking is off. */}
+      <CameraTray />
 
       <div className="tnx-stage-foot">
         <WorldClock />

--- a/docs/superpowers/research/2026-08-23-grid-drag-termination.md
+++ b/docs/superpowers/research/2026-08-23-grid-drag-termination.md
@@ -87,26 +87,46 @@ seed 90210  w0 overlaps w4
 All five seeds fail the no-overlap invariant. **All 50 deterministic tests in that file passed.** Only
 the randomised pass caught it. It must be kept and extended by whoever does this work.
 
-## The fix this asks for
+## The fix — BUILT, shipped in 8b17565
 
-The swap has to be **one atomic exchange applied before the generic loop**, so the loop stays
-push-down-only and keeps its monotonic guarantee.
-
-That needs the held card pre-move rect, which `resolveCollisions` does not have: `settle(items,
-pinnedId)` only ever sees the already-moved board, and `place()` discards the old rect on its first
-line. So this is an API change threading the previous rect through `place`, `settle` and
-`resolveCollisions`, touching a signature with other callers.
+The swap is **one atomic exchange applied before the generic loop**, so the loop stays
+push-down-only and keeps its monotonic guarantee. It needs the held card pre-move rect, which
+is threaded through `placeItem`, `setItemRect`, `place`, `settle` and `resolveCollisions` as an
+**optional trailing argument** — every existing caller passes nothing and settles exactly as
+before.
 
 Acceptance criteria:
 
-- [ ] dragging a card down onto a neighbour swaps them, with no hole
-- [ ] `compact` unchanged, so density and idempotence are untouched
-- [ ] existing `place()` callers keep current behaviour when no previous rect is supplied
-- [ ] the `console-boards.test.ts` board-switch regression still passes
-- [ ] the randomised pass is kept and extended with downward-swap moves
-- [ ] the three-dot "move one row down" and ArrowDown work, since they share the cause
+- [x] dragging a card down onto a neighbour swaps them, with no hole
+- [x] `compact` unchanged, so density and idempotence are untouched
+- [x] existing `place()` callers keep current behaviour when no previous rect is supplied —
+      pinned by a test that asserts the legacy ordering
+- [x] the `console-boards.test.ts` board-switch regression still passes
+- [x] the randomised pass kept, and a **second** randomised block added over seven seeds that
+      passes the leaving rect on every move. The original block could never have caught a
+      regression here: it drives `place()` the way callers did before the argument existed, so
+      it never reaches the new branch
+- [ ] **the three-dot "move one row down" and ArrowDown still do nothing** — see below
 
-## What was shipped instead
+Measured in the browser: dragging p1 down 250px takes the board from `p1 p2 p3 p4` to
+`p2 p1 p3 p4`, card drawn where it lands the whole way, no snap on release. Dragging the
+bottom card into empty space below still does nothing, which is correct for a wall that
+compacts, and it is now honest about it rather than moving and springing back.
+
+### The one criterion not met, and why it is not an engine bug
+
+A one-row nudge cannot reorder on a compacted board, and no change to `resolveCollisions` will
+make it. The pre-pass lifts the displaced neighbour to `held.y - neighbour.h`. Nudge a card
+down one row and that arithmetic goes **negative** — there is nowhere above the held card to
+put the neighbour, because the held card has barely moved. Compaction then returns everything
+to where it began.
+
+The button says "move one row down". On a board that compacts, one row down is not a position
+a card can hold: the only meaningful downward move is *past the next card*. So the fix belongs
+in what the control does — swap with the next widget in reading order — not in the engine. That
+is a small change in the menu's handler and it is deliberately not bundled here.
+
+## What (d) shipped alongside it
 
 Drawing the held card at the settled cell rather than free-tracking the pointer removes the jump
 without touching the layout engine. Measured after: an upward drag ends at 281 having been drawn at

--- a/docs/superpowers/research/2026-08-23-grid-drag-termination.md
+++ b/docs/superpowers/research/2026-08-23-grid-drag-termination.md
@@ -106,25 +106,34 @@ Acceptance criteria:
       passes the leaving rect on every move. The original block could never have caught a
       regression here: it drives `place()` the way callers did before the argument existed, so
       it never reaches the new branch
-- [ ] **the three-dot "move one row down" and ArrowDown still do nothing** — see below
+- [x] the three-dot "move one row down" and ArrowDown now reorder — fixed in the control, not
+      the engine, in d32def7. See below for why that is the right place
 
 Measured in the browser: dragging p1 down 250px takes the board from `p1 p2 p3 p4` to
 `p2 p1 p3 p4`, card drawn where it lands the whole way, no snap on release. Dragging the
 bottom card into empty space below still does nothing, which is correct for a wall that
 compacts, and it is now honest about it rather than moving and springing back.
 
-### The one criterion not met, and why it is not an engine bug
+### Why the nudge was fixed in the control rather than the engine
 
-A one-row nudge cannot reorder on a compacted board, and no change to `resolveCollisions` will
-make it. The pre-pass lifts the displaced neighbour to `held.y - neighbour.h`. Nudge a card
-down one row and that arithmetic goes **negative** — there is nowhere above the held card to
-put the neighbour, because the held card has barely moved. Compaction then returns everything
-to where it began.
+A one-row nudge cannot reorder on a compacted board, and no change to `resolveCollisions` would
+have made it. The pre-pass lifts the displaced neighbour to `held.y - neighbour.h`. Nudge a card
+down one row and that arithmetic goes **negative** — there is nowhere above the held card to put
+the neighbour, because the held card has barely moved. Compaction then returns everything to
+where it began.
 
-The button says "move one row down". On a board that compacts, one row down is not a position
-a card can hold: the only meaningful downward move is *past the next card*. So the fix belongs
-in what the control does — swap with the next widget in reading order — not in the engine. That
-is a small change in the menu's handler and it is deliberately not bundled here.
+The button said "move one row down". On a board that compacts, one row down is not a position a
+card can *hold*: the only meaningful downward move is *past the next card*. So the control now
+asks for that instead — it targets the row that leaves the neighbour exactly its own height of
+room above, and the existing exchange does the rest. ArrowDown shares the handler.
+
+One trap worth recording, because the wrong version looks identical and still does nothing: the
+target must line the held card's **bottom edge** up with the neighbour's, not its **row**.
+Targeting `neighbour.y` leaves the lift needing `neighbour.y - neighbour.h`, negative whenever
+the neighbour is nearer the top than it is tall, so the exchange is skipped. The first
+implementation did exactly that and the button stayed dead.
+
+Verified in the browser: three clicks walk a card from first to last, one place per click.
 
 ## What (d) shipped alongside it
 

--- a/docs/superpowers/research/2026-08-23-grid-drag-termination.md
+++ b/docs/superpowers/research/2026-08-23-grid-drag-termination.md
@@ -1,0 +1,144 @@
+# Console grid: why a downward drag cannot reorder
+
+*Recorded 2026-08-23. Written up here rather than filed as an issue because issue creation was
+refused by a permission gate. The analysis should travel with the PR rather than live in a chat log.*
+
+A downward drag on the console grid cannot reorder cards, and the fix needs an API change rather
+than an edit inside `layoutGrid.ts`. Two cheaper fixes were tried and **both were rejected with
+evidence**. Neither should be retried as-is.
+
+## What is actually wrong
+
+`settle(items, pinnedId)` is `compact(resolveCollisions(items, pinnedId))`.
+
+`resolveCollisions` honours the pin. `compact` does not: it takes no `pinnedId` at all, and its
+loop floats every card up.
+
+Measured at unit level. Board `[A(0,0,3,3), HELD(6,10,3,3)]`, `pinnedId = HELD`:
+
+| stage | HELD.y |
+| --- | --- |
+| requested | 10 |
+| after `resolveCollisions` | 10 — pin honoured |
+| after `compact` | 0 — pin ignored |
+| after `settle` | 0 |
+
+Measured in a browser at 1440x900, default board `p1@56 p2@281 p3@531 p4@706`:
+
+- the held card tracks the pointer exactly, 706 to 1066
+- the dashed ghost **never moves** — it sits at 706 for the whole drag
+- on release the card flies 360px back up to where it started
+
+The frozen ghost is the proof, not the puzzle. `commit()` sets `ghostRect` from the store read
+back **after** `settle`, and only after the `same` early-return. A ghost that exists but never
+moves therefore proves `commit` fired, the store was written, and `settle` put the card back. Had
+`commit` never fired there would be no ghost element at all — which is what a gesture blocked by
+the boot overlay looks like, and is how the two states are told apart.
+
+The same root cause makes the three-dot menu "move one row down" and ArrowDown inert.
+
+Downward reorder was never uniformly dead, which is why it looked intermittent:
+
+- held card moved **onto** a neighbour (overlapping): the neighbour is pushed below it, so the held
+  card stays first in reading order and `compact` restores everything. **Inert.**
+- held card moved **clear of** the neighbour: no overlap, reading order flips, the swap works.
+
+One row can never clear a three-row neighbour, so the menu button is 100 percent dead while a long
+drag occasionally appears to work.
+
+## Rejected fix 1 — pin compact
+
+Give `compact` the `pinnedId` and skip that card in the float-up loop.
+
+Fixes the drag. **Breaks board restore.** `place()` is `settle(next, id)`, so it pins on every
+programmatic placement, not just a live gesture, which exempts restored widgets from compaction and
+fails `tests/unit/console-boards.test.ts > REGRESSION: a board switch no longer destroys the board
+you came from`.
+
+It also defers the jump rather than removing it. Exempting the held card leaves a hole, and the next
+unpinned `settle` closes it, so the card relocates on its own the next time anything else is dragged.
+And because downward moves then really move, the board grows past the row budget: two drags on a
+900px viewport put two cards below the fold where they cannot be grabbed at all.
+
+## Rejected fix 2 — lift the displaced card in resolveCollisions
+
+When the held card lands on a neighbour, lift the neighbour into the gap above instead of pushing it
+down, falling back to a push when it does not fit.
+
+Hand-traces correctly and produces no hole. **It breaks the termination argument**, which that
+function states about itself: since every pass either moves a widget down or exits, the bound is a
+backstop rather than a real limit.
+
+Every pass moving down is what makes progress monotonic. A lift moves a widget up, so a lift can push
+a third card into space a previous pass just cleared, which pushes back. The loop ping-pongs until it
+hits `LIMIT` and returns a board that **still overlaps**. The bound stops being a backstop and becomes
+the thing that ends the loop.
+
+Caught by the randomised pass, not by review:
+
+```
+seed 1      w4 overlaps w8
+seed 7      w4 overlaps w8
+seed 42     w4 overlaps w8
+seed 1337   w5 overlaps w2
+seed 90210  w0 overlaps w4
+```
+
+All five seeds fail the no-overlap invariant. **All 50 deterministic tests in that file passed.** Only
+the randomised pass caught it. It must be kept and extended by whoever does this work.
+
+## The fix this asks for
+
+The swap has to be **one atomic exchange applied before the generic loop**, so the loop stays
+push-down-only and keeps its monotonic guarantee.
+
+That needs the held card pre-move rect, which `resolveCollisions` does not have: `settle(items,
+pinnedId)` only ever sees the already-moved board, and `place()` discards the old rect on its first
+line. So this is an API change threading the previous rect through `place`, `settle` and
+`resolveCollisions`, touching a signature with other callers.
+
+Acceptance criteria:
+
+- [ ] dragging a card down onto a neighbour swaps them, with no hole
+- [ ] `compact` unchanged, so density and idempotence are untouched
+- [ ] existing `place()` callers keep current behaviour when no previous rect is supplied
+- [ ] the `console-boards.test.ts` board-switch regression still passes
+- [ ] the randomised pass is kept and extended with downward-swap moves
+- [ ] the three-dot "move one row down" and ArrowDown work, since they share the cause
+
+## What was shipped instead
+
+Drawing the held card at the settled cell rather than free-tracking the pointer removes the jump
+without touching the layout engine. Measured after: an upward drag ends at 281 having been drawn at
+281, where before it was drawn at 406 and snapped 125px on release.
+
+It does not make downward reordering work, and it is honest about that in a way worth knowing: a
+downward drag now renders as **no movement at all** rather than as movement that is undone. That is
+the correct rendering of an engine that refuses the move, and it is why the fix above is worth doing
+rather than optional.
+
+---
+
+# Appendix: a pre-existing hydration mismatch in BoardTabs
+
+Unrelated to the grid. Found while working nearby, on `main`, older than either branch.
+
+`BoardTabs` in `components/terminal/TerminalHeader.tsx` calls `isBoardEdited(p.id)` directly during
+render (around lines 197 and 221). `isBoardEdited` is `id in read()` in `lib/console/boards.ts`, and
+`read()` hits `localStorage`.
+
+There is no mount gate, so for any board the user has customised:
+
+- the server renders `class="tnx-hdr-board"` — no `localStorage`, nothing is edited
+- the client hydration pass renders `class="tnx-hdr-board is-edited"`, plus the dot
+
+React reports a hydration mismatch and regenerates the tree on the client.
+
+**Status of this claim.** The mechanism is verified by reading the code — the render-time
+`localStorage` read and the absence of a mount gate are both confirmed here. The runtime error itself
+was observed by the peer agent working the stage lane, not reproduced in this session.
+
+**Shape of the fix.** Hold `edited` in state and fill it in an effect after mount, so the first client
+render matches the server, and let the existing `useShellLayout()` subscription drive updates from
+then on. That subscription is already present; the comment above it explains that its value is
+deliberately unused and the re-render is the point.

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -266,6 +266,23 @@ export const BUILTIN_PRESETS: ConsolePreset[] = [
   // an honest "no longer published" tile (see camslot.tsx / CameraImage), which is
   // why seeding is safe at all. The fourth slot is deliberately empty: it is the
   // affordance that teaches the board is yours to fill.
+  //
+  // `name` IS RENDERED — do not drop it. It used to be dead config: WidgetFrame drew
+  // the widget TYPE's title, so all four walls here carried the identical header
+  // "CAMERA WALL" and no user could say which tile a camera would land in. The
+  // registry's `titleOf` (see camslotTitle in camslot.tsx) now reads it. That is what
+  // makes these three strings load-bearing rather than decorative.
+  //
+  // THE WEIGHTS BELOW DO NOTHING ON THIS BOARD, and they are left equal to say so.
+  // `composeWall` hands `arrangeWall` a bare id list; `arrangeWall` takes no weights
+  // at all and tiles fixed 4-column cards with the map pinned at 4 columns by
+  // `CARD_W`. Measured over the whole ROWS ladder the preset test uses (24/28/32/40),
+  // weights of 9/3/3/1 produce rects identical to 3/3/3/3 — stage {0,0,4,rows}, four
+  // cards 4 x rows/2. So the stage cannot be widened from here: it needs `arrangeWall`
+  // (shared with `arrangeConsole` and the reducers' wall mode, and pinned by
+  // tests/unit/terminal-layout-grid.test.ts) or `composeWall` to change, and widening
+  // it also has to keep the "no uncovered cell right of the stage" assertion true —
+  // a 6-column stage leaves 6 columns that 4-wide cards cannot tile.
   { id: "streets", title: "Streets", icon: "📷", blurb: "city squares and crossings, live",
     mapCore: ["cameras", "webcams"],
     build: (rows = DEFAULT_BOARD_ROWS) => composeWall("map2d", rows, [

--- a/lib/console/reducers.ts
+++ b/lib/console/reducers.ts
@@ -110,9 +110,18 @@ export function applyItems(l: ShellLayout, items: readonly GridItem[]): ShellLay
   };
 }
 
-/** Move or resize one item (widget or stage) and settle the board around it. */
-export function setItemRect(l: ShellLayout, id: string, rect: GridRect): ShellLayout {
-  return applyItems(l, place(gridItems(l), id, rect));
+/** Move or resize one item (widget or stage) and settle the board around it.
+ *
+ *  `prevRect` is the rect the item came FROM, and only a live gesture has it. Given
+ *  one, a card dragged onto a neighbour swaps with it instead of shoving it down.
+ *  Omitted, the board settles exactly as it always has. */
+export function setItemRect(
+  l: ShellLayout,
+  id: string,
+  rect: GridRect,
+  prevRect: GridRect | null = null,
+): ShellLayout {
+  return applyItems(l, place(gridItems(l), id, rect, prevRect));
 }
 
 /**

--- a/lib/console/registry.ts
+++ b/lib/console/registry.ts
@@ -17,6 +17,21 @@ export interface WidgetType {
   detail?: ComponentType<WidgetDetailProps>;
   /** Concise, honest text for the frame's "?" help popover (what it shows + its data source). */
   help?: WidgetHelp;
+  /**
+   * A title taken from THIS instance's config, when the type's name is not enough
+   * to tell two of them apart.
+   *
+   * The Streets board is the case that forced it: four camera walls, each with a
+   * `name` in its config ("London", "Madrid", "Prague"), every one of them drawn
+   * with the header CAMERA WALL because the frame rendered the TYPE's title. The
+   * user's report was that they could not aim a camera at a particular wall, and
+   * they were right — the screen did not distinguish the targets.
+   *
+   * Returns undefined to mean "use the type title", which is the answer for most
+   * widgets and for an instance that has not been named. It must never return an
+   * empty string: that would replace a real name with a blank header.
+   */
+  titleOf?: (config: Record<string, unknown>) => string | undefined;
   capabilities?: { filter?: boolean; sort?: boolean };
 }
 

--- a/lib/console/store.ts
+++ b/lib/console/store.ts
@@ -67,7 +67,7 @@ export const shellLayoutStore = {
   resizeWidth(id: string, span: number) { state = R.setWidgetWidth(state, id, span); emit(); },
   /** Move or resize a grid item — a widget, or STAGE_ID for the map. The single
    *  write path for every drag, resize and keyboard nudge. */
-  placeItem(id: string, rect: GridRect) { state = R.setItemRect(state, id, rect); emit(); },
+  placeItem(id: string, rect: GridRect, prevRect: GridRect | null = null) { state = R.setItemRect(state, id, rect, prevRect); emit(); },
   /** Re-seed every position from CONSOLE or WALL, fitted to the window. */
   arrange(mode: "console" | "wall") { state = R.arrangeBoard(state, mode, visibleRows()); emit(); },
   collapseWidget(id: string, c: boolean) { state = R.setWidgetCollapsed(state, id, c); emit(); },

--- a/lib/console/types.ts
+++ b/lib/console/types.ts
@@ -66,6 +66,12 @@ export interface ShellLayout {
  */
 export const MAX_WIDGETS = 200;
 
+/** The ONLY wording of the widget-cap toast, derived from MAX_WIDGETS so the
+ *  number cannot drift out of the copy again. It read "50-widget limit" in four
+ *  separate call sites while the cap here was already 200, so every user who hit
+ *  the cap was told a number four times too small. Import this; never retype it. */
+export const WIDGET_LIMIT_MESSAGE = `${MAX_WIDGETS}-widget limit — remove one to add another`;
+
 export function createDefaultLayout(): ShellLayout {
   return {
     segments: {

--- a/lib/console/widgets/camslot.area.ts
+++ b/lib/console/widgets/camslot.area.ts
@@ -1,0 +1,163 @@
+"use client";
+
+import { getMapInstance } from "@/lib/map/instance";
+import { startDraw } from "@/lib/map/aoi";
+import { loadedCamerasStore } from "@/lib/cameras/loaded";
+import { loadedWebcamsStore } from "@/lib/webcams/loaded";
+import { webcamRef, orderByDistanceFrom } from "@/lib/console/widgets/camslot.arm";
+import {
+  MAX_PICKS, camerasInRing, describePicked, pickKey, pickStore,
+  type PickedCamera,
+} from "@/lib/console/widgets/camslot.pick";
+
+// ── Draw an area, get a camera wall ──────────────────────────────────────────
+//
+// The gesture Sam asked for: "there is no way to use the polygon area selector and
+// send all cameras in that sector to the camera wall."
+//
+// NOTHING NEW IS DRAWN HERE. `lib/map/aoi.ts` already had a polygon tool with the
+// hard parts solved — document-capture clicks so a vertex landing on a marker does
+// not also open its dossier, a 4px drag slop so repositioning the map does not drop
+// a point, and custody of double-click-zoom so the gesture that closes the ring
+// does not also zoom. All this module does is ask for the ring instead of letting
+// it become the console's AOI scope, and turn it into picks.
+//
+// WHY IT MUST NOT SET THE SCOPE. "Build me a wall out of Soho" and "hide everything
+// outside Soho" are different requests. The AOI scope is read by about a dozen
+// widgets and by the export path; setting it as a side effect of picking cameras
+// would silently filter all of them. Hence `startDraw(map, { onFinish })`.
+//
+// WHAT IT COVERS, AND WHAT IT CANNOT. Road cameras come from `loadedCamerasStore`,
+// which holds the whole /api/cameras array client-side; webcams from
+// `loadedWebcamsStore`, which holds an unranked ~2% sample of Windy. Both are
+// populated ONLY while their layer is on. So there are two failure modes that look
+// identical on screen and must not: "your ring is empty" and "we were not looking".
+// Every return below distinguishes them.
+//
+// It deliberately does NOT fan out to /api/webcam-search on finish. The route
+// refuses spans over 30° lat / 60° lon outright, Windy's request ceiling is still
+// unmeasured, and the standing rule in this codebase is that a map gesture is never
+// an implicit search. Widening the search is offered to the user as a button; it is
+// not done to them.
+
+export type AreaPickOutcome =
+  | { kind: "started" }
+  | { kind: "no-map" }
+  | { kind: "busy" }
+  | { kind: "not-ready" };
+
+/**
+ * Begin an area pick. Returns as soon as drawing starts — the picks land later,
+ * when the user closes the ring.
+ *
+ * Turns picking mode on as a side effect, deliberately: someone who has just drawn
+ * a ring around Soho is picking cameras whether or not they pressed the toggle
+ * first, and making them press it afterwards to see the tray would be a riddle.
+ */
+export function startAreaPick(): AreaPickOutcome {
+  const map = getMapInstance();
+  if (!map) return { kind: "no-map" };
+
+  pickStore.setMode("picking");
+  const ok = startDraw(map, { onFinish: (ring) => { pickRing(ring); } });
+  return ok ? { kind: "started" } : { kind: "not-ready" };
+}
+
+export interface RingPickResult {
+  /** Sentence for the user. Always populated, always says something. */
+  message: string;
+  /** How many cameras the ring actually contained, before the basket's cap. */
+  found: number;
+  added: number;
+}
+
+/**
+ * Everything inside a finished ring goes in the basket.
+ *
+ * Exported separately from `startAreaPick` so it can be driven directly by a test
+ * or by a ring that came from somewhere other than the draw tool — and so the
+ * containment rules stay in `camerasInRing`, which is pure and node-tested, rather
+ * than trapped inside an event handler.
+ */
+export function pickRing(ring: readonly [number, number][]): RingPickResult {
+  const rows = loadedCamerasStore.get();
+  const webcams = loadedWebcamsStore.get();
+
+  if (rows.length === 0 && webcams.length === 0) {
+    // Neither layer is on. Saying "no cameras in that area" here would be a
+    // confident wrong answer to a question we never actually asked.
+    const message = "No camera pins are loaded, so an area has nothing to select. Turn on the Cameras or Webcams layer and draw it again.";
+    toast(message);
+    return { message, found: 0, added: 0 };
+  }
+
+  const cams = camerasInRing(rows, ring);
+  const cover = camerasInRing(webcams, ring);
+  const found = cams.length + cover.length;
+
+  if (found === 0) {
+    const message = "No cameras inside that area.";
+    toast(message);
+    return { message, found: 0, added: 0 };
+  }
+
+  const centre = ringCentre(ring);
+  // Nearest the middle of what they drew, first — so a ring holding more than a
+  // wall can carry loses its outer edge rather than an arbitrary slice.
+  const ordered = orderByDistanceFrom(
+    [
+      ...cams.map((c) => ({
+        lat: c.lat, lon: c.lon,
+        picked: {
+          ref: { k: "cam" as const, id: c.id },
+          key: pickKey({ k: "cam", id: c.id }),
+          label: c.name || c.id,
+          lat: c.lat, lon: c.lon,
+          refreshSeconds: c.refreshSeconds,
+          source: c.source,
+        } satisfies PickedCamera,
+      })),
+      ...cover.map((w) => ({
+        lat: w.lat, lon: w.lon,
+        picked: {
+          ref: webcamRef(w.id, w.label),
+          key: pickKey(webcamRef(w.id, w.label)),
+          label: w.label || w.id,
+          lat: w.lat, lon: w.lon,
+          refreshSeconds: WEBCAM_REFRESH_SECONDS,
+          source: "Windy",
+        } satisfies PickedCamera,
+      })),
+    ],
+    centre,
+  );
+
+  const res = pickStore.addFromArea(ordered.map((o) => o.picked), ring, found);
+  let message = describePicked(res, { found, fromArea: true });
+
+  // The cap is the one case where the honest number and the visible number differ,
+  // so it is stated rather than left for the user to infer from a chip count.
+  if (found > MAX_PICKS) {
+    message += ` This area has ${found} cameras and a wall holds ${MAX_PICKS} — the ${MAX_PICKS} nearest its centre were taken.`;
+  }
+  toast(message);
+  return { message, found, added: res.added };
+}
+
+/** Mirrors camslot.tsx and WorldMap — Windy's image tokens last ~10 minutes. */
+const WEBCAM_REFRESH_SECONDS = 600;
+
+/** The mean of a ring's vertices. Good enough to rank distance within one ring,
+ *  which is all it is used for — it is NOT a centroid and must not be shown to
+ *  anyone as "the middle of this area". */
+function ringCentre(ring: readonly [number, number][]): { lat: number; lon: number } {
+  let lat = 0, lon = 0;
+  for (const [x, y] of ring) { lon += x; lat += y; }
+  const n = Math.max(1, ring.length);
+  return { lat: lat / n, lon: lon / n };
+}
+
+function toast(message: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent("tn-toast", { detail: message }));
+}

--- a/lib/console/widgets/camslot.area.ts
+++ b/lib/console/widgets/camslot.area.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { getMapInstance } from "@/lib/map/instance";
-import { startDraw } from "@/lib/map/aoi";
+import { aoiDrawStore, startDraw } from "@/lib/map/aoi";
 import { loadedCamerasStore } from "@/lib/cameras/loaded";
 import { loadedWebcamsStore } from "@/lib/webcams/loaded";
 import { webcamRef, orderByDistanceFrom } from "@/lib/console/widgets/camslot.arm";
@@ -46,6 +46,39 @@ export type AreaPickOutcome =
   | { kind: "busy" }
   | { kind: "not-ready" };
 
+// ── Whose draw is it? ────────────────────────────────────────────────────────
+//
+// `aoiDrawStore` says a ring is being drawn. It does not say what for, and two
+// controls now start one: "Restrict results to area" and "Draw an area". Both
+// render a live vertex counter and a Cancel button while a draw is running, so
+// without this flag BOTH appeared at once — measured on the live stage bar, two
+// stacked "0/3 POINTS / CANCEL" panels, one of which was describing a gesture the
+// user had not asked for. Whichever one the user reads, half the time it is
+// telling them the wrong thing about what closing the ring will do.
+let forPick = false;
+const flagListeners = new Set<() => void>();
+function emitFlag() { for (const fn of flagListeners) fn(); }
+
+function setForPick(v: boolean) {
+  if (forPick === v) return;
+  forPick = v;
+  emitFlag();
+}
+
+export const areaPickStore = {
+  /** True only while the draw in progress was started by the camera picker. */
+  get(): boolean { return forPick; },
+  subscribe(fn: () => void) { flagListeners.add(fn); return () => { flagListeners.delete(fn); }; },
+};
+
+// A cancelled or abandoned draw never reaches onFinish, so the flag has to be
+// cleared from the draw store going idle rather than from the finish path alone.
+// Subscribed once at module load: aoi.ts is imported by the map and by both
+// controls, so there is no later moment that is reliably "after everything".
+aoiDrawStore.subscribe(() => {
+  if (!aoiDrawStore.get().active) setForPick(false);
+});
+
 /**
  * Begin an area pick. Returns as soon as drawing starts — the picks land later,
  * when the user closes the ring.
@@ -59,7 +92,9 @@ export function startAreaPick(): AreaPickOutcome {
   if (!map) return { kind: "no-map" };
 
   pickStore.setMode("picking");
-  const ok = startDraw(map, { onFinish: (ring) => { pickRing(ring); } });
+  setForPick(true);
+  const ok = startDraw(map, { onFinish: (ring) => { setForPick(false); pickRing(ring); } });
+  if (!ok) setForPick(false);
   return ok ? { kind: "started" } : { kind: "not-ready" };
 }
 

--- a/lib/console/widgets/camslot.arm.ts
+++ b/lib/console/widgets/camslot.arm.ts
@@ -1,78 +1,21 @@
-"use client";
-// Map arming — "fill THIS slot from the map" — plus every rule that decides what a
-// map gesture is allowed to add.
+// Camera-slot rules — the geometry, the cap and the append, all pure.
 //
-// WHY THE MODE LIVES HERE AND NOT IN WorldMap. Two functions in WorldMap would
-// otherwise own it, and both are mount-once closures: `wireInteractions` is a
-// `useCallback(…, [])` invoked once at mount (WorldMap.tsx:1074, closing at :1262),
-// and `createThumbnailManager`'s `onPick` is built inside the init effect that
-// closes at :1563. Anything either one closes over is frozen at mount. On top of
-// that, StageHost.tsx:33,37 unmounts <WorldMap/> entirely when a widget is focused,
-// so React state inside it does not survive a focus round trip either. Module state
-// read at EVENT time is the only shape that works for both.
+// WHAT USED TO LIVE HERE. This file also held `armStore`: a module-level "fill THIS
+// slot from the map" mode, plus the `useArmedSlot` / `useIsArmed` hooks over it.
+// Arming chose the DESTINATION FIRST and it was removed — four camera walls on the
+// Streets board all render the same header, so "arm the right one" was a question
+// the screen could not answer. The basket in camslot.pick.ts replaces it and chooses
+// the destination LAST. That file inherits the reason the mode had to be module
+// state rather than React state: `wireInteractions` in WorldMap is a
+// `useCallback(…, [])` invoked once at mount, the thumbnail manager's `onPick` is
+// built inside the init effect, and StageHost unmounts <WorldMap/> entirely when a
+// widget is focused — so anything either closure captures is frozen at mount and
+// component state does not survive a focus round trip.
 //
-// WHY IT IS NOT PERSISTED. Arming is a held modifier key, not a preference. A
-// persisted mode means you reload tomorrow, click a pin expecting a dossier, and
-// silently append to a slot that is scrolled off screen. Contrast camslot.prefs.ts,
-// which IS persisted, because a pause is something the user chose about themselves.
-// It is not widget config either: store.ts:74 configure() -> emit() -> writeBoardLayout,
-// and boards.ts:104 layoutSignature includes `g: w.config`, so an armed flag in there
-// would light the board's "customised" dot on the first click.
-//
-// Everything below the store is PURE and node-tested. WorldMap supplies geometry and
-// side effects; it does not decide anything.
+// Everything left in this file is PURE and node-tested (tests/unit/camslot-arm.test.ts).
+// WorldMap supplies geometry and side effects; it does not decide anything.
 
-import { useSyncExternalStore } from "react";
 import { MAX_STREAMS, streamKey, type StreamRef } from "@/lib/console/widgets/camslot.model";
-
-// ── The mode ────────────────────────────────────────────────────────────────
-
-let armedId: string | null = null;
-const listeners = new Set<() => void>();
-
-function emit(): void {
-  for (const fn of listeners) fn();
-}
-
-export const armStore = {
-  /** The armed widget instance id, or null. Read at EVENT time, never captured. */
-  get(): string | null {
-    return armedId;
-  },
-  /** Arm one slot. Arming a second disarms the first — one target, always. */
-  arm(instanceId: string): void {
-    if (armedId === instanceId) return;
-    armedId = instanceId;
-    emit();
-  },
-  disarm(): void {
-    if (armedId === null) return;
-    armedId = null;
-    emit();
-  },
-  /** The ⊕ button: same slot turns it off, a different slot moves the arm. */
-  toggle(instanceId: string): void {
-    if (armedId === instanceId) this.disarm();
-    else this.arm(instanceId);
-  },
-  subscribe(fn: () => void): () => void {
-    listeners.add(fn);
-    return () => {
-      listeners.delete(fn);
-    };
-  },
-};
-
-/** Server snapshot is null: nothing is armed before hydration, by definition. */
-const serverSnapshot = (): string | null => null;
-
-export function useArmedSlot(): string | null {
-  return useSyncExternalStore(armStore.subscribe, armStore.get, serverSnapshot);
-}
-
-export function useIsArmed(instanceId: string): boolean {
-  return useArmedSlot() === instanceId;
-}
 
 // ── Geometry ────────────────────────────────────────────────────────────────
 
@@ -294,7 +237,7 @@ export function describeAppend(plan: AppendPlan, opts: AppendNoteOpts): string {
       : "Nothing here to add.";
   }
   if (added === 0) {
-    return `This slot is full at ${opts.cap}${capReason(opts)}. Remove a camera, or arm an empty slot.`;
+    return `This wall is full at ${opts.cap}${capReason(opts)}. Remove a camera, or send these to a new wall.`;
   }
 
   const bits: string[] = [];
@@ -316,8 +259,8 @@ export function describeAppend(plan: AppendPlan, opts: AppendNoteOpts): string {
     // the product anyway: a wall is made of slots.
     bits.push(
       opts.capMixed
-        ? "Narrow the box, drop the fastest-refreshing camera, or use a second slot."
-        : "Narrow the box, or use a second slot.",
+        ? "Pick fewer, drop the fastest-refreshing camera, or use a second wall."
+        : "Pick fewer, or use a second wall.",
     );
   }
   return bits.join(" ");

--- a/lib/console/widgets/camslot.create.ts
+++ b/lib/console/widgets/camslot.create.ts
@@ -82,39 +82,69 @@ export function createCamslot(opts: CreateCamslotOptions = {}): CreateCamslotRes
  *  after a scroll, short enough not to become part of the card's appearance. */
 const FLASH_MS = 1400;
 
+/** How long to keep looking for the new card before giving up. React commits when
+ *  it commits — a fixed number of frames is a guess, and the guess was wrong. */
+const REVEAL_DEADLINE_MS = 600;
+
 /**
  * Scroll a freshly added card into view and mark it, once.
  *
- * Deferred by two animation frames, not called inline: `shellLayoutStore.add`
- * emits synchronously, but React has not committed the new node yet, so a
- * `querySelector` on the same tick finds nothing. One frame gets the commit, the
- * second gets the grid's own layout pass — measured against the settle animation,
- * a single frame lands mid-flight and scrolls to a stale box.
+ * WAITING TWO ANIMATION FRAMES DOES NOT WORK, and this is the second version of
+ * this function for that reason. `shellLayoutStore.add` emits synchronously but
+ * React commits on its own schedule, so `querySelector` inside a fixed number of
+ * frames finds nothing. Measured on the live board: a MutationObserver watching
+ * every `[data-grid-id]` in the workspace recorded the marker being applied ZERO
+ * times across repeated adds — the reveal was silently doing nothing at all, which
+ * is precisely the failure it exists to prevent, hiding inside the fix for it.
  *
- * Silent when the node never appears. The alternative — retrying, or throwing —
- * would turn "the board is in a state I did not anticipate" into either a hang or
- * a crash inside a click handler, and the widget itself has already been created
- * correctly either way.
+ * So it polls per frame until the node exists, with a deadline. Bounded, so a card
+ * that never arrives costs 600ms of empty frames rather than a hang, and the widget
+ * itself has been created correctly either way.
+ *
+ * THE MARKER IS A DATA ATTRIBUTE, NOT A CLASS, and that is not a style preference.
+ * `className` is a prop React owns on these nodes; the board re-renders on the very
+ * store write that created the card, and any class added imperatively is liable to
+ * be reconciled away. React does not touch attributes it never rendered, so
+ * `data-just-added` survives.
  */
 export function revealWidget(id: string): void {
   if (typeof window === "undefined") return;
 
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      const el = document.querySelector<HTMLElement>(`[data-grid-id="${CSS.escape(id)}"]`);
-      if (!el) return;
+  const selector = `[data-grid-id="${CSS.escape(id)}"]`;
 
-      // `block: "nearest"` rather than "center": the board is a scroll container
-      // inside a fixed console band, and centring a card at the bottom of a short
-      // board scrolls past the cards the user was already looking at. "Nearest"
-      // moves the minimum needed to bring it fully in, which for an on-screen
-      // card is nothing at all.
-      el.scrollIntoView({ block: "nearest", inline: "nearest", behavior: prefersReducedMotion() ? "auto" : "smooth" });
+  const mark = (el: HTMLElement) => {
+    // `block: "nearest"` rather than "center": the board is a scroll container
+    // inside a fixed console band, and centring a card at the bottom of a short
+    // board scrolls past the cards the user was already looking at. "Nearest"
+    // moves the minimum needed to bring it fully in, which for a card already on
+    // screen is nothing at all.
+    el.scrollIntoView({ block: "nearest", inline: "nearest", behavior: prefersReducedMotion() ? "auto" : "smooth" });
+    el.setAttribute("data-just-added", "");
+    window.setTimeout(() => el.removeAttribute("data-just-added"), FLASH_MS);
+  };
 
-      el.classList.add("is-just-added");
-      window.setTimeout(() => el.classList.remove("is-just-added"), FLASH_MS);
-    });
+  const found = document.querySelector<HTMLElement>(selector);
+  if (found) { mark(found); return; }
+
+  // WATCH FOR IT RATHER THAN GUESSING WHEN IT ARRIVES. The first version waited a
+  // fixed two animation frames and never fired; the second polled with
+  // requestAnimationFrame and fired, but late and erratically — rAF is throttled to
+  // roughly one callback a second in a tab that is not visible, which is also every
+  // tab a headless test runs in. A MutationObserver fires on the insertion itself,
+  // so this is correct whether or not frames are being served.
+  const obs = new MutationObserver(() => {
+    const el = document.querySelector<HTMLElement>(selector);
+    if (!el) return;
+    obs.disconnect();
+    window.clearTimeout(giveUp);
+    mark(el);
   });
+  obs.observe(document.body, { childList: true, subtree: true });
+
+  // Bounded, so a card that never arrives costs one disconnect rather than an
+  // observer that lives for the rest of the session. The widget itself has already
+  // been created correctly either way.
+  const giveUp = window.setTimeout(() => obs.disconnect(), REVEAL_DEADLINE_MS);
 }
 
 function prefersReducedMotion(): boolean {

--- a/lib/console/widgets/camslot.create.ts
+++ b/lib/console/widgets/camslot.create.ts
@@ -85,39 +85,69 @@ export function createCamslot(opts: CreateCamslotOptions = {}): CreateCamslotRes
  *  after a scroll, short enough not to become part of the card's appearance. */
 const FLASH_MS = 1400;
 
+/** How long to keep looking for the new card before giving up. React commits when
+ *  it commits — a fixed number of frames is a guess, and the guess was wrong. */
+const REVEAL_DEADLINE_MS = 600;
+
 /**
  * Scroll a freshly added card into view and mark it, once.
  *
- * Deferred by two animation frames, not called inline: `shellLayoutStore.add`
- * emits synchronously, but React has not committed the new node yet, so a
- * `querySelector` on the same tick finds nothing. One frame gets the commit, the
- * second gets the grid's own layout pass — measured against the settle animation,
- * a single frame lands mid-flight and scrolls to a stale box.
+ * WAITING TWO ANIMATION FRAMES DOES NOT WORK, and this is the second version of
+ * this function for that reason. `shellLayoutStore.add` emits synchronously but
+ * React commits on its own schedule, so `querySelector` inside a fixed number of
+ * frames finds nothing. Measured on the live board: a MutationObserver watching
+ * every `[data-grid-id]` in the workspace recorded the marker being applied ZERO
+ * times across repeated adds — the reveal was silently doing nothing at all, which
+ * is precisely the failure it exists to prevent, hiding inside the fix for it.
  *
- * Silent when the node never appears. The alternative — retrying, or throwing —
- * would turn "the board is in a state I did not anticipate" into either a hang or
- * a crash inside a click handler, and the widget itself has already been created
- * correctly either way.
+ * So it polls per frame until the node exists, with a deadline. Bounded, so a card
+ * that never arrives costs 600ms of empty frames rather than a hang, and the widget
+ * itself has been created correctly either way.
+ *
+ * THE MARKER IS A DATA ATTRIBUTE, NOT A CLASS, and that is not a style preference.
+ * `className` is a prop React owns on these nodes; the board re-renders on the very
+ * store write that created the card, and any class added imperatively is liable to
+ * be reconciled away. React does not touch attributes it never rendered, so
+ * `data-just-added` survives.
  */
 export function revealWidget(id: string): void {
   if (typeof window === "undefined") return;
 
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      const el = document.querySelector<HTMLElement>(`[data-grid-id="${CSS.escape(id)}"]`);
-      if (!el) return;
+  const selector = `[data-grid-id="${CSS.escape(id)}"]`;
 
-      // `block: "nearest"` rather than "center": the board is a scroll container
-      // inside a fixed console band, and centring a card at the bottom of a short
-      // board scrolls past the cards the user was already looking at. "Nearest"
-      // moves the minimum needed to bring it fully in, which for an on-screen
-      // card is nothing at all.
-      el.scrollIntoView({ block: "nearest", inline: "nearest", behavior: prefersReducedMotion() ? "auto" : "smooth" });
+  const mark = (el: HTMLElement) => {
+    // `block: "nearest"` rather than "center": the board is a scroll container
+    // inside a fixed console band, and centring a card at the bottom of a short
+    // board scrolls past the cards the user was already looking at. "Nearest"
+    // moves the minimum needed to bring it fully in, which for a card already on
+    // screen is nothing at all.
+    el.scrollIntoView({ block: "nearest", inline: "nearest", behavior: prefersReducedMotion() ? "auto" : "smooth" });
+    el.setAttribute("data-just-added", "");
+    window.setTimeout(() => el.removeAttribute("data-just-added"), FLASH_MS);
+  };
 
-      el.classList.add("is-just-added");
-      window.setTimeout(() => el.classList.remove("is-just-added"), FLASH_MS);
-    });
+  const found = document.querySelector<HTMLElement>(selector);
+  if (found) { mark(found); return; }
+
+  // WATCH FOR IT RATHER THAN GUESSING WHEN IT ARRIVES. The first version waited a
+  // fixed two animation frames and never fired; the second polled with
+  // requestAnimationFrame and fired, but late and erratically — rAF is throttled to
+  // roughly one callback a second in a tab that is not visible, which is also every
+  // tab a headless test runs in. A MutationObserver fires on the insertion itself,
+  // so this is correct whether or not frames are being served.
+  const obs = new MutationObserver(() => {
+    const el = document.querySelector<HTMLElement>(selector);
+    if (!el) return;
+    obs.disconnect();
+    window.clearTimeout(giveUp);
+    mark(el);
   });
+  obs.observe(document.body, { childList: true, subtree: true });
+
+  // Bounded, so a card that never arrives costs one disconnect rather than an
+  // observer that lives for the rest of the session. The widget itself has already
+  // been created correctly either way.
+  const giveUp = window.setTimeout(() => obs.disconnect(), REVEAL_DEADLINE_MS);
 }
 
 function prefersReducedMotion(): boolean {

--- a/lib/console/widgets/camslot.create.ts
+++ b/lib/console/widgets/camslot.create.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { shellLayoutStore } from "@/lib/console/store";
+import { MAX_STREAMS, sanitizeCamslotConfig, type StreamRef } from "@/lib/console/widgets/camslot.model";
+
+// ── Making a camera wall, from anywhere ──────────────────────────────────────
+//
+// Four separate surfaces now need to mint a camslot: the ghost "+" tile at the end
+// of the wall, the stage bar's button, the empty-board rescue panel, and the map's
+// "send these to the wall". Before this file each of them would have hand-rolled
+// `shellLayoutStore.add("camslot", …)`, and the four would have drifted — a
+// different default dwell here, a forgotten sanitise there, and only one of them
+// bothering to make the new card visible.
+//
+// THE VISIBILITY PROBLEM IS THE POINT OF THIS MODULE, not a nicety bolted onto it.
+// `addWidget` places a new card at `findFreeSpot`, and the Streets board is tiled
+// by `arrangeWall` to cover all twelve columns for the full row budget — so there
+// is no free cell, and the scan falls through to `{ x: 0, y: rowsUsed }`: the first
+// row BELOW the board. Measured on the live board at 1440x900, adding a camera wall
+// from the command palette put it at `top: 856px` in a 900px viewport. Nothing
+// scrolled to it, nothing flashed, and the palette stayed open over the top. The
+// user's report was "I add a camera wall and nothing happens", and they were right
+// to say so — 44px of a 174px card, below the world-clock strip, is not feedback.
+//
+// So creating and revealing are ONE call here. A caller cannot get the first
+// without the second and quietly reintroduce the bug.
+
+/** A camera wall's opening cell. Wider than the generic 4x7 because a camera tile
+ *  showing a 16:9 frame at four columns is smaller than the controls on its own
+ *  header — this is the smallest size at which a new empty slot reads as a place
+ *  a picture will go. */
+const CAMSLOT_SIZE = { w: 4, h: 9 };
+
+export interface CreateCamslotOptions {
+  /** Shown as the card's title. A place, not a description — "Soho", "Trafalgar
+   *  Square". Omitted for a blank slot, which titles itself "Camera wall". */
+  name?: string;
+  /** What to put in it. Sanitised here, so a caller may pass anything it scraped. */
+  streams?: StreamRef[];
+  /** Dwell per view when it holds more than one. Defaults to the model's own. */
+  intervalMs?: number;
+  /** Scroll the new card into view and flash it. Defaults ON, and the default is
+   *  the whole reason this function exists — pass `false` only when the caller has
+   *  already guaranteed the card is on screen. */
+  reveal?: boolean;
+}
+
+export interface CreateCamslotResult {
+  ok: boolean;
+  id?: string;
+  /** Set when `ok` is false, ready to show the user. */
+  reason?: string;
+}
+
+/**
+ * Add a camera wall to the open board and put it where the user can see it.
+ *
+ * Returns rather than throws on capacity, because every caller is a click handler
+ * and all of them owe the user a sentence rather than a stack trace.
+ */
+export function createCamslot(opts: CreateCamslotOptions = {}): CreateCamslotResult {
+  const config = sanitizeCamslotConfig({
+    streams: (opts.streams ?? []).slice(0, MAX_STREAMS),
+    intervalMs: opts.intervalMs,
+    name: opts.name,
+  });
+
+  const res = shellLayoutStore.add("camslot", {
+    config: config as unknown as Record<string, unknown>,
+    width: CAMSLOT_SIZE.w,
+  });
+
+  if (!res.ok) {
+    return { ok: false, reason: "This board is full — remove a widget to add another." };
+  }
+
+  if (opts.reveal !== false) revealWidget(res.id);
+  return { ok: true, id: res.id };
+}
+
+/** How long the new card wears its highlight. Long enough to find with your eye
+ *  after a scroll, short enough not to become part of the card's appearance. */
+const FLASH_MS = 1400;
+
+/**
+ * Scroll a freshly added card into view and mark it, once.
+ *
+ * Deferred by two animation frames, not called inline: `shellLayoutStore.add`
+ * emits synchronously, but React has not committed the new node yet, so a
+ * `querySelector` on the same tick finds nothing. One frame gets the commit, the
+ * second gets the grid's own layout pass — measured against the settle animation,
+ * a single frame lands mid-flight and scrolls to a stale box.
+ *
+ * Silent when the node never appears. The alternative — retrying, or throwing —
+ * would turn "the board is in a state I did not anticipate" into either a hang or
+ * a crash inside a click handler, and the widget itself has already been created
+ * correctly either way.
+ */
+export function revealWidget(id: string): void {
+  if (typeof window === "undefined") return;
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLElement>(`[data-grid-id="${CSS.escape(id)}"]`);
+      if (!el) return;
+
+      // `block: "nearest"` rather than "center": the board is a scroll container
+      // inside a fixed console band, and centring a card at the bottom of a short
+      // board scrolls past the cards the user was already looking at. "Nearest"
+      // moves the minimum needed to bring it fully in, which for an on-screen
+      // card is nothing at all.
+      el.scrollIntoView({ block: "nearest", inline: "nearest", behavior: prefersReducedMotion() ? "auto" : "smooth" });
+
+      el.classList.add("is-just-added");
+      window.setTimeout(() => el.classList.remove("is-just-added"), FLASH_MS);
+    });
+  });
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}

--- a/lib/console/widgets/camslot.create.ts
+++ b/lib/console/widgets/camslot.create.ts
@@ -29,7 +29,10 @@ import { MAX_STREAMS, sanitizeCamslotConfig, type StreamRef } from "@/lib/consol
  *  showing a 16:9 frame at four columns is smaller than the controls on its own
  *  header — this is the smallest size at which a new empty slot reads as a place
  *  a picture will go. */
-const CAMSLOT_SIZE = { w: 4, h: 9 };
+/** The cell footprint a new wall takes. Exported because the grid draws a ghost
+ *  tile in the cell this card WILL occupy, and a second copy of these numbers
+ *  would let the preview drift away from the thing it previews. */
+export const CAMSLOT_SIZE = { w: 4, h: 9 };
 
 export interface CreateCamslotOptions {
   /** Shown as the card's title. A place, not a description — "Soho", "Trafalgar

--- a/lib/console/widgets/camslot.pick.ts
+++ b/lib/console/widgets/camslot.pick.ts
@@ -1,0 +1,244 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { bboxOfRing, pointInRing } from "@/lib/shell/scope";
+import { MAX_STREAMS, streamKey, type StreamRef } from "@/lib/console/widgets/camslot.model";
+import type { LatLon } from "@/lib/console/widgets/camslot.arm";
+
+// ── The camera basket ────────────────────────────────────────────────────────
+//
+// What this replaces, and why the replacement is a different shape rather than a
+// tidier version of the same thing.
+//
+// ARMING chose the DESTINATION FIRST. You pressed a ⊕ hidden inside one widget's
+// hover-only control bar, and from then on every camera you clicked went into that
+// one slot. Three things went wrong with it, and all three were reported by the
+// person using it rather than found in review:
+//
+//  • The destinations are indistinguishable. Four camera walls on the Streets
+//    board all render the header "CAMERA WALL", so "arm the right one" is a
+//    question the screen does not answer.
+//  • The mode is invisible unless you pressed the button yourself. Coming back to
+//    a console that is already armed, nothing tells you why clicking a pin behaves
+//    differently from yesterday.
+//  • It has no answer for "everything in this area". Arming appends to one slot;
+//    it cannot say "make me a wall out of Soho".
+//
+// PICKING chooses the destination LAST. Cameras accumulate in a basket that is
+// drawn on screen the whole time it is non-empty, and only when the user presses
+// "Send to wall" do they say where. A click, a shift-drag box and a drawn polygon
+// all feed the same basket, so the three gestures need one mental model instead of
+// three, and "make a wall out of this area" is the same button as "make a wall out
+// of these two cameras I clicked".
+//
+// MODULE STATE, not React state — this constraint is inherited from arming and has
+// not gone away. `wireInteractions` in WorldMap is a `useCallback(…, [])` invoked
+// once at mount, and the thumbnail manager's `onPick` is built inside the init
+// effect: anything either closes over is frozen at mount. On top of that StageHost
+// unmounts <WorldMap/> entirely when a widget is focused, so component state would
+// not survive a round trip through a focused widget either. State read at EVENT
+// time is the only shape that works for both.
+//
+// NOT PERSISTED, deliberately. A basket is a gesture in progress, not a
+// preference. Restoring one at next login would greet the user with a tray full of
+// cameras they have no memory of choosing, and — worse — `boards.ts` builds its
+// "customised" signature from widget config, so anything that leaks into config
+// lights the edited dot on boards nobody touched.
+
+/** A camera the user has chosen but not yet placed. */
+export interface PickedCamera {
+  /** What actually goes into a slot. */
+  ref: StreamRef;
+  /** `streamKey(ref)` — identity for dedup. Stored rather than recomputed so the
+   *  basket can be deduped without importing the model into a hot loop. */
+  key: string;
+  /** What to call it in the tray, and what to seed a new wall's name from. */
+  label: string;
+  lat: number;
+  lon: number;
+  /** Poll cadence in seconds, where the source states one. Feeds `cadenceCap` at
+   *  send time. Optional, and optional on purpose: a missing cadence must degrade
+   *  to a stated fallback rather than to a confident wrong number. */
+  refreshSeconds?: number;
+  /** Owning network, e.g. "TfL". Shown in the tray so a user can tell a road
+   *  camera from a Windy webcam before committing to it. */
+  source?: string;
+}
+
+/**
+ * The basket holds at most one wall's worth.
+ *
+ * A slot caps at `MAX_STREAMS`, so a basket that could grow past it would be
+ * promising a wall it cannot build. Refusing at the same number lets the tray say
+ * "this area has 143 cameras, a wall holds 60" while the box is being filled —
+ * which is a fact the user can act on — instead of discovering the truncation
+ * after they press send.
+ */
+export const MAX_PICKS = MAX_STREAMS;
+
+export interface MergeResult {
+  next: PickedCamera[];
+  added: number;
+  duplicates: number;
+  /** Rows dropped because the basket is full. */
+  refused: number;
+}
+
+/**
+ * Fold new picks into the basket: dedup by stream key, keep insertion order, stop
+ * at the cap.
+ *
+ * REFUSES rather than evicting. Dropping the oldest to make room for the newest
+ * would silently unpick a camera the user chose deliberately, and they would only
+ * notice it missing from the finished wall.
+ *
+ * Pure — `tests/unit/camslot-pick.test.ts` drives it directly.
+ */
+export function mergePicks(
+  existing: readonly PickedCamera[],
+  incoming: readonly PickedCamera[],
+  cap: number = MAX_PICKS,
+): MergeResult {
+  const next = [...existing];
+  const seen = new Set(existing.map((p) => p.key));
+  let added = 0;
+  let duplicates = 0;
+  let refused = 0;
+
+  for (const row of incoming) {
+    if (seen.has(row.key)) { duplicates += 1; continue; }
+    if (next.length >= cap) { refused += 1; continue; }
+    seen.add(row.key);
+    next.push(row);
+    added += 1;
+  }
+
+  return { next: added > 0 ? next : [...existing], added, duplicates, refused };
+}
+
+/**
+ * Everything inside a drawn ring.
+ *
+ * The ring's bounding box is a cheap reject before the O(vertices) test, the same
+ * order `withinScope` uses — a polygon over Soho against 19,000 loaded cameras
+ * runs the ray cast on the handful the bbox admits rather than all of them.
+ *
+ * Non-finite coordinates are DROPPED, never coerced. `lat ?? 0` would place a
+ * camera in the Gulf of Guinea, and a ring drawn there would then "contain" every
+ * broken row in the feed.
+ */
+export function camerasInRing<T extends LatLon>(
+  rows: readonly T[],
+  ring: readonly [number, number][],
+): T[] {
+  if (ring.length < 3) return [];
+  const [west, south, east, north] = bboxOfRing(ring);
+  const out: T[] = [];
+  for (const r of rows) {
+    if (!Number.isFinite(r.lat) || !Number.isFinite(r.lon)) continue;
+    if (r.lon < west || r.lon > east || r.lat < south || r.lat > north) continue;
+    if (pointInRing(r.lon, r.lat, ring)) out.push(r);
+  }
+  return out;
+}
+
+/** What the map is currently doing with a click on a camera. */
+export type PickMode = "off" | "picking";
+
+interface PickState {
+  mode: PickMode;
+  picks: PickedCamera[];
+  /** Vertices of the ring the picks came from, when they came from one. Kept so
+   *  the tray can name the selection and offer to widen the search inside the same
+   *  area without asking the user to draw it again. */
+  ring: [number, number][] | null;
+  /** How many cameras the last area query actually found, which can exceed
+   *  `picks.length` once the cap bites. Printing `picks.length` as the area's total
+   *  would be the coverage lie the rest of this codebase exists to avoid. */
+  foundInArea: number;
+}
+
+let state: PickState = { mode: "off", picks: [], ring: null, foundInArea: 0 };
+const listeners = new Set<() => void>();
+function emit() { for (const fn of listeners) fn(); }
+
+export const pickStore = {
+  get(): PickState { return state; },
+
+  /** Turn picking on or off. Turning it off keeps the basket — the user may be
+   *  panning the map between selections, and throwing their work away for a mode
+   *  toggle would be a trap. `clear()` is the only thing that empties it. */
+  setMode(mode: PickMode) {
+    if (state.mode === mode) return;
+    state = { ...state, mode };
+    emit();
+  },
+
+  add(rows: readonly PickedCamera[]): MergeResult {
+    const res = mergePicks(state.picks, rows);
+    if (res.added > 0) { state = { ...state, picks: res.next }; emit(); }
+    return res;
+  },
+
+  /** Record an area selection: its picks, its ring, and the honest total. */
+  addFromArea(rows: readonly PickedCamera[], ring: readonly [number, number][], found: number): MergeResult {
+    const res = mergePicks(state.picks, rows);
+    state = { ...state, picks: res.next, ring: [...ring], foundInArea: found };
+    emit();
+    return res;
+  },
+
+  remove(key: string) {
+    if (!state.picks.some((p) => p.key === key)) return;
+    state = { ...state, picks: state.picks.filter((p) => p.key !== key) };
+    emit();
+  },
+
+  clear() {
+    if (state.picks.length === 0 && state.ring === null) return;
+    state = { ...state, picks: [], ring: null, foundInArea: 0 };
+    emit();
+  },
+
+  /** Everything off: used when the board changes under the basket. */
+  reset() {
+    state = { mode: "off", picks: [], ring: null, foundInArea: 0 };
+    emit();
+  },
+
+  subscribe(fn: () => void) { listeners.add(fn); return () => { listeners.delete(fn); }; },
+};
+
+/** Nothing is picked before hydration, by definition — so the server snapshot is a
+ *  stable frozen empty rather than a fresh object, which would loop the store. */
+const SERVER_STATE: PickState = { mode: "off", picks: [], ring: null, foundInArea: 0 };
+
+export function usePicks(): PickState {
+  return useSyncExternalStore(pickStore.subscribe, pickStore.get, () => SERVER_STATE);
+}
+
+/**
+ * A name for a wall built from a set of picks.
+ *
+ * Prefers the shared leading words of the labels, because the camera feeds already
+ * caption themselves by place — "London: Trafalgar Square" and "London: Oxford
+ * Circus" agree on "London", and that is a better name than anything a centroid
+ * lookup would invent. Falls back to counting, never to guessing: naming a drawn
+ * polygon "Southern England" from its centre is a claim this product cannot
+ * support.
+ */
+export function nameForPicks(picks: readonly PickedCamera[], areaLabel?: string): string {
+  if (areaLabel) return areaLabel;
+  if (picks.length === 0) return "";
+  if (picks.length === 1) return picks[0].label;
+
+  const prefix = picks[0].label.split(/[:,–—-]/)[0]?.trim();
+  if (prefix && prefix.length >= 3 && picks.every((p) => p.label.startsWith(prefix))) {
+    return prefix;
+  }
+  return `${picks.length} cameras`;
+}
+
+/** Dedup key for a camera row, exported so callers building `PickedCamera` do not
+ *  each reach for the model. */
+export function pickKey(ref: StreamRef): string { return streamKey(ref); }

--- a/lib/console/widgets/camslot.pick.ts
+++ b/lib/console/widgets/camslot.pick.ts
@@ -142,6 +142,49 @@ export function camerasInRing<T extends LatLon>(
   return out;
 }
 
+export interface PickNoteOpts {
+  /** How many the gesture actually found, before the basket's cap. Distinct from
+   *  `added + duplicates + refused` only when a caller filtered first. */
+  found?: number;
+  /** True when the gesture was a drawn area rather than a click or a box. */
+  fromArea?: boolean;
+}
+
+/**
+ * One sentence for what a gesture did to the basket.
+ *
+ * Every branch says something. A gesture that produced no visible consequence is
+ * the failure this whole interception layer exists to prevent — "the map moved a
+ * bit" is not an answer to a click, and neither is silence when everything you
+ * just boxed was already picked.
+ *
+ * The refusal branch names BOTH numbers, because "60 picked" alone reads as
+ * success when fourteen cameras were dropped on the floor.
+ */
+export function describePicked(res: MergeResult, opts: PickNoteOpts = {}): string {
+  const where = opts.fromArea ? " in this area" : "";
+  const n = (c: number, s: string, p = `${s}s`) => `${c} ${c === 1 ? s : p}`;
+
+  if (res.added === 0 && res.duplicates === 0 && res.refused === 0) {
+    return `No cameras${where}.`;
+  }
+  if (res.added === 0 && res.refused > 0) {
+    return `The basket is full at ${MAX_PICKS} — ${n(res.refused, "camera")} not picked. Send or clear what you have first.`;
+  }
+  if (res.added === 0) {
+    return res.duplicates === 1
+      ? "That one is already picked."
+      : `All ${res.duplicates} were already picked.`;
+  }
+
+  const parts = [`Picked ${n(res.added, "camera")}${where}.`];
+  if (res.duplicates > 0) parts.push(`${n(res.duplicates, "was", "were")} already in the basket.`);
+  if (res.refused > 0) {
+    parts.push(`${res.refused} more would not fit — a basket holds ${MAX_PICKS}.`);
+  }
+  return parts.join(" ");
+}
+
 /** What the map is currently doing with a click on a camera. */
 export type PickMode = "off" | "picking";
 
@@ -197,6 +240,28 @@ export const pickStore = {
   clear() {
     if (state.picks.length === 0 && state.ring === null) return;
     state = { ...state, picks: [], ring: null, foundInArea: 0 };
+    emit();
+  },
+
+  /**
+   * Keep only these picks, dropping the rest.
+   *
+   * For a PARTIAL send: a wall took eight of the twelve you had and refused four
+   * because of its cadence cap. Clearing the basket there would destroy those four
+   * at the same moment the message says "use a second wall" — advice the user could
+   * no longer follow, because the cameras it referred to are gone. They stay.
+   *
+   * The area context is dropped regardless, and that is deliberate. Once part of a
+   * ring's contents has been placed, the leftovers are no longer "what is in this
+   * area": keeping `foundInArea` would leave the tray printing "this area has 143
+   * cameras" above a basket of four, which is true about the area and false about
+   * the thing the sentence appears to describe.
+   */
+  retain(keys: readonly string[]) {
+    const keep = new Set(keys);
+    const picks = state.picks.filter((p) => keep.has(p.key));
+    if (picks.length === state.picks.length && state.ring === null) return;
+    state = { ...state, picks, ring: null, foundInArea: 0 };
     emit();
   },
 

--- a/lib/console/widgets/camslot.send.ts
+++ b/lib/console/widgets/camslot.send.ts
@@ -1,0 +1,287 @@
+"use client";
+// ── Sending the basket somewhere ─────────────────────────────────────────────
+//
+// The basket (camslot.pick.ts) collects cameras without asking where they go. This
+// file is the other half: the moment the user finally says "there", and the only
+// place in the app that turns a pile of picks into a camera wall.
+//
+// It is its own module for the same reason camslot.create.ts is — the decision is
+// shared. The tray's menu, and anything else that later wants to hand a selection to
+// a wall, must agree about what "a camera wall on this board" is, what it is called,
+// and what happens when the destination cannot take everything. Two copies of that
+// would disagree the first time one of them was edited.
+//
+// NOTHING HERE THROWS. Every caller is a click handler, and a rejected send owes the
+// user a sentence rather than a stack trace — the same contract createCamslot()
+// keeps, for the same reason.
+
+import { shellLayoutStore } from "@/lib/console/store";
+import { createCamslot, revealWidget } from "@/lib/console/widgets/camslot.create";
+import { pickStore, nameForPicks, type PickedCamera } from "@/lib/console/widgets/camslot.pick";
+import {
+  cadenceCap,
+  describeAppend,
+  orderByDistanceFrom,
+  planAppend,
+  FALLBACK_REFRESH_SECONDS,
+  type LatLon,
+} from "@/lib/console/widgets/camslot.arm";
+import { DEFAULT_INTERVAL_MS, sanitizeCamslotConfig, streamKey, type StreamRef } from "@/lib/console/widgets/camslot.model";
+import { loadedCamerasStore } from "@/lib/cameras/loaded";
+import { scopeStore } from "@/lib/shell/scope";
+
+/** Where a basket is going: a brand new wall, or the id of one already on the board. */
+export type SendTarget = "new" | string;
+
+export interface SendResult {
+  ok: boolean;
+  /** Ready to show the user, on every path. Never empty. */
+  message: string;
+  /** The wall that received them, when one did. */
+  widgetId?: string;
+}
+
+/** One row of the "send to" menu. */
+export interface CamslotTarget {
+  id: string;
+  name: string;
+  /** Streams the wall holds right now — the number the menu prints. */
+  count: number;
+}
+
+/** The widget type id this module can send to. */
+const CAMSLOT_TYPE = "camslot";
+
+/** Mirrors camslot.tsx:34 and WorldMap.tsx:309 — Windy's image tokens last ~10
+ *  minutes and /api/webcam-image is bounded by that. */
+const WEBCAM_REFRESH_SECONDS = 600;
+
+/**
+ * The cadence of a stream ALREADY in a wall.
+ *
+ * A mirror of `refreshForRef` in WorldMap.tsx:315-319, and it has to stay one: the
+ * cap the tray computes and the cap the map computed must be the same number, or the
+ * same wall would report two different limits depending on which gesture filled it.
+ * Road cameras are the only kind whose cadence varies, and loadedCamerasStore is the
+ * only place the client holds it.
+ */
+function refreshForRef(ref: StreamRef): number | undefined {
+  if (ref.k === "webcam") return WEBCAM_REFRESH_SECONDS;
+  if (ref.k === "yt") return undefined; // an embed is not polled; it has no cadence
+  return loadedCamerasStore.get().find((c) => c.id === ref.id)?.refreshSeconds;
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * The middle of the selection — the MEAN of the picked coordinates, not the centre
+ * of their bounding box.
+ *
+ * A bbox centre is equidistant from both extremes by construction, so a basket of
+ * forty Soho cameras plus one stray in Croydon puts the stray and the far edge of
+ * Soho at exactly the same distance, and the tie is then broken by array order: the
+ * cap would drop a camera the user was working on and keep the one they mis-clicked,
+ * for arithmetic reasons nobody could see. The mean sits inside whichever cluster the
+ * selection actually is, so the stray is the thing that goes.
+ *
+ * Null when nothing in the basket has usable coordinates. A centre derived from
+ * `lat ?? 0` would sit in the Gulf of Guinea and order every camera by its distance
+ * from there, which is the arbitrary sample `orderByDistanceFrom` exists to prevent.
+ */
+function selectionCentre(picks: readonly PickedCamera[]): LatLon | null {
+  let lat = 0;
+  let lon = 0;
+  let n = 0;
+  for (const p of picks) {
+    if (!Number.isFinite(p.lat) || !Number.isFinite(p.lon)) continue;
+    lat += p.lat;
+    lon += p.lon;
+    n += 1;
+  }
+  return n > 0 ? { lat: lat / n, lon: lon / n } : null;
+}
+
+/**
+ * Board reading order: top row first, then left to right.
+ *
+ * The grid `rect` is what the user actually sees, so it is what the menu is ordered
+ * by — `widgets[]` array order is authoring order and on a board anyone has dragged
+ * it bears no relation to where the cards ended up. A widget with no rect has not
+ * been through a sanitize pass yet (hand-built layouts, and the window between
+ * `add()` and the first layout); those sort last in array order rather than being
+ * dropped, because a wall missing from the menu is a wall you cannot send to.
+ */
+function inReadingOrder<T extends { rect?: { x: number; y: number } }>(rows: readonly T[]): T[] {
+  return rows
+    .map((w, i) => ({ w, i }))
+    .sort((a, b) => {
+      const ar = a.w.rect;
+      const br = b.w.rect;
+      if (!ar && !br) return a.i - b.i;
+      if (!ar) return 1;
+      if (!br) return -1;
+      return ar.y - br.y || ar.x - br.x || a.i - b.i;
+    })
+    .map((e) => e.w);
+}
+
+/**
+ * Every camera wall on the open board, in the order they read on screen.
+ *
+ * The NUMBER in the fallback name is the wall's position in this list, not a count of
+ * the unnamed ones. "Camera wall 3" then means the third wall down the board, which
+ * is something the user can look at and verify; numbering only the unnamed ones would
+ * make "Camera wall 2" the fifth card on screen, and a label that has to be decoded
+ * is worse than no label at all.
+ */
+export function camslotTargets(): CamslotTarget[] {
+  const walls = shellLayoutStore.get().widgets.filter((w) => w.type === CAMSLOT_TYPE);
+  return inReadingOrder(walls).map((w, i) => {
+    const cfg = sanitizeCamslotConfig(w.config);
+    return {
+      id: w.id,
+      name: cfg.name ?? `Camera wall ${i + 1}`,
+      count: cfg.streams.length,
+    };
+  });
+}
+
+/**
+ * Send the basket to a wall — a new one, or one already on the board.
+ *
+ * Empties the basket only when something actually landed. An append refused in full
+ * has not moved the user's work anywhere, and clearing it there would leave them
+ * holding a message that says "use a second wall" with nothing left to send.
+ */
+export function sendPicksToWall(target: SendTarget): SendResult {
+  try {
+    const picks = pickStore.get().picks;
+    if (picks.length === 0) return { ok: false, message: "Nothing picked yet." };
+    return target === "new" ? sendToNew(picks) : sendToExisting(target, picks);
+  } catch {
+    // A click handler must not take the console down with it. No path here is
+    // expected to throw; this is the backstop for the ones nobody predicted.
+    return { ok: false, message: "Could not send those to a camera wall." };
+  }
+}
+
+/**
+ * The area's own name, when there is one worth using.
+ *
+ * BOTH conditions are required and they check different things. `ring` says the picks
+ * came from a drawn area at all; the scope still being in `aoi` mode says the label
+ * currently in the scope store still describes that area. A scope switched back to
+ * World since the ring was drawn is labelled "World", and naming a wall of eight Soho
+ * cameras "World" is the kind of confident wrong answer this codebase spends most of
+ * its comments avoiding.
+ */
+function areaLabel(): string | undefined {
+  if (!pickStore.get().ring) return undefined;
+  const scope = scopeStore.get();
+  if (scope.mode !== "aoi") return undefined;
+  const label = (scope.label ?? "").trim();
+  return label || undefined;
+}
+
+/**
+ * A NEW wall is capped by cadence too, and this is not symmetry for its own sake.
+ *
+ * The basket holds up to MAX_PICKS (60), but a slot can only show as many views as
+ * its dwell and its fastest member allow: sixty cameras at a 5s dwell take five
+ * minutes to come round, so a camera that republishes every 60s would be showing a
+ * five-minute-old frame for most of the cycle. `cadenceCap` is the number of views
+ * that can still be current, and it is 12 for that example — a fifth of what would
+ * otherwise be written.
+ *
+ * Without this, "send 60 to a new wall" silently built a wall that could not honour
+ * its own contents while the identical send to an EXISTING wall refused politely
+ * and said why. Two paths, two answers, same request.
+ */
+function sendToNew(picks: readonly PickedCamera[]): SendResult {
+  const name = nameForPicks(picks, areaLabel());
+
+  const cap = cadenceCap(picks.map((p) => p.refreshSeconds), DEFAULT_INTERVAL_MS);
+  // Centre-out, so a cap that bites drops the outside of what was chosen rather
+  // than whatever happened to be clicked last. Same centre the existing-wall path
+  // uses, deliberately — two send paths that ranked differently would drop
+  // different cameras from the same basket.
+  const centre = selectionCentre(picks);
+  const ordered = centre ? orderByDistanceFrom(picks, centre) : [...picks];
+  const taken = ordered.slice(0, cap);
+  const dropped = picks.length - taken.length;
+
+  const res = createCamslot({ name, streams: taken.map((p) => p.ref) });
+  if (!res.ok) return { ok: false, message: res.reason ?? "Could not add a camera wall." };
+
+  pickStore.clear();
+  const what = plural(taken.length, "camera");
+  const head = name ? `New camera wall "${name}" — ${what}.` : `New camera wall — ${what}.`;
+  if (dropped === 0) return { ok: true, widgetId: res.id, message: head };
+
+  return {
+    ok: true,
+    widgetId: res.id,
+    message: `${head} ${plural(dropped, "camera")} left out: a wall this fast can hold ${cap} before the oldest view goes stale. Send the rest to a second wall.`,
+  };
+}
+
+
+function sendToExisting(id: string, picks: readonly PickedCamera[]): SendResult {
+  const widget = shellLayoutStore.get().widgets.find((w) => w.id === id && w.type === CAMSLOT_TYPE);
+  if (!widget) return { ok: false, message: "That camera wall is gone." };
+
+  // Read the playlist from the STORE, never from anything captured when the menu was
+  // opened: the picker, another tray send, or a share-link load may have changed it
+  // in between, and writing a stale array would silently drop those streams.
+  const cfg = sanitizeCamslotConfig(widget.config);
+
+  // The cap is set by the FASTEST-refreshing member of the RESULTING playlist, so the
+  // streams already in the wall count too — sending a 60s camera into a wall of 300s
+  // ones is exactly the case that moves it, and ignoring the existing members would
+  // let the cap drift up on every send. Mirrors appendToArmedSlot in WorldMap.
+  const cadences = [...cfg.streams.map(refreshForRef), ...picks.map((p) => p.refreshSeconds)];
+  const cap = cadenceCap(cadences, cfg.intervalMs);
+
+  // CENTRE-OUT, and the ordering is what makes the message true rather than a
+  // stylistic choice. When the cap bites, describeAppend says "Added the N nearest
+  // the centre" — a sentence the user can check against the map. Sending the basket
+  // in click order and printing that line would be a claim about a selection nobody
+  // made, which is the exact failure `orderByDistanceFrom` was written to stop.
+  // A basket with no usable coordinates keeps its own order; there is no centre to be
+  // nearest to, and inventing one would be worse than leaving it alone.
+  const centre = selectionCentre(picks);
+  const ordered = centre ? orderByDistanceFrom(picks, centre) : [...picks];
+  const plan = planAppend(cfg.streams, ordered.map((p) => p.ref), cap);
+
+  const resolved = cadences.map((s) =>
+    typeof s === "number" && s > 0 ? s : FALLBACK_REFRESH_SECONDS,
+  );
+  const capSetBySeconds = Math.min(...resolved, FALLBACK_REFRESH_SECONDS);
+  const capMixed = new Set(resolved).size > 1;
+
+  if (plan.next) shellLayoutStore.configure(id, { streams: plan.next });
+  // Reveal even when nothing was added: "already in this wall" is a claim the user is
+  // entitled to check, and they cannot check a card scrolled off the bottom of the
+  // board — which on the Streets board is exactly where the walls are.
+  revealWidget(id);
+
+  // `available` is deliberately omitted. describeAppend prints "N with a live feed"
+  // from it, and the basket does not carry availability — passing picks.length would
+  // be asserting every pick is live, which is a coverage claim we cannot make.
+  const message = describeAppend(plan, { cap, capSetBySeconds, capMixed });
+
+  if (plan.added === 0) return { ok: false, message, widgetId: id };
+
+  if (plan.refused > 0) {
+    // A partial send keeps what the wall would not take. The message it comes with
+    // ends "use a second wall" — advice that would be impossible to follow if the
+    // basket were emptied of the very cameras it refers to.
+    const placed = new Set((plan.next ?? []).map(streamKey));
+    pickStore.retain(ordered.filter((p) => !placed.has(p.key)).map((p) => p.key));
+  } else {
+    pickStore.clear();
+  }
+  return { ok: true, message, widgetId: id };
+}

--- a/lib/console/widgets/camslot.tsx
+++ b/lib/console/widgets/camslot.tsx
@@ -23,7 +23,7 @@ import CamslotPicker from "@/lib/console/widgets/camslot.picker";
 import CamslotDetail from "@/lib/console/widgets/camslot.detail";
 import { useHistoryRecorder } from "@/lib/cameras/history";
 import { streamHealth, useStreamHealth, liveStreams, benchedNote } from "@/lib/console/widgets/camslot.health";
-import { armStore, useIsArmed } from "@/lib/console/widgets/camslot.arm";
+import { pickStore } from "@/lib/console/widgets/camslot.pick";
 import {
   sanitizeCamslotConfig,
   nextIndex,
@@ -161,17 +161,15 @@ function CamslotBody({ instanceId, config }: WidgetBodyProps) {
   const [visible, setVisible] = useState(true);
   const [picking, setPicking] = useState(false);
   const hostRef = useRef<HTMLDivElement | null>(null);
-  const armed = useIsArmed(instanceId);
 
-  // Arming and the picker are two routes to the same append, so being in both at
-  // once is meaningless — and it is also what would strand a ring behind a closed
-  // dialog, because ConsoleShell's Escape handler returns early whenever any
-  // [role="dialog"] is mounted and the picker is one. Opening the picker ends
-  // arming, which removes the collision without touching that shared guard.
-  const openPicker = useCallback(() => {
-    armStore.disarm();
-    setPicking(true);
-  }, []);
+  // Two routes out of an empty slot, and they are deliberately different things.
+  // The PICKER is a dialog owned by this slot: search a place, paste a YouTube
+  // link, add or remove streams here. MAP PICKING is not owned by this slot at all
+  // — it turns the map into a selection surface and the cameras collect in a shared
+  // basket, which is what lets the user choose the destination at send time rather
+  // than committing to one before they have found anything.
+  const openPicker = useCallback(() => setPicking(true), []);
+  const pickOnMap = useCallback(() => pickStore.setMode("picking"), []);
 
   // Names and cadences come from the shared camera poller — ref-counted, so several
   // slots share one 60s poll instead of each starting their own.
@@ -268,8 +266,16 @@ function CamslotBody({ instanceId, config }: WidgetBodyProps) {
           {all.length > 0 ? (
             <>
               <span className="tn-cs-note">{unavailable ?? "Nothing in this slot is answering."}</span>
+              {/* This branch used to dead-end: one button into the picker and no way
+                  back to the map at all, on the one state a user is most likely to
+                  want to replace what is here. Both routes now appear. The picker's
+                  label stays "change", not "add" — the slot is NOT empty, and the
+                  note directly above has just said so. */}
               <button className="tn-cs-add" onClick={() => openPicker()}>
                 Change what is in this slot
+              </button>
+              <button className="tn-cs-add" onClick={() => pickOnMap()}>
+                ◎ Pick cameras on the map
               </button>
             </>
           ) : (
@@ -281,14 +287,10 @@ function CamslotBody({ instanceId, config }: WidgetBodyProps) {
                   header controls only render once a slot has something in it — so
                   without this the primary path ("give me a blank tile, let me drag a
                   box over Soho") had no way in. */}
-              <button
-                className={armed ? "tn-cs-add tn-cs-arm is-on" : "tn-cs-add tn-cs-arm"}
-                aria-pressed={armed}
-                onClick={() => armStore.toggle(instanceId)}
-              >
-                {armed ? "⊕ Picking from the map. Esc to stop" : "⊕ Pick from the map"}
+              <button className="tn-cs-add" onClick={() => pickOnMap()}>
+                ◎ Pick cameras on the map
               </button>
-              <span>Search a place, paste a YouTube link, or pick on the map</span>
+              <span>Search a place, paste a YouTube link, or collect cameras from the map</span>
             </>
           )}
         </div>
@@ -352,15 +354,6 @@ function CamslotBody({ instanceId, config }: WidgetBodyProps) {
             {paused ? "▶" : "❙❙"}
           </button>
         )}
-        <button
-          className={armed ? "tn-cs-arm is-on" : "tn-cs-arm"}
-          aria-pressed={armed}
-          aria-label={armed ? "Stop picking from the map" : "Pick cameras from the map"}
-          title={armed ? "Armed. Click a pin or shift-drag a box on the map. Esc to stop." : "Pick from the map"}
-          onClick={() => armStore.toggle(instanceId)}
-        >
-          ⊕
-        </button>
         <button aria-label="Add or remove cameras" onClick={() => openPicker()}>
           ＋
         </button>
@@ -390,9 +383,52 @@ function CamslotBody({ instanceId, config }: WidgetBodyProps) {
   );
 }
 
+/**
+ * What THIS slot is called, as opposed to what this KIND of widget is called.
+ *
+ * WidgetFrame renders `type.title` for every instance, so the four camera walls on
+ * the Streets board all carried the identical header "CAMERA WALL" while their
+ * configs said London, Madrid and Prague. `CamslotConfig.name` was set by the
+ * preset and rendered nowhere. That is most of why "I can't tell which widget a
+ * camera would go into" was true — the destinations were literally indistinguishable.
+ *
+ * Registry meta calls this and falls back to `type.title` when it returns undefined,
+ * so the contract is: return a name this slot has EARNED, or nothing.
+ *
+ *  1. `name` — what the board author or the user called it. Always wins.
+ *  2. A one-stream slot with a title in its own config. "London: Trafalgar Square"
+ *     is a better header than "Camera wall" and it costs nothing to read. Only
+ *     `StreamRef.t` on a webcam qualifies: the directory lookup and the camera
+ *     poller are React hooks, and a header is not worth a fetch.
+ *  3. Otherwise undefined. A rotating slot has no single subject, and naming it
+ *     after whichever stream happens to be first would be a header that changes
+ *     meaning without changing text.
+ *
+ * Never "" — an empty string is a truthy-looking falsy value that would render as a
+ * blank header instead of falling back, which is worse than the problem this fixes.
+ * `config` is untrusted (it rides inside `?c=` links), so it is sanitized, not cast.
+ */
+export function camslotTitle(config: Record<string, unknown>): string | undefined {
+  const cfg = sanitizeCamslotConfig(config);
+  if (cfg.name) return cfg.name;
+  if (cfg.streams.length !== 1) return undefined;
+  const only = cfg.streams[0];
+  if (only.k !== "webcam") return undefined;
+  const t = (only.t ?? "").trim();
+  return t || undefined;
+}
+
 export const CAMSLOT_WIDGET = {
   id: "camslot",
   title: "Camera wall",
+  // Optional registry meta: WidgetFrame prefers titleOf(instance.config) and falls
+  // back to `title`. Declared here whether or not `WidgetType` has learned the
+  // property yet — CAMSLOT_WIDGET is a named const, not an inline literal, so
+  // `registerWidget(CAMSLOT_WIDGET)` is a plain assignability check with no excess-
+  // property check, and an extra method neither fails to compile nor gets stripped.
+  // No cast is involved, so if the shared type ever declares an INCOMPATIBLE
+  // `titleOf` this line goes red rather than quietly disagreeing.
+  titleOf: camslotTitle,
   icon: "🎦",
   category: "Cameras",
   defaultHeight: 260,

--- a/lib/console/widgets/sources.tsx
+++ b/lib/console/widgets/sources.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/console/sourceWidgets";
 import { rollupHelp, sourceHelp } from "@/lib/console/sourceCards";
 import type { FreshKind } from "@/lib/sources/freshKind";
+import { WIDGET_LIMIT_MESSAGE } from "@/lib/console/types";
 
 const FRESH_LABEL: Record<FreshKind, string> = {
   off: "off",
@@ -158,7 +159,7 @@ function RollupRow({ id }: { id: string }) {
           const r = shellLayoutStore.add(widgetTypeForSource(id));
           if (!r.ok) {
             window.dispatchEvent(
-              new CustomEvent("tn-toast", { detail: "50-widget limit — remove one to add another" }),
+              new CustomEvent("tn-toast", { detail: WIDGET_LIMIT_MESSAGE }),
             );
           }
         }}

--- a/lib/map/aoi.ts
+++ b/lib/map/aoi.ts
@@ -240,12 +240,33 @@ export function isDrawing(): boolean {
   return draw.active;
 }
 
+export interface DrawOptions {
+  /**
+   * What a finished ring is FOR.
+   *
+   * Omitted, the ring becomes the console's AOI scope — the original and still the
+   * default behaviour, which every existing caller relies on.
+   *
+   * Supplied, the scope is left completely alone and the ring is handed to the
+   * caller instead. The camera picker needs this: "make me a wall out of Soho" and
+   * "hide everything outside Soho" are different requests, and quietly doing the
+   * second while the user asked for the first would filter a dozen unrelated
+   * widgets as a side effect of picking some cameras. The drawing, the vertex
+   * counter, the click-capture and the double-click-zoom custody are identical for
+   * both, which is why this is an option rather than a second implementation.
+   *
+   * Called only for a ring that reached MIN_VERTICES. An abandoned draw calls
+   * nothing.
+   */
+  onFinish?: (ring: [number, number][]) => void;
+}
+
 /**
  * Begin drawing. Click to place a vertex, Enter or double-click to finish, Escape
  * to abandon. Finishing with fewer than three vertices abandons instead: two
  * points is a line, and a line as an "area" would filter the console to nothing.
  */
-export function startDraw(map: MapLibreMap): boolean {
+export function startDraw(map: MapLibreMap, opts: DrawOptions = {}): boolean {
   if (draw.active) return false;
   if (!ensureLayers(map)) return false; // style not up: nothing to draw on yet
   setDraw({ active: true, vertices: [] });
@@ -302,6 +323,7 @@ export function startDraw(map: MapLibreMap): boolean {
     const ring = draw.vertices;
     teardown();
     if (ring.length < MIN_VERTICES) return; // not an area - abandon, never filter
+    if (opts.onFinish) { opts.onFinish(ring); return; }
     scopeStore.set(aoiScope(ring, aoiLabel(ring)));
   };
 

--- a/lib/terminal/layoutGrid.ts
+++ b/lib/terminal/layoutGrid.ts
@@ -105,8 +105,46 @@ export function rowsUsed(items: readonly GridRect[]): number {
 export function resolveCollisions(
   items: readonly GridItem[],
   pinnedId: string | null,
+  prevRect: GridRect | null = null,
 ): GridItem[] {
   const out = items.map((i) => ({ ...i }));
+
+  // ── THE SWAP, applied ONCE and BEFORE the loop below ──────────────────────
+  //
+  // Drag a card DOWN onto its neighbour and the neighbour should rise into the
+  // space you just left. The loop below cannot express that: it only ever moves
+  // a widget DOWN, which is exactly what lets it terminate — "every pass either
+  // moves a widget down or exits" is the whole argument that its bound is a
+  // backstop rather than a real limit. Teaching that loop to lift things breaks
+  // the argument, and it breaks it in practice, not just on paper: an earlier
+  // attempt failed the randomised no-overlap invariant on 5 of 5 seeds while all
+  // 50 deterministic cases passed, because a lift can free space a later pass
+  // refills, and the two ping-pong until LIMIT ends the loop mid-overlap.
+  //
+  // So the exchange happens HERE, once, as a plain assignment, and the loop is
+  // left exactly as it was. It needs the rect the held card came FROM, which is
+  // why the caller supplies it; without one this is skipped and every existing
+  // caller behaves as it always did.
+  if (pinnedId !== null && prevRect) {
+    const held = out.find((i) => i.id === pinnedId);
+    // DOWNWARD ONLY. An upward drag already works: the loop pushes the card that
+    // was there down, which is the direction it is allowed to move things, and
+    // compaction then closes up behind. prevRect is here to tell the two apart.
+    if (held && held.y > prevRect.y) {
+      const blocking = out
+        .filter((i) => i.id !== pinnedId && overlaps(held, i))
+        .sort((a, b) => a.y - b.y)[0];
+      if (blocking) {
+        // Lift the topmost displaced card to sit directly above the held one.
+        // Anything else it now overlaps is left to the loop, which pushes DOWN
+        // and therefore still terminates. That is the whole reason this is a
+        // single assignment out here rather than a rule inside the loop.
+        const y = held.y - blocking.h;
+        if (y >= 0 && !overlaps({ ...blocking, y }, held)) blocking.y = y;
+      }
+    }
+  }
+
   const LIMIT = out.length * out.length + 64;
 
   for (let pass = 0; pass < LIMIT; pass++) {
@@ -149,8 +187,12 @@ export function compact(items: readonly GridItem[]): GridItem[] {
 }
 
 /** Resolve overlaps, then close the gaps. The board state after any user action. */
-export function settle(items: readonly GridItem[], pinnedId: string | null): GridItem[] {
-  return compact(resolveCollisions(items, pinnedId));
+export function settle(
+  items: readonly GridItem[],
+  pinnedId: string | null,
+  prevRect: GridRect | null = null,
+): GridItem[] {
+  return compact(resolveCollisions(items, pinnedId, prevRect));
 }
 
 /**
@@ -164,10 +206,11 @@ export function place(
   items: readonly GridItem[],
   id: string,
   rect: GridRect,
+  prevRect: GridRect | null = null,
 ): GridItem[] {
   if (!items.some((i) => i.id === id)) return items as GridItem[];
   const next = items.map((i) => (i.id === id ? clampRect({ ...i, ...rect }) : i));
-  return settle(next, id);
+  return settle(next, id, prevRect);
 }
 
 /**

--- a/lib/terminal/layoutGrid.ts
+++ b/lib/terminal/layoutGrid.ts
@@ -138,9 +138,16 @@ export function resolveCollisions(
  * its own output changes nothing, which the tests assert because a compactor that
  * drifts would make every drag shuffle the board.
  */
-export function compact(items: readonly GridItem[]): GridItem[] {
+export function compact(items: readonly GridItem[], pinnedId: string | null = null): GridItem[] {
   const placed: GridItem[] = [];
   for (const item of readingOrder(items)) {
+    // The held card does not fall. Without this, a drag DOWNWARD is undone inside
+    // the same settle() that performed it: resolveCollisions honours the pin, then
+    // this loop floats the held card straight back up to the first supported row,
+    // so the card follows the pointer, the dashed ghost never leaves the cell you
+    // started in, and on release the card flies back to where it began. The same
+    // root cause made the menu's "move one row down" and ArrowDown inert.
+    if (pinnedId !== null && item.id === pinnedId) { placed.push({ ...item }); continue; }
     let y = item.y;
     while (y > 0 && !placed.some((p) => overlaps({ ...item, y: y - 1 }, p))) y--;
     placed.push({ ...item, y });
@@ -150,7 +157,7 @@ export function compact(items: readonly GridItem[]): GridItem[] {
 
 /** Resolve overlaps, then close the gaps. The board state after any user action. */
 export function settle(items: readonly GridItem[], pinnedId: string | null): GridItem[] {
-  return compact(resolveCollisions(items, pinnedId));
+  return compact(resolveCollisions(items, pinnedId), pinnedId);
 }
 
 /**

--- a/lib/terminal/layoutGrid.ts
+++ b/lib/terminal/layoutGrid.ts
@@ -138,16 +138,9 @@ export function resolveCollisions(
  * its own output changes nothing, which the tests assert because a compactor that
  * drifts would make every drag shuffle the board.
  */
-export function compact(items: readonly GridItem[], pinnedId: string | null = null): GridItem[] {
+export function compact(items: readonly GridItem[]): GridItem[] {
   const placed: GridItem[] = [];
   for (const item of readingOrder(items)) {
-    // The held card does not fall. Without this, a drag DOWNWARD is undone inside
-    // the same settle() that performed it: resolveCollisions honours the pin, then
-    // this loop floats the held card straight back up to the first supported row,
-    // so the card follows the pointer, the dashed ghost never leaves the cell you
-    // started in, and on release the card flies back to where it began. The same
-    // root cause made the menu's "move one row down" and ArrowDown inert.
-    if (pinnedId !== null && item.id === pinnedId) { placed.push({ ...item }); continue; }
     let y = item.y;
     while (y > 0 && !placed.some((p) => overlaps({ ...item, y: y - 1 }, p))) y--;
     placed.push({ ...item, y });
@@ -157,7 +150,7 @@ export function compact(items: readonly GridItem[], pinnedId: string | null = nu
 
 /** Resolve overlaps, then close the gaps. The board state after any user action. */
 export function settle(items: readonly GridItem[], pinnedId: string | null): GridItem[] {
-  return compact(resolveCollisions(items, pinnedId), pinnedId);
+  return compact(resolveCollisions(items, pinnedId));
 }
 
 /**

--- a/lib/terminal/useGridDrag.ts
+++ b/lib/terminal/useGridDrag.ts
@@ -308,16 +308,56 @@ export function useGridDrag(containerRef: React.RefObject<HTMLElement | null>) {
   const nudge = useCallback(
     (id: string, rect: GridRect, d: { dx?: number; dy?: number; dw?: number; dh?: number }) => {
       playFlip.current = captureFlip(containerRef.current);
-      // `rect` is where the item is NOW, so it doubles as the rect being left.
-      // Passing it is what makes "move one row down" work: without it the board
-      // pushed the neighbour further down and compaction put everything back, so
-      // the button was inert no matter how many times it was pressed.
-      shellLayoutStore.placeItem(id, clampRect({
+      // A PURE VERTICAL NUDGE MOVES PAST A CARD, NOT BY A ROW.
+      //
+      // The board compacts, so one row down is not a position a card can HOLD:
+      // move a card down a single row and compaction floats it straight back,
+      // which is why this button did nothing however many times it was pressed.
+      // The only downward move the board can honour is "past the next card", so
+      // that is what the control does — it targets the neighbour's own row and
+      // lets the exchange in resolveCollisions do the rest.
+      //
+      // Only for a plain up/down with no horizontal or size component; every
+      // other combination keeps the literal one-cell step, which works because
+      // nothing compacts sideways.
+      const vertical = d.dy && !d.dx && !d.dw && !d.dh;
+      let target = {
         x: rect.x + (d.dx ?? 0),
         y: Math.max(0, rect.y + (d.dy ?? 0)),
         w: rect.w + (d.dw ?? 0),
         h: rect.h + (d.dh ?? 0),
-      }), rect);
+      };
+
+      if (vertical) {
+        const items = gridItems(shellLayoutStore.get()).filter((i) => i.id !== id);
+        // Only cards that actually share columns with this one are in the way.
+        const inColumn = items.filter((i) => i.x < rect.x + rect.w && rect.x < i.x + i.w);
+        const neighbour = d.dy! > 0
+          ? inColumn.filter((i) => i.y > rect.y).sort((a, b) => a.y - b.y)[0]
+          : inColumn.filter((i) => i.y < rect.y).sort((a, b) => b.y - a.y)[0];
+        // Going DOWN, line the held card's BOTTOM up with the neighbour's, so the
+        // neighbour has exactly its own height of room above to be lifted into.
+        // Targeting the neighbour's own row instead looks equivalent and is not:
+        // it leaves the lift needing `neighbour.y - neighbour.h`, which is
+        // negative whenever the neighbour is nearer the top than it is tall, so
+        // the exchange is skipped and the button goes back to doing nothing.
+        // Going UP the loop does the work, and the neighbour's row is right.
+        //
+        // No neighbour that way means the edge of the board. Leave the literal
+        // step: it does nothing, which is the honest answer to "move past the
+        // next card" when there is no next card.
+        if (neighbour) {
+          target = {
+            ...target,
+            y: d.dy! > 0
+              ? Math.max(0, neighbour.y + neighbour.h - rect.h)
+              : neighbour.y,
+          };
+        }
+      }
+
+      // `rect` is where the item is NOW, so it doubles as the rect being left.
+      shellLayoutStore.placeItem(id, clampRect(target), rect);
     },
     [containerRef],
   );

--- a/lib/terminal/useGridDrag.ts
+++ b/lib/terminal/useGridDrag.ts
@@ -126,7 +126,9 @@ export function useGridDrag(containerRef: React.RefObject<HTMLElement | null>) {
     s.committed = target;
 
     playFlip.current = captureFlip(containerRef.current);
-    shellLayoutStore.placeItem(s.id, target);
+    // s.origin is where this gesture started — the board needs it to know which
+    // way the exchange goes when the held card lands on a neighbour.
+    shellLayoutStore.placeItem(s.id, target, s.origin);
 
     // Where it ACTUALLY landed: settle may float the card up into a gap, so the
     // placeholder has to show the settled cell, not the raw pointer target.
@@ -306,12 +308,16 @@ export function useGridDrag(containerRef: React.RefObject<HTMLElement | null>) {
   const nudge = useCallback(
     (id: string, rect: GridRect, d: { dx?: number; dy?: number; dw?: number; dh?: number }) => {
       playFlip.current = captureFlip(containerRef.current);
+      // `rect` is where the item is NOW, so it doubles as the rect being left.
+      // Passing it is what makes "move one row down" work: without it the board
+      // pushed the neighbour further down and compaction put everything back, so
+      // the button was inert no matter how many times it was pressed.
       shellLayoutStore.placeItem(id, clampRect({
         x: rect.x + (d.dx ?? 0),
         y: Math.max(0, rect.y + (d.dy ?? 0)),
         w: rect.w + (d.dw ?? 0),
         h: rect.h + (d.dh ?? 0),
-      }));
+      }), rect);
     },
     [containerRef],
   );

--- a/lib/terminal/useGridDrag.ts
+++ b/lib/terminal/useGridDrag.ts
@@ -61,6 +61,9 @@ interface Session {
   pointerId: number;
   /** The last rect committed to the store, so an unchanged frame does no work. */
   committed: GridRect;
+  /** Where the board actually SETTLED the card — read back after settle(), not the
+   *  raw pointer target. This is what the held card is drawn at. */
+  landed: GridRect;
   moved: boolean;
 }
 
@@ -128,7 +131,9 @@ export function useGridDrag(containerRef: React.RefObject<HTMLElement | null>) {
     // Where it ACTUALLY landed: settle may float the card up into a gap, so the
     // placeholder has to show the settled cell, not the raw pointer target.
     const landed = gridItems(shellLayoutStore.get()).find((i) => i.id === s.id);
-    setState((prev) => ({ ...prev, ghostRect: landed ? { x: landed.x, y: landed.y, w: landed.w, h: landed.h } : target }));
+    const rect = landed ? { x: landed.x, y: landed.y, w: landed.w, h: landed.h } : target;
+    s.landed = rect;
+    setState((prev) => ({ ...prev, ghostRect: rect }));
   }, [containerRef]);
 
   const onPointerMove = useCallback((e: PointerEvent) => {
@@ -145,9 +150,26 @@ export function useGridDrag(containerRef: React.RefObject<HTMLElement | null>) {
     const dy = Math.round(dyPx / rowStep());
 
     if (s.mode === "move") {
-      // Straight to the DOM: this runs at refresh rate.
-      s.el.style.transform = `translate(${dxPx}px, ${dyPx}px)`;
+      // Commit FIRST, then draw — the transform below reads what settle() decided.
       commit(s, clampRect({ ...s.origin, x: s.origin.x + dx, y: Math.max(0, s.origin.y + dy) }));
+
+      // THE CARD IS DRAWN WHERE IT WILL LAND, NOT UNDER THE POINTER.
+      //
+      // Free-tracking the pointer made the card promise a position the engine had
+      // already decided not to honour: it followed the cursor the whole way down,
+      // the dashed ghost stayed on the cell it started in, and flipOne paid the
+      // debt at release with a flight back — measured at 360px. That flight IS the
+      // jump people report. Drawing the card at the settled cell means there is
+      // nothing left to animate on release, because it is already there.
+      //
+      // The cost, and it is deliberate: the card no longer tracks the pointer 1:1.
+      // It moves in whole cells and stops where it will actually go. A card that
+      // stops where it will land is honest; one that follows your finger and then
+      // teleports is not.
+      const colW = columnWidth(s.containerWidth);
+      const tx = (s.landed.x - s.origin.x) * (colW + GAP_PX);
+      const ty = (s.landed.y - s.origin.y) * rowStep();
+      s.el.style.transform = `translate(${tx}px, ${ty}px)`;
       return;
     }
 
@@ -257,6 +279,7 @@ export function useGridDrag(containerRef: React.RefObject<HTMLElement | null>) {
         el,
         pointerId: e.pointerId,
         committed: { ...rect },
+        landed: { ...rect },
         moved: false,
       };
 

--- a/lib/webcams/loaded.ts
+++ b/lib/webcams/loaded.ts
@@ -1,0 +1,44 @@
+"use client";
+// A snapshot of the webcams the map has drawn, mirroring lib/cameras/loaded.ts.
+//
+// WHY THIS EXISTS. Road cameras have been readable outside WorldMap since
+// loadedCamerasStore shipped; webcams were not — they lived only in a component
+// ref (`webcamsRef`), so anything outside the map that wanted "the webcams on
+// screen" could not have them. That was survivable while every webcam gesture was
+// a map gesture. Drawing an area to build a camera wall is not: the control that
+// starts the draw sits on the stage bar, outside <WorldMap/>, and a picker that
+// silently covered road cameras but not webcams would under-report a Soho ring by
+// most of what is actually there and never say so.
+//
+// THE SAME TWO CAVEATS APPLY AS FOR CAMERAS, and they are worse here. This is
+// populated only while the Webcams layer is on, so an empty result means "we were
+// not looking", not "there is nothing there". And what /api/webcams serves is an
+// unranked ~2% sample of Windy's catalogue from fourteen fixed region boxes —
+// measured 2026-08-15, it held 0 webcams for Madrid, Paris, Barcelona and
+// Amsterdam while Windy's own answer for the Madrid box was 528. So the count in
+// here is a floor, never a total, and no caller may print it as one.
+
+export interface LoadedWebcam {
+  id: string;
+  /** Display title as the feed gave it. */
+  label: string;
+  lat: number;
+  lon: number;
+}
+
+let cams: LoadedWebcam[] = [];
+const listeners = new Set<() => void>();
+
+export const loadedWebcamsStore = {
+  set(next: LoadedWebcam[]) {
+    cams = next;
+    for (const fn of listeners) fn();
+  },
+  get(): LoadedWebcam[] {
+    return cams;
+  },
+  subscribe(cb: () => void): () => void {
+    listeners.add(cb);
+    return () => { listeners.delete(cb); };
+  },
+};

--- a/lib/widgets/dock.ts
+++ b/lib/widgets/dock.ts
@@ -15,6 +15,7 @@
 
 import { shellLayoutStore } from "@/lib/console/store";
 import { widgetTypeForGroup, widgetTypeForSource } from "@/lib/console/sourceWidgets";
+import { WIDGET_LIMIT_MESSAGE } from "@/lib/console/types";
 
 function toast(message: string): void {
   if (typeof window === "undefined") return;
@@ -31,7 +32,7 @@ function addOnce(type: string, label: string): void {
   const open = shellLayoutStore.get().widgets.filter((w) => w.type === type);
   if (open.length > 0) return;
   const r = shellLayoutStore.add(type);
-  if (!r.ok) toast("50-widget limit — remove one to add another");
+  if (!r.ok) toast(WIDGET_LIMIT_MESSAGE);
   else toast(`${label} added to your workspace`);
 }
 

--- a/tests/unit/camslot-arm.test.ts
+++ b/tests/unit/camslot-arm.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
-  armStore,
   normalizeBounds,
   camerasInBounds,
   orderByDistanceFrom,
@@ -23,51 +22,6 @@ const cam = (id: string, lat: number, lon: number, refreshSeconds?: number) => (
   available: true,
   live: false,
   refreshSeconds,
-});
-
-describe("armStore", () => {
-  beforeEach(() => armStore.disarm());
-
-  it("holds one slot at a time — arming a second disarms the first", () => {
-    armStore.arm("a");
-    expect(armStore.get()).toBe("a");
-    armStore.arm("b");
-    expect(armStore.get()).toBe("b");
-  });
-
-  it("toggles the same slot off", () => {
-    armStore.toggle("a");
-    expect(armStore.get()).toBe("a");
-    armStore.toggle("a");
-    expect(armStore.get()).toBeNull();
-  });
-
-  it("toggling a DIFFERENT slot moves the arm rather than disarming", () => {
-    armStore.arm("a");
-    armStore.toggle("b");
-    expect(armStore.get()).toBe("b");
-  });
-
-  it("notifies subscribers and stops after unsubscribe", () => {
-    let n = 0;
-    const off = armStore.subscribe(() => n++);
-    armStore.arm("a");
-    armStore.disarm();
-    expect(n).toBe(2);
-    off();
-    armStore.arm("b");
-    expect(n).toBe(2);
-  });
-
-  it("does not notify when nothing actually changed", () => {
-    let n = 0;
-    const off = armStore.subscribe(() => n++);
-    armStore.disarm(); // already disarmed
-    armStore.arm("a");
-    armStore.arm("a"); // same slot
-    off();
-    expect(n).toBe(1);
-  });
 });
 
 describe("webcamRef", () => {
@@ -283,7 +237,7 @@ describe("describeAppend", () => {
     const note = describeAppend(plan, { available: 29, cap: 24, capSetBySeconds: 120, capMixed: false });
     expect(note).toContain("120s");
     expect(note).not.toContain("fastest-refreshing");
-    expect(note).toContain("second slot");
+    expect(note).toContain("second wall");
   });
 
   it("does not claim a selection it did not make", () => {

--- a/tests/unit/camslot-pick.test.ts
+++ b/tests/unit/camslot-pick.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_PICKS, camerasInRing, mergePicks, nameForPicks, pickKey,
+  type PickedCamera,
+} from "@/lib/console/widgets/camslot.pick";
+
+const pick = (id: string, label = id, lat = 51.5, lon = -0.12): PickedCamera => ({
+  ref: { k: "cam", id },
+  key: pickKey({ k: "cam", id }),
+  label, lat, lon,
+});
+
+describe("mergePicks", () => {
+  it("appends new picks in the order they were chosen", () => {
+    const r = mergePicks([pick("a")], [pick("b"), pick("c")]);
+    expect(r.next.map((p) => p.key)).toEqual(["cam:a", "cam:b", "cam:c"]);
+    expect(r.added).toBe(2);
+  });
+
+  it("counts a camera already in the basket as a duplicate and does not re-add it", () => {
+    const r = mergePicks([pick("a")], [pick("a"), pick("b")]);
+    expect(r.added).toBe(1);
+    expect(r.duplicates).toBe(1);
+    expect(r.next.map((p) => p.key)).toEqual(["cam:a", "cam:b"]);
+  });
+
+  it("dedups within a single incoming batch, not only against the basket", () => {
+    // A box drag can hand the same camera twice when it appears in two layers.
+    const r = mergePicks([], [pick("a"), pick("a")]);
+    expect(r.added).toBe(1);
+    expect(r.duplicates).toBe(1);
+  });
+
+  it("refuses past the cap rather than evicting what the user already chose", () => {
+    const full = Array.from({ length: 3 }, (_, i) => pick(`f${i}`));
+    const r = mergePicks(full, [pick("new1"), pick("new2")], 3);
+    expect(r.added).toBe(0);
+    expect(r.refused).toBe(2);
+    // The originals survive untouched — nothing was pushed out to make room.
+    expect(r.next.map((p) => p.key)).toEqual(["cam:f0", "cam:f1", "cam:f2"]);
+  });
+
+  it("partially fills when the batch straddles the cap, and reports both halves", () => {
+    const r = mergePicks([pick("a")], [pick("b"), pick("c"), pick("d")], 3);
+    expect(r.added).toBe(2);
+    expect(r.refused).toBe(1);
+    expect(r.next).toHaveLength(3);
+  });
+
+  it("returns the existing array unchanged when nothing was added", () => {
+    const existing = [pick("a")];
+    const r = mergePicks(existing, [pick("a")]);
+    expect(r.next).toEqual(existing);
+  });
+
+  it("defaults its cap to one wall's worth", () => {
+    const many = Array.from({ length: MAX_PICKS + 5 }, (_, i) => pick(`m${i}`));
+    const r = mergePicks([], many);
+    expect(r.next).toHaveLength(MAX_PICKS);
+    expect(r.refused).toBe(5);
+  });
+});
+
+describe("camerasInRing", () => {
+  // A unit square around the origin, stored open (no repeated closing vertex).
+  const square: [number, number][] = [[0, 0], [0, 1], [1, 1], [1, 0]];
+
+  it("keeps points inside and drops points outside", () => {
+    const rows = [
+      { id: "in", lat: 0.5, lon: 0.5 },
+      { id: "out-east", lat: 0.5, lon: 2 },
+      { id: "out-north", lat: 3, lon: 0.5 },
+    ];
+    expect(camerasInRing(rows, square).map((r) => r.id)).toEqual(["in"]);
+  });
+
+  it("drops non-finite coordinates rather than coercing them to zero", () => {
+    // `lat ?? 0` would put this row at 0,0 — inside a ring nobody drew it into.
+    const rows = [{ id: "broken", lat: Number.NaN, lon: 0.5 }];
+    expect(camerasInRing(rows, square)).toEqual([]);
+  });
+
+  it("returns nothing for a ring that is not an area", () => {
+    const rows = [{ id: "in", lat: 0.5, lon: 0.5 }];
+    expect(camerasInRing(rows, [[0, 0], [1, 1]])).toEqual([]);
+  });
+
+  it("respects concavity — a bbox test alone would admit the notch", () => {
+    // An L: the top-right quadrant is cut out of the unit square.
+    const ell: [number, number][] = [[0, 0], [0, 1], [0.5, 1], [0.5, 0.5], [1, 0.5], [1, 0]];
+    const inNotch = { id: "notch", lat: 0.75, lon: 0.75 };
+    const inArm = { id: "arm", lat: 0.25, lon: 0.25 };
+    const kept = camerasInRing([inNotch, inArm], ell).map((r) => r.id);
+    expect(kept).toEqual(["arm"]);
+  });
+});
+
+describe("nameForPicks", () => {
+  it("prefers an explicit area label over anything derived", () => {
+    expect(nameForPicks([pick("a", "London: Trafalgar Square")], "Soho")).toBe("Soho");
+  });
+
+  it("uses the single camera's own name when there is only one", () => {
+    expect(nameForPicks([pick("a", "London: Trafalgar Square")])).toBe("London: Trafalgar Square");
+  });
+
+  it("lifts the place the labels agree on", () => {
+    const picks = [
+      pick("a", "London: Trafalgar Square"),
+      pick("b", "London: Oxford Circus"),
+    ];
+    expect(nameForPicks(picks)).toBe("London");
+  });
+
+  it("counts rather than guessing when the labels do not agree", () => {
+    const picks = [pick("a", "London: Trafalgar Square"), pick("b", "Madrid: Cortes")];
+    expect(nameForPicks(picks)).toBe("2 cameras");
+  });
+
+  it("is empty for an empty basket", () => {
+    expect(nameForPicks([])).toBe("");
+  });
+});

--- a/tests/unit/camslot-send.test.ts
+++ b/tests/unit/camslot-send.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { shellLayoutStore } from "@/lib/console/store";
+import { createDefaultLayout, type GridRect, type WidgetInstance } from "@/lib/console/types";
+import { loadedCamerasStore } from "@/lib/cameras/loaded";
+import { pickKey, pickStore, type PickedCamera } from "@/lib/console/widgets/camslot.pick";
+import { sanitizeCamslotConfig } from "@/lib/console/widgets/camslot.model";
+import { camslotTargets, sendPicksToWall } from "@/lib/console/widgets/camslot.send";
+
+// Node environment, so nothing here renders. That is deliberate and it bounds what
+// this file can claim: it covers the two exports that are pure functions of the
+// layout store and the basket, and nothing about the tray that draws them.
+
+function widget(
+  id: string,
+  type: string,
+  rect: GridRect | undefined,
+  config: Record<string, unknown> = {},
+): WidgetInstance {
+  return { id, type, segment: "left", order: 0, width: 4, height: 200, rect, collapsed: false, config };
+}
+
+/** `set`, not `replace`: replace runs sanitizeLayout, which fills in a rect for any
+ *  widget lacking one — and the rect is precisely what these tests are pinning. */
+function setBoard(...widgets: WidgetInstance[]): void {
+  shellLayoutStore.set({ ...createDefaultLayout(), widgets });
+}
+
+function pick(id: string, o: Partial<PickedCamera> = {}): PickedCamera {
+  return {
+    ref: { k: "cam", id },
+    key: pickKey({ k: "cam", id }),
+    label: o.label ?? id,
+    lat: o.lat ?? 51.5,
+    lon: o.lon ?? -0.12,
+    refreshSeconds: o.refreshSeconds,
+    source: o.source,
+  };
+}
+
+function streamsOf(id: string): string[] {
+  const w = shellLayoutStore.get().widgets.find((x) => x.id === id);
+  return sanitizeCamslotConfig(w?.config).streams.map((s) => (s.k === "yt" ? s.videoId : s.id));
+}
+
+beforeEach(() => {
+  setBoard();
+  pickStore.reset();
+  loadedCamerasStore.set([]);
+});
+
+afterEach(() => {
+  shellLayoutStore.replace(createDefaultLayout());
+  pickStore.reset();
+  loadedCamerasStore.set([]);
+});
+
+describe("camslotTargets", () => {
+  it("lists the walls in board reading order, not the order they were authored in", () => {
+    // Authored bottom-first on purpose: widgets[] is authoring order and a dragged
+    // board bears no relation to it, so a menu built from the array would list the
+    // walls in an order the user cannot see on screen.
+    setBoard(
+      widget("bottom", "camslot", { x: 0, y: 6, w: 4, h: 9 }, { name: "Prague" }),
+      widget("top-right", "camslot", { x: 6, y: 0, w: 4, h: 9 }, { name: "Madrid" }),
+      widget("top-left", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { name: "London" }),
+    );
+    expect(camslotTargets().map((t) => t.name)).toEqual(["London", "Madrid", "Prague"]);
+    expect(camslotTargets().map((t) => t.id)).toEqual(["top-left", "top-right", "bottom"]);
+  });
+
+  it("numbers an unnamed wall by its place on the board, not among the unnamed ones", () => {
+    setBoard(
+      widget("a", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { name: "London" }),
+      widget("b", "camslot", { x: 6, y: 0, w: 4, h: 9 }),
+      widget("c", "camslot", { x: 0, y: 6, w: 4, h: 9 }),
+    );
+    // "Camera wall 2" is the second card down the board — a claim the user can check.
+    // Numbering only the unnamed ones would make it the first unnamed one, which on
+    // this board is also the second card, but on a board whose first two walls are
+    // named would be the third. The label has to survive that.
+    expect(camslotTargets().map((t) => t.name)).toEqual(["London", "Camera wall 2", "Camera wall 3"]);
+  });
+
+  it("counts only camera walls, and numbers them among themselves", () => {
+    setBoard(
+      widget("markets", "markets", { x: 0, y: 0, w: 4, h: 6 }),
+      widget("wall", "camslot", { x: 4, y: 0, w: 4, h: 9 }),
+    );
+    expect(camslotTargets()).toEqual([{ id: "wall", name: "Camera wall 1", count: 0 }]);
+  });
+
+  it("prints the number of streams the wall will actually render, not the raw array length", () => {
+    setBoard(
+      widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, {
+        // Two real refs and two that sanitizeCamslotConfig throws away. A `?c=` share
+        // link can carry any JSON at all into config, so the count has to be taken
+        // after that filter or the menu would advertise streams that never appear.
+        streams: [{ k: "cam", id: "a" }, { k: "cam", id: "b" }, { k: "nope" }, null],
+      }),
+    );
+    expect(camslotTargets()[0].count).toBe(2);
+  });
+
+  it("keeps a wall with no rect in the menu, sorted last", () => {
+    // A widget has no rect between add() and the first sanitize pass. Dropping it
+    // would make a freshly created wall unreachable from the menu that created it.
+    setBoard(
+      widget("unplaced", "camslot", undefined, { name: "Unplaced" }),
+      widget("placed", "camslot", { x: 0, y: 3, w: 4, h: 9 }, { name: "Placed" }),
+    );
+    expect(camslotTargets().map((t) => t.name)).toEqual(["Placed", "Unplaced"]);
+  });
+});
+
+describe("sendPicksToWall — an empty basket", () => {
+  it("refuses with a sentence rather than making an empty wall", () => {
+    setBoard();
+    expect(sendPicksToWall("new")).toEqual({ ok: false, message: "Nothing picked yet." });
+    expect(shellLayoutStore.get().widgets).toHaveLength(0);
+  });
+
+  it("gives the same answer for a named target, and touches nothing", () => {
+    setBoard(widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { streams: [{ k: "cam", id: "a" }] }));
+    expect(sendPicksToWall("wall").message).toBe("Nothing picked yet.");
+    expect(streamsOf("wall")).toEqual(["a"]);
+  });
+});
+
+describe("sendPicksToWall — a target that is not there", () => {
+  it("says the wall is gone and keeps the basket", () => {
+    setBoard();
+    pickStore.add([pick("a"), pick("b")]);
+
+    const r = sendPicksToWall("w-removed-while-the-menu-was-open");
+
+    expect(r.ok).toBe(false);
+    expect(r.message).toBe("That camera wall is gone.");
+    expect(r.widgetId).toBeUndefined();
+    // The picks are the user's work. Losing them because the destination vanished
+    // would punish them for something the board did.
+    expect(pickStore.get().picks.map((p) => p.key)).toEqual(["cam:a", "cam:b"]);
+  });
+
+  it("treats a live widget of another type as gone rather than writing streams into it", () => {
+    setBoard(widget("markets", "markets", { x: 0, y: 0, w: 4, h: 6 }));
+    pickStore.add([pick("a")]);
+
+    expect(sendPicksToWall("markets").message).toBe("That camera wall is gone.");
+    expect(shellLayoutStore.get().widgets[0].config).toEqual({});
+  });
+});
+
+describe("sendPicksToWall — the cadence cap", () => {
+  // One 60s camera at a 5s dwell caps the wall at 12 (camslot.arm cadenceCap), so
+  // thirteen picks is the smallest selection that has to refuse one.
+  function thirteenFastPicks(): PickedCamera[] {
+    const near = Array.from({ length: 12 }, (_, i) =>
+      pick(`near${i}`, { lat: 51.5, lon: -0.12 + i * 0.001, refreshSeconds: 60 }),
+    );
+    // A stray, far enough out that it is unambiguously the last one centre-out.
+    return [...near, pick("stray", { lat: 55.9, lon: -3.2, refreshSeconds: 60 })];
+  }
+
+  it("says how many were refused, why, and what the cap is", () => {
+    setBoard(widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { streams: [], intervalMs: 5000 }));
+    pickStore.add(thirteenFastPicks());
+
+    const r = sendPicksToWall("wall");
+
+    expect(r.ok).toBe(true);
+    expect(r.widgetId).toBe("wall");
+    // The honest denominator, then the cap and the cadence that set it. MAX_PICKS is
+    // 60; this wall's real ceiling is 12, and the message is the only place the user
+    // ever learns that.
+    expect(r.message).toContain("13 cameras here.");
+    expect(r.message).toContain("Added the 12 nearest the centre.");
+    expect(r.message).toContain("1 refused, because the cap is 12 because a camera here refreshes every 60s.");
+    expect(streamsOf("wall")).toHaveLength(12);
+  });
+
+  it("refuses the pick furthest from the centre of the selection, not the last one added", () => {
+    setBoard(widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { streams: [], intervalMs: 5000 }));
+    // The stray goes into the basket FIRST, so insertion order and centre-out order
+    // disagree. Insertion order would keep the stray and drop a camera in the cluster
+    // the user was working in — and would make "the 12 nearest the centre" a lie.
+    const [...near] = thirteenFastPicks().slice(0, 12);
+    pickStore.add([pick("stray", { lat: 55.9, lon: -3.2, refreshSeconds: 60 }), ...near]);
+
+    sendPicksToWall("wall");
+
+    expect(streamsOf("wall")).not.toContain("stray");
+    expect(streamsOf("wall")).toHaveLength(12);
+  });
+
+  it("empties the basket when the wall took everything", () => {
+    setBoard(widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { streams: [], intervalMs: 5000 }));
+    // Twelve, not thirteen: exactly the cap, so nothing is refused.
+    pickStore.add(thirteenFastPicks().slice(0, 12));
+
+    sendPicksToWall("wall");
+
+    expect(pickStore.get().picks).toEqual([]);
+  });
+
+  it("keeps the ones the wall refused, so 'use a second wall' is still possible", () => {
+    // Thirteen fast cameras into a wall whose cap is 12: twelve land, the stray is
+    // refused. Emptying the basket here would destroy the camera the accompanying
+    // message tells the user to send somewhere else.
+    setBoard(widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { streams: [], intervalMs: 5000 }));
+    pickStore.add(thirteenFastPicks());
+
+    const r = sendPicksToWall("wall");
+
+    expect(r.ok).toBe(true);
+    expect(pickStore.get().picks.map((p) => p.key)).toEqual(["cam:stray"]);
+  });
+
+  it("drops the area context when only part of the selection was placed", () => {
+    // The leftovers are no longer "what is in this area", so the tray must stop
+    // captioning them with the area's total.
+    setBoard(widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, { streams: [], intervalMs: 5000 }));
+    pickStore.addFromArea(thirteenFastPicks(), [[0, 0], [0, 1], [1, 1]], 143);
+
+    sendPicksToWall("wall");
+
+    expect(pickStore.get().ring).toBeNull();
+    expect(pickStore.get().foundInArea).toBe(0);
+  });
+
+  it("keeps the basket when the wall is already full and nothing could be added", () => {
+    // Twelve 60s cameras already in the wall: the cap is 12 and it is met, so every
+    // incoming pick is refused. "Use a second wall" is only actionable advice if the
+    // picks are still there to send.
+    loadedCamerasStore.set(
+      Array.from({ length: 12 }, (_, i) => ({
+        id: `seat${i}`, name: `seat${i}`, lat: 51.5, lon: -0.12,
+        available: true, live: true, refreshSeconds: 60,
+      })),
+    );
+    setBoard(
+      widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, {
+        streams: Array.from({ length: 12 }, (_, i) => ({ k: "cam", id: `seat${i}` })),
+        intervalMs: 5000,
+      }),
+    );
+    pickStore.add([pick("extra", { refreshSeconds: 60 })]);
+
+    const r = sendPicksToWall("wall");
+
+    expect(r.ok).toBe(false);
+    expect(r.message).toContain("This wall is full at 12");
+    expect(pickStore.get().picks.map((p) => p.key)).toEqual(["cam:extra"]);
+    expect(streamsOf("wall")).toHaveLength(12);
+  });
+
+  it("counts the streams already in the wall when working out the cap", () => {
+    // The wall holds one 60s camera; every pick is a 300s one. Ignoring the sitting
+    // tenant would compute a cap of 60 and admit all thirteen.
+    loadedCamerasStore.set([
+      { id: "quick", name: "quick", lat: 51.5, lon: -0.12, available: true, live: true, refreshSeconds: 60 },
+    ]);
+    setBoard(
+      widget("wall", "camslot", { x: 0, y: 0, w: 4, h: 9 }, {
+        streams: [{ k: "cam", id: "quick" }],
+        intervalMs: 5000,
+      }),
+    );
+    pickStore.add(Array.from({ length: 13 }, (_, i) => pick(`slow${i}`, { refreshSeconds: 300 })));
+
+    const r = sendPicksToWall("wall");
+
+    expect(r.message).toContain("the cap is 12 because a camera here refreshes every 60s");
+    // 12 seats total, one already taken.
+    expect(streamsOf("wall")).toHaveLength(12);
+  });
+});
+
+describe("sendPicksToWall — a new wall", () => {
+  it("adds one, names it from the picks, and empties the basket", () => {
+    setBoard();
+    pickStore.add([pick("a", { label: "London: Oxford Circus" }), pick("b", { label: "London: Strand" })]);
+
+    const r = sendPicksToWall("new");
+
+    expect(r.ok).toBe(true);
+    expect(r.message).toBe('New camera wall "London" — 2 cameras.');
+    const added = shellLayoutStore.get().widgets.find((w) => w.id === r.widgetId);
+    expect(added?.type).toBe("camslot");
+    expect(sanitizeCamslotConfig(added?.config).name).toBe("London");
+    expect(pickStore.get().picks).toEqual([]);
+  });
+});

--- a/tests/unit/camslot-title.test.ts
+++ b/tests/unit/camslot-title.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { CAMSLOT_WIDGET, camslotTitle } from "@/lib/console/widgets/camslot";
+
+// WHAT THIS GUARDS. WidgetFrame renders `type.title` for every instance, so four
+// camera walls on the Streets board all read "CAMERA WALL" while their configs said
+// London, Madrid and Prague. `titleOf` is the registry hook that lets an instance
+// name itself; the frame falls back to `type.title` when it returns undefined.
+//
+// The contract has exactly one hard rule: it must never return "". An empty string
+// is not a fallback — the frame would render a blank header and the widget would be
+// less identifiable than before the fix. Every case below asserts it, including the
+// ones that are supposed to return undefined.
+
+/** Anything `titleOf` returns must be either undefined or non-empty. Asserted on
+ *  every case rather than only the interesting ones, because "" can only arrive
+ *  through a path nobody expected it on. */
+function neverBlank(out: string | undefined): string | undefined {
+  expect(out).not.toBe("");
+  if (out !== undefined) expect(out.trim().length).toBeGreaterThan(0);
+  return out;
+}
+
+const webcam = (id: string, t?: string) => (t ? { k: "webcam", id, t } : { k: "webcam", id });
+
+describe("camslotTitle — name present", () => {
+  it("returns the slot's own name, which is the whole point", () => {
+    expect(neverBlank(camslotTitle({ name: "London", streams: [] }))).toBe("London");
+  });
+
+  it("the name wins over a stream that also has a title", () => {
+    const out = camslotTitle({
+      name: "London",
+      streams: [webcam("windy:1420893641", "London: Trafalgar Square")],
+    });
+    expect(neverBlank(out)).toBe("London");
+  });
+
+  it("a whitespace-only name is not a name — it falls through, never to \"\"", () => {
+    expect(neverBlank(camslotTitle({ name: "   ", streams: [] }))).toBeUndefined();
+  });
+
+  it("a padded name is trimmed", () => {
+    expect(neverBlank(camslotTitle({ name: "  Madrid  ", streams: [] }))).toBe("Madrid");
+  });
+});
+
+describe("camslotTitle — no name, one stream", () => {
+  it("borrows the single webcam's own title", () => {
+    const out = camslotTitle({ streams: [webcam("windy:1345327762", "Prague: Wenceslas Square")] });
+    expect(neverBlank(out)).toBe("Prague: Wenceslas Square");
+  });
+
+  it("a lone webcam with no title falls back to the widget type, not to an id", () => {
+    // "Webcam 1345327762" is a worse header than "Camera wall": it looks like a
+    // name while telling the user nothing about where the picture is.
+    expect(neverBlank(camslotTitle({ streams: [webcam("windy:1345327762")] }))).toBeUndefined();
+  });
+
+  it("a lone road camera has no cheap title in config, so it falls back", () => {
+    // A `cam` ref carries an id and nothing else; resolving it means the camera
+    // poller, which is a React hook. A header is not worth a fetch.
+    expect(neverBlank(camslotTitle({ streams: [{ k: "cam", id: "tfl:JamCams_00001" }] }))).toBeUndefined();
+  });
+
+  it("a lone YouTube stream falls back", () => {
+    expect(neverBlank(camslotTitle({ streams: [{ k: "yt", videoId: "dQw4w9WgXcQ" }] }))).toBeUndefined();
+  });
+});
+
+describe("camslotTitle — no name, several streams", () => {
+  it("a rotating slot has no single subject, so it does not borrow the first one's", () => {
+    const out = camslotTitle({
+      streams: [
+        webcam("windy:1420893641", "London: Trafalgar Square"),
+        webcam("windy:1606332744", "Madrid: Plaza Canalejas"),
+      ],
+    });
+    expect(neverBlank(out)).toBeUndefined();
+  });
+
+  it("an empty slot falls back", () => {
+    expect(neverBlank(camslotTitle({ streams: [] }))).toBeUndefined();
+  });
+
+  it("two streams where only ONE carries a title still falls back", () => {
+    const out = camslotTitle({
+      streams: [webcam("windy:1420893641", "London: Trafalgar Square"), webcam("windy:1606332744")],
+    });
+    expect(neverBlank(out)).toBeUndefined();
+  });
+});
+
+describe("camslotTitle — garbage config", () => {
+  // Config rides inside `?c=` share links, so a stranger's JSON reaches this
+  // function. It must be total: never throw, never return "".
+  const junk: unknown[] = [
+    {},
+    { name: 42, streams: "nope" },
+    { name: null, streams: null },
+    { streams: [null, 7, "cam", { k: "nope" }] },
+    { name: "", streams: [{ k: "webcam", id: "windy:1", t: "   " }] },
+    { streams: [{ k: "webcam", id: "windy:1", t: "" }] },
+    { streams: { 0: webcam("windy:1", "Nope") } },
+    { name: ["London"], streams: [] },
+  ];
+
+  for (const [i, raw] of junk.entries()) {
+    it(`survives junk config #${i} and never returns ""`, () => {
+      expect(() => camslotTitle(raw as Record<string, unknown>)).not.toThrow();
+      expect(neverBlank(camslotTitle(raw as Record<string, unknown>))).toBeUndefined();
+    });
+  }
+
+  it("a webcam whose only title is whitespace falls back rather than blanking the header", () => {
+    const out = camslotTitle({ streams: [{ k: "webcam", id: "windy:1", t: "  \t " }] });
+    expect(neverBlank(out)).toBeUndefined();
+  });
+
+  it("an over-long name is truncated by the sanitizer but stays non-empty", () => {
+    const out = neverBlank(camslotTitle({ name: "x".repeat(500), streams: [] }));
+    expect(out).toBeDefined();
+    expect(out!.length).toBeLessThanOrEqual(80);
+  });
+});
+
+describe("the registry entry actually carries it", () => {
+  // Wiring test, not a logic test: `titleOf` only fixes anything if it is on the
+  // object WidgetFrame reads. The four Streets walls stayed identical for exactly
+  // this reason — `CamslotConfig.name` existed and was rendered nowhere.
+  it("CAMSLOT_WIDGET exposes titleOf and it is the function under test", () => {
+    const meta = CAMSLOT_WIDGET as { titleOf?: (c: Record<string, unknown>) => string | undefined };
+    expect(typeof meta.titleOf).toBe("function");
+    expect(meta.titleOf!({ name: "London", streams: [] })).toBe("London");
+    expect(meta.titleOf!({ streams: [] })).toBeUndefined();
+  });
+
+  it("still declares a type title for the frame to fall back to", () => {
+    expect(CAMSLOT_WIDGET.title.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/terminal-layout-grid.test.ts
+++ b/tests/unit/terminal-layout-grid.test.ts
@@ -185,6 +185,63 @@ describe("settle — randomised", () => {
   });
 });
 
+describe("settle — randomised, with a pre-move rect", () => {
+  // The block above drives place() the way every caller did before the swap
+  // existed, so it never reaches the pre-pass. This one passes the rect the item
+  // is actually leaving, which is what a live drag does, so the swap runs on
+  // every single move. Same contract: whatever comes back is a valid board.
+  //
+  // It exists because the first attempt at this feature put the lift INSIDE the
+  // collision loop, which broke that loop's "every pass moves a widget down"
+  // termination argument. All 50 deterministic tests passed; the randomised pass
+  // failed on 5 of 5 seeds with cards left overlapping. Nothing else caught it.
+  for (const seed of [1, 7, 42, 1337, 90210, 5150, 24601]) {
+    it(`holds every invariant over 200 swapping moves (seed ${seed})`, () => {
+      const rand = rng(seed);
+      let board: GridItem[] = compact(
+        Array.from({ length: 9 }, (_, i) => it_(`w${i}`, (i % 4) * 3, Math.floor(i / 4) * 5, 3, 5)),
+      );
+      for (let n = 0; n < 200; n++) {
+        const target = board[Math.floor(rand() * board.length)];
+        const prev = { x: target.x, y: target.y, w: target.w, h: target.h };
+        board = place(
+          board,
+          target.id,
+          {
+            x: Math.floor(rand() * 14) - 1,
+            y: Math.floor(rand() * 24) - 1,
+            w: 1 + Math.floor(rand() * 13),
+            h: 1 + Math.floor(rand() * 12),
+          },
+          prev,
+        );
+        expect(board).toHaveLength(9);
+        expectValid(board);
+      }
+    });
+  }
+
+  it("a downward move past a neighbour exchanges them rather than doing nothing", () => {
+    const board = [it_("a", 0, 0, 6, 3), it_("b", 0, 3, 6, 3), it_("c", 0, 6, 6, 3)];
+    const out = place(board, "a", { x: 0, y: 3, w: 6, h: 3 }, { x: 0, y: 0, w: 6, h: 3 });
+    expectValid(out);
+    expect(readingOrder(out).map((i) => i.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("leaves an upward move alone, which already worked", () => {
+    const board = [it_("a", 0, 0, 6, 3), it_("b", 0, 3, 6, 3), it_("c", 0, 6, 6, 3)];
+    const out = place(board, "c", { x: 0, y: 0, w: 6, h: 3 }, { x: 0, y: 6, w: 6, h: 3 });
+    expectValid(out);
+    expect(readingOrder(out).map((i) => i.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("without a pre-move rect the board settles exactly as it always did", () => {
+    const board = [it_("a", 0, 0, 6, 3), it_("b", 0, 3, 6, 3), it_("c", 0, 6, 6, 3)];
+    const legacy = place(board, "a", { x: 0, y: 3, w: 6, h: 3 });
+    expect(readingOrder(legacy).map((i) => i.id)).toEqual(["a", "b", "c"]);
+  });
+});
+
 describe("readingOrder", () => {
   it("sorts top-to-bottom then left-to-right", () => {
     const order = readingOrder([

--- a/tests/unit/widget-limit-copy.test.ts
+++ b/tests/unit/widget-limit-copy.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { MAX_WIDGETS, WIDGET_LIMIT_MESSAGE } from "@/lib/console/types";
+
+/**
+ * The widget-cap toast said "50-widget limit" in FOUR call sites while MAX_WIDGETS
+ * was already 200, so anyone who hit the cap was told a number four times too small.
+ * The copy is now derived from the constant. This guard exists so the next person to
+ * change the cap cannot leave a stale number behind in a string literal.
+ */
+const ROOTS = ["lib", "components", "app"];
+const SKIP = new Set(["node_modules", ".next", "__snapshots__"]);
+const SEP = String.fromCharCode(92); // avoids a literal backslash in this file
+const norm = (p: string) => p.split(SEP).join("/");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (SKIP.has(name)) continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(p)) out.push(p);
+  }
+  return out;
+}
+
+describe("widget-limit copy", () => {
+  it("states the real cap", () => {
+    expect(WIDGET_LIMIT_MESSAGE).toContain(String(MAX_WIDGETS));
+  });
+
+  it("is not hardcoded with a stale number anywhere in the app", () => {
+    const offenders: string[] = [];
+    for (const root of ROOTS) {
+      for (const file of walk(root)) {
+        const src = readFileSync(file, "utf8");
+        for (const line of src.split("\n")) {
+          // A literal "<n>-widget limit" in code. The definition's own explanatory
+          // comment is allowed to quote the historical wrong number.
+          const m = line.match(/(\d+)-widget limit/);
+          if (!m) continue;
+          if (norm(file).endsWith("lib/console/types.ts") && line.trimStart().startsWith("*")) continue;
+          if (m[1] !== String(MAX_WIDGETS)) offenders.push(`${file}: ${line.trim()}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Twenty-one commits against the Streets board, all of it found by driving the board rather than reading it. Three groups: getting cameras onto a wall, telling the walls apart, and making the grid honour the gestures it advertises.

## Getting cameras onto a wall

The original report was that mapping a camera onto a widget was impossible. It nearly was. Arming asked which of four identically-titled CAMERA WALL cards you meant before you had chosen a single camera, from a plus that only appeared on hover inside one of them.

Picking now runs the other way round. Click a pin, shift-drag a box, or draw a ring; the cameras collect in a visible tray; the destination is chosen last, from a menu that names each wall. Drawing an area reuses the existing polygon tool through a new `onFinish` option rather than borrowing the console-wide AOI, because "build me a wall out of Soho" and "hide everything outside Soho" are different requests and one must not silently perform the other.

Two deliberate behaviour changes came with it, tests updated to match:

- A partial send keeps what the wall refused. Its message ends "use a second wall", which was impossible to follow when the basket had just been emptied of the cameras it referred to.
- A new wall is capped by cadence like an existing one. Sixty picks including a 60s camera have a cap of twelve at a 5s dwell; the new-wall path used to build the wall anyway and say nothing, while the identical send to an existing wall refused politely and explained why.

Adding a wall also now reveals it. `createCamslot()` is the single way to mint one and creating and revealing are one call, so a caller cannot take the first without the second and quietly bring back "I add a camera wall and nothing happens". The reveal itself was doing nothing, twice over: a fixed two-frame wait does not survive React committing when it commits, and rAF polling is throttled to roughly one callback a second in any tab that is not visible, which is every tab a headless test runs in. It now watches for the insertion with a MutationObserver on a bounded deadline, and marks with a data attribute rather than a class, since className is a prop React owns on those nodes.

## Telling the walls apart

The registry gains an optional `titleOf(config)` and the frame prefers it to the type's title. camslot had supplied one since the widget was reworked and nothing consumed it, so four walls each carrying a name in config all still drew the header CAMERA WALL. Per-card controls follow the card now ("Remove London", not "Remove Camera wall"); the help popover keeps the type name, because it explains what a camera wall is.

The command palette was then the surface still reading "Focus Camera wall #1..#4", numbered against nothing on screen, so someone who could finally see London on a card could not find London in the palette. Same precedence as the frame, and the `#n` disambiguator is keyed on the resolved title rather than the type, so three uniquely named walls need no numbering at all.

Falls back to the type title, which stays correct for the roughly seventy widgets that only appear on a board once.

## The grid

Dragging a card downward did nothing. `resolveCollisions` only ever pushes a displaced card down, so the card you dropped stayed first in reading order and compaction returned the board to exactly where it started. The same cause made the menu's move-down and ArrowDown inert.

The exchange now happens once, before the collision loop, and the loop is untouched. That ordering is the whole design: an earlier attempt put the lift inside the loop and broke its "every pass either moves a widget down or exits" termination argument, and while all fifty deterministic tests passed, the randomised pass failed on five of five seeds with cards left overlapping. There is a second randomised block now that passes the leaving rect on every move, over seven seeds. `compact` is not touched, so density and idempotence are unchanged.

Also here:

- The held card is drawn where it will land rather than under the pointer. Measured before: a card dragged 360px down followed the cursor while the dashed target box never left its starting cell, then flew 360px back on release. That flight is the jump people report.
- Move down moves something. One row down is not a position a card can hold on a board that compacts, so the control targets the row that leaves the neighbour exactly its own height of room above. Three clicks now walk a card from first to last.
- The height chips stop lying. They read the legacy px field that only the preset buttons write, so a drag-resize never updated them. Height now reads `rect.h` first, as width already did.
- Remove is a small button in the card header, not the nineteenth entry of a menu that scrolls internally. It sits inboard of the three-dot button because the 16x16 resize handle is pinned to the corner at z-index 20; placed outboard it rendered and was silently unclickable.
- An empty board carries its own rescue panel, plus a ghost tile placed by `findFreeSpot`, the same scan the store runs on a real add.
- The map search box was painted 182px under the layer key on Streets. The existing un-centring rule could never fire, because it is a viewport media query and Streets is a narrow stage inside a wide window. It is a container query on `.tn-cw-stage` now, which is the mismatch that was the bug.
- Two draw panels appeared at once, both narrating the same ring, since the camera picker borrows the AOI polygon tool. `aoiDrawStore` says a ring is being drawn but not what for; `areaPickStore` does.
- The widget limit copy states the real number, with a test to stop it drifting again.

`docs/superpowers/research/2026-08-23-grid-drag-termination.md` records why two earlier fixes were backed out, with the failing seeds, so the next attempt does not rediscover them.

## Verification

- Full unit suite green on this branch: 278 files, 2512 tests.
- Six new unit files cover the picking, sending, titling, limit copy and grid changes (153 tests of that total).
- The camera picking was checked in a real browser rather than asserted: a CDP click on a real pin at z14 over London took the basket from 0 to 2; a shift-drag box picked the one camera it actually contained, checked against `/api/cameras`; a four-vertex ring over Fitzrovia picked the one camera and zero webcams genuinely inside it, checked against both APIs; and a send appended to the London wall, which then read 3 and displayed the picked camera.
- Grid moves, the reveal timing, the overlap measurements and the palette naming were each measured in the browser before and after, with the numbers quoted in the individual commits.

## Risk

`placeItem`, `setItemRect`, `place`, `settle` and `resolveCollisions` gain an optional trailing argument for the rect a dragged card came from. Every existing caller passes nothing and settles exactly as before, and there is a test pinning that.
