### PR TITLE
Take the bar off the top of the hero, and give it the real mark

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -36,8 +36,18 @@ export default function SiteLayout({ children }: { children: React.ReactNode }) 
   // ScrollGround's to own from the first scroll frame onward, but leaving it off
   // the initial HTML meant every cold load painted a bone instrument bar and
   // daylight type over a black stage until hydration corrected it.
+  //
+  // `pv-bar-night` joins it for the same reason and by the same argument. It is
+  // now the class that decides whether the bar has a background AT ALL, so off
+  // the initial HTML every cold load flashed a full glass plate across the black
+  // stage until hydration. Safe for the rest of the group: /privacy renders no
+  // `.pv-bar`, so the class matches nothing there. A future (site) page with a
+  // bar but NO hero would need to clear it — ScrollGround only removes it when a
+  // [data-pv-hero] exists.
   return (
-    <div className={`pv-root pv-night ${archivo.variable} ${publicSans.variable} ${plexMono.variable}`}>
+    <div
+      className={`pv-root pv-night pv-bar-night ${archivo.variable} ${publicSans.variable} ${plexMono.variable}`}
+    >
       {children}
     </div>
   );

--- a/app/provenance.css
+++ b/app/provenance.css
@@ -27,6 +27,10 @@
   --pv-ash: #c9d1d6;
   --pv-dusk: #2b3640;
   --pv-ink: #0b1016;
+  /* The night stage's own black, one notch below the ramp's ink. It was a literal
+     in two places; it is a token because THREE things have to agree on it now —
+     the hero stage, the closing bookend, and the ground behind the sticky bar. */
+  --pv-stage: #05070c;
 
   /* ── semantic (inherited from the app's own meanings) ── */
   --pv-teal: #0e7d97;
@@ -88,7 +92,13 @@
   inset: 0;
   z-index: 0;
   pointer-events: none;
-  background-color: color-mix(in oklab, var(--pv-bone), var(--pv-ink) calc(var(--pv-g) * 100%));
+  /* The dark stop is the STAGE, not `--pv-ink`. `.pv-bar` is sticky, which keeps
+     it IN FLOW, so at scroll 0 the top 44px of the page is ground and the hero
+     starts below it. The moment the bar lost its background and its hairline, that
+     44px of #0b1016 showed as a band across a #05070c stage — the seam the hairline
+     had been hiding. Landing the ramp on the stage's own black is what makes
+     "transparent" literally true. The daylight end is unchanged. */
+  background-color: color-mix(in oklab, var(--pv-bone), var(--pv-stage) calc(var(--pv-g) * 100%));
 }
 
 .pv-progress {
@@ -261,15 +271,37 @@
   outline-offset: 3px;
 }
 
-/* ─────────────────────────── instrument bar ─────────────────────────── */
+/* ─────────────────────────── instrument bar ───────────────────────────
+   ONE CENTRED CLUSTER: the mark, the wordmark, and the three places worth going.
+   That is why this is `justify-content: center` and not a three-column grid —
+   with nothing in the side slots there is no width to compensate for. The live
+   coverage readout that used to sit here held the slack with `flex: 1`, and it
+   was what pushed the links out to the right edge.
 
+   TWO STATES OFF ONE SIGNAL THAT ALREADY EXISTS. `.pv-bar-night` is on
+   `.pv-root` exactly while the hero is the thing directly under the bar
+   (ScrollGround.tsx:96-98, `y < heroH - BAR_H`). The whole transparent → glass
+   handover reads off that class. Do NOT add a second scroll listener, a second
+   class, or a second custom property for it.
+
+   GLASS IS THE BASE AND TRANSPARENT IS THE OVERRIDE, not the other way round,
+   and `pv-bar-night` is server-rendered in (site)/layout.tsx so the override is
+   in the first paint. Written as `:not(.pv-bar-night)` the glass plate would
+   flash across the black stage on every cold load until hydration — the same
+   trap `.pv-night` is server-rendered to avoid. */
 .pv-bar {
   position: sticky;
   top: 0;
   z-index: 50;
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  justify-content: center;
+  /* Wider than the gap inside `.pv-bar-links`, or the cluster reads as five
+     loose words instead of a lockup followed by a nav. */
+  gap: 2rem;
+  /* 44px is load bearing in two other places and all three must agree: `BAR_H`
+     in ScrollGround.tsx, which decides where the handover fires, and the
+     `calc(100svh - 44px)` hero geometry further down this file. */
   height: 44px;
   padding: 0 1.25rem;
   border-bottom: 1px solid var(--pv-rule);
@@ -285,7 +317,13 @@
     color-mix(in oklab, var(--pv-bone), var(--pv-ink) calc(var(--pv-bar-g, 1) * 100%)) 82%,
     transparent
   );
-  backdrop-filter: blur(10px);
+  /* Through a variable so the night state can ramp it to zero rather than snap
+     `none`: `blur(0px)` interpolates and `none` does not, and the snap is visible
+     on the way back UP the page as an unblurred wash over the stage. The
+     `-webkit-` alias is the house pattern everywhere else; this rule was the one
+     place missing it. */
+  backdrop-filter: blur(var(--pv-bar-blur, 10px)) saturate(1.05);
+  -webkit-backdrop-filter: blur(var(--pv-bar-blur, 10px)) saturate(1.05);
   font-family: var(--pv-mono);
   font-size: 0.72rem;
   letter-spacing: 0.06em;
@@ -293,21 +331,51 @@
   color: var(--pv-fg-mute);
   /* The handover happens the instant the hero's bottom edge clears the bar, so it
      is a step, not a ramp. Ease it or it snaps. */
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease,
+    backdrop-filter 0.3s ease, -webkit-backdrop-filter 0.3s ease;
 }
 
-/* While the night stage is the thing under the bar, the bar wears night type —
-   independently of `.pv-night`, which by then has already handed the document
-   over to daylight. */
+/* A SCRIM, NOT A PLATE. Over the hero the bar has no background and no rule, but
+   the h1 slides directly under it on the way out — #f4f8fa display type passing
+   beneath an #e8eef1 wordmark, both unreadable for the length of the transit.
+   This is a top-down wash that reaches ZERO opacity at the bar's own bottom edge,
+   so it has no edge of its own: the bar still reads as absent while the type
+   stays legible. `--pv-bar-scrim: 0` gives the strict "nothing at all" reading.
+
+   Transitioned opacity on a pseudo-element rather than a transitioned gradient:
+   gradient interpolation is not worth betting a cold load on across engines.
+   `z-index: -1` keeps it above the bar's own background and below its text,
+   inside the stacking context `z-index: 50` already creates. */
+.pv-bar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: linear-gradient(to bottom, var(--pv-stage), transparent);
+  opacity: var(--pv-bar-scrim, 0);
+  transition: opacity 0.3s ease;
+}
+
+/* Over the night stage the bar is not a bar: no plate, no rule, no blur, so the
+   top of the page reads as the stage rather than as furniture laid across it.
+
+   This is also where the bar wears night type — independently of `.pv-night`,
+   which by then has already handed the document over to daylight.
+
+   `border-bottom-color: transparent` and not `border: none`: `box-sizing` is
+   border-box, so removing the border would give the content box an extra pixel
+   and shift the cluster half a pixel on every handover. */
 .pv-root.pv-bar-night .pv-bar {
+  background-color: transparent;
+  border-bottom-color: transparent;
+  --pv-bar-blur: 0px;
+  --pv-bar-scrim: 0.55;
   color: #7a8892;
-  border-bottom-color: rgba(232, 238, 241, 0.16);
 }
-.pv-root.pv-bar-night .pv-wordmark {
+.pv-root.pv-bar-night .pv-wordmark,
+.pv-root.pv-bar-night .pv-bar-links a.pv-bar-go {
   color: #e8eef1;
-}
-.pv-root.pv-bar-night .pv-bar-live {
-  color: #93a3ae;
 }
 .pv-root.pv-bar-night .pv-bar-links a {
   color: #7a8892;
@@ -315,61 +383,135 @@
 .pv-root.pv-bar-night .pv-bar-links a:hover {
   color: #e8eef1;
 }
+.pv-root.pv-bar-night .pv-bar-rule {
+  background: rgba(232, 238, 241, 0.22);
+}
 .pv-root.pv-bar-night .pv-wordmark,
-.pv-root.pv-bar-night .pv-bar-live,
 .pv-root.pv-bar-night .pv-bar-links a {
   transition: color 0.3s ease;
 }
-.pv-wordmark {
+/* `.pv-root .pv-wordmark` and not `.pv-wordmark`, because `.pv-root a` at the top
+   of this file is (0,2,0) and a bare `.pv-wordmark` is only (0,1,0). The bare
+   selector lost, silently, and the site wordmark has been rendering in the LINK
+   accent in daylight ever since — against its own `color: var(--pv-fg)`. Night
+   never showed it because `.pv-root.pv-bar-night .pv-wordmark` is (0,3,0) and wins.
+   The wordmark is identity, not a link: it should not wear the link colour, and it
+   should not change hue when the page changes ground. */
+.pv-root .pv-wordmark {
   font-family: var(--pv-display);
   font-weight: 900;
   font-variation-settings: "wdth" 112;
   font-size: 0.86rem;
   letter-spacing: 0.3em;
+  /* CSS puts tracking after the LAST glyph too, so 0.3em of dead space hangs off
+     the right of the wordmark and drags the whole centred cluster left of true
+     centre. Claw it back — the centring is optical or it is nothing. */
+  margin-right: -0.3em;
   text-transform: uppercase;
   color: var(--pv-fg);
   display: flex;
   align-items: center;
   gap: 0.6rem;
   flex: none;
+  white-space: nowrap;
   text-decoration: none;
 }
-.pv-dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: var(--pv-teal);
-  flex: none;
+/* The mark draws every part from `currentColor`, which is what lets one asset
+   serve both skins. The part rules (`.mk-ring`, `.mk-fill`, `.mk-dot`, and the
+   idle orbit) live in globals.css, which the ROOT layout loads on every route
+   including this one, so they apply here and are not repeated.
+   What DOES need saying is the colour: `.tn-mark` also sets
+   `color: var(--tnx-ink)`, and `--tnx-ink` is defined only under `.tn-terminal`
+   (globals.css:3087, :3255), a selector that does not exist on this page. The
+   variable is therefore invalid here and the colour already falls back to
+   `inherit` BY ACCIDENT. Say it outright, or the day somebody widens the scope of
+   `--tnx-ink` the mark turns console-coloured on the site with nothing to point
+   at. */
+.pv-wordmark .tn-mark {
+  color: inherit;
 }
-.pv-bar-live {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  color: var(--pv-fg-dim);
-  font-variant-numeric: tabular-nums;
+/* Separates the identity from the navigation, so the cluster reads as one object
+   with two halves rather than five loose words. */
+.pv-bar-rule {
+  width: 1px;
+  height: 14px;
+  background: var(--pv-rule-hi);
+  flex: none;
 }
 .pv-bar-links {
   display: flex;
-  gap: 1.25rem;
+  align-items: center;
+  gap: 1.5rem;
   flex: none;
-}
-/* Narrow viewports keep only the action. The other two are anchors to sections the
-   reader is about to scroll through anyway, and at 390px they overflowed the bar
-   and took the whole page sideways with them. */
-@media (max-width: 40rem) {
-  .pv-bar-links { display: none; }
-  .pv-bar { gap: 0.85rem; padding: 0 0.9rem; }
-  .pv-wordmark { letter-spacing: 0.16em; font-size: 0.8rem; }
-  .pv-bar-live { font-size: 0.66rem; }
 }
 .pv-bar-links a {
   color: var(--pv-fg-mute);
   text-decoration: none;
+  white-space: nowrap; /* nothing wraps to a second line in a 44px bar */
 }
 .pv-bar-links a:hover {
   color: var(--pv-fg);
+}
+/* The one action in the bar, so the one link at full contrast. The arrow and the
+   contrast are the whole distinction — a bordered pill inside a centred cluster
+   reads as a fourth object and pulls the group off balance. */
+.pv-bar-links a.pv-bar-go {
+  color: var(--pv-fg);
+}
+/* Narrow viewports keep only the action — and now actually do. This block used to
+   hide `.pv-bar-links` outright, which took "Open the map" with it and left a
+   phone with no route into the product but the hero button, while the comment
+   here claimed the opposite. The two that go are anchors to sections the reader
+   is about to scroll through anyway; the map is the only thing in the bar you
+   cannot reach by scrolling.
+
+   Named classes and not `:nth-child` — the next person to reorder these links
+   should not silently change which two disappear. */
+@media (max-width: 40rem) {
+  .pv-bar { gap: 1.25rem; padding: 0 0.9rem; }
+  .pv-root .pv-wordmark { letter-spacing: 0.16em; margin-right: -0.16em; font-size: 0.8rem; }
+  .pv-bar-links { gap: 1rem; }
+  .pv-bar-rule, .pv-bar-jump { display: none; }
+}
+/* Phones: tighten before giving anything up. MEASURED at 390 (the commonest phone
+   width), where the untightened cluster left only 34px of slack — enough today and
+   not enough if Archivo fails to load and a wider fallback stands in. */
+@media (max-width: 30rem) {
+  .pv-bar { gap: 1rem; }
+  .pv-root .pv-wordmark {
+    font-size: 0.76rem;
+    letter-spacing: 0.12em;
+    margin-right: -0.12em;
+    gap: 0.45rem;
+  }
+  .pv-root .pv-wordmark .tn-mark { width: 20px; height: 20px; }
+}
+/* Below 23rem the LETTERS finally go and the mark alone carries the identity,
+   leaving the bar as mark + action. This is the one width where they genuinely
+   cannot coexist, and it is measured rather than guessed: at 320 (iPhone SE) the
+   tightened cluster still wants more than the 291px of usable width there, and no
+   type size that keeps the wordmark legible closes the gap — the honest choice is
+   the identity or the action, and on a 320px phone the action wins. 390 and 430
+   keep both.
+
+   Worth knowing WHY this needed measuring at all: `.pv-root` is `overflow-x: clip`,
+   so an over-wide bar never reaches `documentElement.scrollWidth`. It is clipped
+   in silence, and the verifier's no-sideways-scroll sweep reports 0 either way —
+   it would have passed this bar at 320 while the cluster hung 36px off the edge.
+   The cluster has to be measured against the bar's own content box.
+
+   Clipped rather than `display: none`, so the link keeps its accessible name —
+   a link whose only remaining content is an aria-hidden SVG has no name at all. */
+@media (max-width: 23rem) {
+  .pv-wordmark-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+  .pv-root .pv-wordmark { margin-right: 0; gap: 0; }
 }
 
 /* ─────────────────────────── hero (the night stage) ───────────────────────────
@@ -389,7 +531,7 @@
      breathing room are derived from it, so the composition holds at any size. */
   --pv-globe-r: min(60vw, calc(0.86 * (100svh - 44px)));
   min-height: calc(100svh - 44px);
-  background: #05070c;
+  background: var(--pv-stage);
   overflow: hidden;
   display: grid;
   align-content: center;
@@ -1342,10 +1484,10 @@
      same fate because it already sets z-index: 1. */
   position: relative;
   z-index: 1;
-  /* The same black as the hero, not `--pv-ink`. The closing section is the other
+  /* `--pv-stage`, the same black as the hero and NOT `--pv-ink`. The other
      half of a bookend — "everything above was this" lands because the reader is
      standing back on the stage they started on, under the same sky. */
-  background: #05070c;
+  background: var(--pv-stage);
   color: #e8eef1;
   min-height: 100svh;
   display: flex;

--- a/components/marketing/InstrumentBar.tsx
+++ b/components/marketing/InstrumentBar.tsx
@@ -1,59 +1,61 @@
-"use client";
-
-import { useEffect, useState } from "react";
+import Mark from "@/components/brand/Mark";
 import { BRAND } from "@/lib/brand";
 
-interface Coverage {
-  total?: number;
-  online?: number;
-  feeds?: { answered?: number; total?: number };
-}
-
 /**
- * The site wears the app's own status bar, and the first claim it makes is a
- * measured one. Counts come from /api/coverage — the same endpoint the console
- * uses — never from a number typed into the markup.
+ * The site's one piece of chrome: the mark, the name, and the three places worth
+ * going. Nothing else.
  *
- * If the fetch fails, the slot stays empty. A stale hardcoded figure on the one
- * page arguing for trustworthiness is worse than no figure.
+ * IT IS NOT A BAR OVER THE HERO. The plate, the hairline and the blur are all
+ * suppressed while the night stage is behind it, so the top of the page is the
+ * stage and not a strip of furniture laid across it. It becomes glass only once
+ * the hero has cleared and there is document underneath that the type needs
+ * separating from.
+ *
+ * That handover is pure CSS. `ScrollGround` already toggles `.pv-bar-night` on
+ * `.pv-root` for exactly this condition — the ground DIRECTLY BENEATH the bar,
+ * which during the hero exit is not the same as the page's — so provenance.css
+ * hangs both states off that one class. Do not add a scroll listener here: this
+ * page has exactly one, by design, and a second would fight it.
+ *
+ * WHAT USED TO BE HERE. A live camera count fetched from /api/coverage, and a
+ * teal dot standing in for a logo. The count went because the bar is navigation
+ * and a number is not a destination — the page still has to earn that claim, and
+ * still does, in the hero status rail and the generated source wall, both of
+ * which are measured and both of which the verifier checks. Dropping it also
+ * takes the last client-side fetch off the landing page, which is why there is
+ * no "use client" above.
  */
 export default function InstrumentBar() {
-  const [cov, setCov] = useState<Coverage | null>(null);
-
-  useEffect(() => {
-    const ac = new AbortController();
-    fetch("/api/coverage", { signal: ac.signal })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => d && setCov(d as Coverage))
-      .catch(() => {});
-    return () => ac.abort();
-  }, []);
-
-  const cams = cov?.total;
-  const feeds = cov?.feeds;
-  const live =
-    typeof cams === "number" && cams > 0
-      ? `${cams.toLocaleString()} cameras${
-          feeds?.answered && feeds?.total ? ` · ${feeds.answered} of ${feeds.total} feeds answering` : ""
-        }`
-      : "";
-
   return (
-    <div className="pv-bar">
+    <nav className="pv-bar" aria-label="Site">
       <a className="pv-wordmark" href="#top">
-        <span className="pv-dot" />
-        {BRAND.name}
+        {/* No `title`: it sits against the wordmark, so a label here would put a
+            second "Provenance" in the accessibility tree. `idle` runs the slow
+            orbit on the ring dots — the ambient "this thing is live" tell. */}
+        <Mark size={24} idle />
+        {/* In its own span so the narrow-viewport rule can take the LETTERS away
+            without taking the accessible name with them — below 30rem the mark
+            alone is the home link, and a link whose only content is an
+            aria-hidden SVG has no name at all. */}
+        <span className="pv-wordmark-text">{BRAND.name}</span>
       </a>
-      <span className="pv-bar-live">{live}</span>
+
+      <span className="pv-bar-rule" aria-hidden="true" />
+
       <span className="pv-bar-links">
-        <a href="#sources">Sources</a>
-        {/* The ledger, not the repo. The bar's job is to get you to the two things
-            that back the claim it is making one slot to the left — every source,
-            and what each of them is doing right now. The repo link is in the
-            footer and in the hero's second button. */}
-        <a href="#ledger">Status</a>
-        <a href="/app">Open the map →</a>
+        {/* The two things that back the claim the page is making — every source,
+            and what each of them is doing right now. The repo link lives in the
+            footer and in the hero's second button, per AGPL §13. */}
+        <a className="pv-bar-jump" href="#sources">
+          Sources
+        </a>
+        <a className="pv-bar-jump" href="#ledger">
+          Status
+        </a>
+        <a className="pv-bar-go" href="/app">
+          Open the map →
+        </a>
       </span>
-    </div>
+    </nav>
   );
 }

--- a/scripts/verify-provenance.mjs
+++ b/scripts/verify-provenance.mjs
@@ -353,11 +353,18 @@ layerBreadth
   ? pass("globe renders the registry's aggregated sources")
   : fail("globe is not using the aggregated signal sources");
 
-// ── 5. the instrument bar shows a MEASURED count, not a typed one ──────────
-const barText = await page.locator(".pv-bar-live").innerText();
-/\d/.test(barText)
-  ? pass("instrument bar shows live coverage", barText)
-  : fail("instrument bar empty", `"${barText}" (honest if /api/coverage failed)`);
+// ── 5. (removed) the instrument bar's coverage readout ─────────────────────
+// The bar no longer carries a number, so there is nothing here to assert. The
+// readout is not hidden and not moved: the /api/coverage fetch is gone from
+// InstrumentBar entirely, which is what let it go back to being a server
+// component. Keeping a green tick here — by hiding an element with a digit in
+// it, or by re-pointing the assertion at some other number — would have left a
+// guard that no longer guards anything, which is the exact failure this file
+// exists to prevent.
+//
+// The rule it enforced is unchanged and is still checked where numbers actually
+// appear: check 3b on the hero status rail, and the source-wall card count
+// below. Both are generated from SOURCE_CATALOG rather than typed.
 
 // ── 6. the ground lifts out of the hero, then plunges into the adapter ─────
 // Leg 1: leaving the night stage has to reach daylight, or the whole document is


### PR DESCRIPTION
The landing page opened on a full-width instrument bar: a teal placeholder dot, a live camera count stretched across the middle, three links pushed to the right edge, and a hairline under all of it. On a page whose first move is a full-bleed night stage, that read as a strip of furniture laid across the view.

It is now **one centred cluster** — the mark, the name, and the three places worth going — with no plate, no rule and no blur while the stage is behind it. It becomes glass only once the hero has cleared and there is document underneath that the type needs separating from.

**Visual review, with before/after evidence at six viewports:** https://claude.ai/code/artifact/7537b326-cc73-4cd1-b5ba-4624280e3240

## The handover costs no JavaScript

`ScrollGround` already publishes `.pv-bar-night` for exactly this condition — the ground *directly beneath the bar*, which during the hero exit is not the page's ground. Both states hang off that one class, so the page still has exactly one scroll subscriber.

Glass is the **base** rule and transparent is the **override**, not the other way round: `.pv-bar-night` is now server-rendered in `(site)/layout.tsx` so the transparent state is in the first paint. Written as `:not(.pv-bar-night)` a glass plate would flash across the black stage on every cold load until hydration — the same trap `.pv-night` already exists to avoid.

## The count is gone

A nav is not where a claim belongs, and the page still earns that claim where numbers actually appear — the hero status rail and the generated source wall, both from `SOURCE_CATALOG`, both still asserted. Dropping it also takes the last client-side fetch off the landing page, so `InstrumentBar` is a server component again.

**Check 5 in `verify-provenance.mjs` is deleted, not satisfied.** It asserted `.pv-bar-live` contains a digit; that element no longer exists. Hiding an element with a number in it, or re-pointing the assertion at some other figure, would have kept a green tick for a guard that guards nothing — which is the failure this file exists to prevent. Check 3b still holds the same line on the hero rail.

## Four defects found on the way, all pre-existing

**A two-blacks seam the hairline was hiding.** `.pv-bar` is `position: sticky`, which keeps it *in flow*, so at scroll 0 the top 44px of the page is `.pv-ground`, not hero. The ground landed on `--pv-ink` `#0b1016` while the stage is `#05070c`; removing the border exposed a 44px band of the wrong black. Both are now one `--pv-stage` token — which is also what the closing section's comment already meant by "the same black as the hero, not `--pv-ink`".

**The wordmark has never been the colour it declares.** `.pv-root a` at (0,2,0) silently beats `.pv-wordmark` at (0,1,0), so in daylight the wordmark rendered in the *link* accent against its own `color: var(--pv-fg)`. Night never showed it because the night rule is (0,3,0). Fixed so identity does not change hue with the ground — **this one is a judgement call and trivially reversible if you prefer the teal.**

**Every phone had lost the only route into the product.** The narrow-viewport rule hid `.pv-bar-links` outright, taking "Open the map →" with it, while the comment above it claimed *"Narrow viewports keep only the action."* Measured at 320px, the old CTA had a width of **zero**.

**The overflow guard cannot see overflow.** `.pv-root` is `overflow-x: clip`, so an over-wide element is clipped in silence and never reaches `documentElement.scrollWidth`. The no-sideways-scroll sweep reports 0 either way — it passed this cluster while it hung **36px off the edge** at 320px. The responsive rules are therefore measured against the bar's own content box. **This affects every element on that page, not just the nav.**

## Verification

- `tsc --noEmit` clean; **2678 tests across 293 files**, run twice.
- `verify-provenance.mjs` **40/43** against this branch at 1440×900.
- Bar wears night at scroll 0, holds it at `heroH×0.9`, hands over at `heroH+120` — all three pass.
- Zero console errors and zero 4xx on `/`.
- Measured at 14 widths from 1920 to 320: no overflow, CTA present throughout, minimum headroom 70px, bar exactly 44px everywhere. `BAR_H` and both `calc(100svh - 44px)` expressions are untouched.

The three verifier failures are **pre-existing and were not assumed to be**. Each was baselined by pointing the same script at production, which *is* `origin/main`:

| Failure | Evidence it predates this branch |
|---|---|
| bottom CTA offscreen | byte-identical on both — `y=-28, vh=900, docH=11379, barH=44` |
| `getSource` of null | reproduces on prod, where it **crashes** the run at `:351` — a check that passes here |
| no empty layers reported | upstream signal-layer data state; nothing in this diff touches a layer |

## Two notes for whoever touches this page next

1. `overflow-x: clip` on `.pv-root` defeats the no-sideways-scroll sweep. Measure elements against their own content box; do not trust `scrollWidth` on `/`.
2. `verify-provenance.mjs` can be pointed at a URL, so `node scripts/verify-provenance.mjs https://provenance-online.vercel.app` gives a zero-disk `origin/main` baseline without a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpFZmB4S4AgX4CSppmmjuw
