### PR TITLE
Ask GDACS one hazard type at a time, and stop letting a tightened API pass as a quiet day

### DIFF
--- a/lib/signals/gdacs.ts
+++ b/lib/signals/gdacs.ts
@@ -1,5 +1,5 @@
 import type { SignalFeature, SignalSource } from "@/lib/signals/types";
-import { degraded, observed } from "@/lib/signals/outcome";
+import { degraded, degradedWith, observed } from "@/lib/signals/outcome";
 
 // GDACS — the Global Disaster Alert & Coordination System (UN/EC). One keyless
 // GeoJSON feed of the CURRENT global disaster picture: earthquakes, tropical
@@ -7,28 +7,38 @@ import { degraded, observed } from "@/lib/signals/outcome";
 // alert level. Complements the per-hazard feeds (USGS quakes, EONET fires/floods)
 // with a single multi-hazard, severity-scored, alert-coloured overlay. The marker
 // is GDACS's representative centroid. Confirmed live 2026-06-27; re-verified
-// 2026-08-13 after upstream began requiring `eventtype` — see ENDPOINT below.
+// 2026-08-13 after upstream began requiring `eventtype` — see below.
 
 /**
- * EVENTTYPE IS MANDATORY. Calling this endpoint bare — as this adapter did until
- * 2026-08-13 — now answers HTTP 400 `{"message":"Eventtype is required."}`. GDACS
- * added the requirement at some point after the 2026-06-27 verification above, and
- * because `fetch()` below returns `[]` on any non-ok response, the layer reported a
- * clean, quiet zero rather than a failure. It looked exactly like "no disasters
- * today" while being a hard 400 on every single poll.
+ * EVENTTYPE IS MANDATORY, AND SINCE SOME POINT AFTER 2026-08-13, SINGULAR.
  *
- * The parameter is SEMICOLON-separated, not comma-separated or repeated. All six
- * hazard codes, measured 2026-08-13: 289 events (TC 203, WF 32, DR 24, FL 15,
- * EQ 10, VO 5). The response shape is unchanged, so `normalizeGdacs` needed no
- * edit — this was one missing query parameter, nothing more.
+ * Round one (fixed 2026-08-13): calling the event-list endpoint bare answered
+ * HTTP 400 `{"message":"Eventtype is required."}`. The fix then was one query
+ * parameter, semicolon-joining all six hazard codes into one request — measured
+ * that day at 289 events (TC 203, WF 32, DR 24, FL 15, EQ 10, VO 5).
+ *
+ * Round two (fixed 2026-08-28): that same semicolon-joined request now answers
+ * HTTP 400 `{"message":"Please specify only 1 eventtype."}`. GDACS tightened the
+ * parameter again, some time in the 15 days between. Because `fetch()` returned
+ * `[]` on any non-ok response, the layer went back to publishing a clean, quiet
+ * zero — indistinguishable from "no disasters today" — on every poll in between.
+ * The parser was never wrong either time; the request shape was.
+ *
+ * The fix this time is structural, not one parameter: `gdacsEndpointFor()` below
+ * builds one single-type URL, `fetch()` issues six requests in parallel (one per
+ * `GDACS_EVENT_TYPES` code) and `mergeGdacsResults()` — a PURE function, unit
+ * tested independently of the network — folds them into one outcome. A hazard
+ * type that fails does not empty the other five: see `mergeGdacsResults` for how
+ * a partial round is reported.
  *
  * TS (tsunami) is deliberately absent: `gdacsEventLabel` maps it because GDACS
  * documents the code, but the event list does not accept it as a filter value.
  */
 export const GDACS_EVENT_TYPES = ["EQ", "TC", "FL", "VO", "DR", "WF"] as const;
-/** Exported so a regression test can assert the parameter is still there. */
-export const GDACS_ENDPOINT =
-  `https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP?eventtype=${GDACS_EVENT_TYPES.join(";")}`;
+/** One hazard type per request — GDACS rejects more than one as of 2026-08-28. */
+export function gdacsEndpointFor(eventType: string): string {
+  return `https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP?eventtype=${eventType}`;
+}
 const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 
 export const GDACS_ATTRIBUTION = "Disaster alerts © GDACS (UN OCHA / European Commission JRC)";
@@ -133,6 +143,43 @@ export function normalizeGdacs(geojson: { features?: GdacsFeature[] }): SignalFe
   return out;
 }
 
+/** One hazard type's fetch, resolved — never thrown, so `Promise.all` cannot short-circuit. */
+export interface GdacsTypeResult {
+  type: string;
+  ok: boolean;
+  features?: GdacsFeature[];
+  reason?: string;
+}
+
+/**
+ * Fold six per-hazard-type results into one outcome-tagged `SignalFeature[]`. PURE —
+ * no network, no Date.now() default, so it is exercised directly by unit tests.
+ *
+ * A hazard type failing does not empty the layer: the other five still merge into a
+ * real result. All six failing is the only path that reports nothing. A PARTIAL round
+ * uses `degradedWith` (ok: false, but real rows attached) rather than `observed`,
+ * because asserting `ok: true` when a third of the requests failed would be the exact
+ * comfortable lie lib/signals/outcome.ts exists to rule out — even though, unlike that
+ * helper's usual last-good-cache case, every row here really was read this instant.
+ */
+export function mergeGdacsResults(results: GdacsTypeResult[], at: number): SignalFeature[] {
+  const succeeded = results.filter((r) => r.ok);
+  const failed = results.filter((r) => !r.ok);
+
+  if (succeeded.length === 0) {
+    return degraded(failed[0]?.reason ?? "upstream read failed", at);
+  }
+
+  const merged = normalizeGdacs({ features: succeeded.flatMap((r) => r.features ?? []) });
+
+  if (failed.length > 0) {
+    const types = failed.map((f) => f.type).join(",");
+    return degradedWith(merged, `partial: ${types} failed (${failed[0]!.reason})`, at);
+  }
+
+  return observed(merged, at);
+}
+
 export const GDACS_SOURCE: SignalSource = {
   id: "gdacs",
   label: "Disaster alerts",
@@ -142,18 +189,26 @@ export const GDACS_SOURCE: SignalSource = {
   attribution: GDACS_ATTRIBUTION,
   metric: { field: "alertScore", domain: [0, 3] },
   async fetch() {
-    try {
-      const res = await fetch(GDACS_ENDPOINT, {
-        headers: { "User-Agent": UA, Accept: "application/json" },
-        signal: AbortSignal.timeout(15_000),
-      });
-      // The 400 described above is exactly this branch: it now reports "http 400"
-      // instead of a clean zero, so a missing parameter cannot pass for a quiet day.
-      if (!res.ok) return degraded(`http ${res.status}`);
-      const json = (await res.json()) as { features?: GdacsFeature[] };
-      return observed(normalizeGdacs(json));
-    } catch (e) {
-      return degraded((e as Error)?.name === "TimeoutError" ? "timeout" : "upstream read failed");
-    }
+    const at = Date.now();
+    const results = await Promise.all(
+      GDACS_EVENT_TYPES.map(async (type): Promise<GdacsTypeResult> => {
+        try {
+          const res = await fetch(gdacsEndpointFor(type), {
+            headers: { "User-Agent": UA, Accept: "application/json" },
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (!res.ok) return { type, ok: false, reason: `http ${res.status}` };
+          const json = (await res.json()) as { features?: GdacsFeature[] };
+          return { type, ok: true, features: json.features ?? [] };
+        } catch (e) {
+          return {
+            type,
+            ok: false,
+            reason: (e as Error)?.name === "TimeoutError" ? "timeout" : "upstream read failed",
+          };
+        }
+      }),
+    );
+    return mergeGdacsResults(results, at);
   },
 };

--- a/tests/unit/signals-gdacs.test.ts
+++ b/tests/unit/signals-gdacs.test.ts
@@ -4,10 +4,13 @@ import {
   normalizeGdacs,
   gdacsEventLabel,
   gdacsAlertColor,
+  gdacsEndpointFor,
+  mergeGdacsResults,
   GDACS_SOURCE,
-  GDACS_ENDPOINT,
   GDACS_EVENT_TYPES,
+  type GdacsTypeResult,
 } from "@/lib/signals/gdacs";
+import { readOutcome } from "@/lib/signals/outcome";
 import { rowMetric } from "@/lib/console/signals/signalCard";
 
 test("normalizes the GDACS multi-hazard FeatureCollection", () => {
@@ -86,26 +89,25 @@ test("declares GDACS's real alert score (0–3) as the metric and it resolves pe
   }
 });
 
-// ── Regression: the layer was silently empty in production ──────────────────
+// ── Regression: the layer was silently empty in production, twice ───────────
 //
-// GDACS began rejecting a bare event-list call with HTTP 400
-// {"message":"Eventtype is required."}. Because GDACS_SOURCE.fetch() returns []
-// on any non-ok response, the layer published a clean zero on every poll and
-// looked identical to "no disasters today". The parser was never wrong; the URL
-// was. These assert the URL, which is the thing that actually broke.
+// Round one (2026-08-13): GDACS began rejecting a bare event-list call with HTTP
+// 400 {"message":"Eventtype is required."}. Round two (2026-08-28): the fix for
+// round one — one request, all six codes semicolon-joined — started failing the
+// same way with {"message":"Please specify only 1 eventtype."}. Both times
+// GDACS_SOURCE.fetch() turned a hard 400 into a clean, quiet zero, indistinguishable
+// from "no disasters today". The parser was never wrong either time; the request
+// shape was. These assert the request shape, which is the thing that actually broke.
 
-test("the event-list URL carries the mandatory eventtype parameter", () => {
-  expect(GDACS_ENDPOINT).toContain("eventtype=");
-  const value = new URL(GDACS_ENDPOINT).searchParams.get("eventtype");
-  expect(value).toBeTruthy();
-  expect(value).not.toBe("");
-});
-
-test("eventtype is semicolon-separated, which is the form GDACS accepts", () => {
-  const value = new URL(GDACS_ENDPOINT).searchParams.get("eventtype")!;
-  expect(value).toBe(GDACS_EVENT_TYPES.join(";"));
-  // A comma-separated list is the obvious thing to reach for and it is wrong here.
-  expect(value).not.toContain(",");
+test("each hazard type gets its own single-type URL", () => {
+  for (const type of GDACS_EVENT_TYPES) {
+    const url = gdacsEndpointFor(type);
+    const value = new URL(url).searchParams.get("eventtype");
+    expect(value).toBe(type);
+    // The round-two regression: GDACS now rejects more than one type per request.
+    expect(value).not.toContain(";");
+    expect(value).not.toContain(",");
+  }
 });
 
 test("every hazard code we request is one the label map understands", () => {
@@ -116,4 +118,46 @@ test("every hazard code we request is one the label map understands", () => {
 
 test("requests all six hazard types, so the layer is not quietly single-hazard", () => {
   expect([...GDACS_EVENT_TYPES].sort()).toEqual(["DR", "EQ", "FL", "TC", "VO", "WF"]);
+});
+
+// ── mergeGdacsResults: the fan-out/fan-in this fix introduced ────────────────
+
+const okResult = (type: string, eventId: number): GdacsTypeResult => ({
+  type,
+  ok: true,
+  features: [
+    { geometry: { coordinates: [10, 20] }, properties: { eventid: eventId, episodeid: 1, eventtype: type, alertlevel: "Green" } },
+  ],
+});
+const failResult = (type: string, reason: string): GdacsTypeResult => ({ type, ok: false, reason });
+
+test("all six types succeeding merges into one observed result", () => {
+  const results = GDACS_EVENT_TYPES.map((t, i) => okResult(t, i + 1));
+  const out = mergeGdacsResults(results, 1000);
+  expect(readOutcome(out)).toMatchObject({ ok: true, at: 1000 });
+  expect(out).toHaveLength(6);
+});
+
+test("all six types failing reports nothing, not a false quiet day", () => {
+  const results = GDACS_EVENT_TYPES.map((t) => failResult(t, "http 400"));
+  const out = mergeGdacsResults(results, 1000);
+  expect(readOutcome(out)).toMatchObject({ ok: false, reason: "http 400", at: 1000 });
+  expect(out).toHaveLength(0);
+});
+
+test("one type failing keeps the other five, flagged degraded rather than silently OK", () => {
+  const results: GdacsTypeResult[] = [
+    okResult("EQ", 1),
+    okResult("TC", 2),
+    okResult("FL", 3),
+    okResult("VO", 4),
+    okResult("DR", 5),
+    failResult("WF", "http 500"),
+  ];
+  const out = mergeGdacsResults(results, 2000);
+  const outcome = readOutcome(out);
+  expect(outcome?.ok).toBe(false); // partial is not success, even with real rows attached
+  expect(outcome?.reason).toContain("WF");
+  expect(outcome?.reason).toContain("http 500");
+  expect(out).toHaveLength(5); // the five that succeeded are not thrown away
 });


### PR DESCRIPTION
GDACS has broken this layer's request shape twice in fifteen days, the same way both times: a hard 400 that `fetch()` turned into a clean, quiet zero — indistinguishable from an actual calm day.

## What landed

**Round one, fixed 2026-08-13** (already in `main`): a bare event-list call started answering `{"message":"Eventtype is required."}`. The fix was one query parameter — `eventtype`, all six hazard codes semicolon-joined into a single request.

**Round two, found and fixed here:** that same semicolon-joined request now answers `{"message":"Please specify only 1 eventtype."}`. GDACS tightened the parameter again some time in the 15 days between. Confirmed directly against their endpoint before touching any code:

```
$ curl ".../geteventlist/MAP?eventtype=EQ;TC;FL;VO;DR;WF"
{"message":"Please specify only 1 eventtype."}
$ curl ".../geteventlist/MAP?eventtype=EQ"
{"type":"FeatureCollection","features":[...]}   # 200, real data
```

The fix this time is structural, not one parameter, because a single-request shape no longer exists: `gdacsEndpointFor(type)` builds one single-hazard-type URL, `fetch()` issues the six in parallel, and a new pure function, `mergeGdacsResults()`, folds the six outcomes into one. A hazard type failing does not empty the other five — it uses the existing `degradedWith()` helper (real rows, `ok: false`) rather than either `observed` (which would assert health a third of the requests didn't have) or `degraded` (which would throw away five good hazard types over one bad one).

## Verification

- Reproduced the failure and the fix against GDACS directly (see the curl output above) before writing any code.
- `mergeGdacsResults` is exercised by three new unit tests, independent of the network: all-six-succeed → `observed`; all-six-fail → `degraded`, nothing merged in; one-fails-five-succeed → `degradedWith`, the five real rows kept, reason names the failed type.
- `npx tsc --noEmit`: clean.
- Full suite: **2,514 tests / 278 files green** (2 more than `main` — the new merge tests, net of the two URL-shape tests this replaced).
- Grepped the repo for any other reference to the removed `GDACS_ENDPOINT` constant: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
