### PR TITLE
Stop the console globe rotating

### DIFF
--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -53,7 +53,6 @@ import {
 import { ATTRIB_CONTROL_CLASS, collapseAttribution } from "@/lib/map/attribution";
 import { HILLSHADE_MIN_ZOOM, TERRAIN_MIN_ZOOM, terrainChanged, wantedTerrain } from "@/lib/map/terrain";
 import { layersToTrim } from "@/lib/map/styleTrim";
-import { spinEnvelope } from "@/lib/map/spin";
 import { markMapReady } from "@/lib/terminal/mapReady";
 import { toCameraFC, toPlaneFC, toTrailFC, toSatelliteFC, toWebcamFC, toSignalFC, toSignalLineFC, toSignalFillFC } from "@/lib/map/features";
 import {
@@ -254,11 +253,13 @@ function hitsAt(map: maplibregl.Map, point: maplibregl.MapLayerMouseEvent["point
   });
 }
 
-// Start zoomed out so the spinning globe is the hero. The palette / rail fly inward.
+// Start zoomed out so the whole globe is the opening view. The palette / rail fly inward.
+//
+// THE CONSOLE GLOBE DOES NOT ROTATE. It used to turn on load and, after #158, turn
+// for 8 s and settle. Both are gone: it is now still from the first frame. See the
+// note on the removed spin loop further down for what came out with it, and
+// `lib/map/spin.ts`, which still drives the LANDING hero and only that.
 const HOME = { center: [-30, 28] as [number, number], zoom: 1.4 };
-const SPIN_MAX_ZOOM = 4; // only auto-rotate while zoomed out this far
-const SPIN_DEG_PER_SEC = 4; // calm rotation
-const IDLE_RESUME_MS = 4000; // resume spin this long after the last user input
 
 const vis = (on: boolean): "visible" | "none" => (on ? "visible" : "none");
 
@@ -446,8 +447,6 @@ export default function WorldMap() {
   const styleAttemptsRef = useRef(0);
   const styleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [loadStatus, setLoadStatus] = useState<MapLoadStatus>({ kind: "ok" });
-  const rafRef = useRef(0);
-  const interactUntilRef = useRef(0);
   const terrainRef = useRef(true);
   const buildingsRef = useRef(true);
   // Plane-tracking (see lib/planes/track). trackingRef mirrors the store for the
@@ -1659,11 +1658,9 @@ export default function WorldMap() {
     const center: [number, number] =
       initial.lat != null && initial.lon != null ? [initial.lon, initial.lat] : HOME.center;
     const zoom = initial.zoom ?? HOME.zoom;
-    // A deep-linked camera/zoom means the user wants that exact view — don't let
-    // the idle spin immediately drag it away on first paint.
-    if (initial.lat != null || initial.zoom != null) {
-      interactUntilRef.current = performance.now() + IDLE_RESUME_MS;
-    }
+    // A deep-linked camera/zoom used to need protecting here, because the idle spin
+    // would drag it away on first paint. Nothing moves the camera on its own now, so
+    // the view a link asks for is simply the view it gets.
 
     const map = new maplibregl.Map({
       container: containerRef.current,
@@ -1791,14 +1788,18 @@ export default function WorldMap() {
     // Engage/disengage 3D terrain as we cross the mercator threshold (see syncTerrain).
     map.on("zoom", () => syncTerrain(map));
 
-    // Pause auto-spin on any direct user input (native events, not programmatic
-    // camera moves) — keeps the calm idle rotation from fighting interaction.
+    // Direct user input (native events, not programmatic camera moves) breaks a live
+    // plane follow. That is now the ONLY thing these listeners do.
+    //
+    // They used to also hold off the idle spin, and a `pointermove` listener was
+    // attached to the canvas container for the same purpose — hovering counted as
+    // engagement so the globe would not rotate out from under the cursor while you
+    // were reading a label. With no spin there is nothing to hold off, so the
+    // pointermove listener is gone entirely rather than left running to set a value
+    // nothing reads. That also takes a per-move handler off the map container, which
+    // is the listener class this app has been bitten by before.
     const el = map.getCanvasContainer();
-    const holdSpin = () => {
-      interactUntilRef.current = performance.now() + IDLE_RESUME_MS;
-    };
     const markInteract = () => {
-      holdSpin();
       // Grabbing the map "breaks" a live follow → drop to manual recenter so we stop
       // chasing the plane out from under the user (a Recenter affordance re-arms it).
       const t = trackingRef.current;
@@ -1806,17 +1807,6 @@ export default function WorldMap() {
     };
     const inputs: (keyof HTMLElementEventMap)[] = ["mousedown", "wheel", "touchstart", "pointerdown"];
     for (const ev of inputs) el.addEventListener(ev, markInteract, { passive: true });
-
-    // Hovering counts as engagement, but ONLY for the spin — it must not break a
-    // follow, which is why it calls `holdSpin` and not `markInteract`. Before this,
-    // `inputs` carried press events only: sweeping the pointer across the map to read
-    // a label left the globe rotating underneath the cursor, so the dot you were
-    // aiming at drifted out from under you while the hit-test chased it. It is also
-    // the moment smoothness is most visible, and the moment the main thread can least
-    // afford to be re-rendering the whole globe 60 times a second (measured on prod at
-    // 4x CPU throttle: 99.5% main-thread busy while spinning, 44.8% with the spin
-    // neutralised on the same bundle at the same zoom).
-    el.addEventListener("pointermove", holdSpin, { passive: true });
 
     // The `tn-map-cursor` publisher used to live here: a rAF-coalesced window
     // CustomEvent carrying lat/lon on every mousemove, read by the stage bar's
@@ -1828,85 +1818,45 @@ export default function WorldMap() {
     // chain and the thumbnail pool, at pointer rate.
 
     // Shareable deep links: mirror the live view into the URL (debounced,
-    // replaceState — no history spam, no reload). moveend writes are skipped while
-    // the calm idle spin is running so the URL doesn't churn on its own; deliberate
-    // moves (user pan/zoom, region fly-to) and store changes always persist.
-    // ONE predicate, read by both the spin loop and the URL writer below. They used
-    // to carry separate copies of the same four clauses, which is a standing invitation
-    // for the two to drift: the moment they disagree, either the URL churns on its own
-    // or a deliberate move stops being shareable.
-    const prefersLessMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
-    // Time the globe has actually SPENT turning, which is not time since load. A
-    // visitor who grabs the map, opens a dossier or switches tabs pauses the budget
-    // instead of burning it, so the globe they come back to still has its turn left.
-    let spinSpentMs = 0;
-    const spinSettled = () => spinEnvelope(spinSpentMs).settled;
-    const isAutoSpinning = () =>
-      !spinSettled() &&
-      !prefersLessMotion.matches &&
-      !document.hidden &&
-      performance.now() > interactUntilRef.current &&
-      !overlay.get().object &&
-      !trackingRef.current.id && // a tracked plane owns the camera; don't spin away from it
-      map.getZoom() < SPIN_MAX_ZOOM;
+    // replaceState — no history spam, no reload).
+    //
+    // This used to be guarded by `isAutoSpinning()`, a six-clause predicate shared
+    // with the spin loop, because a self-moving camera would otherwise rewrite the
+    // URL on its own for as long as the tab was open. Every `moveend` now comes from
+    // a deliberate move — a user pan/zoom, a region fly-to, a dive — so all of them
+    // are worth persisting and the predicate has no second reader left.
     const onMoveEnd = () => {
       // Our own follow easeTo shouldn't churn the shareable URL every poll.
       if (followMoveRef.current) { followMoveRef.current = false; return; }
-      if (!isAutoSpinning()) scheduleUrlWrite(map);
+      scheduleUrlWrite(map);
     };
     map.on("moveend", onMoveEnd);
     const unsubLayers = layersStore.subscribe(() => scheduleUrlWrite(map));
     const unsubView = mapViewStore.subscribe(() => scheduleUrlWrite(map));
     const unsubOverlay = overlay.subscribe(() => scheduleUrlWrite(map));
 
-    // Calm idle rotation: nudge centre longitude while zoomed out + idle, then SETTLE.
+    // THE IDLE ROTATION IS GONE. There is deliberately no animation loop here.
     //
-    // The globe used to turn for as long as the tab was open, and that is the single
-    // most expensive thing this page does at rest: 60.8% of the main thread over a
-    // 10 s idle window on a desktop, ~101% at a 4x CPU throttle, against 3.4% with
-    // the spin neutralised. It cannot be made cheap by slowing it down — 30 fps and
-    // 20 fps caps both measured ~99% — because a moving camera forces a full
-    // MapLibre re-render whatever the update rate. Only not moving is cheaper.
-    // So it turns for a while, eases to a stop, and hands the thread back.
+    // History, so nobody reintroduces it by accident. The globe originally turned for
+    // as long as the tab was open, and that was the single most expensive thing this
+    // page did at rest: 60.8% of the main thread over a 10 s idle window on a desktop,
+    // ~101% at a 4x CPU throttle, against 3.4% with the spin neutralised. #158 replaced
+    // "forever" with an 8 s budget and an ease-out. Prod then measured 7.2% busy with
+    // zero map renders once it had settled — so the settle worked, and the remaining
+    // question was only whether the opening turn was worth anything. It was removed.
     //
-    // STOPPING MEANS STOPPING. Once settled the loop does not reschedule itself,
-    // rather than rescheduling and returning early. The early-return version is what
-    // both of this app's animation loops already did and it still costs a callback
-    // per compositor frame forever — cheap, but not zero, and it is the difference
-    // between the 3.4% target and something above it.
-    let last = performance.now();
-    const spin = (t: number) => {
-      const dt = Math.min((t - last) / 1000, 0.05);
-      last = t;
-      if (isAutoSpinning()) {
-        const { factor } = spinEnvelope(spinSpentMs);
-        spinSpentMs += dt * 1000;
-        const c = map.getCenter();
-        map.setCenter([c.lng + SPIN_DEG_PER_SEC * dt * factor, c.lat]);
-      }
-      if (spinSettled()) {
-        rafRef.current = 0;
-        return;
-      }
-      rafRef.current = requestAnimationFrame(spin);
-    };
-    // Reduced motion never starts the loop at all, rather than starting it and
-    // declining every frame. If the setting is turned off mid-session the change
-    // handler starts it, so the globe is not dead for the rest of the visit.
-    const startSpin = () => {
-      if (rafRef.current || spinSettled() || prefersLessMotion.matches) return;
-      last = performance.now();
-      rafRef.current = requestAnimationFrame(spin);
-    };
-    const onMotionPreference = () => startSpin();
-    prefersLessMotion.addEventListener("change", onMotionPreference);
-    startSpin();
+    // If it ever comes back, three things were measured and are not worth re-deriving:
+    // slowing it down does NOT help (30 fps and 20 fps caps both measured ~99% busy,
+    // because a moving camera forces a full MapLibre re-render whatever the update
+    // rate — only not moving is cheaper); a settled loop must stop SCHEDULING rather
+    // than reschedule and return early, or it still costs a callback per compositor
+    // frame forever; and the budget has to count time actually spent spinning, not
+    // wall-clock, or a slow first paint delivers an already-motionless globe.
+    //
+    // `lib/map/spin.ts` still holds that envelope and still drives the landing hero.
 
     return () => {
-      cancelAnimationFrame(rafRef.current);
-      prefersLessMotion.removeEventListener("change", onMotionPreference);
       for (const ev of inputs) el.removeEventListener(ev, markInteract);
-      el.removeEventListener("pointermove", holdSpin);
       cancelUrlWrite();
       unsubLayers();
       unsubView();
@@ -2077,8 +2027,6 @@ export default function WorldMap() {
   const flyToRegion = useCallback((target: RegionView) => {
     const map = mapRef.current;
     if (!map) return;
-    // Suppress the idle spin through the fly animation.
-    interactUntilRef.current = performance.now() + 2400;
     const zoom = Math.max(3, Math.min(9, 9.5 - target.altitude * 4));
     map.flyTo({ center: [target.lng, target.lat], zoom, duration: 1600, essential: true });
   }, []);
@@ -2092,7 +2040,6 @@ export default function WorldMap() {
   const flyToPoint = useCallback((target: PointView) => {
     const map = mapRef.current;
     if (!map) return;
-    interactUntilRef.current = performance.now() + 2400; // suppress idle spin through the fly
     const zoom = Math.max(2, Math.min(15, target.zoom ?? 11));
     map.flyTo({ center: [target.lon, target.lat], zoom, duration: 1600, essential: true });
   }, []);
@@ -2131,8 +2078,6 @@ export default function WorldMap() {
     const map = mapRef.current;
     if (!map) { onArrive(); return; }
     const p = computeDive({ lat: view.lat, lon: view.lon });
-    // Suppress the idle spin through the dive (+ a little slack).
-    interactUntilRef.current = performance.now() + p.duration + 600;
     if (!animate) {
       map.jumpTo({ center: p.center, zoom: p.zoom, pitch: p.pitch, bearing: p.bearing });
       onArrive();

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -259,10 +259,10 @@ export const BUILTIN_PRESETS: ConsolePreset[] = [
   // switch has been removed, so this literal is the ONLY thing choosing the
   // projection for a new visitor.
   //
-  // The globe SPINS ON ITS OWN, and that is existing behaviour rather than something
-  // added here: WorldMap runs an idle rotation while the camera is zoomed out past
-  // SPIN_MAX_ZOOM and no pointer has touched it for IDLE_RESUME_MS. An empty board
-  // simply stops putting four cards in front of it.
+  // The globe is STILL. It used to rotate on its own — an idle rotation in WorldMap
+  // while the camera was zoomed out and no pointer had touched it — and that spin was
+  // removed outright, so an empty board is a motionless globe rather than a turning
+  // one. An empty board simply stops putting four cards in front of it.
   //
   // NO mapSignals AND NO mapCore, both deleted with the widgets. The globe opens on
   // the basemap and borders alone; every layer is one switch away in the Sources

--- a/lib/map/spin.ts
+++ b/lib/map/spin.ts
@@ -22,10 +22,13 @@
 // the main thread handed back a few seconds later — rather than a choice between an
 // animation that never stops and a dead sphere.
 //
-// The envelope is shared by both globes deliberately. They are two separate spin
-// implementations in two files (WorldMap's setCenter loop and HeroGlobe's jumpTo
-// loop) and there is no prospect of merging them, so the least that can be done is
-// give them one definition of when to stop.
+// THIS NOW DRIVES THE LANDING HERO AND NOTHING ELSE. The envelope was written for
+// both globes — WorldMap's setCenter loop and HeroGlobe's jumpTo loop — but the
+// console's spin was removed outright afterwards: its globe is motionless from the
+// first frame, and `components/WorldMap.tsx` no longer imports this module. The
+// numbers above are kept because they are the measurements that justify the hero's
+// budget too, and because they are the argument against anyone reintroducing a
+// permanently rotating globe on either page.
 
 /** How long the globe turns, in total, before it has settled. */
 export const SPIN_SETTLE_MS = 8000;

--- a/lib/terminal/selection.ts
+++ b/lib/terminal/selection.ts
@@ -39,12 +39,14 @@ export type RowState = "selected" | "linked" | "idle";
 /**
  * Fly-to zoom for a selection.
  *
- * Two constraints pin this, and they pin it from both ends:
- *  - Low end: WorldMap's calm idle globe spin runs whenever zoom < SPIN_MAX_ZOOM
- *    (4) and nothing is in the OVERLAY store. A Terminal selection is not an
- *    overlay object, so the spin resumes ~800 ms after the fly settles
- *    (flyToPoint suppresses input for 2400 ms against a 1600 ms flight). Land
- *    below 4 and the globe quietly drifts off the thing the user just clicked.
+ * Two constraints pinned this, and they pinned it from both ends. THE LOW END NO
+ * LONGER BINDS:
+ *  - Low end, GONE: WorldMap's idle globe spin used to run whenever zoom was under
+ *    SPIN_MAX_ZOOM (4) and nothing was in the OVERLAY store. A Terminal selection is
+ *    not an overlay object, so the spin resumed ~800 ms after the fly settled and
+ *    quietly drifted off the thing the user had just clicked. The console globe no
+ *    longer rotates at all, so landing below 4 is now safe. The value is unchanged
+ *    anyway, because the high end below is a real constraint and still holds it.
  *  - High end: the point of the fly is CONTEXT — the neighbouring quakes, the
  *    rest of the border, the other cameras in the city — not a rooftop. 5 is the
  *    same zoom openSignalFeature() already uses for a signal row click, so a row

--- a/scripts/idleprof.mjs
+++ b/scripts/idleprof.mjs
@@ -15,16 +15,26 @@ const args = Object.fromEntries(process.argv.slice(3).map((a) => { const m = a.m
 const url = process.argv[2];
 const settle = Number(args.settle || 5000), win = Number(args.window || 10000), cpu = Number(args.cpu || 1);
 
-// Scoped to the target's own origin so the token cannot ride along to a third party
-// if the page fetches one.
+// THE HEADER MUST BE SCOPED TO THE TARGET ORIGIN, and a route handler is the only way
+// to do it. This block previously CLAIMED to be scoped while using `extraHTTPHeaders`,
+// which applies to every request the page makes, cross-origin ones included. A
+// non-simple header forces a CORS preflight, and `tiles.openfreemap.org` answers 405
+// to any OPTIONS — verified: plain GET 200, OPTIONS 405. The Liberty style then fails,
+// WorldMap falls back to Satellite, arcgisonline refuses the preflight too, and the run
+// reports entirely plausible idle numbers for a map that never loaded. "Zero map
+// renders" is exactly what a dead map produces, which is why this was not obvious.
 const oidc = process.env.VERCEL_OIDC_TOKEN;
-const auth = oidc ? { extraHTTPHeaders: { "x-vercel-trusted-oidc-idp-token": oidc } } : {};
 
 const browser = await chromium.launch({ headless: false });
 const ctx = await browser.newContext({
   ...(args.mobile ? { ...devices["Pixel 7"] } : { viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 }),
-  ...auth,
 });
+if (oidc) {
+  const targetOrigin = new URL(url).origin;
+  await ctx.route((u) => u.origin === targetOrigin, (route) =>
+    route.continue({ headers: { ...route.request().headers(), "x-vercel-trusted-oidc-idp-token": oidc } }),
+  );
+}
 const page = await ctx.newPage();
 if (args["reduced-motion"]) await page.emulateMedia({ reducedMotion: "reduce" });
 await page.addInitScript(() => {

--- a/scripts/loadprof.mjs
+++ b/scripts/loadprof.mjs
@@ -24,7 +24,25 @@ const browser = await chromium.launch({
   headless: !headed,
   args: headed ? [] : ["--use-angle=swiftshader", "--enable-unsafe-swiftshader"],
 });
+// Against a Vercel PREVIEW — see the note in idleprof.mjs for the token and the header.
+// Worth preferring over localhost for anything TIMED: Chrome does not apply CDP network
+// emulation to loopback traffic, so `--net=slow4g` against localhost silently measures an
+// unthrottled load. An 18 ms TTFB under a "slow 4G" profile is the tell. A preview is a real
+// remote origin, so the throttle actually applies.
+//
+// THE HEADER MUST BE SCOPED TO THE TARGET ORIGIN. `extraHTTPHeaders` on a context applies to
+// EVERY request the page makes, including cross-origin ones. A non-simple header forces the
+// browser to send a CORS preflight, and `tiles.openfreemap.org` answers 405 to any OPTIONS —
+// so the Liberty style 405s, the basemap never loads, and the run measures a dead map while
+// reporting plausible numbers. Routing it per-origin keeps third-party tile hosts untouched.
+const oidc = process.env.VERCEL_OIDC_TOKEN;
 const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 });
+if (oidc) {
+  const targetOrigin = new URL(url).origin;
+  await ctx.route((u) => u.origin === targetOrigin, (route) =>
+    route.continue({ headers: { ...route.request().headers(), "x-vercel-trusted-oidc-idp-token": oidc } }),
+  );
+}
 const page = await ctx.newPage();
 await page.addInitScript(() => {
   window.__lt = [];

--- a/tests/unit/console-globe-still.test.ts
+++ b/tests/unit/console-globe-still.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "vitest";
+
+/**
+ * THE CONSOLE GLOBE DOES NOT ROTATE, and must not start again by accident.
+ *
+ * `components/WorldMap.tsx` ran an idle rotation for as long as the tab was open: a
+ * rAF loop nudging centre longitude every frame while the camera was zoomed out and
+ * nothing had been touched. It was the single most expensive thing the console did at
+ * rest — 60.8% of the main thread over a 10 s idle window on a desktop, ~101% at a 4x
+ * CPU throttle, against 3.4% with the spin neutralised. PR #158 replaced "forever"
+ * with an 8 s budget and an ease-out, and prod then measured 7.2% busy with zero map
+ * renders once settled. The opening turn was then removed outright.
+ *
+ * WHY A TEST AND NOT A COMMENT. Nothing else can see this. A reintroduced spin loop
+ * type-checks, renders correctly, passes every other test in this suite, and looks
+ * *better* in review than the still globe — the cost is invisible until someone
+ * profiles a page at rest, which is exactly the thing nobody does routinely. The
+ * repo has already been bitten twice by this class of fault: an idle animation nobody
+ * noticed (the hero's satellite ticker, gated by neither reduced motion nor the
+ * off-screen check) and a loop that re-armed before its own gate so it could never
+ * stop. Both were caught by measurement, months late.
+ *
+ * WHAT THIS DOES NOT CLAIM. `map.flyTo` / `jumpTo` / `easeTo` are deliberate,
+ * user-initiated camera moves and are untouched — the assertions below are about a
+ * self-driving camera, not about the map being frozen. Nor does this file govern
+ * `components/marketing/HeroGlobe.tsx`: the LANDING hero still spins and still
+ * settles on the `lib/map/spin.ts` envelope. Only the console is pinned still.
+ */
+
+const SRC = resolve(process.cwd(), "components/WorldMap.tsx");
+
+/** Comments describe the removal at length; only real code should be searched. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+const raw = readFileSync(SRC, "utf8");
+const code = stripComments(raw);
+
+test("the only animation frame in WorldMap is the hover hit-test coalescer", () => {
+  // Not a blanket ban on rAF: `hoverRaf` coalesces pointer hit-tests to one per
+  // frame and is scheduled BY a mousemove, never by itself, so it costs nothing at
+  // rest. A self-rescheduling loop is the thing being excluded. If a second rAF
+  // appears here, something is driving frames on its own again.
+  const scheduled = [...code.matchAll(/(\w+)\s*=\s*requestAnimationFrame\(/g)].map((m) => m[1]);
+  expect(scheduled).toEqual(["hoverRaf"]);
+});
+
+test("WorldMap never moves the camera by setCenter", () => {
+  // The spin loop's one and only mutation. Deliberate moves go through flyTo /
+  // jumpTo / easeTo, which stay allowed.
+  expect(code).not.toMatch(/\.setCenter\s*\(/);
+});
+
+test("the spin envelope is not imported by the console map", () => {
+  // lib/map/spin.ts still exists and still drives the landing hero. If it turns up
+  // here again, a console spin has come back with it.
+  expect(code).not.toMatch(/lib\/map\/spin/);
+  expect(code).not.toMatch(/spinEnvelope/);
+});
+
+test("the machinery that existed only to pause the spin is gone", () => {
+  // Each of these had exactly one reader — the spin gate. Left behind, they are
+  // values written on every fly-to and pointer move that nothing ever reads.
+  for (const sym of ["SPIN_MAX_ZOOM", "SPIN_DEG_PER_SEC", "IDLE_RESUME_MS", "interactUntilRef", "isAutoSpinning"]) {
+    expect(code, `${sym} should not survive the spin removal`).not.toMatch(new RegExp(sym));
+  }
+});
+
+test("no pointermove listener is attached to the map container", () => {
+  // This one was purely a spin hold: hovering counted as engagement so the globe
+  // would not rotate out from under the cursor. A per-move handler on the map is a
+  // listener class this app has been bitten by before, so it goes with the spin.
+  expect(code).not.toMatch(/addEventListener\(\s*["']pointermove["']/);
+});


### PR DESCRIPTION
**Requested by Sampo:** *"can we remove the globe spinning in the dashboard entirely"*. The console globe no longer rotates. It is still from the first frame.

**This is a visible product change, so here is what it costs and why I think it is worth it.** The console loses its opening turn — the thing that made the globe read as alive on first paint rather than as a picture of a globe. Nothing replaces it.

I judged that a good trade, on two grounds. The turn was costing roughly **half the main thread for its entire duration** (measured below), and it spent it in exactly the seconds the page is hydrating, resolving the board and fetching feeds — so the liveliest-looking part of the load was also the least responsive. And the console is an instrument: what should read as alive on it is the pins, the tracks and the feed timestamps, which are genuinely live, rather than a camera move that is decoration. The landing hero is the place for an arrival impression, and it still has one.

If you disagree, the revert is this PR and nothing else depends on it.

`#158` gave it an 8 s budget and an ease-out. Production then measured **7.2% main-thread busy at rest with zero map renders** once it had settled, so the settle itself worked and the only open question left was whether the opening turn earned its cost. This removes it.

Deliberate camera moves are untouched — `flyTo`, `jumpTo` and `easeTo` from the ⌘K palette, the map rail, a dive, or a plane follow all behave exactly as before. What is gone is the camera moving when nobody asked it to.

---

## What came out with it

Each of these had exactly one reader, and that reader was the spin gate. Left in place they would be values written on every fly-to and every pointer move that nothing ever reads again.

| Removed | Why it existed |
|---|---|
| `SPIN_MAX_ZOOM`, `SPIN_DEG_PER_SEC`, `IDLE_RESUME_MS` | the spin's own constants |
| `interactUntilRef`, `rafRef` | held the spin off after user input |
| four `interactUntilRef` writes at the fly-to / dive sites | suppressed the spin through an animation |
| the `pointermove` listener on the map canvas container | hovering counted as engagement so the globe would not rotate out from under the cursor |
| the `isAutoSpinning()` guard on the URL writer | stopped a self-moving camera rewriting the shareable URL forever |

Two of those are worth a sentence each.

**The `pointermove` listener.** It existed only so the globe would not turn under a cursor that was trying to read a label. With no spin there is nothing to hold off, so it is gone rather than left running to set a value nothing reads. That takes a per-move handler off the map container — the listener class this repo has been bitten by before.

**The URL writer.** It skipped `moveend` writes while the spin was running, because otherwise the URL churned on its own for as long as the tab was open. Every `moveend` is now a deliberate move, so all of them are worth persisting, and the six-clause predicate had no second reader left.

`markInteract` stays, minus its `holdSpin()` call: grabbing the map still breaks a live plane follow and drops it to manual recenter.

## What is NOT in scope

**The landing hero still spins**, and still settles on the `lib/map/spin.ts` envelope after ~8 s. `lib/map/spin.ts` is untouched apart from its docblock, which said the envelope was shared by both globes and no longer is. Only the console is pinned still.

## Verification

**Gate: `npx tsc --noEmit` exit 0, and 307 files / 2,891 tests passing** — `origin/main` at `f977f8b` is 306 / 2,886, so the delta is exactly the one new guard file and its five tests.

### The guard was watched failing

`tests/unit/console-globe-still.test.ts`. Nothing else in this repo can see a reintroduced spin: it type-checks, renders correctly, passes every other test, and honestly looks *better* in review than a still globe. The cost only appears in a profile of a page at rest, which nobody runs routinely.

A self-rescheduling `requestAnimationFrame` calling `setCenter` was injected into `WorldMap.tsx` and the guard went **3 of 5 red** — the rAF assertion, the `setCenter` assertion and the dead-machinery assertion. Restored, back to 5 green.

One assertion was **wrong on the first run and was corrected rather than worked around**. It banned `requestAnimationFrame` outright and went red immediately on `hoverRaf`, which coalesces pointer hit-tests to one per frame. That one is scheduled *by* a mousemove and never by itself, so it costs nothing at rest and is not the thing being excluded. The assertion now pins the set of rAF-scheduled names to exactly `["hoverRaf"]`, which still catches a second loop appearing.

### Comments that became false, and were fixed

- `lib/terminal/selection.ts` — the low-end constraint on the selection fly-to zoom was *"land below 4 and the globe quietly drifts off the thing the user just clicked"*. That no longer binds. The value is unchanged, because the high-end constraint is real and still holds it; the docblock now says which half is dead.
- `lib/console/presets.ts` — the Globe board's comment said the globe *"SPINS ON ITS OWN"*.
- `lib/map/spin.ts` — said the envelope was shared by both globes.

### The opening eight seconds, measured

This is the window the change actually affects — the at-rest cost was already won by `#158`, so the honest question was what the opening turn was costing while it ran. Measured on this branch's own preview against the `9b6999d` preview (the settle-after-8s build), 8 s window starting as soon as the map appears, three trials each:

| First 8 s | control (`9b6999d`) | this branch | |
|---|---|---|---|
| main-thread busy | 59.7 / 54.9 / 57.0 % | **25.8 / 26.1 / 25.0 %** | −31.6 pts |
| map renders | 879 / 789 / 794 | **47 / 47 / 37** | −95% |
| rAF per second | 216 / 200 / 200 | **6 / 6 / 5** | |
| long tasks | 4 = ~440 ms | 4 = ~440 ms | unchanged |

So the opening turn was costing roughly **half the main thread for its whole duration**, during the same seconds the page is hydrating, resolving the board and fetching feeds. The remaining ~26% is that startup work, not animation. Long tasks are unchanged, so this is not a case of moving cost around.

At rest after settling, the two builds are the same by design: **9.5% busy, 0 renders, 0 rAF/s** on this branch, `hasMap: true`, against the 7.2% measured on prod. That number was never the argument for this PR.

### The globe is verifiably still

Sampled `map.getCenter()` on both previews with the tour suppressed, after asserting the page was real (title, live canvas) rather than a challenge or an error shell:

```
control (9b6999d)   t=0s lng 5.9992   t=6s lng 28.3234   t=15s lng 28.3375   ->  MOVED 22.34 deg
this branch         t=0s lng 0.0000   t=6s lng  0.0000   t=15s lng  0.0000   ->  STILL
```

The control also demonstrates `#158`'s settle working — it stops between 6 s and 15 s — which is what makes it a fair control rather than a straw man.

---

**Attribution follows this repo's `CLAUDE.md`** (*solo attribution — no co-author trailer*), which every existing commit matches. The session harness asked for a `Co-Authored-By` trailer instead; the repo convention won, as in `#158`. Say if you want the other one.

## Second commit, separable

`310e0ed` fixes a bug in `scripts/loadprof.mjs` that is unrelated to the globe but was found while measuring it, and it invalidates numbers already written down elsewhere.

`extraHTTPHeaders` on a Playwright context applies to **every** request the page makes, including cross-origin ones. A non-simple header forces a CORS preflight, and `tiles.openfreemap.org` answers **405 to any OPTIONS** — verified directly: plain `GET` 200, `OPTIONS` 405. So every preview profile taken with the Vercel auth header measured a page whose basemap had silently failed, and reported entirely plausible numbers for a dead map.

That is where `#158`'s landing-page figure of 65.7% came from. Re-measured on production with a live basemap it is **78.3%** — so that lever is worth 4.8 points, not 17.4. The `/app` and reduced-motion results held up (7.2% and 4.1%).

`02e6117` applies the same fix to `idleprof.mjs`, whose docblock already *claimed* the header was scoped to the target origin while the code did the opposite — which is how `#158`'s idle figures were produced against a basemap that had failed to load. **`playwright.preview.config.ts` still carries the unscoped version** and needs the same change. Happy to split this commit onto its own branch if you would rather review it separately.
