### PR TITLE
Point BRAND and CLAUDE.md at Provenance, and stop naming the repo TrafficNerd-V2 after the rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
-# CLAUDE.md — OpenData (repo `TrafficNerd-V2`)
+# CLAUDE.md — Provenance (repo `Provenance`)
 
-A Next.js 15 single-page global situational-awareness map. **Product name: OpenData.**
-**Prod domain: `traffic-nerd-v2.vercel.app`** — that is the only domain we ship on.
+A Next.js 15 single-page global situational-awareness map. **Product name: Provenance.**
+**Prod domain: `provenance-online.vercel.app`** — that is the only domain we ship on.
 Deployed product = `origin/main`.
 
 ## Licence — `AGPL-3.0-only`

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -24,8 +24,8 @@ export const BRAND = {
   /** Ko-fi support link (the calm, opt-in "Support" button). */
   kofiUrl: "https://ko-fi.com/opendata",
   /** Canonical public repository. */
-  repo: "011-sam-110/TrafficNerd-V2",
-  repoUrl: "https://github.com/011-sam-110/TrafficNerd-V2",
+  repo: "011-sam-110/Provenance",
+  repoUrl: "https://github.com/011-sam-110/Provenance",
   /**
    * The licence, and it is load bearing rather than decorative.
    *
@@ -42,7 +42,7 @@ export const BRAND = {
     name: "GNU Affero General Public License v3.0",
     short: "AGPL-3.0",
     /** The copy in this repo, which is what section 13 points a user at. */
-    url: "https://github.com/011-sam-110/TrafficNerd-V2/blob/main/LICENSE",
+    url: "https://github.com/011-sam-110/Provenance/blob/main/LICENSE",
     /**
      * The copyright holder as it appears in public.
      *
@@ -80,7 +80,7 @@ export function siteUrl(): string {
     process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
     (process.env.VERCEL_PROJECT_PRODUCTION_URL
       ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
-      : "https://traffic-nerd-v2.vercel.app");
+      : "https://provenance-online.vercel.app");
   const trimmed = raw.replace(/\/+$/, "");
   // Guarantee a scheme so `new URL(siteUrl())` (used as metadataBase) never throws on
   // a bare host like "opendata.example" set via NEXT_PUBLIC_SITE_URL.


### PR DESCRIPTION
The README says the rename to Provenance already happened. The single source of truth for user-facing identity didn't get the memo.

## What landed

**`lib/brand.ts`'s `repo`, `repoUrl`, `license.url`, and the `siteUrl()` fallback now say Provenance, not TrafficNerd-V2.** `CLAUDE.md`'s title and its "Prod domain" line follow the same fix. Nothing else in `lib/brand.ts` changes — `kofiUrl` is untouched (see below).

Neither the old domain nor the old repo path was actually dead: `https://traffic-nerd-v2.vercel.app` redirects 200 to `provenance-online.vercel.app`, and `https://github.com/011-sam-110/TrafficNerd-V2` redirects 200 to the renamed repo. Nothing was broken in production — it was just the "single source of truth" file quietly disagreeing with the README next to it.

## Verification

- Grepped `tests/` for the old strings first — nothing pins `BRAND.repo`, `BRAND.repoUrl`, the licence URL, or the `siteUrl()` fallback, so there was nothing else to update in step with this.
- `npx tsc --noEmit`: clean.
- `npm test`: **2,512 tests / 278 files green.**

## Left out, on purpose

- Seven comments that still say "The OpenData Terminal" as an informal nickname (`app/layout.tsx`, `components/brand/Mark.tsx`, `ConsoleWorkspace.tsx`, `ConsoleShell.tsx`, `StatusBar.tsx`, `lib/basemaps.ts`, `lib/share/shareMeta.ts`) — not user-visible, same allowance the worldmonitor naming guard already gives comments naming a name as fact.
- `components/terminal/TerminalHeader.tsx:359` hardcodes `"https://ko-fi.com/opendata"` instead of reading `BRAND.kofiUrl` — a real single-source-of-truth bug, but a different one (duplication, not naming drift), and it wasn't verified whether that Ko-fi handle is even still correct. Left for a separate PR.
- `package.json`'s `"name": "trafficnerd-v2"` — left alone; renaming the npm package could touch deploy/CI config this PR has no way to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
