### PR TITLE
Point the Planes layer's attribution at adsb.lol, and stop crediting the OpenSky feed removed for licensing reasons

### DIFF
--- a/components/shell/SourceCatalog.tsx
+++ b/components/shell/SourceCatalog.tsx
@@ -21,6 +21,7 @@ import {
   type LayerKey,
 } from "@/lib/layers";
 import { signalsByGroup } from "@/lib/signals/registry";
+import { ADSB_ATTRIBUTION } from "@/lib/sources/adsb";
 import { signalsStore, useSignals, useSignalCounts } from "@/lib/signals/store";
 import {
   useSignalFreshness,
@@ -75,9 +76,10 @@ const LAYER_META: Record<LayerKey, LayerMeta> = {
     source: `${CAMERA_REGIONS.length} agency feeds — TfL · Caltrans · SCDOT · Digitraffic · 511 · DriveBC & more`,
     fresh: "cameras",
   },
-  // OpenSky, not adsb.lol: app/api/planes imports fetchAircraft from lib/sources/opensky.
-  // adsb.lol backs the separate military-air SIGNAL layer only.
-  planes: { name: "Planes", group: "Air", accent: "#d97706", source: "OpenSky Network — global ADS-B snapshot", fresh: "planes" },
+  // adsb.lol, not OpenSky: OpenSky's global /states/all was removed on licensing
+  // grounds (app/api/planes/route.ts). Production has been served entirely by the
+  // adsb.lol grid sweep for months — this rail just said the wrong thing about it.
+  planes: { name: "Planes", group: "Air", accent: "#d97706", source: ADSB_ATTRIBUTION, fresh: "planes" },
   satellites: { name: "Satellites", group: "Space", accent: "#7c3aed", source: "CelesTrak TLE · SGP4 (local)", fresh: "satellites" },
   // NOT "soon": AIS shipped as a signal layer (lib/signals/ais.ts, registered at
   // lib/signals/registry.ts:121) and is rendered by this very rail under Maritime.

--- a/lib/sources/catalog.ts
+++ b/lib/sources/catalog.ts
@@ -5,6 +5,7 @@
 // only — live count/freshness are read from the existing stores by lib/sources/live.ts.
 
 import { SIGNALS } from "@/lib/signals/registry";
+import { ADSB_ATTRIBUTION } from "@/lib/sources/adsb";
 
 export type SourceKind = "core" | "signal";
 
@@ -27,12 +28,12 @@ export const CORE_IDS = ["cameras", "planes", "satellites", "webcams"] as const;
 const CORE_SOURCES: CatalogSource[] = [
   { id: "cameras",    kind: "core", label: "Cameras",    group: "Cameras",  color: "#0e7d97", attribution: "TfL · Caltrans · SCDOT · Digitraffic · 511 · DriveBC · MUP Srbije · Putevi Srbije", refreshMs: 300_000 },
   { id: "webcams",    kind: "core", label: "Webcams",    group: "Cameras",  color: "#ec4899", attribution: "Windy.com — global webcams", refreshMs: 600_000 },
-  // OpenSky, not adsb.lol: app/api/planes → lib/sources/opensky.ts pulls the global
-  // /states/all snapshot. adsb.lol backs only the separate military-air SIGNAL layer
-  // (lib/signals/military-air.ts) — same false-attribution bug already fixed for the
-  // Source Catalog rail's LAYER_META (components/shell/SourceCatalog.tsx:72-74), still
-  // live here because this is a different descriptor list.
-  { id: "planes",     kind: "core", label: "Planes",     group: "Aviation", color: "#d97706", attribution: "OpenSky Network — global ADS-B snapshot", refreshMs: 12_000 },
+  // adsb.lol, not OpenSky: OpenSky's global /states/all was the source until it was
+  // removed on licensing grounds (app/api/planes/route.ts, lib/sources/opensky.ts
+  // fetchAircraftOnce). Production has been served entirely by the adsb.lol grid
+  // sweep for months — this descriptor just said the wrong thing about it. Same
+  // string, same fix, in components/shell/SourceCatalog.tsx's LAYER_META.
+  { id: "planes",     kind: "core", label: "Planes",     group: "Aviation", color: "#d97706", attribution: ADSB_ATTRIBUTION, refreshMs: 12_000 },
   { id: "satellites", kind: "core", label: "Satellites", group: "Space",    color: "#7c3aed", attribution: "CelesTrak TLE · SGP4 (local)", refreshMs: 1_000 },
 ];
 

--- a/tests/unit/honest-strings.test.ts
+++ b/tests/unit/honest-strings.test.ts
@@ -1,5 +1,8 @@
 // Regression coverage for the "four user-visible strings that are false" fixes:
-//   1. lib/sources/catalog.ts   — planes credited to OpenSky, not adsb.lol
+//   1. lib/sources/catalog.ts   — planes credited to their real current source
+//                                 (adsb.lol), not the OpenSky feed removed on
+//                                 licensing grounds (2026-08-31: this test itself
+//                                 had asserted the stale direction — see below)
 //   2. lib/sources/windy.ts     — the MAX_WEBCAMS cap is disclosed via
 //                                 lib/signals/coverage.ts, not silent
 //   3. lib/export.ts            — downloaded files carry OUR name, not the
@@ -27,12 +30,20 @@ afterEach(() => {
 });
 
 // --- 1. catalog.ts: planes attribution --------------------------------------
+//
+// This test used to assert the OPPOSITE of what was true: it required "OpenSky"
+// and forbade "adsb.lol", which meant it was pinned to the bug rather than
+// guarding against it. OpenSky's global snapshot was removed on licensing
+// grounds and production has been served entirely by the adsb.lol grid sweep
+// for months (app/api/planes/route.ts) — the catalog entry just kept crediting
+// the feed that no longer runs. Fixed here alongside lib/sources/catalog.ts and
+// components/shell/SourceCatalog.tsx's LAYER_META, which had the same string.
 
-test("the planes catalog entry credits OpenSky, not adsb.lol", () => {
+test("the planes catalog entry credits adsb.lol, its real current source", () => {
   const planes = getCatalogSource("planes");
   expect(planes).toBeDefined();
-  expect(planes!.attribution.toLowerCase()).not.toContain("adsb.lol");
-  expect(planes!.attribution).toContain("OpenSky");
+  expect(planes!.attribution.toLowerCase()).toContain("adsb.lol");
+  expect(planes!.attribution).not.toContain("OpenSky");
 });
 
 // --- 2. windy.ts: undisclosed cap --------------------------------------------


### PR DESCRIPTION
The Planes core layer's own catalog entry lied about who produces the data it shows.

## Pensábamos
`lib/sources/catalog.ts` and `components/shell/SourceCatalog.tsx` both credit "OpenSky Network — global ADS-B snapshot" as the Planes layer's source — the same string in two places, presumably correct since nothing flagged it.

## Medimos
- `lib/sources/catalog.ts:35` and `components/shell/SourceCatalog.tsx:80`: both literally say `"OpenSky Network — global ADS-B snapshot"`.
- `app/api/planes/route.ts`'s own docblock: *"OpenSky's global `/states/all` was the source until it was removed on licensing grounds... Everything minted now is `adsb.lol`... Production had already been served entirely by the sweep for months."*
- `tests/unit/honest-strings.test.ts`'s existing test for this exact string: `expect(planes!.attribution).toContain("OpenSky")` and `.not.toContain("adsb.lol")` — the regression test was pinned to the stale value, actively guarding the wrong behavior rather than catching it.
- `lib/sources/adsb.ts` already exports a correctly-worded, ready-to-use constant — `ADSB_ATTRIBUTION = "Live aircraft © adsb.lol (community ADS-B receivers)"` — that was sitting unused anywhere in the codebase.

## Resultó
Both display locations were wrong, and the safety net meant to catch exactly this class of bug was itself inverted. Not a case of nobody noticing — the test suite was passing while asserting the false claim.

## Cambiamos
- `lib/sources/catalog.ts` and `SourceCatalog.tsx` now import and use the existing `ADSB_ATTRIBUTION` constant instead of a hardcoded string, in both places.
- `tests/unit/honest-strings.test.ts`: flipped the assertion to require `adsb.lol` and forbid `OpenSky`, with a comment explaining why the old direction existed and was wrong.
- Verified live in a dev browser session that the "Planes" and "Military flights" rail rows now read consistently (`Live aircraft © adsb.lol (community ADS-B receivers)` and `Military ADS-B © adsb.lol / adsb.fi (community feeds)` respectively).

## Todavía no sabemos
- A third occurrence of the same false "OpenSky Network" string exists at `lib/console/widgets/aviation.tsx:103` (the Aviation console widget's help text), found after this fix was already written. Deliberately left out of this PR — different file, same underlying claim, but treating it as its own PR rather than expanding this diff's scope after the fact.
- `CLAUDE.md`'s own "Live-source notes" section (dated 2026-08-10) still states *"Aircraft come from OpenSky, not adsb.lol"* — the exact opposite of current reality. Not touched here since it's your own doc and the call on how to correct it is yours.

## Verification
- `npx tsc --noEmit`: clean.
- Full suite: **2,512 tests / 278 files green.**
- `grep -rn "OpenSky Network"` across the repo (excluding the aviation.tsx widget noted above) returns nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
