### PR TITLE
Make the console map smooth: terrain off by default, basemap warm-up, boot floor, deferred icons

### DIFF
--- a/app/(console)/layout.tsx
+++ b/app/(console)/layout.tsx
@@ -1,0 +1,53 @@
+import ReactDOM from "react-dom";
+import { BASEMAPS, DEFAULT_BASEMAP } from "@/lib/basemaps";
+
+/**
+ * The console's only job at the layout level: start the basemap chain with the
+ * HTML instead of after hydration.
+ *
+ * WHAT THE WAITING ACTUALLY LOOKS LIKE. Measured cold-cache on desktop against
+ * production, worker-aware (a page-session CDP Network capture never sees
+ * MapLibre's vector-tile fetches — the worker issues them, so `scripts/loadprof.mjs`
+ * is blind to them and Playwright's `page.on("request")` is not):
+ *
+ *   canvas 0.67 s → style 1.0 s → TileJSON + sprite JSON + sprite PNG →
+ *   first four tiles 2.3–2.4 s → `load` 2.7 s → first idle 3.0 s
+ *
+ * Nothing before 1.0 s is network-bound. The map canvas lives inside StageHost
+ * behind `dynamic(() => import("@/components/WorldMap"))`, so the browser cannot
+ * learn that `tiles.openfreemap.org` exists until React has hydrated, the chunk has
+ * arrived and MapLibre has constructed a Map. The first request to that host then
+ * pays DNS + TCP + TLS before it transfers a byte, and every later one —
+ * TileJSON, sprite, glyphs, tiles — is queued behind it.
+ *
+ * `preconnect` moves the handshake to parse time; `preload` moves the style
+ * document itself there. Both are hints: if the console is never reached, or the
+ * visitor arrives on a raster basemap, the cost is one unused connection.
+ *
+ * DERIVED FROM THE REGISTRY, NEVER TYPED. DEFAULT_BASEMAP is `streets`
+ * (OpenFreeMap Liberty) and not the `positron` the code around it keeps calling
+ * "the calm light default" — ConsoleShell's skin↔basemap sync only ever swaps
+ * between `dark` and `positron`, so it does not fire on a first load and `streets`
+ * really is the first style fetched. Writing the URL out here would warm the wrong
+ * document the day that constant moves, and nothing would fail: the preload would
+ * go unused and the real style would be fetched exactly as late as it is today.
+ * tests/unit/map-first-paint.test.ts holds that line.
+ */
+export default function ConsoleLayout({ children }: { children: React.ReactNode }) {
+  const { style } = BASEMAPS[DEFAULT_BASEMAP];
+  // The raster entries (`satellite`, `topo`) carry an inline StyleSpecification
+  // rather than a URL. There is no document to fetch for those, and their tile
+  // hosts are a different origin from the vector styles' — so this warms nothing
+  // rather than warming the wrong thing.
+  if (typeof style === "string") {
+    const { origin } = new URL(style);
+    // `anonymous` because that is how MapLibre asks for it: a cross-origin fetch
+    // with default credentials sends none, and a preload whose CORS mode does not
+    // match the real request is not reused — the browser fetches the style twice
+    // and the hint has made things worse. Verified by counting requests to the
+    // style URL on a cold load: it must stay at one.
+    ReactDOM.preconnect(origin, { crossOrigin: "anonymous" });
+    ReactDOM.preload(style, { as: "fetch", crossOrigin: "anonymous" });
+  }
+  return children;
+}

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -53,7 +53,6 @@ import {
 import { ATTRIB_CONTROL_CLASS, collapseAttribution } from "@/lib/map/attribution";
 import { HILLSHADE_MIN_ZOOM, TERRAIN_MIN_ZOOM, terrainChanged, wantedTerrain } from "@/lib/map/terrain";
 import { layersToTrim } from "@/lib/map/styleTrim";
-import { spinEnvelope } from "@/lib/map/spin";
 import { markMapReady } from "@/lib/terminal/mapReady";
 import { toCameraFC, toPlaneFC, toTrailFC, toSatelliteFC, toWebcamFC, toSignalFC, toSignalLineFC, toSignalFillFC } from "@/lib/map/features";
 import {
@@ -254,11 +253,9 @@ function hitsAt(map: maplibregl.Map, point: maplibregl.MapLayerMouseEvent["point
   });
 }
 
-// Start zoomed out so the spinning globe is the hero. The palette / rail fly inward.
+// Start zoomed out, so the whole world is the opening frame. It does not turn:
+// the console's globe is still, and the palette / rail fly inward from here.
 const HOME = { center: [-30, 28] as [number, number], zoom: 1.4 };
-const SPIN_MAX_ZOOM = 4; // only auto-rotate while zoomed out this far
-const SPIN_DEG_PER_SEC = 4; // calm rotation
-const IDLE_RESUME_MS = 4000; // resume spin this long after the last user input
 
 const vis = (on: boolean): "visible" | "none" => (on ? "visible" : "none");
 
@@ -446,10 +443,13 @@ export default function WorldMap() {
   const styleAttemptsRef = useRef(0);
   const styleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [loadStatus, setLoadStatus] = useState<MapLoadStatus>({ kind: "ok" });
-  const rafRef = useRef(0);
-  const interactUntilRef = useRef(0);
-  const terrainRef = useRef(true);
-  const buildingsRef = useRef(true);
+  // Seeded FROM the store, not from a literal. These are read by addAppLayers on
+  // `style.load`, which can land before the effects that sync them, so a hard-coded
+  // starting value is a second copy of a default that must agree with lib/mapView.ts
+  // — and when the defaults flipped to off, the copy is what would have kept
+  // fetching DEM on the first style of every visit.
+  const terrainRef = useRef(mapViewStore.get().terrain);
+  const buildingsRef = useRef(mapViewStore.get().buildings);
   // Plane-tracking (see lib/planes/track). trackingRef mirrors the store for the
   // spin loop + input handlers (no re-render); trackedObjectRef holds the tracked
   // plane's latest WorldObject so addAppLayers can re-seed the ring after a restyle;
@@ -502,7 +502,7 @@ export default function WorldMap() {
   const buildingsOn = view.buildings;
   const layers = useLayers();
   const track = useTrack();
-  trackingRef.current = track; // keep the spin loop / input handlers current without a re-subscribe
+  trackingRef.current = track; // keep the input handlers current without a re-subscribe
   const pins = useMapPins();
   pinsRef.current = pins;
   // Subscribing the map to the selection is cheap in the way the cursor readout is
@@ -1659,12 +1659,6 @@ export default function WorldMap() {
     const center: [number, number] =
       initial.lat != null && initial.lon != null ? [initial.lon, initial.lat] : HOME.center;
     const zoom = initial.zoom ?? HOME.zoom;
-    // A deep-linked camera/zoom means the user wants that exact view — don't let
-    // the idle spin immediately drag it away on first paint.
-    if (initial.lat != null || initial.zoom != null) {
-      interactUntilRef.current = performance.now() + IDLE_RESUME_MS;
-    }
-
     const map = new maplibregl.Map({
       container: containerRef.current,
       style: BASEMAPS[mapViewStore.get().basemap].style,
@@ -1791,32 +1785,25 @@ export default function WorldMap() {
     // Engage/disengage 3D terrain as we cross the mercator threshold (see syncTerrain).
     map.on("zoom", () => syncTerrain(map));
 
-    // Pause auto-spin on any direct user input (native events, not programmatic
-    // camera moves) — keeps the calm idle rotation from fighting interaction.
+    // Grabbing the map "breaks" a live follow → drop to manual recenter so we stop
+    // chasing the plane out from under the user (a Recenter affordance re-arms it).
+    //
+    // This used to do two jobs. The other one was holding off the idle spin on any
+    // direct input, which is why it listened for native events rather than camera
+    // moves; the spin is gone and only the follow break remains.
     const el = map.getCanvasContainer();
-    const holdSpin = () => {
-      interactUntilRef.current = performance.now() + IDLE_RESUME_MS;
-    };
     const markInteract = () => {
-      holdSpin();
-      // Grabbing the map "breaks" a live follow → drop to manual recenter so we stop
-      // chasing the plane out from under the user (a Recenter affordance re-arms it).
       const t = trackingRef.current;
       if (t.id && t.mode === "follow") trackStore.setMode("recenter");
     };
     const inputs: (keyof HTMLElementEventMap)[] = ["mousedown", "wheel", "touchstart", "pointerdown"];
     for (const ev of inputs) el.addEventListener(ev, markInteract, { passive: true });
 
-    // Hovering counts as engagement, but ONLY for the spin — it must not break a
-    // follow, which is why it calls `holdSpin` and not `markInteract`. Before this,
-    // `inputs` carried press events only: sweeping the pointer across the map to read
-    // a label left the globe rotating underneath the cursor, so the dot you were
-    // aiming at drifted out from under you while the hit-test chased it. It is also
-    // the moment smoothness is most visible, and the moment the main thread can least
-    // afford to be re-rendering the whole globe 60 times a second (measured on prod at
-    // 4x CPU throttle: 99.5% main-thread busy while spinning, 44.8% with the spin
-    // neutralised on the same bundle at the same zoom).
-    el.addEventListener("pointermove", holdSpin, { passive: true });
+    // A `pointermove` listener lived here whose only job was to hold the spin off
+    // while the pointer swept the map — otherwise the globe turned under the cursor
+    // and the dot you were aiming at drifted away from it. A still globe cannot do
+    // that, so the listener is gone rather than kept as a per-pointer-event write to
+    // a value nothing reads. The hover hit-test in wireInteractions is unaffected.
 
     // The `tn-map-cursor` publisher used to live here: a rAF-coalesced window
     // CustomEvent carrying lat/lon on every mousemove, read by the stage bar's
@@ -1828,85 +1815,48 @@ export default function WorldMap() {
     // chain and the thumbnail pool, at pointer rate.
 
     // Shareable deep links: mirror the live view into the URL (debounced,
-    // replaceState — no history spam, no reload). moveend writes are skipped while
-    // the calm idle spin is running so the URL doesn't churn on its own; deliberate
-    // moves (user pan/zoom, region fly-to) and store changes always persist.
-    // ONE predicate, read by both the spin loop and the URL writer below. They used
-    // to carry separate copies of the same four clauses, which is a standing invitation
-    // for the two to drift: the moment they disagree, either the URL churns on its own
-    // or a deliberate move stops being shareable.
-    const prefersLessMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
-    // Time the globe has actually SPENT turning, which is not time since load. A
-    // visitor who grabs the map, opens a dossier or switches tabs pauses the budget
-    // instead of burning it, so the globe they come back to still has its turn left.
-    let spinSpentMs = 0;
-    const spinSettled = () => spinEnvelope(spinSpentMs).settled;
-    const isAutoSpinning = () =>
-      !spinSettled() &&
-      !prefersLessMotion.matches &&
-      !document.hidden &&
-      performance.now() > interactUntilRef.current &&
-      !overlay.get().object &&
-      !trackingRef.current.id && // a tracked plane owns the camera; don't spin away from it
-      map.getZoom() < SPIN_MAX_ZOOM;
+    // replaceState — no history spam, no reload).
+    //
+    // Every `moveend` is now a deliberate move, so every one of them is worth
+    // writing. This used to skip the writes the idle spin generated, through a
+    // shared `isAutoSpinning()` predicate that existed so the URL writer and the
+    // spin loop could not drift about what "the map is moving on its own" meant.
+    // With the spin gone the map only moves when someone moves it, and the
+    // predicate went with the loop it was arbitrating.
     const onMoveEnd = () => {
       // Our own follow easeTo shouldn't churn the shareable URL every poll.
       if (followMoveRef.current) { followMoveRef.current = false; return; }
-      if (!isAutoSpinning()) scheduleUrlWrite(map);
+      scheduleUrlWrite(map);
     };
     map.on("moveend", onMoveEnd);
     const unsubLayers = layersStore.subscribe(() => scheduleUrlWrite(map));
     const unsubView = mapViewStore.subscribe(() => scheduleUrlWrite(map));
     const unsubOverlay = overlay.subscribe(() => scheduleUrlWrite(map));
 
-    // Calm idle rotation: nudge centre longitude while zoomed out + idle, then SETTLE.
+    // THE CONSOLE GLOBE DOES NOT TURN. There is no rotation loop here, and that is
+    // the point of this comment: it is the third time this has been narrowed and it
+    // should not come back a fourth.
     //
-    // The globe used to turn for as long as the tab was open, and that is the single
-    // most expensive thing this page does at rest: 60.8% of the main thread over a
-    // 10 s idle window on a desktop, ~101% at a 4x CPU throttle, against 3.4% with
-    // the spin neutralised. It cannot be made cheap by slowing it down — 30 fps and
-    // 20 fps caps both measured ~99% — because a moving camera forces a full
-    // MapLibre re-render whatever the update rate. Only not moving is cheaper.
-    // So it turns for a while, eases to a stop, and hands the thread back.
+    // The globe used to turn for as long as the tab was open — the single most
+    // expensive thing this page did at rest: 60.8% of the main thread over a 10 s
+    // idle window on desktop, ~101% at a 4x CPU throttle, against 3.4% with the
+    // rotation neutralised. #156 gated it on hover, #158 made it ease to a stop
+    // after 8 s (lib/map/spin.ts), and both left the expensive part intact: the
+    // first 8 s of every visit, which is exactly the window in which the style,
+    // the sprite, the glyphs and the first tiles are all arriving.
     //
-    // STOPPING MEANS STOPPING. Once settled the loop does not reschedule itself,
-    // rather than rescheduling and returning early. The early-return version is what
-    // both of this app's animation loops already did and it still costs a callback
-    // per compositor frame forever — cheap, but not zero, and it is the difference
-    // between the 3.4% target and something above it.
-    let last = performance.now();
-    const spin = (t: number) => {
-      const dt = Math.min((t - last) / 1000, 0.05);
-      last = t;
-      if (isAutoSpinning()) {
-        const { factor } = spinEnvelope(spinSpentMs);
-        spinSpentMs += dt * 1000;
-        const c = map.getCenter();
-        map.setCenter([c.lng + SPIN_DEG_PER_SEC * dt * factor, c.lat]);
-      }
-      if (spinSettled()) {
-        rafRef.current = 0;
-        return;
-      }
-      rafRef.current = requestAnimationFrame(spin);
-    };
-    // Reduced motion never starts the loop at all, rather than starting it and
-    // declining every frame. If the setting is turned off mid-session the change
-    // handler starts it, so the globe is not dead for the rest of the visit.
-    const startSpin = () => {
-      if (rafRef.current || spinSettled() || prefersLessMotion.matches) return;
-      last = performance.now();
-      rafRef.current = requestAnimationFrame(spin);
-    };
-    const onMotionPreference = () => startSpin();
-    prefersLessMotion.addEventListener("change", onMotionPreference);
-    startSpin();
+    // Slowing it down does not work and nobody should try it a fourth time — 30 fps
+    // measured 99.4% busy and 20 fps 99.6%, because a moving camera re-renders the
+    // whole globe however rarely the centre is updated. Only NOT MOVING is cheaper.
+    // Sam asked for this directly: "can we remove the globe spinning in the
+    // dashboard entirely".
+    //
+    // lib/map/spin.ts STAYS. The landing hero (components/marketing/HeroGlobe.tsx)
+    // is a different globe on a different page and still uses the envelope; this
+    // says nothing about that one.
 
     return () => {
-      cancelAnimationFrame(rafRef.current);
-      prefersLessMotion.removeEventListener("change", onMotionPreference);
       for (const ev of inputs) el.removeEventListener(ev, markInteract);
-      el.removeEventListener("pointermove", holdSpin);
       cancelUrlWrite();
       unsubLayers();
       unsubView();
@@ -2077,8 +2027,6 @@ export default function WorldMap() {
   const flyToRegion = useCallback((target: RegionView) => {
     const map = mapRef.current;
     if (!map) return;
-    // Suppress the idle spin through the fly animation.
-    interactUntilRef.current = performance.now() + 2400;
     const zoom = Math.max(3, Math.min(9, 9.5 - target.altitude * 4));
     map.flyTo({ center: [target.lng, target.lat], zoom, duration: 1600, essential: true });
   }, []);
@@ -2092,7 +2040,6 @@ export default function WorldMap() {
   const flyToPoint = useCallback((target: PointView) => {
     const map = mapRef.current;
     if (!map) return;
-    interactUntilRef.current = performance.now() + 2400; // suppress idle spin through the fly
     const zoom = Math.max(2, Math.min(15, target.zoom ?? 11));
     map.flyTo({ center: [target.lon, target.lat], zoom, duration: 1600, essential: true });
   }, []);
@@ -2131,8 +2078,6 @@ export default function WorldMap() {
     const map = mapRef.current;
     if (!map) { onArrive(); return; }
     const p = computeDive({ lat: view.lat, lon: view.lon });
-    // Suppress the idle spin through the dive (+ a little slack).
-    interactUntilRef.current = performance.now() + p.duration + 600;
     if (!animate) {
       map.jumpTo({ center: p.center, zoom: p.zoom, pitch: p.pitch, bearing: p.bearing });
       onArrive();

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -707,6 +707,60 @@ export default function WorldMap() {
     [],
   );
 
+  // Rasterise the 33 hand-drawn SVG pictograms and register them with the style.
+  const rasteriseIcons = useCallback(
+    (map: maplibregl.Map) =>
+      Promise.all([
+        loadCameraIcons(map),
+        loadPlaneIcons(map),
+        loadSatelliteIcons(map),
+        loadWebcamIcons(map),
+        loadSignalIcons(map),
+      ]).then(() => {}),
+    [],
+  );
+
+  /**
+   * The same work, but off the first style load's critical path.
+   *
+   * WHAT IT IS WORTH, AND WHAT IT IS NOT. Measured against a preview, cold cache,
+   * desktop: `style.load` at 827 ms, the app layers in place at 1376 ms, first idle
+   * at 2590 ms — and the long task inside that first window is 133 ms. Deferring
+   * does NOT make the map ready sooner: first idle is gated by tile arrival, not by
+   * this. What it does is move a 133 ms block of main-thread time out of the window
+   * where the basemap's own tiles are being decoded, which is the window a visitor
+   * is watching.
+   *
+   * ONLY ON THE FIRST STYLE. A basemap swap wipes every registered image while the
+   * sources still hold real data, so there the work is awaited exactly as before —
+   * deferring it would blank every pin on screen for as long as it took.
+   *
+   * `styleimagemissing` IS THE SAFETY, and it is what makes this safe rather than a
+   * gamble on timing. MapLibre fires it the moment a symbol layer wants an icon that
+   * is not registered, so if camera or signal data arrives before the map goes idle,
+   * the rasterisation is pulled forward by the map itself instead of leaving pins
+   * drawn without their pictograms.
+   */
+  const firstStyleRef = useRef(true);
+  const ensureIcons = useCallback(
+    async (map: maplibregl.Map) => {
+      if (!firstStyleRef.current) {
+        await rasteriseIcons(map);
+        return;
+      }
+      firstStyleRef.current = false;
+      let started = false;
+      const run = () => {
+        if (started) return;
+        started = true;
+        void rasteriseIcons(map);
+      };
+      map.once("idle", run);
+      map.once("styleimagemissing", run);
+    },
+    [rasteriseIcons],
+  );
+
   // Re-add every app source/layer onto the current style. Idempotent, so it runs
   // safely on the first load AND after each basemap swap (setStyle wipes them).
   const addAppLayers = useCallback(
@@ -785,14 +839,10 @@ export default function WorldMap() {
         map.setLayoutProperty(STYLE_OWN_BUILDING_3D, "visibility", "none");
       }
 
-      // Symbol icons are wiped by setStyle — re-rasterise/register them.
-      await Promise.all([
-        loadCameraIcons(map),
-        loadPlaneIcons(map),
-        loadSatelliteIcons(map),
-        loadWebcamIcons(map),
-        loadSignalIcons(map),
-      ]);
+      // Symbol icons are wiped by setStyle — re-rasterise/register them. Awaited on
+      // a swap, deferred to the map's first idle on the very first style: see
+      // ensureIcons for why that is safe and what it is measured to be worth.
+      await ensureIcons(map);
 
       // Sources, seeded from the latest refs. NOTHING clusters: every camera and
       // every webcam is its own feature at every zoom (see CAM_DOT_LAYER).
@@ -1273,7 +1323,7 @@ export default function WorldMap() {
       applyVisibility(map, layersRef.current);
       readyRef.current = true;
     },
-    [applyTerrain, applyVisibility, ensureGeoJSON],
+    [applyTerrain, applyVisibility, ensureGeoJSON, ensureIcons],
   );
 
   // Click + cursor handlers, wired ONCE. Layer-scoped handlers survive basemap

--- a/lib/mapView.ts
+++ b/lib/mapView.ts
@@ -62,7 +62,32 @@ export interface MapViewState {
   buildings: boolean;
 }
 
-let state: MapViewState = { basemap: DEFAULT_BASEMAP, terrain: true, buildings: true };
+/**
+ * Both draw-time extras start OFF, and that is the single largest thing this map
+ * stopped paying for at rest.
+ *
+ * They were ON here until 2026-09-05, unpersisted, on every cold load — so every
+ * visitor bought relief shading and a building extrusion whether or not they ever
+ * descended to a zoom where either could be seen. Measured on one scripted z8
+ * zoom-in over London: 4.3 MB of tiles, of which 2.4 MB in 23 requests was
+ * Terrarium DEM from `elevation-tiles-prod.s3.amazonaws.com` — S3 direct, no CDN,
+ * HTTP/1.1, 410–610 ms TTFB per 60 KB tile from the UK, and the browser will only
+ * run six of those at a time. The same gesture on simplifaisoul/osiris, the same
+ * MapLibre 5.24 on the same machine, dropped zero frames against our five (worst
+ * gap 383 ms). It has no DEM source at all.
+ *
+ * WHAT DOES THE WORK IS THE DEFAULT, not the absence of the source. WorldMap still
+ * declares the DEM source and the hillshade layer on every style load, because an
+ * unused source costs nothing: MapLibre marks a SourceCache `used` only when a
+ * visible layer inside its zoom range reads from it (or terrain does), and an
+ * unused cache issues no requests. Creating it lazily on the toggle would have
+ * bought nothing measurable and cost the layer its position — added later it would
+ * append above the camera pins instead of sitting under them.
+ *
+ * The rail toggles (components/console/maprail/ViewFlyout.tsx) are untouched: this
+ * is a change to what an untouched map costs, not to what the map can do.
+ */
+let state: MapViewState = { basemap: DEFAULT_BASEMAP, terrain: false, buildings: false };
 let flyToFn: ((view: RegionView) => void) | null = null;
 let flyToPointFn: ((view: PointView) => void) | null = null;
 let diveToFn: ((view: DiveView, animate: boolean, onArrive: () => void) => void) | null = null;

--- a/lib/terminal/boot.ts
+++ b/lib/terminal/boot.ts
@@ -28,9 +28,30 @@ export const BOOT_MS = 5000;
  *  finished at 4.2 s — measured on desktop, and ~70% of sessions see the boot, so
  *  it was the gate on the first visit rather than the network. Compressing to this
  *  is a VISIBLE change: the sequence still plays in full, at
- *  `timelineScale(BOOT_MIN_MS)` ≈ 0.43 of its designed speed. It is one constant,
- *  and it is a design call — raise it and the animation slows back down. */
-export const BOOT_MIN_MS = 2600;
+ *  `timelineScale(BOOT_MIN_MS)` of its designed speed. It is one constant, and it
+ *  is a design call — raise it and the animation slows back down.
+ *
+ *  2600 → 2000 on 2026-09-05, because at 2600 THE FLOOR WAS STILL THE GATE. Measured
+ *  against two Vercel previews of the same build system, cold cache, desktop, with
+ *  the plate's own clock taken from the frame it first appears on:
+ *
+ *                          map first idle    plate gone    floor binding by
+ *    origin/main                 2201 ms       2639 ms          438 ms
+ *    perf/map-smooth             1938 ms       2602 ms          664 ms
+ *
+ *  Both plates left at BOOT_MIN_MS + the fade, not when the map was ready — so the
+ *  660 ms the terrain, spin and preconnect work had just taken off the map's load
+ *  was being handed straight back to a full-screen overlay. Every millisecond a
+ *  faster map earns is invisible until this number moves with it.
+ *
+ *  WHAT IT COSTS, SAID PLAINLY. The sequence is scaled to fit, so it now plays at
+ *  ≈0.28 of its designed speed rather than ≈0.43, and the six subsystem checks land
+ *  about 67 ms apart instead of 112 ms. It reads as fast. It is one constant and one
+ *  test line to put back, and 2300 is the middle setting (≈0.36, checks ~94 ms
+ *  apart, plate gone ~300 ms earlier than today rather than ~600 ms). The floor only
+ *  binds where the map is ready first: on a slow connection `bootEndMs` still tracks
+ *  the map and the 5 s ceiling is unchanged. */
+export const BOOT_MIN_MS = 2000;
 
 /** The dissolve, taken out of the tail. The handoff starts BOOT_FADE_MS before the
  *  end and the overlay is unmounted at the end exactly. */

--- a/scripts/gesture.mjs
+++ b/scripts/gesture.mjs
@@ -1,0 +1,139 @@
+// Site-agnostic map gesture profiler: how smooth is a MapLibre page under a real
+// wheel-zoom and drag-pan, measured as main-thread frame gaps + long tasks.
+// usage (cwd MUST be the Provenance repo so playwright resolves):
+//   node <this> <url> [--settle=8000] [--shot=path.png] [--out=path.json] [--steps=30] [--label=name]
+import fs from "node:fs";
+import { loadPlaywright } from "./playwright.mjs";
+const { chromium } = await loadPlaywright();
+
+const args = Object.fromEntries(process.argv.slice(3).map((a) => { const m = a.match(/^--([^=]+)(?:=(.*))?$/); return m ? [m[1], m[2] ?? true] : [a, true]; }));
+const url = process.argv[2];
+const settle = Number(args.settle || 8000);
+const steps = Number(args.steps || 30);
+const label = args.label || url;
+const ablate = String(args.ablate || "").split(",").filter(Boolean);
+const first = !!args.first;
+
+const browser = await chromium.launch({ headless: false, args: ["--enable-precise-memory-info"] });
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 });
+const page = await ctx.newPage();
+await page.addInitScript(() => {
+  // Provenance-only seeds: skip the boot plate + tour so gestures reach the canvas. Harmless elsewhere.
+  try {
+    localStorage.setItem("tn.tour.v1", JSON.stringify({ v: 1, d: { seenVersion: 99 } }));
+    localStorage.setItem("tn.terminal.boot.v1", JSON.stringify({ v: 1, d: { seenVersion: 1 } }));
+  } catch {}
+  window.__ft = [];
+  const loop = (t) => { window.__ft.push(t); requestAnimationFrame(loop); };
+  requestAnimationFrame(loop);
+  window.__lt = [];
+  try { new PerformanceObserver((l) => { for (const e of l.getEntries()) window.__lt.push([e.startTime, e.duration]); }).observe({ type: "longtask", buffered: true }); } catch {}
+  window.__mapRenders = 0;
+});
+if (ablate.includes("no-spin")) {
+  // Same trick as scripts/profile-map.mjs: refuse to SCHEDULE WorldMap's spin rAF (it re-arms from its own callback).
+  await page.addInitScript(() => {
+    const raf = window.requestAnimationFrame.bind(window);
+    let fakeId = 1e7; window.__spinBlocked = 0;
+    window.requestAnimationFrame = (cb) => {
+      try { if (typeof cb === "function" && /setCenter\(/.test(Function.prototype.toString.call(cb))) { window.__spinBlocked++; return fakeId++; } } catch {}
+      return raf(cb);
+    };
+  });
+}
+// Deployment Protection, scoped to the ORIGIN UNDER TEST and to nothing else.
+//
+// THE TRAP THIS AVOIDS, measured 2026-09-05. A context-level `extraHTTPHeaders`
+// applies to EVERY request the page makes, cross-origin ones included. A
+// non-simple header forces a CORS preflight, and `tiles.openfreemap.org` answers
+// 405 to ANY OPTIONS (plain GET 200, OPTIONS 405). So the basemap style fails,
+// WorldMap falls back to Satellite, arcgisonline's preflight is refused too, and
+// the map loads NOTHING while the run reports entirely plausible numbers. The tell
+// in a dump is `Image=64/0KB`, zero `.pbf`, and net::ERR_FAILED on the style URL.
+//
+// Supplied by `vercel env run` so it never reaches a command line, a log or a file:
+//   vercel env run --project traffic-nerd-v2 -- node scripts/<this> <preview-url>/app
+const OIDC = process.env.VERCEL_OIDC_TOKEN;
+if (OIDC) {
+  const targetOrigin = new URL(url).origin;
+  await ctx.route(
+    (u) => u.origin === targetOrigin,
+    (route) => route.continue({ headers: { ...route.request().headers(), "x-vercel-trusted-oidc-idp-token": OIDC } }),
+  );
+}
+// Network, including worker-initiated tile fetches (Playwright sees those; page-session CDP does not).
+const reqs = [];
+page.on("requestfinished", async (r) => {
+  try { const s = await r.sizes(); reqs.push({ url: r.url(), t: performance.now(), bytes: s.responseBodySize + s.responseHeadersSize }); } catch {}
+});
+const consoleErrors = [];
+page.on("pageerror", (e) => consoleErrors.push(String(e).slice(0, 160)));
+
+const now = () => page.evaluate(() => performance.now());
+async function phase(name, fn) {
+  const r0 = await page.evaluate(() => ({ renders: window.__mapRenders, reqs: 0 }));
+  const n0 = reqs.length;
+  const t0 = await now();
+  await fn();
+  const t1 = await now();
+  await page.waitForTimeout(900); // inertia / settle tail
+  const t2 = await now();
+  const r1 = await page.evaluate(() => ({ renders: window.__mapRenders }));
+  const data = await page.evaluate(([a, b]) => {
+    const ft = window.__ft.filter((t) => t >= a && t <= b);
+    const gaps = []; for (let i = 1; i < ft.length; i++) gaps.push(ft[i] - ft[i - 1]);
+    gaps.sort((x, y) => x - y);
+    const pct = (p) => gaps.length ? gaps[Math.min(gaps.length - 1, Math.floor(p * gaps.length))] : null;
+    const lt = window.__lt.filter(([s]) => s >= a && s <= b);
+    return { frames: ft.length, gapMean: gaps.length ? gaps.reduce((s, g) => s + g, 0) / gaps.length : null, gapP95: pct(0.95), gapMax: gaps.length ? gaps[gaps.length - 1] : null, dropped: gaps.filter((g) => g > 50).length, longTasks: lt.length, longTaskMs: lt.reduce((s, [, d]) => s + d, 0) };
+  }, [t0, t2]);
+  const bytes = reqs.slice(n0).reduce((s, r) => s + r.bytes, 0);
+  const kinds = {};
+  for (const r of reqs.slice(n0)) {
+    const k = /elevation-tiles|terrarium/.test(r.url) ? "dem" : /natural_earth/.test(r.url) ? "relief" : /\/planet\/\d+\/|\/vector\/|\.mvt|\.pbf(\?|$)/.test(r.url) && !/fonts/.test(r.url) ? "vector" : /fonts\/|glyph/.test(r.url) ? "glyph" : /sprite/.test(r.url) ? "sprite" : /arcgisonline|cartocdn\.com\/(dark|light)_all|opentopomap/.test(r.url) ? "raster" : /\/api\//.test(r.url) ? "api" : "other";
+    kinds[k] = kinds[k] || { n: 0, kb: 0 }; kinds[k].n++; kinds[k].kb += r.bytes / 1024;
+  }
+  const byKind = Object.entries(kinds).map(([k, v]) => `${k}=${v.n}/${Math.round(v.kb)}KB`).join(" ");
+  const tileReqs = reqs.slice(n0).filter((r) => /\.pbf|\.png|\.jpg|\.webp|proxy-tiles|\/planet\/|tile/i.test(r.url)).length;
+  results.push({ name, gestureMs: Math.round(t1 - t0), windowMs: Math.round(t2 - t0), ...data, renders: r1.renders - r0.renders, requests: reqs.length - n0, tileReqs, kb: Math.round(bytes / 1024), zoom: await zoomOf(), byKind });
+}
+
+const zoomOf = () => page.evaluate(() => window.__map?.getZoom?.()?.toFixed(2) ?? null);
+
+const wall0 = performance.now();
+await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+await page.waitForSelector("canvas.maplibregl-canvas", { timeout: 60000 });
+await page.waitForFunction(() => !document.querySelector(".tnx-boot"), { timeout: 30000 }).catch(() => {});
+await page.evaluate(() => { const m = window.__map; if (m?.on) m.on("render", () => window.__mapRenders++); });
+if (ablate.includes("terrain-off")) await page.evaluate(() => window.__worldmap?.setTerrain(false));
+if (ablate.includes("buildings-off")) await page.evaluate(() => { const m = window.__map; const hide = () => { try { if (m.getLayer("tn-buildings-3d")) m.setLayoutProperty("tn-buildings-3d", "visibility", "none"); } catch {} }; hide(); m.on("style.load", hide); });
+const results = [];
+if (first) await phase("first-10s", async () => { await page.waitForTimeout(10000); });
+await page.waitForTimeout(settle);
+if (args.shot) await page.screenshot({ path: String(args.shot) });
+
+const box = await page.locator("canvas.maplibregl-canvas").first().boundingBox();
+const cx = Math.round(box.x + box.width / 2), cy = Math.round(box.y + box.height / 2);
+await page.mouse.move(cx, cy);
+await page.waitForTimeout(300);
+
+await phase("zoom-in", async () => {
+  for (let i = 0; i < steps; i++) { await page.mouse.move(cx + (i % 3) - 1, cy + ((i * 7) % 3) - 1); await page.mouse.wheel(0, -100); await page.waitForTimeout(45); }
+});
+await phase("pan", async () => {
+  await page.mouse.down();
+  for (let i = 0; i < 40; i++) { await page.mouse.move(cx + i * 6, cy + Math.round(Math.sin(i / 6) * 40)); await page.waitForTimeout(30); }
+  await page.mouse.up();
+});
+await phase("zoom-out", async () => {
+  for (let i = 0; i < steps; i++) { await page.mouse.move(cx + (i % 3) - 1, cy + ((i * 5) % 3) - 1); await page.mouse.wheel(0, 100); await page.waitForTimeout(45); }
+});
+await phase("rest", async () => { await page.waitForTimeout(2500); });
+
+const heap = await page.evaluate(() => performance.memory ? Math.round(performance.memory.usedJSHeapSize / 1048576) : null);
+const out = { label, url, settle, steps, ablate, results, heapMB: heap, consoleErrors: consoleErrors.slice(0, 5), totalRequests: reqs.length, totalKB: Math.round(reqs.reduce((s, r) => s + r.bytes, 0) / 1024) };
+if (args.out) fs.writeFileSync(String(args.out), JSON.stringify(out, null, 1));
+console.log(`\n=== ${label}  (settle ${settle} ms, ${steps} wheel steps)  heap ${heap} MB  requests ${reqs.length} / ${out.totalKB} KB  errors ${consoleErrors.length}`);
+console.log("phase      gesture  frames  gap mean  p95    max   >50ms  longtasks(ms)  renders  reqs(tiles)  KB    zoom");
+for (const r of results) console.log(`${r.name.padEnd(10)} ${String(r.gestureMs).padStart(6)}  ${String(r.frames).padStart(6)}  ${r.gapMean?.toFixed(1).padStart(7)}  ${r.gapP95?.toFixed(0).padStart(4)}  ${r.gapMax?.toFixed(0).padStart(5)}  ${String(r.dropped).padStart(5)}  ${String(r.longTasks).padStart(3)} (${String(Math.round(r.longTaskMs)).padStart(5)})  ${String(r.renders).padStart(7)}  ${String(r.requests).padStart(4)} (${String(r.tileReqs).padStart(3)})  ${String(r.kb).padStart(5)}  ${r.zoom ?? "-"}   ${r.byKind}`);
+await browser.close();

--- a/scripts/idleprof.mjs
+++ b/scripts/idleprof.mjs
@@ -15,16 +15,31 @@ const args = Object.fromEntries(process.argv.slice(3).map((a) => { const m = a.m
 const url = process.argv[2];
 const settle = Number(args.settle || 5000), win = Number(args.window || 10000), cpu = Number(args.cpu || 1);
 
-// Scoped to the target's own origin so the token cannot ride along to a third party
-// if the page fetches one.
 const oidc = process.env.VERCEL_OIDC_TOKEN;
-const auth = oidc ? { extraHTTPHeaders: { "x-vercel-trusted-oidc-idp-token": oidc } } : {};
 
 const browser = await chromium.launch({ headless: false });
-const ctx = await browser.newContext({
-  ...(args.mobile ? { ...devices["Pixel 7"] } : { viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 }),
-  ...auth,
-});
+const ctx = await browser.newContext(
+  args.mobile ? { ...devices["Pixel 7"] } : { viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 },
+);
+
+// SCOPED TO THE TARGET ORIGIN, and it has to be. This said "scoped" while passing
+// the token as a context-level `extraHTTPHeaders`, which is not the same thing and
+// is not harmless: those headers go on EVERY request the page makes, cross-origin
+// included, a non-simple header forces a CORS preflight, and
+// `tiles.openfreemap.org` answers 405 to ANY OPTIONS (plain GET 200, OPTIONS 405).
+// The style request fails, WorldMap falls back to Satellite, arcgisonline's
+// preflight is refused too, and the map loads NOTHING — while the run reports
+// entirely plausible idle numbers, because a page with no map really is quiet.
+// Every preview measurement taken through this script before 2026-09-05 was of a
+// dead map: "/app 9.0% busy, ZERO map renders" is what that looks like. The tell in
+// a dump is `Image=64/0KB`, no `.pbf` at all, and net::ERR_FAILED on the style URL.
+if (oidc) {
+  const targetOrigin = new URL(url).origin;
+  await ctx.route(
+    (u) => u.origin === targetOrigin,
+    (route) => route.continue({ headers: { ...route.request().headers(), "x-vercel-trusted-oidc-idp-token": oidc } }),
+  );
+}
 const page = await ctx.newPage();
 if (args["reduced-motion"]) await page.emulateMedia({ reducedMotion: "reduce" });
 await page.addInitScript(() => {

--- a/scripts/waterfall.mjs
+++ b/scripts/waterfall.mjs
@@ -1,0 +1,77 @@
+// Load waterfall that INCLUDES worker-initiated fetches (MapLibre pulls vector tiles
+// inside its worker; a page-session CDP Network capture never sees them).
+// usage (cwd = Provenance repo): node <this> <url> [--wait=15000] [--cpu=1] [--net=slow4g] [--out=x.json]
+import fs from "node:fs";
+import { loadPlaywright } from "./playwright.mjs";
+const { chromium } = await loadPlaywright();
+const args = Object.fromEntries(process.argv.slice(3).map((a) => { const m = a.match(/^--([^=]+)(?:=(.*))?$/); return m ? [m[1], m[2] ?? true] : [a, true]; }));
+const url = process.argv[2];
+const waitMs = Number(args.wait || 15000), cpu = Number(args.cpu || 1);
+const NET = { slow4g: { downloadThroughput: (1.6 * 1024 * 1024) / 8, uploadThroughput: (750 * 1024) / 8, latency: 150 } };
+
+const browser = await chromium.launch({ headless: false });
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 });
+const page = await ctx.newPage();
+await page.addInitScript(() => {
+  window.__marks = {};
+  const t0 = performance.now(); const seen = {};
+  const iv = setInterval(() => {
+    const t = Math.round(performance.now());
+    if (!seen.canvas && document.querySelector("canvas.maplibregl-canvas")) { seen.canvas = 1; window.__marks.mapCanvas = t; }
+    if (!seen.veil && document.querySelector(".tnx-boot")) { seen.veil = 1; window.__marks.veilSeen = t; }
+    if (seen.veil && !seen.veilGone && !document.querySelector(".tnx-boot")) { seen.veilGone = 1; window.__marks.veilGone = t; }
+    if (!seen.map && window.__map?.once) { seen.map = 1; window.__marks.mapHandle = t;
+      window.__map.once("load", () => { window.__marks.mapLoad = Math.round(performance.now()); });
+      window.__map.once("idle", () => { window.__marks.mapFirstIdle = Math.round(performance.now()); });
+      window.__map.once("style.load", () => { window.__marks.styleLoad = Math.round(performance.now()); });
+      window.__marks.sourcedata = []; window.__map.on("sourcedata", (e) => { if (e.isSourceLoaded && e.sourceId) window.__marks.sourcedata.push([Math.round(performance.now()), e.sourceId]); });
+    }
+    if (t - t0 > 60000) clearInterval(iv);
+  }, 8);
+});
+// Deployment Protection, scoped to the ORIGIN UNDER TEST and to nothing else.
+//
+// THE TRAP THIS AVOIDS, measured 2026-09-05. A context-level `extraHTTPHeaders`
+// applies to EVERY request the page makes, cross-origin ones included. A
+// non-simple header forces a CORS preflight, and `tiles.openfreemap.org` answers
+// 405 to ANY OPTIONS (plain GET 200, OPTIONS 405). So the basemap style fails,
+// WorldMap falls back to Satellite, arcgisonline's preflight is refused too, and
+// the map loads NOTHING while the run reports entirely plausible numbers. The tell
+// in a dump is `Image=64/0KB`, zero `.pbf`, and net::ERR_FAILED on the style URL.
+//
+// Supplied by `vercel env run` so it never reaches a command line, a log or a file:
+//   vercel env run --project traffic-nerd-v2 -- node scripts/<this> <preview-url>/app
+const OIDC = process.env.VERCEL_OIDC_TOKEN;
+if (OIDC) {
+  const targetOrigin = new URL(url).origin;
+  await ctx.route(
+    (u) => u.origin === targetOrigin,
+    (route) => route.continue({ headers: { ...route.request().headers(), "x-vercel-trusted-oidc-idp-token": OIDC } }),
+  );
+}
+const cdp = await ctx.newCDPSession(page);
+if (cpu > 1) await cdp.send("Emulation.setCPUThrottlingRate", { rate: cpu });
+if (NET[args.net]) { await cdp.send("Network.enable"); await cdp.send("Network.emulateNetworkConditions", { offline: false, ...NET[args.net] }); }
+
+let nav0 = 0;
+const rows = new Map();
+page.on("request", (r) => { const t = Date.now(); if (!nav0) nav0 = t; rows.set(r, { url: r.url(), type: r.resourceType(), start: t - nav0, worker: !!r.serviceWorker() ? "sw" : (r.frame() ? "" : "worker") }); });
+page.on("requestfinished", async (r) => { const row = rows.get(r); if (!row) return; row.end = Date.now() - nav0; try { const s = await r.sizes(); row.kb = (s.responseBodySize + s.responseHeadersSize) / 1024; const resp = await r.response(); row.status = resp?.status(); row.cache = resp?.headers()["x-vercel-cache"] || resp?.headers()["cf-cache-status"] || resp?.headers()["x-cache"] || ""; } catch {} });
+page.on("requestfailed", (r) => { const row = rows.get(r); if (row) { row.end = Date.now() - nav0; row.failed = r.failure()?.errorText; } });
+
+await page.goto(url, { waitUntil: "commit" });
+await page.waitForTimeout(waitMs);
+const marks = await page.evaluate(() => window.__marks);
+await browser.close();
+
+const list = [...rows.values()].filter((r) => !r.url.startsWith("data:")).sort((a, b) => a.start - b.start);
+const short = (u) => u.replace("https://provenance-online.vercel.app", "").replace("https://tiles.openfreemap.org", "OFM").replace("https://osirisai.live", "").replace(/\?dpl=[^&]+/, "").replace(/url=https%3A%2F%2F/, "url=").slice(0, 100);
+const { sourcedata, ...m } = marks;
+console.log(`=== ${url} cpu=${cpu} net=${args.net || "none"}\nmarks ${JSON.stringify(m)}`);
+console.log("sources loaded: " + (sourcedata || []).map(([t, id]) => `${id}@${t}`).join(" "));
+console.log(" start    end    KB  type      who     url");
+for (const r of list) console.log(`${String(r.start).padStart(6)} ${String(r.end ?? "-").padStart(6)} ${String(Math.round(r.kb ?? 0)).padStart(5)}  ${(r.type || "").padEnd(9)} ${(r.worker || "page").padEnd(7)} ${r.failed ? "FAIL " : ""}${r.status && r.status !== 200 ? r.status + " " : ""}${r.cache ? "[" + r.cache + "] " : ""}${short(r.url)}`);
+const kinds = {};
+for (const r of list) { const k = /\/planet\/\d+\/|\/vector\//.test(r.url) ? "vector-tile" : /fonts\/|\.pbf/.test(r.url) ? "glyph" : /sprite/.test(r.url) ? "sprite" : /styles\/|style\.json/.test(r.url) ? "style" : /\/api\//.test(r.url) ? "api" : r.type; kinds[k] = kinds[k] || { n: 0, kb: 0, last: 0 }; kinds[k].n++; kinds[k].kb += r.kb || 0; kinds[k].last = Math.max(kinds[k].last, r.end || 0); }
+console.log("by kind: " + Object.entries(kinds).map(([k, v]) => `${k}=${v.n}/${Math.round(v.kb)}KB(last ${v.last})`).join("  "));
+if (args.out) fs.writeFileSync(String(args.out), JSON.stringify({ url, marks, list }, null, 1));

--- a/tests/unit/map-first-paint.test.ts
+++ b/tests/unit/map-first-paint.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { BASEMAPS, DEFAULT_BASEMAP } from "@/lib/basemaps";
+import { mapViewStore } from "@/lib/mapView";
+
+/**
+ * What the console map costs before the visitor has asked for anything.
+ *
+ * THE COMPARISON THIS FILE COMES FROM. Measured 2026-09-05 against
+ * simplifaisoul/osiris, which runs the SAME MapLibre 5.24 on the same machine and
+ * drops zero frames on the same scripted zoom gesture while this map dropped five,
+ * worst gap 383 ms. It does not win by being lighter overall — it parses a 7.9 MB
+ * camera JSON at load and its canvas appears LATER than ours on throttled mobile.
+ * It wins on what it declines to do at rest: no terrain, no hillshade, no DEM
+ * source, no opening rotation, and buildings only once the user turns them on.
+ *
+ * Of the 4.3 MB of tiles this map fetched during one z8 zoom-in, 2.4 MB in 23
+ * requests was Terrarium DEM from `elevation-tiles-prod.s3.amazonaws.com` — S3
+ * direct, no CDN, HTTP/1.1, 410–610 ms TTFB per 60 KB tile from the UK, browser-
+ * queued six at a time. None of it was asked for.
+ *
+ * These are the parts of that decision that survive in a node environment. The
+ * frame numbers themselves cannot be asserted here (vitest has no DOM and no GPU),
+ * so they are re-measured against a deployment; what is pinned here is the shape
+ * that made them: the defaults, the absence of the rotation loop, and the fact that
+ * the basemap warm-up is DERIVED from the registry rather than typed out again.
+ */
+
+const src = (rel: string) => readFileSync(resolve(__dirname, "../..", rel), "utf8");
+
+describe("the map opens cheap", () => {
+  it("starts with terrain and 3D buildings OFF", () => {
+    // Both were ON, unpersisted, on every cold load — so every visitor paid for
+    // relief shading and an extrusion layer whether or not they ever descended to a
+    // zoom where either is visible. The rail toggles stay; only the default moves.
+    const view = mapViewStore.get();
+    expect(view.terrain).toBe(false);
+    expect(view.buildings).toBe(false);
+  });
+});
+
+describe("the console globe does not rotate on its own", () => {
+  const world = src("components/WorldMap.tsx");
+
+  /**
+   * Sam's own words, from the channel log: "can we remove the globe spinning in the
+   * dashboard entirely". PR #158 shipped a compromise instead — the spin settles
+   * after 8 s — and that still re-renders the whole globe every frame for those 8 s,
+   * which is exactly the window in which the first tiles are arriving and the main
+   * thread is least able to afford it.
+   *
+   * A source read, because the decision cannot be reached any other way from here:
+   * vitest runs in the node environment in this repo, so WorldMap cannot be mounted
+   * and a rotation loop cannot be observed. The spin ENVELOPE keeps its own unit
+   * test (tests/unit/spin.test.ts) — lib/map/spin.ts is still the landing hero's,
+   * and this says nothing about that globe.
+   */
+  it("does not import the spin envelope", () => {
+    // The IMPORT, not the string. WorldMap's own comment names lib/map/spin.ts to
+    // say the landing hero still owns it, and a bare substring match on the path
+    // failed on that sentence the first time this ran.
+    expect(world).not.toMatch(/^import[^\n]*lib\/map\/spin/m);
+  });
+
+  it("has no rotation loop and no rate to run it at", () => {
+    expect(world).not.toMatch(/SPIN_DEG_PER_SEC|SPIN_MAX_ZOOM|IDLE_RESUME_MS/);
+    expect(world).not.toMatch(/requestAnimationFrame\(spin\)/);
+  });
+});
+
+describe("the basemap warm-up", () => {
+  const layout = src("app/(console)/layout.tsx");
+
+  /**
+   * The basemap chain used to start after hydration AND after the dynamic import of
+   * WorldMap resolved: canvas at 0.67 s, style at 1.0 s, TileJSON + sprite + glyphs
+   * after that, first tiles at 2.3 s. `preconnect` + `preload` in the console
+   * layout start it with the HTML instead.
+   *
+   * DERIVED, NOT TYPED. DEFAULT_BASEMAP is `streets` (OpenFreeMap Liberty), not the
+   * positron everyone assumes, and the skin↔basemap sync in ConsoleShell only ever
+   * swaps between `dark` and `positron` — so it does not fire on a first load and
+   * `streets` really is the first style fetched. A hand-typed URL here would warm
+   * the wrong style the day that constant moves, and nothing would fail: the preload
+   * would simply go unused and the real style would be fetched late, exactly as it
+   * is today.
+   */
+  it("reads the URL to warm out of the basemap registry", () => {
+    expect(layout).toMatch(/DEFAULT_BASEMAP/);
+    expect(layout).not.toMatch(/https:\/\/tiles\./);
+  });
+
+  it("the default basemap is a style URL a browser can be told to fetch", () => {
+    // The raster entries (`satellite`, `topo`) carry an inline StyleSpecification
+    // rather than a URL, and there is nothing to preload for those. This is what
+    // makes the layout's `typeof style === "string"` guard a real branch.
+    expect(typeof BASEMAPS[DEFAULT_BASEMAP].style).toBe("string");
+  });
+});

--- a/tests/unit/terminal-boot.test.ts
+++ b/tests/unit/terminal-boot.test.ts
@@ -35,7 +35,11 @@ const TOTALS = [BOOT_MIN_MS, 3200, 4000, BOOT_MS];
 describe("boot timeline", () => {
   it("runs between the floor and the ceiling", () => {
     expect(BOOT_MS).toBe(5000);
-    expect(BOOT_MIN_MS).toBe(2600);
+    // 2600 until 2026-09-05, when the floor was measured to be the gate: the map
+    // was first idle 1938 ms into the plate and the plate held to 2602 ms. Moving
+    // it is a design call, so it is pinned rather than left free — see the comment
+    // on the constant for what the compression costs and what 2300 would buy.
+    expect(BOOT_MIN_MS).toBe(2000);
     expect(BOOT_MIN_MS).toBeLessThan(BOOT_MS);
     expect(BOOT_FADE_MS + BOOT_READY_HOLD_MS).toBeLessThan(BOOT_MIN_MS);
     expect(BOOT_REDUCED_MS).toBeLessThan(1000);


### PR DESCRIPTION
Four changes from the 2026-09-05 comparison against `simplifaisoul/osiris` — the same
MapLibre 5.24 on the same machine, which drops zero frames on the scripted gesture that
still costs us six on main.

**#159 landed the fifth one while this was being measured.** That PR removed the console
globe's rotation independently, with the same reasoning and the same deletions, and it is
now on main. This branch has been merged onto it: the spin removal is main's, its guard
test `console-globe-still.test.ts` is main's and passes against this branch's WorldMap, and
the two spin assertions this branch had were dropped rather than left as a second guard
over one fact. `scripts/idleprof.mjs` is main's version too — #159 made the same
origin-scoping fix.

**Visual review, before/after shots, and the two open decisions:**
https://claude.ai/code/artifact/e4576501-7206-46a1-852f-00fa475c6e67

## Measured against main AS IT IS NOW, i.e. with #159 already in

Preview against preview, same build system, same machine, same hour, headed Chromium
(headless falls back to SwiftShader and invents long tasks). One scripted wheel-zoom into
London, a drag-pan, a wheel-zoom back out to the globe.

| phase | | main (5ba61ed) | this branch |
|---|---|---|---|
| zoom-in | dropped frames | 6 | **3** |
| | worst gap | 517 ms | **233 ms** |
| | long tasks | 1,114 ms | **337 ms** |
| | gap p95 | 25 ms | **9 ms** |
| | DEM fetched | 32 req / 1,697 KB | **none** |
| pan | worst gap | 58 ms | **66 ms** |
| zoom-out | dropped frames | 3 | **0** |
| | worst gap | 183 ms | **50 ms** |
| | long tasks | 284 ms | **0 ms** |
| heap after the gesture | | 90 MB | **54 MB** |

Run-to-run variance is real and single-digit frame counts are approximate — a colder tile
cache moves them by one or two. The DEM row does not move: it is zero by construction.

Load, cold cache, desktop, measured from the frame the canvas appears (against f977f8b,
before #159 — the spin does not touch these):

| | before | after |
|---|---|---|
| style document loaded | 335 ms | **31 ms** |
| map first idle | 2,091 ms | **1,840 ms** |
| boot plate on screen | 2,659 ms | **2,153 ms** |
| what ended the plate | the 2600 ms floor | **the map** |

## What is in this PR

1. **Terrain and 3D buildings default off.** Both were on, unpersisted, on every cold load.
   Of the 4.3 MB one z8 zoom-in fetched, 2.4 MB across 23 requests was Terrarium DEM from
   `elevation-tiles-prod.s3.amazonaws.com` — S3 direct, no CDN, HTTP/1.1, 410–610 ms TTFB
   per 60 KB tile from the UK, six at a time. The rail toggles are untouched.
   The DEM source is still declared: an unused source costs nothing (MapLibre marks a
   SourceCache `used` only when a visible layer in its zoom range reads from it), and
   creating it lazily would have cost the hillshade its position — added later it appends
   above the camera pins instead of under them. `terrainRef`/`buildingsRef` are now seeded
   from the store rather than from a second copy of the default, because `addAppLayers`
   reads them on `style.load`, which can land before the effects that sync them.
2. **The basemap chain starts with the HTML.** A console layout that preconnects to the
   tile host and preloads the style document, derived from `DEFAULT_BASEMAP` — which is
   `streets`/Liberty, not the `positron` the surrounding code keeps calling the default.
3. **`BOOT_MIN_MS` 2600 → 2000.** The plate was leaving at its floor, not at map-ready, so
   the time the other changes saved was handed straight back to a full-screen overlay.
   **This is a visible design call**: the sequence scales to fit, so it plays at ~0.28 of
   its designed speed rather than ~0.43 and the six checks land ~67 ms apart instead of
   ~112 ms. One constant and one test line put it back; 2300 is the middle setting. The
   5 s ceiling and slow-connection behaviour are unchanged.
4. **Icon rasterisation off the first style's path.** 33 SVG pictograms deferred to the
   map's first idle, on the first style only — a basemap swap still awaits them or every
   pin on screen would blank. `styleimagemissing` is the safety: if data arrives before
   idle, MapLibre pulls the work forward itself. Worth 133 ms of main-thread time moved
   out of the tile-decode window; it does not make the map ready sooner, because first
   idle is gated by tile arrival.

## The trade to look at

At the default globe view nothing changes — hillshade has been gated to z6+ since #158.
Zoomed into mountains it does: relief shading is gone until terrain is toggled on in the
rail. Both shots are in the artifact.

## Also in here

- `scripts/waterfall.mjs` and `scripts/gesture.mjs` — the instruments that produced every
  number above, previously loose in a temp folder. A page-session CDP capture never sees
  MapLibre's vector-tile fetches, because the worker issues them; these use Playwright
  request events and take origin-scoped Deployment-Protection auth.
- **Not fixed here:** `playwright.preview.config.ts` still passes the protection token as
  context-level `extraHTTPHeaders`, which CORS-preflights `tiles.openfreemap.org` (405 to
  any OPTIONS) and silently kills the basemap, so a run reports plausible numbers for a
  page with no map. It cannot be origin-scoped from a config; the fix is a shared fixture
  plus an import change in all nine e2e specs, which is its own piece of work.

Gate on the merged tree: `npx tsc --noEmit` clean, 308 files / 2,895 unit tests pass,
including #159's guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195zJYBGAnYMfRWRbCGffcN
