### PR TITLE
Stop the map animating for nobody: gate the hero, yield the spin on hover

### DIFF
--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -1734,8 +1734,11 @@ export default function WorldMap() {
     // Pause auto-spin on any direct user input (native events, not programmatic
     // camera moves) — keeps the calm idle rotation from fighting interaction.
     const el = map.getCanvasContainer();
-    const markInteract = () => {
+    const holdSpin = () => {
       interactUntilRef.current = performance.now() + IDLE_RESUME_MS;
+    };
+    const markInteract = () => {
+      holdSpin();
       // Grabbing the map "breaks" a live follow → drop to manual recenter so we stop
       // chasing the plane out from under the user (a Recenter affordance re-arms it).
       const t = trackingRef.current;
@@ -1743,6 +1746,17 @@ export default function WorldMap() {
     };
     const inputs: (keyof HTMLElementEventMap)[] = ["mousedown", "wheel", "touchstart", "pointerdown"];
     for (const ev of inputs) el.addEventListener(ev, markInteract, { passive: true });
+
+    // Hovering counts as engagement, but ONLY for the spin — it must not break a
+    // follow, which is why it calls `holdSpin` and not `markInteract`. Before this,
+    // `inputs` carried press events only: sweeping the pointer across the map to read
+    // a label left the globe rotating underneath the cursor, so the dot you were
+    // aiming at drifted out from under you while the hit-test chased it. It is also
+    // the moment smoothness is most visible, and the moment the main thread can least
+    // afford to be re-rendering the whole globe 60 times a second (measured on prod at
+    // 4x CPU throttle: 99.5% main-thread busy while spinning, 44.8% with the spin
+    // neutralised on the same bundle at the same zoom).
+    el.addEventListener("pointermove", holdSpin, { passive: true });
 
     // The `tn-map-cursor` publisher used to live here: a rAF-coalesced window
     // CustomEvent carrying lat/lon on every mousemove, read by the stage bar's
@@ -1757,10 +1771,17 @@ export default function WorldMap() {
     // replaceState — no history spam, no reload). moveend writes are skipped while
     // the calm idle spin is running so the URL doesn't churn on its own; deliberate
     // moves (user pan/zoom, region fly-to) and store changes always persist.
+    // ONE predicate, read by both the spin loop and the URL writer below. They used
+    // to carry separate copies of the same four clauses, which is a standing invitation
+    // for the two to drift: the moment they disagree, either the URL churns on its own
+    // or a deliberate move stops being shareable.
+    const prefersLessMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     const isAutoSpinning = () =>
+      !prefersLessMotion.matches &&
+      !document.hidden &&
       performance.now() > interactUntilRef.current &&
       !overlay.get().object &&
-      !trackingRef.current.id &&
+      !trackingRef.current.id && // a tracked plane owns the camera; don't spin away from it
       map.getZoom() < SPIN_MAX_ZOOM;
     const onMoveEnd = () => {
       // Our own follow easeTo shouldn't churn the shareable URL every poll.
@@ -1777,12 +1798,7 @@ export default function WorldMap() {
     const spin = (t: number) => {
       const dt = Math.min((t - last) / 1000, 0.05);
       last = t;
-      if (
-        performance.now() > interactUntilRef.current &&
-        !overlay.get().object &&
-        !trackingRef.current.id && // a tracked plane owns the camera; don't spin away from it
-        map.getZoom() < SPIN_MAX_ZOOM
-      ) {
+      if (isAutoSpinning()) {
         const c = map.getCenter();
         map.setCenter([c.lng + SPIN_DEG_PER_SEC * dt, c.lat]);
       }
@@ -1793,6 +1809,7 @@ export default function WorldMap() {
     return () => {
       cancelAnimationFrame(rafRef.current);
       for (const ev of inputs) el.removeEventListener(ev, markInteract);
+      el.removeEventListener("pointermove", holdSpin);
       cancelUrlWrite();
       unsubLayers();
       unsubView();

--- a/components/marketing/HeroGlobe.tsx
+++ b/components/marketing/HeroGlobe.tsx
@@ -455,10 +455,26 @@ export default function HeroGlobe({
     function spinLoop() {
       if (disposed) return;
       spin = window.requestAnimationFrame(spinLoop);
-      if (paused || reduce.matches || !map.loaded()) return;
+      if (paused || offScreen || reduce.matches || !map.loaded()) return;
       const c = map.getCenter();
       map.jumpTo({ center: [c.lng + 0.035, c.lat] });
     }
+
+    // Scrolled past the hero, a drifting globe is a full MapLibre re-render per frame
+    // that nobody can see. Measured on prod at the FOOT of the landing page, before
+    // this gate: `calculatePosMatrix` was still 5.2% of main-thread self time with the
+    // hero entirely off screen.
+    //
+    // This is a SEPARATE flag from `paused` on purpose. `paused` is owned by the
+    // pointer/drag/visibility handlers, and `release()` resets it to `document.hidden`
+    // — so parking the off-screen state in it would let a stray pointerleave restart
+    // the drift under a hero that is nowhere near the viewport.
+    let offScreen = false;
+    const vis = new IntersectionObserver(
+      (entries) => { for (const e of entries) offScreen = !e.isIntersecting; },
+      { rootMargin: "100% 0px" },
+    );
+    vis.observe(el);
 
     // Pause the drift while the tab is hidden or the pointer is on the globe, so a
     // backgrounded hero costs nothing and hovering to read a label does not fight
@@ -496,11 +512,24 @@ export default function HeroGlobe({
       const title = hits[0]?.properties?.title;
       if (typeof title === "string" && title) say(title);
     });
-    map.on("mousemove", (e) => {
-      const hits = map.queryRenderedFeatures(e.point, {
+    // Coalesced to one hit-test per FRAME, not one per pointer event. A mouse
+    // delivers moves faster than the compositor paints, and each of these is a
+    // queryRenderedFeatures across four layers — the same storm that was taken out of
+    // the console's map in #154. Only the newest point matters for a cursor shape, so
+    // dropping the intermediate ones changes nothing a user can see.
+    let hoverPt: maplibregl.Point | null = null;
+    let hoverRaf = 0;
+    const runHover = () => {
+      hoverRaf = 0;
+      if (disposed || !hoverPt) return;
+      const hits = map.queryRenderedFeatures(hoverPt, {
         layers: DATA_LAYERS.filter((id) => map.getLayer(id)),
       });
       map.getCanvas().style.cursor = hits.length ? "pointer" : touch ? "" : "grab";
+    };
+    map.on("mousemove", (e) => {
+      hoverPt = e.point;
+      if (!hoverRaf) hoverRaf = window.requestAnimationFrame(runHover);
     });
 
     return () => {
@@ -511,6 +540,8 @@ export default function HeroGlobe({
       if (satTimer) clearInterval(satTimer);
       if (resume) clearTimeout(resume);
       if (spin) cancelAnimationFrame(spin);
+      if (hoverRaf) cancelAnimationFrame(hoverRaf);
+      vis.disconnect();
       el.removeEventListener("pointerenter", onEnter);
       el.removeEventListener("pointerleave", onLeave);
       document.removeEventListener("visibilitychange", onVis);

--- a/components/marketing/Starfield.tsx
+++ b/components/marketing/Starfield.tsx
@@ -7,7 +7,7 @@ import {
   precessFromJ2000,
   skyBasis,
   stereographicScale,
-  projectSky,
+  projectSkyInto,
   type Vec3,
   type SkyBasis,
 } from "@/lib/sky/astro";
@@ -289,6 +289,32 @@ export default function Starfield({ className = "pv-hero-stars" }: { className?:
     let w = 0;
     let h = 0;
 
+    // WHY THIS GATE EXISTS. `draw` projects all 8,920 catalogue stars and fills a
+    // path (plus a radial-gradient halo for the bright ones) on every tick. That is
+    // the single most expensive thing on the landing page, and none of it is worth
+    // anything once the hero has scrolled away. Measured on prod before this gate,
+    // at 4x CPU throttle: parked at the FOOT of the page — hero entirely off screen
+    // — the main thread was still 98% busy, and this file was still the top frame at
+    // 17.9% of self time. Every one of those pixels was painted into a canvas nobody
+    // could see. The observer costs one callback per intersection change.
+    //
+    // `onScreen` starts false: the first IntersectionObserver callback fires before
+    // paint and flips it, so a hero that IS in view loses nothing.
+    let onScreen = false;
+    const io = new IntersectionObserver(
+      (entries) => { for (const e of entries) onScreen = e.isIntersecting; },
+      // A whole viewport of margin: start drawing just before the hero scrolls back
+      // in, so it is never caught mid-fade with an empty sky.
+      { rootMargin: "100% 0px" },
+    );
+    io.observe(canvas);
+
+    // rAF alone already throttles a background tab to ~1fps, but that still wakes the
+    // whole projection loop once a second on a machine the user has walked away from.
+    // HeroGlobe.tsx pauses on the same signal (see its `onVis`); this matches it.
+    const onVis = () => { if (!document.hidden) last = 0; };
+    document.addEventListener("visibilitychange", onVis);
+
     function resize() {
       if (!canvas) return;
       const dpr = Math.min(2, window.devicePixelRatio || 1);
@@ -421,9 +447,26 @@ export default function Starfield({ className = "pv-hero-stars" }: { className?:
       refreshPrecession(new Date());
     }
 
-    function projectAt(dirs: Float64Array, i: number, basis: SkyBasis, scale: number) {
-      const v: Vec3 = [dirs[i * 3], dirs[i * 3 + 1], dirs[i * 3 + 2]];
-      return projectSky(v, basis, scale);
+    // Two scratch points, reused for the whole frame. The pair exists because the
+    // Milky Way and the constellation lines each need two projected ends live at
+    // once; the star loop only ever uses the first.
+    const ptA = { x: 0, y: 0 };
+    const ptB = { x: 0, y: 0 };
+
+    // Reads the direction straight out of the flat Float64Array and writes the
+    // result into `out`. The old form packed a `Vec3` tuple per call and returned a
+    // fresh `SkyPoint`, which — across 8,920 stars at the 30fps cap below — was
+    // roughly 800k short-lived objects a second of GC pressure on the main thread,
+    // for the entire time the hero was on screen. `projectSkyInto` is the same
+    // maths; `projectSky` is now a wrapper over it, so the astro tests cover both.
+    function projectAt(
+      dirs: Float64Array,
+      i: number,
+      basis: SkyBasis,
+      scale: number,
+      out: { x: number; y: number },
+    ): boolean {
+      return projectSkyInto(dirs[i * 3], dirs[i * 3 + 1], dirs[i * 3 + 2], basis, scale, out);
     }
 
     function drawMilkyWay(basis: SkyBasis, scale: number, cx: number, cy: number) {
@@ -436,13 +479,12 @@ export default function Starfield({ className = "pv-hero-stars" }: { className?:
       const maxJump = Math.max(w, h) * 2 + 400;
       for (let i = 0; i < mwCount; i++) {
         const j = (i + 1) % mwCount;
-        const p0 = projectAt(milkyDirs, i, basis, scale);
-        const p1 = projectAt(milkyDirs, j, basis, scale);
-        if (!p0 || !p1) continue;
-        const x0 = cx + p0.x;
-        const y0 = cy + p0.y;
-        const x1 = cx + p1.x;
-        const y1 = cy + p1.y;
+        if (!projectAt(milkyDirs, i, basis, scale, ptA)) continue;
+        if (!projectAt(milkyDirs, j, basis, scale, ptB)) continue;
+        const x0 = cx + ptA.x;
+        const y0 = cy + ptA.y;
+        const x1 = cx + ptB.x;
+        const y1 = cy + ptB.y;
         if (Math.abs(x1 - x0) > maxJump || Math.abs(y1 - y0) > maxJump) continue;
         // Both ends off the same side, well past it — skip drawing a segment
         // that never touches the visible canvas at all.
@@ -473,10 +515,9 @@ export default function Starfield({ className = "pv-hero-stars" }: { className?:
       const reduceMotion = reduce.matches;
       const margin = 3;
       for (let i = 0; i < count; i++) {
-        const p = projectAt(starDirs, i, basis, scale);
-        if (!p) continue;
-        const x = cx + p.x;
-        const y = cy + p.y;
+        if (!projectAt(starDirs, i, basis, scale, ptA)) continue;
+        const x = cx + ptA.x;
+        const y = cy + ptA.y;
         if (x < -margin || x > w + margin || y < -margin || y > h + margin) continue;
 
         const twinkle = reduceMotion ? 1 : 0.72 + 0.28 * Math.sin(timeSec * speed[i] + phase[i]);
@@ -511,13 +552,12 @@ export default function Starfield({ className = "pv-hero-stars" }: { className?:
       ctx.strokeStyle = `rgba(210, 224, 255, ${CONSTELLATION_LINE_ALPHA})`;
       ctx.lineWidth = CONSTELLATION_LINE_WIDTH;
       for (const [a, b] of lines) {
-        const pa = projectAt(starDirs, a, basis, scale);
-        const pb = projectAt(starDirs, b, basis, scale);
-        if (!pa || !pb) continue;
-        const xa = cx + pa.x;
-        const ya = cy + pa.y;
-        const xb = cx + pb.x;
-        const yb = cy + pb.y;
+        if (!projectAt(starDirs, a, basis, scale, ptA)) continue;
+        if (!projectAt(starDirs, b, basis, scale, ptB)) continue;
+        const xa = cx + ptA.x;
+        const ya = cy + ptA.y;
+        const xb = cx + ptB.x;
+        const yb = cy + ptB.y;
         const aOn = xa > -margin && xa < w + margin && ya > -margin && ya < h + margin;
         const bOn = xb > -margin && xb < w + margin && yb > -margin && yb < h + margin;
         if (!aOn || !bOn) continue;
@@ -531,6 +571,9 @@ export default function Starfield({ className = "pv-hero-stars" }: { className?:
     let last = 0;
     function draw(t: number) {
       raf = window.requestAnimationFrame(draw);
+      // Off screen or in a hidden tab: keep the loop alive so it resumes instantly,
+      // but do no projection, no fill and — the expensive part — no layout read.
+      if (!onScreen || document.hidden) return;
       if (t - last < 33) return; // ~30fps is plenty for a twinkle
       last = t;
       if (!ctx || !canvas) return;
@@ -602,6 +645,8 @@ export default function Starfield({ className = "pv-hero-stars" }: { className?:
       disposed = true;
       window.cancelAnimationFrame(raf);
       ro.disconnect();
+      io.disconnect();
+      document.removeEventListener("visibilitychange", onVis);
     };
   }, []);
 

--- a/lib/sky/astro.ts
+++ b/lib/sky/astro.ts
@@ -240,14 +240,48 @@ export function stereographicScale(degrees: number, pixels: number): number {
  * folding the far half of the sky back into the frame.
  */
 export function projectSky(v: Vec3, basis: SkyBasis, scale: number): SkyPoint | null {
-  const n = normalise(v);
-  const f = dot(n, basis.forward);
-  if (f <= -0.999) return null; // at or past the projection pole
+  const out = { x: 0, y: 0 };
+  return projectSkyInto(v[0], v[1], v[2], basis, scale, out) ? out : null;
+}
+
+/**
+ * `projectSky` with no allocation, for per-frame loops over a whole catalogue.
+ *
+ * Same maths, same cull, same numbers — `projectSky` is now a thin wrapper over
+ * this, so the unit tests covering it cover both. The difference is only what the
+ * heap sees. The tuple form allocates THREE objects per call: the `Vec3` the
+ * caller packs, the fresh unit vector `normalise` returns, and the `SkyPoint`
+ * result. Starfield.tsx calls it once per catalogue star per tick — 8,920 stars at
+ * its 30fps cap is ~268k calls and ~800k short-lived objects a second, which is GC
+ * pressure on the main thread for the whole time the hero is on screen.
+ *
+ * Takes loose components rather than a `Vec3` because the callers hold their data
+ * in a flat `Float64Array`; packing a tuple to pass it would put back the very
+ * allocation this exists to remove. Writes into a caller-owned `out` and returns
+ * false where `projectSky` returns null.
+ */
+export function projectSkyInto(
+  vx: number,
+  vy: number,
+  vz: number,
+  basis: SkyBasis,
+  scale: number,
+  out: { x: number; y: number },
+): boolean {
+  const m = Math.hypot(vx, vy, vz);
+  // Matches `normalise`'s degenerate branch: a zero-length direction becomes +x.
+  const nx = m > 0 ? vx / m : 1;
+  const ny = m > 0 ? vy / m : 0;
+  const nz = m > 0 ? vz / m : 0;
+  const fwd = basis.forward;
+  const f = nx * fwd[0] + ny * fwd[1] + nz * fwd[2];
+  if (f <= -0.999) return false; // at or past the projection pole
   const k = (2 * scale) / (1 + f);
-  return {
-    x: k * dot(n, basis.right),
-    // Screen y grows downward; the basis is in world orientation, so flip here and
-    // only here.
-    y: -k * dot(n, basis.up),
-  };
+  const r = basis.right;
+  const u = basis.up;
+  out.x = k * (nx * r[0] + ny * r[1] + nz * r[2]);
+  // Screen y grows downward; the basis is in world orientation, so flip here and
+  // only here.
+  out.y = -k * (nx * u[0] + ny * u[1] + nz * u[2]);
+  return true;
 }

--- a/scripts/profile-map.mjs
+++ b/scripts/profile-map.mjs
@@ -9,6 +9,7 @@
 // Run:  node scripts/profile-map.mjs [baseUrl] [--headed] [--start=z] [--ablate=a,b] [--label=name]
 //       node scripts/profile-map.mjs http://localhost:3080 --headed
 //       node scripts/profile-map.mjs http://localhost:3080 --headed --start=11
+//       node scripts/profile-map.mjs --headed --idle=14 --ablate=no-spin   (idle cost)
 //
 // USE --headed FOR ANYTHING YOU INTEND TO BELIEVE. Headless Chromium falls back to
 // SwiftShader, which rasterises WebGL on the CPU: it reported ~33 s of long tasks
@@ -27,6 +28,31 @@
 //   no-satellites  satellites layer off (kills the 1 Hz re-render)
 //   no-planes      planes layer off
 //   no-cameras     cameras layer off
+//   no-spin        neutralise the calm idle rotation (WorldMap's setCenter rAF loop)
+//
+// `no-spin` is the ablation for "why does the map feel heavy when I am not touching
+// it". The idle rotation moves the camera every frame, and a moving camera means
+// MapLibre re-renders continuously — matrices, style-expression evaluation, the lot.
+// Measured against prod, `--idle=14 --start=3`, headed on an Arc iGPU:
+//
+//                      frames rendered   sourcedata   long tasks
+//     baseline                     810          123    1 (62 ms)
+//     --ablate=no-spin               0            0            0
+//
+// 810 full renders in fourteen seconds with nobody touching the map. Main-thread
+// BUSY over the same window: 99.5% -> 44.8% at 4x CPU throttle, 26.1% -> 6.2%
+// unthrottled. So on a mid-range machine the console has no headroom left at rest,
+// which is why interaction feels rough rather than the interaction itself being slow.
+//
+// It does NOT scale with how often setCenter is called: throttling the loop to 30fps
+// and 20fps measured 99.4% and 99.6% busy, i.e. unchanged. Movement is the cost, not
+// the call, and only not-moving is cheaper.
+//
+// USE --start=3 (OR LOWER) WITH THIS ABLATION. The default start zoom is 4 and
+// WorldMap's guard is `getZoom() < SPIN_MAX_ZOOM` with SPIN_MAX_ZOOM = 4, so the
+// default parks the camera exactly ON the boundary where the spin is already off.
+// The first run of this ablation was done that way and reported 0 frames for BOTH
+// arms — a real null result in appearance, and measuring nothing in fact.
 //
 // Output: one JSON per run under profile-out/, plus a terminal summary.
 
@@ -45,7 +71,7 @@ mkdirSync(OUT, { recursive: true });
 
 const KNOWN = new Set([
   "terrain-guard", "terrain-off", "no-blur", "low-zoom",
-  "no-satellites", "no-planes", "no-cameras",
+  "no-satellites", "no-planes", "no-cameras", "no-spin",
 ]);
 for (const a of ABLATIONS) {
   if (!KNOWN.has(a)) {
@@ -89,6 +115,12 @@ const WHEEL_GAP_MS = 60;
 // where production does thousands. Per-FRAME, not per-notch — the live capture
 // showed ~140 pointer events across a ~6 s gesture (~24/s), not 60.
 const HOVER = argv.includes("--hover");
+// --idle=<seconds> replaces the wheel gesture with a do-nothing window. The console
+// spends most of its life here — nobody touching it, the calm rotation running — and
+// it is the ONLY gesture on which `no-spin` means anything: every wheel step calls
+// markInteract, which suppresses the spin for IDLE_RESUME_MS anyway, so a zoom run
+// ablates something that was already switched off and honestly reports no difference.
+const IDLE_S = Number((argv.find((a) => a.startsWith("--idle=")) || "").replace("--idle=", "")) || 0;
 
 // Headless Chromium falls back to SwiftShader, which rasterises WebGL on the CPU and
 // manufactures long tasks that do not exist on a real GPU. --headed uses the actual
@@ -143,6 +175,30 @@ if (layerOff.satellites || layerOff.planes || layerOff.cameras) {
       ships: false, webcams: false, weather: false, countries: true };
     localStorage.setItem("tn.layers.v1", JSON.stringify({ v: 1, d }));
   }, layerOff);
+}
+
+// Neutralise the idle spin by refusing to SCHEDULE it. WorldMap's loop re-arms
+// itself from inside its own callback, so declining the first rAF ends it for good,
+// and nothing else on the page is touched — same build, same bundle, one behaviour
+// removed. Matching on `setCenter(` survives minification because it is a property
+// access on the MapLibre map, not a local the minifier may rename.
+if (ABLATIONS.includes("no-spin")) {
+  await page.addInitScript(() => {
+    const raf = window.requestAnimationFrame.bind(window);
+    let fakeId = 1e7;
+    window.__spinBlocked = 0;
+    window.requestAnimationFrame = (cb) => {
+      try {
+        if (typeof cb === "function" && /setCenter\(/.test(Function.prototype.toString.call(cb))) {
+          window.__spinBlocked += 1;
+          return fakeId++;
+        }
+      } catch {
+        /* a cross-origin or native callback cannot be stringified; let it through */
+      }
+      return raf(cb);
+    };
+  });
 }
 
 // PerformanceObserver has to exist before the work happens, not after.
@@ -264,21 +320,36 @@ if (HOVER) {
   });
 }
 const wallStart = Date.now();
-for (let i = 0; i < WHEEL_STEPS; i++) {
-  const z = await page.evaluate(() => window.__map.getZoom());
-  if (DIR === "out" ? z <= floor : z >= ceiling) break;
-  await page.mouse.wheel(0, WHEEL_DELTA);
-  await page.waitForTimeout(WHEEL_GAP_MS);
+if (IDLE_S > 0) {
+  // Park the pointer off the map first: `pointermove` over the canvas holds the spin
+  // off, so measuring idle with the cursor sitting on the map measures the opposite
+  // of what it claims to. Then wait out IDLE_RESUME_MS before the window opens.
+  await page.mouse.move(4, 4);
+  await page.waitForTimeout(5000);
+  await page.evaluate(() => { const P = window.__prof; P.frames.length = 0; P.longtasks.length = 0; });
+  await page.waitForTimeout(IDLE_S * 1000);
+} else {
+  for (let i = 0; i < WHEEL_STEPS; i++) {
+    const z = await page.evaluate(() => window.__map.getZoom());
+    if (DIR === "out" ? z <= floor : z >= ceiling) break;
+    await page.mouse.wheel(0, WHEEL_DELTA);
+    await page.waitForTimeout(WHEEL_GAP_MS);
+  }
+  // Let the last inertial zoom and its tile/cluster work finish.
+  await page.waitForFunction(() => window.__map.isMoving() === false, { timeout: 20000 }).catch(() => {});
+  await page.waitForTimeout(1500);
 }
-// Let the last inertial zoom and its tile/cluster work finish.
-await page.waitForFunction(() => window.__map.isMoving() === false, { timeout: 20000 }).catch(() => {});
-await page.waitForTimeout(1500);
 const wallMs = Date.now() - wallStart;
 if (HOVER) await page.evaluate(() => { window.__prof.hoverStop = true; });
 
 const raw = await page.evaluate(() => {
   const P = window.__prof;
   return {
+    // Reported ALWAYS, not only under the ablation, so `no-spin: 0` on an ablated run
+    // reads as "this ablation matched nothing" rather than as a genuine null result.
+    // The match is on minified output; a MapLibre or bundler change could quietly stop
+    // it hitting, and the numbers would then look like a finding instead of a no-op.
+    spinBlocked: window.__spinBlocked ?? null,
     setTerrain: P.setTerrain, setTerrainSkipped: P.setTerrainSkipped,
     qrf: P.qrf, qrfMs: P.qrfMs, qrfByLayer: { ...P.qrfByLayer }, sourcedata: P.sourcedata,
     mousemoves: P.mousemoves,
@@ -302,10 +373,13 @@ const ltWorst = raw.longtasks.reduce((a, t) => Math.max(a, t.dur), 0);
 const result = {
   label: LABEL,
   ablations: ABLATIONS,
+  spinBlocked: raw.spinBlocked,
   base: BASE,
   renderMode: HEADED ? "headed-gpu" : "headless-swiftshader",
   at: new Date().toISOString(),
-  gesture: { wheelSteps: WHEEL_STEPS, delta: WHEEL_DELTA, gapMs: WHEEL_GAP_MS, wallMs, dir: DIR, hover: HOVER },
+  gesture: IDLE_S > 0
+    ? { kind: "idle", idleSeconds: IDLE_S, wallMs, hover: HOVER }
+    : { kind: "wheel", wheelSteps: WHEEL_STEPS, delta: WHEEL_DELTA, gapMs: WHEEL_GAP_MS, wallMs, dir: DIR, hover: HOVER },
   mousemoveEvents: raw.mousemoves,
   // THE number for the hover fix: 26 before (13 layers x enter+leave), <=1 after.
   // Null without --hover, because a run with no pointer stream cannot measure it.

--- a/tests/unit/sky-astro.test.ts
+++ b/tests/unit/sky-astro.test.ts
@@ -5,6 +5,7 @@ import {
   gmstDegrees,
   precessFromJ2000,
   projectSky,
+  projectSkyInto,
   skyBasis,
   stereographicScale,
   vectorToEquatorial,
@@ -298,5 +299,67 @@ describe("precessFromJ2000", () => {
   it("does nothing at J2000 itself", () => {
     const v = equatorialToVector(123, 45);
     expect(angularSeparationDeg(v, precessFromJ2000(v, J2000))).toBeLessThan(1e-4);
+  });
+});
+
+/**
+ * `projectSkyInto` exists ONLY to take the allocation out of the per-frame path —
+ * Starfield calls it once per catalogue star per tick.
+ *
+ * BE CLEAR ABOUT WHAT THIS DOES AND DOES NOT CATCH. `projectSky` is currently a
+ * thin wrapper over `projectSkyInto`, so for as long as that holds, this compares
+ * one implementation with itself and CANNOT see a bug in the shared body. That was
+ * checked rather than assumed: perturbing `out.x` by one part in 10^7 leaves these
+ * two cases green and is caught instead by "scales so the requested angle lands on
+ * the requested radius" above. The maths is guarded by those tests, not by this one.
+ *
+ * What this pins is the WRAPPER RELATIONSHIP, which is the thing most likely to be
+ * broken by a future edit: give `projectSky` its own copy of the maths again — an
+ * easy-looking revert, or a well-meant "inline it for speed" — and the two drift
+ * apart with only the hero's sky to show for it. It also covers two boundaries the
+ * cases above do not reach: the behind-the-camera cull and the zero-length
+ * direction. Equality is exact, not approximate: sharing an implementation means
+ * any difference at all is a divergence rather than drift.
+ */
+describe("projectSkyInto (the allocation-free path)", () => {
+  it("returns exactly what projectSky returns, across the sphere and past the cull", () => {
+    const basis = skyBasis({ lngDeg: 12, latDeg: 41, gmstDeg: 233, bearingDeg: 27 });
+    const scale = stereographicScale(60, 220);
+    const out = { x: 0, y: 0 };
+    let culled = 0;
+    let projected = 0;
+
+    for (let ra = 0; ra < 360; ra += 7) {
+      for (let dec = -87; dec <= 87; dec += 6) {
+        const v = equatorialToVector(ra, dec);
+        const want = projectSky(v, basis, scale);
+        const ok = projectSkyInto(v[0], v[1], v[2], basis, scale, out);
+
+        expect(ok).toBe(want !== null);
+        if (!want) {
+          culled += 1;
+          continue;
+        }
+        projected += 1;
+        expect(out.x).toBe(want.x);
+        expect(out.y).toBe(want.y);
+      }
+    }
+    // Guard the guard: a sweep that never projected anything, or never hit the
+    // behind-the-camera cull, would pass while proving nothing.
+    expect(projected).toBeGreaterThan(500);
+    expect(culled).toBeGreaterThan(0);
+  });
+
+  it("matches projectSky's degenerate branch for a zero-length direction", () => {
+    const basis = skyBasis({ lngDeg: 0, latDeg: 0, gmstDeg: 0 });
+    const scale = stereographicScale(60, 100);
+    const out = { x: 0, y: 0 };
+    const want = projectSky([0, 0, 0], basis, scale);
+    expect(projectSkyInto(0, 0, 0, basis, scale, out)).toBe(want !== null);
+    if (want) {
+      expect(out.x).toBe(want.x);
+      expect(out.y).toBe(want.y);
+    }
   });
 });


### PR DESCRIPTION
An efficiency sweep of the live product, measured against prod rather than guessed at. Every number below is reproducible with `scripts/profile-map.mjs`, headed, on an Arc iGPU.

## The landing page never stopped drawing

`Starfield` projects all 8,920 catalogue stars and fills a path for each one on every tick. `HeroGlobe` drifts the globe a frame at a time. Neither had any idea whether the hero was on screen.

Parked at the **foot** of the page — hero entirely out of view, scrolled 10,461px down — the main thread was still **98% busy** at 4x CPU throttle, and `Starfield` was still the top frame at **17.9% of self time**. Every pixel of it was painted into a canvas nobody could see.

Both now gate on an `IntersectionObserver` with a viewport of `rootMargin`, so they resume *before* the hero scrolls back rather than after. `Starfield` also pauses on a hidden tab, which `HeroGlobe` already did.

Verified by counting per-frame layout reads over a fixed window, top of page vs bottom:

| build | top | bottom | ratio |
|---|---|---|---|
| prod (today) | 96/s | 87/s | **0.91** — never stops |
| this branch | 324/s | 59/s | **0.18** |

## The console spin never yielded to a hover

`inputs` carried press events only — `mousedown`, `wheel`, `touchstart`, `pointerdown`. Sweeping the pointer across the map to read a label left the globe rotating underneath the cursor: the dot you were aiming at drifted out from under you while the hit-test chased it.

`pointermove` now holds the spin too. It calls `holdSpin` and **not** `markInteract`, deliberately — hovering must not break a live plane follow.

Main-thread busy over a 12s hover, against the same window idle, 4x throttle:

| build | idle | hovering |
|---|---|---|
| prod | 99.5% | **99.4%** — hovering bought nothing |
| this branch | 99.5% | **66.8%** |

That matters because the spin has no cheap setting. Idle at z3 for 14s against prod:

| | frames rendered | sourcedata | long tasks |
|---|---|---|---|
| baseline | **810** | 123 | 1 (62ms) |
| `--ablate=no-spin` | **0** | 0 | 0 |

Throttling the loop to 30fps and 20fps measured 99.4% and 99.6% busy — unchanged. **Movement is the cost, not the `setCenter` call**, so only not-moving is cheaper.

The rotation is a product decision and is left alone. What changed is that it gets out of the way when someone is using the map, and it now stops for `prefers-reduced-motion` and a hidden tab like every other motion in the codebase already did. The spin predicate and the URL writer also stop carrying separate copies of the same four clauses.

## ~800k allocations a second in the star loop

`projectSky` takes a `Vec3` and returns a fresh `SkyPoint`, and `normalise` allocates a third array inside it — three objects per star per tick, ~268k calls a second at the 30fps cap.

`projectSkyInto` is the same maths over loose components, writing into a caller-owned point. `projectSky` is now a wrapper over it, so the existing astro tests cover both paths. Confirmed the suite catches a divergence by injecting a one-part-in-10^7 error and watching it go red.

The new equivalence test says plainly what it does **not** catch: with `projectSky` wrapping `projectSkyInto`, it compares one implementation with itself and cannot see a bug in the shared body. What it pins is the wrapper relationship, plus the cull boundary and the zero-length direction.

## Also

`HeroGlobe` ran `queryRenderedFeatures` across four layers on **every** mousemove — the same storm taken out of the console map in #154. Coalesced to one hit-test per frame.

## Harness

`--ablate=no-spin` and `--idle=N` are new in `scripts/profile-map.mjs`.

Two traps are written into its header because both nearly produced a false result here:

- The ablation records how many callbacks it actually blocked, so a bundler change that stops it matching reads as a no-op rather than as a finding.
- **Use `--start=3` with it.** The default start zoom is 4 and the guard is `zoom < 4`, so the default parks the camera exactly on the boundary where the spin is already off. The first run of this ablation was done that way and reported 0 frames for *both* arms — a convincing null result that measured nothing.

## Verification

`npx tsc --noEmit` clean. 2,747 tests pass (2,745 + 2 new). Landing page and console both checked in a real browser: zero console errors, sky and globe render correctly, and both resume after being scrolled away and back.
