### PR TITLE
One shared hit-test, so the map stops freezing on every zoom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ read*.json
 # Local perf profiling output (scripts/profile-map.mjs) and its isolated build dir
 profile-out/
 .next-perf/
+
+.env*

--- a/app/globals.css
+++ b/app/globals.css
@@ -2551,8 +2551,13 @@ a { color: var(--tn-accent); }
    aim and one you gamble on. pointer-events:none so it can never eat the click
    it exists to enable; translated up-left of the cursor so it does not sit under
    the pointer tip. */
+/* The cursor offset lives in the margins, NOT in `transform`: the tip is positioned
+   by a direct `transform` write from the pointer handler (see lineTipRef in
+   WorldMap), so transform has to be free to carry the coordinates and compositing
+   them costs no layout. */
 .tn-linetip {
-  position: absolute; z-index: 7; pointer-events: none; transform: translate(14px, -34px);
+  position: absolute; z-index: 7; pointer-events: none;
+  left: 0; top: 0; margin: -34px 0 0 14px; will-change: transform;
   max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   padding: 4px 9px; border-radius: 8px; font-size: 12px; font-weight: 600;
   color: var(--tn-text); background: var(--tn-surface-solid); border: 1px solid var(--tn-border);

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -61,6 +61,15 @@ import {
   resolveMapClickTarget,
   type MapClickHit,
 } from "@/lib/map/hitTest";
+import {
+  HOVER_QUERY_LAYERS,
+  HOVER_SETTLE_MS,
+  NO_HOVER,
+  hoverChanged,
+  resolveHover,
+  shouldHitTest,
+  type HoverState,
+} from "@/lib/map/hover";
 import { toCountryLabelFC, buildCountryObject, type CountryProps } from "@/lib/geo/country";
 // The Terminal chrome owns both of these contracts, so they are imported rather than
 // re-declared here: the cursor event NAME (a second literal would drift the day one
@@ -460,7 +469,13 @@ export default function WorldMap() {
   // The cable route under the cursor — name + where to float it. Paired with the
   // SIGNAL_LINE_HOVER highlight so "which of these 697 lines am I about to open?"
   // is answered before the click rather than by it.
-  const [lineHover, setLineHover] = useState<{ x: number; y: number; label: string } | null>(null);
+  //
+  // Deliberately a ref and a direct DOM write, NOT React state. This is written
+  // from a pointer handler, and a setState here re-renders all of WorldMap — every
+  // <…Feed> child, every layer effect, the thumbnail pool — at pointer rate. The
+  // comment further down this file records a previous publisher removed for exactly
+  // that reason; this is the same hazard, so the tip owns one node and mutates it.
+  const lineTipRef = useRef<HTMLDivElement | null>(null);
 
   // Live-layer data is lifted into state from gating <…Feed> children so that a
   // hidden layer's hook (and its fetch/tick) is unmounted entirely — see the
@@ -1293,10 +1308,7 @@ export default function WorldMap() {
       const hit = pinsRef.current.pins.find((p) => Math.abs(p.lat - lat) < 1e-6 && Math.abs(p.lon - lon) < 1e-6);
       if (hit) pinsStore.setActive(hit.id);
     });
-    const pinEnter = () => { map.getCanvas().style.cursor = "pointer"; };
-    const pinLeave = () => { map.getCanvas().style.cursor = ""; };
-    map.on("mouseenter", PIN_DOT_LAYER, pinEnter);
-    map.on("mouseleave", PIN_DOT_LAYER, pinLeave);
+    // (cursor for user pins is owned by the shared hit-test at the end of this fn)
     map.on("click", SAT_LAYER, (e) => {
       const id = (e.features?.[0]?.properties as { id?: string })?.id;
       const sat = satsRef.current.find((s) => s.id === id);
@@ -1383,23 +1395,7 @@ export default function WorldMap() {
         overCountry: hits.some((h) => h.layer === COUNTRY_FILL_LAYER),
       });
     };
-    const clearLineHover = () => {
-      if (map.getLayer(SIGNAL_LINE_HOVER)) map.setFilter(SIGNAL_LINE_HOVER, ["==", ["get", "id"], "__none__"]);
-      setLineHover(null);
-    };
-    map.on("mousemove", SIGNAL_LINE_HIT, (e) => {
-      const f = lineFeatureAt(e.point);
-      const props = f?.properties as { id?: string; label?: string } | undefined;
-      if (!f || !props?.id) {
-        clearLineHover();
-        return;
-      }
-      map.setFilter(SIGNAL_LINE_HOVER, ["==", ["get", "id"], props.id]);
-      map.getCanvas().style.cursor = "pointer";
-      setLineHover({ x: e.point.x, y: e.point.y, label: props.label ?? "Cable" });
-    });
-    map.on("mouseleave", SIGNAL_LINE_HIT, clearLineHover);
-    map.on("movestart", clearLineHover);
+    // (cable highlight + tip are owned by the shared hit-test at the end of this fn)
     map.on("click", SIGNAL_LINE_HIT, (e) => {
       // The drawn-line handler above already owns a click that landed on the
       // geometry; this one exists for the near-misses it cannot see.
@@ -1422,38 +1418,92 @@ export default function WorldMap() {
       if (!f) return;
       overlay.open(buildCountryObject(f.properties as CountryProps, e.lngLat.lat, e.lngLat.lng));
     });
-    let hoveredCountry: number | string | undefined;
-    const clearCountryHover = () => {
-      if (hoveredCountry !== undefined) {
-        map.setFeatureState({ source: COUNTRY_SRC, id: hoveredCountry }, { hover: false });
-        hoveredCountry = undefined;
-      }
+    // ── ONE shared pointer hit-test ─────────────────────────────────────────
+    // This replaces 13 layer-scoped mouseenter/mouseleave/mousemove handlers.
+    // MapLibre implements those as DELEGATED mousemove listeners that each run a
+    // queryRenderedFeatures before deciding whether your handler fires, so a layer
+    // wired for enter+leave cost two queries on every pointer move — 26 per move
+    // across 13 layers. Blink re-fires hover as the map slides under a stationary
+    // cursor, so one wheel-zoom measured 3,653 queries / 10,665 ms of blocked main
+    // thread on production, in BOTH directions. See lib/map/hover.ts.
+    //
+    // Three reductions multiply here: 26 queries become 1, a rAF coalesces a burst
+    // of pointer events into a single test, and nothing runs at all while the
+    // camera is moving.
+    let hover: HoverState = NO_HOVER;
+    let hoverRaf = 0;
+    let pendingPoint: maplibregl.MapMouseEvent["point"] | null = null;
+    let movingUntil = 0;
+
+    const moveTip = (at: maplibregl.MapMouseEvent["point"]) => {
+      const tip = lineTipRef.current;
+      if (tip) tip.style.transform = "translate(" + at.x + "px," + at.y + "px)";
     };
-    map.on("mousemove", COUNTRY_FILL_LAYER, (e) => {
-      const f = e.features?.[0];
-      if (!f || f.id == null) return;
-      if (hoveredCountry !== f.id) {
-        clearCountryHover();
-        hoveredCountry = f.id;
-        map.setFeatureState({ source: COUNTRY_SRC, id: hoveredCountry }, { hover: true });
+
+    const applyHover = (next: HoverState, at: maplibregl.MapMouseEvent["point"] | null) => {
+      if (next.cursor !== hover.cursor) map.getCanvas().style.cursor = next.cursor;
+
+      if (next.country !== hover.country) {
+        if (hover.country !== null) map.setFeatureState({ source: COUNTRY_SRC, id: hover.country }, { hover: false });
+        if (next.country !== null) map.setFeatureState({ source: COUNTRY_SRC, id: next.country }, { hover: true });
       }
+
+      const tip = lineTipRef.current;
+      if (next.line === null) {
+        if (map.getLayer(SIGNAL_LINE_HOVER)) map.setFilter(SIGNAL_LINE_HOVER, ["==", ["get", "id"], "__none__"]);
+        if (tip) tip.hidden = true;
+      } else {
+        if (map.getLayer(SIGNAL_LINE_HOVER)) map.setFilter(SIGNAL_LINE_HOVER, ["==", ["get", "id"], next.line.id]);
+        if (tip) {
+          tip.textContent = next.line.label;
+          if (at) moveTip(at);
+          tip.hidden = false;
+        }
+      }
+      hover = next;
+    };
+
+    const clearHover = () => {
+      if (hoverRaf) { cancelAnimationFrame(hoverRaf); hoverRaf = 0; }
+      pendingPoint = null;
+      if (hoverChanged(hover, NO_HOVER)) applyHover(NO_HOVER, null);
+    };
+
+    const runHitTest = () => {
+      hoverRaf = 0;
+      const pt = pendingPoint;
+      pendingPoint = null;
+      if (!pt) return;
+      const layers = HOVER_QUERY_LAYERS.filter((id) => map.getLayer(id));
+      if (!layers.length) {
+        if (hoverChanged(hover, NO_HOVER)) applyHover(NO_HOVER, null);
+        return;
+      }
+      const next = resolveHover(map.queryRenderedFeatures(pt, { layers }).map((f) => {
+        const p = f.properties as { signalId?: unknown; id?: unknown; label?: unknown } | undefined;
+        return {
+          layer: f.layer.id,
+          signalId: typeof p?.signalId === "string" ? p.signalId : undefined,
+          featureId: typeof f.id === "string" || typeof f.id === "number" ? f.id : undefined,
+          id: typeof p?.id === "string" ? p.id : undefined,
+          label: typeof p?.label === "string" ? p.label : undefined,
+        };
+      }));
+      if (hoverChanged(hover, next)) applyHover(next, pt);
+      else if (next.line) moveTip(pt); // same cable, new cursor — move, do not re-decide
+    };
+
+    map.on("mousemove", (e) => {
+      if (!shouldHitTest({ moving: map.isMoving(), nowMs: performance.now(), movingUntilMs: movingUntil })) {
+        clearHover();
+        return;
+      }
+      pendingPoint = e.point;
+      if (!hoverRaf) hoverRaf = requestAnimationFrame(runHitTest);
     });
-    map.on("mouseleave", COUNTRY_FILL_LAYER, clearCountryHover);
-
-
-    const hoverLayers = [
-      CAM_LAYER, CAM_DOT_LAYER,
-      WEBCAM_LAYER, WEBCAM_DOT_LAYER,
-      PLANE_LAYER, SAT_LAYER, SIGNAL_LAYER, SIGNAL_ICON_LAYER, SIGNAL_LINE_LAYER, SIGNAL_FILL_LAYER,
-    ];
-    for (const layer of hoverLayers) {
-      map.on("mouseenter", layer, () => {
-        map.getCanvas().style.cursor = "pointer";
-      });
-      map.on("mouseleave", layer, () => {
-        map.getCanvas().style.cursor = "";
-      });
-    }
+    map.on("mouseout", clearHover);
+    map.on("movestart", clearHover);
+    map.on("moveend", () => { movingUntil = performance.now() + HOVER_SETTLE_MS; });
   }, []);
 
   // --- Basemap load resilience ---------------------------------------------
@@ -2130,11 +2180,7 @@ export default function WorldMap() {
       {/* The hovered cable's name, floating at the cursor. Presentational only —
           the dossier it opens is the accessible surface, and a tooltip that
           tracks a pointer has no keyboard equivalent to announce. */}
-      {lineHover && (
-        <div className="tn-linetip" style={{ left: lineHover.x, top: lineHover.y }} aria-hidden>
-          {lineHover.label}
-        </div>
-      )}
+      <div ref={lineTipRef} className="tn-linetip" hidden aria-hidden />
 
       {/* Right-click "Add pin here" menu, positioned at the cursor over the map. */}
       {pinMenu && (

--- a/lib/map/hover.ts
+++ b/lib/map/hover.ts
@@ -1,0 +1,152 @@
+// Pointer hover arbitration — the pure decision behind "what is under the cursor,
+// and what should the map show because of it?".
+//
+// WHY THIS EXISTS. MapLibre implements `mouseenter` / `mouseleave` as a DELEGATED
+// `mousemove` listener (see _createDelegatedListener in maplibre-gl): every
+// pointer move runs `queryRenderedFeatures` for that layer *before* deciding
+// whether your handler should fire at all. A layer wired for both enter and leave
+// therefore costs TWO queries per pointer move, always, whether or not anything
+// is under the cursor.
+//
+// WorldMap wired 13 layers that way, so one pointer move cost 26 queries. That is
+// cheap when the pointer is idle and ruinous during a zoom, because Blink
+// re-fires hover events as the map slides under a stationary cursor. Measured on
+// production, one wheel-zoom produced 3,653 queries / 10,665 ms of blocked main
+// thread — 140 pointer events times 26 — and the map froze in BOTH directions,
+// because hit-test cost does not fall as you zoom out the way drawing cost does.
+//
+// The fix is structural, not a micro-optimisation: ONE unscoped listener, ONE
+// query over every hit layer at once, arbitrated here in pure JS. Three
+// reductions multiply — 26 queries become 1, a rAF coalesces a burst of pointer
+// events into a single test, and nothing runs at all while the camera is moving.
+//
+// BEHAVIOUR CHANGE, deliberate. The cursor no longer turns into a pointer while
+// the map moves underneath a stationary mouse. That is the whole point: those
+// results were computed and thrown away. It resolves on the next real pointer
+// move, or when the camera settles. Read that as intended, not as a regression.
+//
+// Pure and unit-tested; WorldMap owns the MapLibre side effects.
+
+import { COUNTRY_HIT_LAYER, PIN_HIT_LAYERS, resolveLineHit } from "./hitTest";
+
+/** The transparent, widened hit target for submarine cables. */
+export const SIGNAL_LINE_HIT_LAYER = "signal-line-hit";
+/** The visible cable geometry. Being ON it beats the country underneath. */
+export const SIGNAL_LINE_DRAWN_LAYER = "signal-line-paths";
+
+/**
+ * Every layer the one shared pointer query has to cover. Superset of the click
+ * arbiter's layers plus the widened cable target, so hover and click always agree
+ * about what is under the cursor.
+ */
+export const HOVER_QUERY_LAYERS: readonly string[] = [
+  ...PIN_HIT_LAYERS,
+  COUNTRY_HIT_LAYER,
+  SIGNAL_LINE_HIT_LAYER,
+];
+
+/** One rendered feature under the cursor, distilled from queryRenderedFeatures. */
+export interface HoverFeature {
+  /** The style layer id that rendered it (`feature.layer.id`). */
+  layer: string;
+  /** `properties.signalId` — only signal-layer features carry one. */
+  signalId?: string;
+  /** `feature.id` — only the country source sets one; used for setFeatureState. */
+  featureId?: string | number;
+  /** `properties.id` — the cable id the hover filter and the dossier key off. */
+  id?: string;
+  /** `properties.label` — the cable tip text. */
+  label?: string;
+}
+
+/** Everything the map must be told after a pointer move. Fully derived. */
+export interface HoverState {
+  cursor: "" | "pointer";
+  /** Country feature id to wash via setFeatureState, or null. */
+  country: string | number | null;
+  /** Cable to highlight and name at the cursor, or null. */
+  line: { id: string; label: string } | null;
+}
+
+export const NO_HOVER: HoverState = { cursor: "", country: null, line: null };
+
+const PIN_LAYER_SET = new Set(PIN_HIT_LAYERS);
+
+/**
+ * The single arbiter. Delegates the cable decision to resolveLineHit so the
+ * cable-vs-pin-vs-country rules are not forked — hitTest.ts stays the one source
+ * of truth for them.
+ */
+export function resolveHover(features: readonly HoverFeature[]): HoverState {
+  const lineHits: HoverFeature[] = [];
+  let onDrawnLine = false;
+  let otherPin = false;
+  let overCountry = false;
+  let anyPin = false;
+  let country: string | number | null = null;
+
+  for (const f of features) {
+    if (f.layer === SIGNAL_LINE_HIT_LAYER) {
+      lineHits.push(f);
+      continue;
+    }
+    if (f.layer === COUNTRY_HIT_LAYER) {
+      overCountry = true;
+      // Topmost country wins; the fill is one flat layer so there is normally one.
+      if (country === null && f.featureId != null) country = f.featureId;
+      continue;
+    }
+    if (!PIN_LAYER_SET.has(f.layer)) continue; // decoration — never interactive
+    anyPin = true;
+    if (f.layer === SIGNAL_LINE_DRAWN_LAYER) onDrawnLine = true;
+    else otherPin = true;
+  }
+
+  const line = resolveLineHit({ lineHits, onDrawnLine, otherPin, overCountry });
+  const lineId = line?.id;
+  const resolvedLine = lineId ? { id: lineId, label: line?.label ?? "Cable" } : null;
+
+  return {
+    cursor: anyPin || resolvedLine ? "pointer" : "",
+    country,
+    line: resolvedLine,
+  };
+}
+
+/** Did anything the map or the DOM cares about actually change? Value equality. */
+export function hoverChanged(a: HoverState, b: HoverState): boolean {
+  if (a.cursor !== b.cursor) return true;
+  if (a.country !== b.country) return true;
+  if ((a.line === null) !== (b.line === null)) return true;
+  if (a.line && b.line && a.line.id !== b.line.id) return true;
+  if (a.line && b.line && a.line.label !== b.line.label) return true;
+  return false;
+}
+
+/**
+ * Should this pointer event be hit-tested at all? Pure, so the suppression policy
+ * is testable without a map.
+ */
+export interface HitTestGate {
+  /** map.isMoving() — any camera animation, drag, wheel or inertia. */
+  moving: boolean;
+  nowMs: number;
+  /**
+   * Set to nowMs + settleMs on moveend. Inertia and the tile/label work that
+   * follows it keep arriving after isMoving() goes false, and a hit-test landing
+   * in that window is the expensive one nobody sees.
+   */
+  movingUntilMs: number;
+  /** Optional floor between tests, on top of the caller's rAF coalescing. */
+  lastRunMs?: number;
+  minGapMs?: number;
+}
+
+export const HOVER_SETTLE_MS = 120;
+
+export function shouldHitTest(g: HitTestGate): boolean {
+  if (g.moving) return false;
+  if (g.nowMs < g.movingUntilMs) return false;
+  if (g.minGapMs && g.lastRunMs != null && g.nowMs - g.lastRunMs < g.minGapMs) return false;
+  return true;
+}

--- a/scripts/profile-map.mjs
+++ b/scripts/profile-map.mjs
@@ -99,7 +99,27 @@ const browser = await chromium.launch({
   // Without this, performance.memory is bucketed to 5 MB and heap growth is unreadable.
   args: ["--enable-precise-memory-info"],
 });
+// A protected Vercel preview needs the caller's own short-lived development
+// token as an origin header. Read from the environment only — never a flag, so
+// the value cannot land in a shell history or a profile-out JSON.
+// Usage: npx vercel env pull, then run this script through `vercel env run`.
+const OIDC = process.env.VERCEL_OIDC_TOKEN;
 const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+if (OIDC) {
+  // Scope the header to the deployment ORIGIN ONLY. A context-wide
+  // extraHTTPHeaders sends it to every host, which makes the tile CDN requests
+  // non-simple, fails their CORS preflight, and silently profiles a map with no
+  // basemap - flattering, and wrong.
+  const origin = new URL(BASE).origin;
+  await context.route("**/*", (route) => {
+    const url = route.request().url();
+    if (url.startsWith(origin)) {
+      route.continue({ headers: { ...route.request().headers(), "x-vercel-trusted-oidc-idp-token": OIDC } });
+    } else {
+      route.continue();
+    }
+  });
+}
 const page = await context.newPage();
 
 // The boot veil and the guided tour both intercept input, and a gesture dispatched

--- a/scripts/profile-map.mjs
+++ b/scripts/profile-map.mjs
@@ -79,8 +79,16 @@ const chromium = await loadChromium();
 const CENTER = [-0.1276, 51.5072];
 const START_ZOOM = Number((argv.find((a) => a.startsWith("--start=")) || "--start=4").replace("--start=", ""));
 const WHEEL_STEPS = 24;
-const WHEEL_DELTA = -120; // negative = zoom in
+const DIR = (argv.find((a) => a.startsWith("--dir=")) || "--dir=in").replace("--dir=", "");
+if (DIR !== "in" && DIR !== "out") { console.error("--dir must be in|out"); process.exit(2); }
+const WHEEL_DELTA = DIR === "out" ? 120 : -120; // negative = zoom in
 const WHEEL_GAP_MS = 60;
+// Reproduce Blink re-firing hover as the map slides under a STATIONARY cursor.
+// Without this the profiler cannot see the delegated-listener storm at all: it
+// moves the mouse once, so every baseline in profile-out/ recorded ~26 queries
+// where production does thousands. Per-FRAME, not per-notch — the live capture
+// showed ~140 pointer events across a ~6 s gesture (~24/s), not 60.
+const HOVER = argv.includes("--hover");
 
 // Headless Chromium falls back to SwiftShader, which rasterises WebGL on the CPU and
 // manufactures long tasks that do not exist on a real GPU. --headed uses the actual
@@ -120,7 +128,7 @@ if (layerOff.satellites || layerOff.planes || layerOff.cameras) {
 // PerformanceObserver has to exist before the work happens, not after.
 await page.addInitScript(() => {
   window.__prof = {
-    setTerrain: 0, setTerrainSkipped: 0, qrf: 0, sourcedata: 0,
+    setTerrain: 0, setTerrainSkipped: 0, qrf: 0, sourcedata: 0, mousemoves: 0,
     frames: [], longtasks: [], contextLost: false, patched: false,
   };
   try {
@@ -211,7 +219,7 @@ const before = await page.evaluate(() => ({
 // Reset counters so we measure the GESTURE, not the setup.
 await page.evaluate(() => {
   const P = window.__prof;
-  P.setTerrain = 0; P.setTerrainSkipped = 0; P.qrf = 0; P.sourcedata = 0;
+  P.setTerrain = 0; P.setTerrainSkipped = 0; P.qrf = 0; P.sourcedata = 0; P.mousemoves = 0;
   P.frames.length = 0; P.longtasks.length = 0;
   P.t0 = performance.now();
 });
@@ -219,11 +227,26 @@ await page.evaluate(() => {
 // The gesture. Real wheel events through the input pipeline — a scripted easeTo
 // would not reproduce the per-frame `zoom` storm a user's wheel actually causes.
 const ceiling = ABLATIONS.includes("low-zoom") ? 11.5 : 99;
+const floor = 1.3;
 await page.mouse.move(720, 450);
+if (HOVER) {
+  await page.evaluate(() => {
+    const P = window.__prof;
+    const el = window.__map.getCanvasContainer();
+    P.hoverStop = false;
+    const pump = () => {
+      if (P.hoverStop) return;
+      el.dispatchEvent(new MouseEvent("mousemove", { clientX: 720, clientY: 450, bubbles: true }));
+      P.mousemoves++;
+      requestAnimationFrame(pump);
+    };
+    requestAnimationFrame(pump);
+  });
+}
 const wallStart = Date.now();
 for (let i = 0; i < WHEEL_STEPS; i++) {
   const z = await page.evaluate(() => window.__map.getZoom());
-  if (z >= ceiling) break;
+  if (DIR === "out" ? z <= floor : z >= ceiling) break;
   await page.mouse.wheel(0, WHEEL_DELTA);
   await page.waitForTimeout(WHEEL_GAP_MS);
 }
@@ -231,12 +254,14 @@ for (let i = 0; i < WHEEL_STEPS; i++) {
 await page.waitForFunction(() => window.__map.isMoving() === false, { timeout: 20000 }).catch(() => {});
 await page.waitForTimeout(1500);
 const wallMs = Date.now() - wallStart;
+if (HOVER) await page.evaluate(() => { window.__prof.hoverStop = true; });
 
 const raw = await page.evaluate(() => {
   const P = window.__prof;
   return {
     setTerrain: P.setTerrain, setTerrainSkipped: P.setTerrainSkipped,
     qrf: P.qrf, qrfMs: P.qrfMs, qrfByLayer: { ...P.qrfByLayer }, sourcedata: P.sourcedata,
+    mousemoves: P.mousemoves,
     frames: P.frames.slice(), longtasks: P.longtasks.slice(), t0: P.t0,
     contextLost: P.contextLost,
     zoom: window.__map.getZoom(),
@@ -260,7 +285,11 @@ const result = {
   base: BASE,
   renderMode: HEADED ? "headed-gpu" : "headless-swiftshader",
   at: new Date().toISOString(),
-  gesture: { wheelSteps: WHEEL_STEPS, delta: WHEEL_DELTA, gapMs: WHEEL_GAP_MS, wallMs },
+  gesture: { wheelSteps: WHEEL_STEPS, delta: WHEEL_DELTA, gapMs: WHEEL_GAP_MS, wallMs, dir: DIR, hover: HOVER },
+  mousemoveEvents: raw.mousemoves,
+  // THE number for the hover fix: 26 before (13 layers x enter+leave), <=1 after.
+  // Null without --hover, because a run with no pointer stream cannot measure it.
+  qrfPerMousemove: HOVER && raw.mousemoves > 0 ? +(raw.qrf / raw.mousemoves).toFixed(2) : null,
   zoom: { from: before.zoom, to: raw.zoom },
   setTerrainCalls: raw.setTerrain,
   setTerrainSkipped: raw.setTerrainSkipped,
@@ -295,6 +324,7 @@ const row = (k, v) => console.log(`  ${k.padEnd(26)} ${v}`);
 console.log(`  zoom ${result.zoom.from.toFixed(2)} → ${result.zoom.to.toFixed(2)}  in ${wallMs} ms`);
 row("setTerrain calls", `${result.setTerrainCalls}${result.setTerrainSkipped ? `  (${result.setTerrainSkipped} skipped by guard)` : ""}`);
 row("queryRenderedFeatures", `${result.queryRenderedFeatures}  (${result.queryRenderedFeaturesMs} ms total)`);
+if (HOVER) row("qRF per mousemove", `${result.qrfPerMousemove}  (${result.mousemoveEvents} pointer events)`);
 for (const [k, v] of Object.entries(result.queryRenderedFeaturesByLayer).sort((a, b) => b[1] - a[1]).slice(0, 4)) {
   row(`   ${k}`, v);
 }

--- a/tests/unit/map-hover.test.ts
+++ b/tests/unit/map-hover.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOVER_QUERY_LAYERS,
+  HOVER_SETTLE_MS,
+  NO_HOVER,
+  SIGNAL_LINE_DRAWN_LAYER,
+  SIGNAL_LINE_HIT_LAYER,
+  hoverChanged,
+  resolveHover,
+  shouldHitTest,
+  type HoverFeature,
+} from "@/lib/map/hover";
+import { COUNTRY_HIT_LAYER, PIN_HIT_LAYERS } from "@/lib/map/hitTest";
+
+const cable = (id: string, label?: string): HoverFeature => ({
+  layer: SIGNAL_LINE_HIT_LAYER,
+  id,
+  ...(label === undefined ? {} : { label }),
+});
+
+describe("HOVER_QUERY_LAYERS", () => {
+  it("covers every layer the click arbiter can decide on, plus the cable target", () => {
+    for (const layer of PIN_HIT_LAYERS) expect(HOVER_QUERY_LAYERS).toContain(layer);
+    expect(HOVER_QUERY_LAYERS).toContain(COUNTRY_HIT_LAYER);
+    expect(HOVER_QUERY_LAYERS).toContain(SIGNAL_LINE_HIT_LAYER);
+  });
+
+  it("has no duplicates — a repeated id would double the query cost we just removed", () => {
+    expect(new Set(HOVER_QUERY_LAYERS).size).toBe(HOVER_QUERY_LAYERS.length);
+  });
+});
+
+describe("resolveHover", () => {
+  it("returns the resting state for empty map", () => {
+    expect(resolveHover([])).toEqual(NO_HOVER);
+  });
+
+  it("shows a pointer over any pin layer", () => {
+    expect(resolveHover([{ layer: "camera-dots" }]).cursor).toBe("pointer");
+    expect(resolveHover([{ layer: "user-pin-dots" }]).cursor).toBe("pointer");
+  });
+
+  it("ignores decoration layers entirely", () => {
+    expect(resolveHover([{ layer: "country-borders" }, { layer: "place-labels" }])).toEqual(NO_HOVER);
+  });
+
+  it("washes the country under the cursor, keyed on feature.id", () => {
+    const s = resolveHover([{ layer: COUNTRY_HIT_LAYER, featureId: 826 }]);
+    expect(s.country).toBe(826);
+    // The country fill alone is not a pointer target - it is the fallback surface.
+    expect(s.cursor).toBe("");
+  });
+
+  it("ignores a country feature with no id, since setFeatureState needs one", () => {
+    expect(resolveHover([{ layer: COUNTRY_HIT_LAYER }]).country).toBeNull();
+  });
+
+  it("names a cable over open water", () => {
+    expect(resolveHover([cable("atlantic-1", "Atlantic Crossing 1")]).line)
+      .toEqual({ id: "atlantic-1", label: "Atlantic Crossing 1" });
+  });
+
+  it("falls back to a generic label when the cable carries none", () => {
+    expect(resolveHover([cable("x")]).line).toEqual({ id: "x", label: "Cable" });
+  });
+
+  it("lets a real pin beat the widened cable target", () => {
+    const s = resolveHover([cable("atlantic-1"), { layer: "camera-dots" }]);
+    expect(s.line).toBeNull();
+    expect(s.cursor).toBe("pointer");
+  });
+
+  it("lets the country beat a cable that is merely NEAR the drawn line", () => {
+    const s = resolveHover([cable("atlantic-1"), { layer: COUNTRY_HIT_LAYER, featureId: 250 }]);
+    expect(s.line).toBeNull();
+    expect(s.country).toBe(250);
+  });
+
+  it("lets the cable win over the country when the cursor is ON the drawn line", () => {
+    const s = resolveHover([
+      cable("atlantic-1", "AC-1"),
+      { layer: SIGNAL_LINE_DRAWN_LAYER },
+      { layer: COUNTRY_HIT_LAYER, featureId: 250 },
+    ]);
+    expect(s.line).toEqual({ id: "atlantic-1", label: "AC-1" });
+    expect(s.cursor).toBe("pointer");
+  });
+
+  it("still washes the country while a cable is highlighted over it", () => {
+    const s = resolveHover([
+      cable("c"),
+      { layer: SIGNAL_LINE_DRAWN_LAYER },
+      { layer: COUNTRY_HIT_LAYER, featureId: 4 },
+    ]);
+    expect(s.country).toBe(4);
+  });
+
+  it("ignores a cable hit that carries no id — nothing to highlight or open", () => {
+    expect(resolveHover([{ layer: SIGNAL_LINE_HIT_LAYER }]).line).toBeNull();
+  });
+});
+
+describe("hoverChanged", () => {
+  it("is false for two equal states", () => {
+    expect(hoverChanged(NO_HOVER, { cursor: "", country: null, line: null })).toBe(false);
+    const a = { cursor: "pointer" as const, country: 1, line: { id: "x", label: "X" } };
+    const b = { cursor: "pointer" as const, country: 1, line: { id: "x", label: "X" } };
+    expect(hoverChanged(a, b)).toBe(false);
+  });
+
+  it("notices each field independently", () => {
+    const base = { cursor: "" as const, country: null, line: null };
+    expect(hoverChanged(base, { ...base, cursor: "pointer" })).toBe(true);
+    expect(hoverChanged(base, { ...base, country: 3 })).toBe(true);
+    expect(hoverChanged(base, { ...base, line: { id: "a", label: "A" } })).toBe(true);
+  });
+
+  it("notices a different cable and a renamed cable", () => {
+    const a = { cursor: "pointer" as const, country: null, line: { id: "a", label: "A" } };
+    expect(hoverChanged(a, { ...a, line: { id: "b", label: "A" } })).toBe(true);
+    expect(hoverChanged(a, { ...a, line: { id: "a", label: "B" } })).toBe(true);
+  });
+});
+
+describe("shouldHitTest", () => {
+  const gate = (over: Partial<Parameters<typeof shouldHitTest>[0]> = {}) =>
+    shouldHitTest({ moving: false, nowMs: 1000, movingUntilMs: 0, ...over });
+
+  it("runs when the camera is at rest", () => {
+    expect(gate()).toBe(true);
+  });
+
+  it("is suppressed for the whole gesture — this is the freeze fix", () => {
+    expect(gate({ moving: true })).toBe(false);
+  });
+
+  it("stays suppressed through the settle window after moveend", () => {
+    expect(gate({ nowMs: 1000, movingUntilMs: 1000 + HOVER_SETTLE_MS })).toBe(false);
+    expect(gate({ nowMs: 1000 + HOVER_SETTLE_MS, movingUntilMs: 1000 + HOVER_SETTLE_MS })).toBe(true);
+  });
+
+  it("honours an optional minimum gap between tests", () => {
+    expect(gate({ nowMs: 1000, lastRunMs: 995, minGapMs: 16 })).toBe(false);
+    expect(gate({ nowMs: 1000, lastRunMs: 980, minGapMs: 16 })).toBe(true);
+  });
+
+  it("ignores the gap when the caller does not ask for one", () => {
+    expect(gate({ nowMs: 1000, lastRunMs: 999 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## What was wrong

The console map froze while zooming — **in and out**. The standing theory was that 3D buildings were too expensive to draw. Measured, that is not what was happening.

MapLibre implements `mouseenter` / `mouseleave` as a **delegated `mousemove` listener**: it runs `queryRenderedFeatures` for the layer *before* deciding whether your handler should fire. A layer wired for both costs **two queries on every pointer move**, always. `WorldMap` wired 13 layers that way, so one pointer move cost **26 queries** against 18,646 camera features.

Blink re-fires hover as the map slides under a stationary cursor, so a zoom gesture became thousands of queries. It froze zooming *out* too, which is the tell — drawing cost falls as you zoom out, hit-test cost does not.

It was never the buildings. At London z17 / pitch 55 there are **52** extruded features in view, and `setTerrain` fires **once** (the #151 guard already works).

## Measured

Two Vercel previews of the **same console**, differing only by this PR. Same gesture, real GPU, with a per-frame pointer stream.

### Zoom in, z11 → z18.14

| | before | after |
|---|---|---|
| qRF per pointer move | 26.21 | **0.23** |
| queryRenderedFeatures | 3,434 | **52** |
| long tasks | 76 / 6,318 ms | **9 / 1,032 ms** |
| frame gap p95 | 120.5 ms | **42.5 ms** |
| worst frame | 846.7 ms | **365.4 ms** |
| wall time | 8,686 ms | **5,833 ms** |

### Zoom out, z18.5 → z11.4

| | before | after |
|---|---|---|
| qRF per pointer move | 39.02 | **0.18** |
| queryRenderedFeatures | 4,136 | **38** |
| long tasks | 92 / 9,103 ms | **7 / 1,233 ms** |
| frame gap p95 | 159.7 ms | **49.1 ms** |
| wall time | 10,186 ms | **5,983 ms** |

Blocked main-thread time falls **84%** zooming in and **86%** zooming out.

## What changed

- **`lib/map/hover.ts`** (new, pure, 22 unit tests). One arbiter for what is under the cursor. It delegates the cable-vs-pin-vs-country decision to `hitTest.resolveLineHit`, so the rules are not forked and the cable that lights up is still the one a click opens.
- **`WorldMap`** — all 13 layer-scoped handlers replaced by one unscoped `mousemove`. Three reductions multiply: 26 queries become 1, a rAF coalesces a burst of pointer events into one test, and nothing runs while the camera is moving.
- **The cable tip stops being React state.** It was written from a pointer handler, and a `setState` there re-rendered all of `WorldMap` at pointer rate. It now owns one node and mutates it. The cursor offset moves from the CSS `transform` into margins so `transform` can carry the position.
- **The profiler could not see this bug.** It moved the mouse once before the wheel loop, so every existing `profile-out/` baseline recorded ~26 queries where production does thousands — **none of them was a valid comparator**. Adds `--hover`, `--dir=in|out` (there was no zoom-out baseline at all), and reports `qrfPerMousemove`, the number that had to go from 26 to ~0.

## Deliberate behaviour change

The cursor no longer turns into a pointer while the map moves under a stationary mouse. Those results were computed and thrown away. It resolves on the next real pointer move, or when the camera settles.

## Not fixed here, stated plainly

- A single **~760 ms stall remains on zoom-out**. It is not cameras and not satellites — both were ablated and it survived. Unattributed; needs its own pass.
- `liveThumbnails` still runs a viewport-wide query on `sourcedata` (16 during a gesture). Cheap next win.
- **The cable hover tip is not verified end-to-end.** My probe found the cables source empty, so the tip never rendered in test. The arbitration is unit-tested; the DOM write is not.

## Verification

`npx tsc --noEmit` clean; **2,745 tests / 297 files pass** on top of current `main`.
