### PR TITLE
Say what adsb.lol actually does in the aviation widget's help text, and stop crediting the removed OpenSky snapshot

### DIFF
--- a/lib/console/help.ts
+++ b/lib/console/help.ts
@@ -127,15 +127,15 @@ const WIDGET_EXPLAINERS: WidgetExplainer[] = [
     whatItShows:
       "A row is an aircraft that was broadcasting an ADS-B position in the last snapshot, with its callsign, a guessed type and its reported altitude in kilometres.",
     method:
-      "Read from OpenSky's single global /states/all snapshot, which aircraft transponders feed. Altitude and squawk are the aircraft's own reported values, and squawks 7500/7600/7700 raise a critical alert. The TYPE is not broadcast and not looked up — it is our own guess from altitude, speed and on-ground state, which is why the dossier renders it as \"· est.\".",
+      "Read from adsb.lol, a community ADS-B receiver network reached as a bounded grid sweep of point+radius queries rather than one global snapshot. Altitude and squawk are the aircraft's own reported values, and squawks 7500/7600/7700 raise a critical alert. The TYPE is not broadcast and not looked up — it is our own guess from altitude, speed and on-ground state, which is why the dossier renders it as \"· est.\".",
     confidence: "measured",
     coverage:
-      "Worldwide by construction — one global snapshot rather than a swept grid — but only where volunteer receivers hear the aircraft. Good over Europe and North America, thin over oceans, deserts and much of Africa and Asia.",
+      "NOT worldwide by construction — a bounded grid sweep of point+radius queries over the busiest airspace, capped by adsb.lol's rate limit to whichever cells answer inside the time budget, and only where volunteer receivers hear the aircraft. Dense over North America and Europe, thin to empty over oceans, deserts and much of Africa, Asia, South America and Oceania.",
     limitations: [
       "Gaps are receiver coverage, not empty sky. An aircraft with no receiver in range does not exist in this feed, and there is no way to tell that case from an aircraft that is not flying.",
       "Aircraft that do not want to be seen switch the transponder off or broadcast a false identity, so the flights most worth watching are the ones most likely to be missing.",
-      "There is NO military flag on this panel. The alert rule supports one, but OpenSky carries no military classification, so that alert can never fire here — military traffic appears only on the separate Military aircraft signal layer.",
-      "OpenSky's anonymous tier is credit-capped, so one snapshot is shared across the whole deployment and refreshed roughly every four minutes. Rows are minutes old by design, and on a bad day the panel serves the last good snapshot rather than nothing.",
+      "There is NO military flag on this panel. The alert rule supports one, but adsb.lol carries no military classification, so that alert can never fire here — military traffic appears only on the separate Military aircraft signal layer.",
+      "adsb.lol rate-limits the sweep, so one snapshot is cached and shared across the whole deployment and refreshed roughly every four minutes. Rows are minutes old by design, and on a bad day the panel serves the last good snapshot rather than nothing.",
       "The list is capped at 200 rows out of everything airborne, sorted by altitude or callsign. It is a slice, never a census.",
       "No origin, destination, registration or operator is carried here; the aircraft dossier fetches those separately when you open one.",
     ],

--- a/lib/console/widgets/aviation.tsx
+++ b/lib/console/widgets/aviation.tsx
@@ -100,7 +100,7 @@ export const AVIATION_WIDGET = {
   // now says where military traffic actually lives.
   help: {
     what: "Aircraft airborne right now, from open ADS-B, listed by altitude. An emergency squawk (7500/7600/7700) raises a critical alert; military traffic is its own signal layer, not this one.",
-    source: "OpenSky Network global snapshot (keyless ADS-B)",
+    source: "adsb.lol community ADS-B receiver sweep (keyless)",
   },
   capabilities: { filter: true, sort: true },
 };

--- a/tests/unit/honest-strings.test.ts
+++ b/tests/unit/honest-strings.test.ts
@@ -9,6 +9,14 @@
 //                                 competitor's (already fixed pre-existing; guarded here)
 //   4. lib/events/alerting.ts   — outbound webhook source line carries OUR
 //                                 brand, not the competitor's (already fixed pre-existing; guarded here)
+//   5. lib/console/widgets/aviation.tsx + lib/console/help.ts — the aviation
+//                                 widget's own help popover and trust card still
+//                                 credited "OpenSky" (a single global snapshot, an
+//                                 anonymous credit cap) two places after #1 fixed
+//                                 the short catalog attribution string. Same root
+//                                 cause, later found: OpenSky was removed from the
+//                                 live fetch path entirely (lib/sources/opensky.ts),
+//                                 adsb.lol's bounded grid sweep is the sole source.
 import { afterEach, expect, test } from "vitest";
 import { getCatalogSource } from "@/lib/sources/catalog";
 import {
@@ -23,6 +31,8 @@ import { readCoverage } from "@/lib/signals/coverage";
 import { exportFilename } from "@/lib/export";
 import { postWebhook, type AlertHit } from "@/lib/events/alerting";
 import { BRAND } from "@/lib/brand";
+import { AVIATION_WIDGET } from "@/lib/console/widgets/aviation";
+import { widgetExplainerFor } from "@/lib/console/help";
 
 const realFetch = globalThis.fetch;
 afterEach(() => {
@@ -44,6 +54,39 @@ test("the planes catalog entry credits adsb.lol, its real current source", () =>
   expect(planes).toBeDefined();
   expect(planes!.attribution.toLowerCase()).toContain("adsb.lol");
   expect(planes!.attribution).not.toContain("OpenSky");
+});
+
+// --- 1b. aviation widget help + trust card: same fix, two places found later ---
+//
+// #1 above fixed the short catalog attribution string. Two more places credited
+// the same removed feed: the aviation widget's own "?" popover source line, and
+// three sentences in its trust card describing OpenSky-specific mechanism (a
+// single global /states/all snapshot, an anonymous credit cap) that do not
+// describe how adsb.lol's bounded grid sweep actually works. Guard both so
+// neither can drift back to naming the removed feed.
+
+test("the aviation widget's help.source credits adsb.lol, not OpenSky", () => {
+  const source = AVIATION_WIDGET.help?.source ?? "";
+  expect(source.toLowerCase()).toContain("adsb.lol");
+  expect(source).not.toContain("OpenSky");
+});
+
+test("the aviation trust card describes adsb.lol's real mechanism, not OpenSky's", () => {
+  const e = widgetExplainerFor("aviation");
+  expect(e).toBeDefined();
+  const text = [e!.method, e!.coverage, ...e!.limitations].join(" ");
+  expect(text).not.toContain("OpenSky");
+  expect(text.toLowerCase()).toContain("adsb.lol");
+  // The false "single global snapshot" claim must not survive as a description
+  // of how data is currently gathered — it's a bounded grid sweep instead.
+  expect(e!.method).toMatch(/grid sweep/i);
+  expect(e!.coverage).toMatch(/grid sweep/i);
+  // The false "OpenSky anonymous credit cap" reason for the shared cadence must
+  // not survive; the real constraint is adsb.lol's own rate limit.
+  expect(e!.limitations.join(" ")).toMatch(/adsb\.lol rate-limits/i);
+  // These structural facts are unchanged by the fix and must still hold.
+  expect(e!.limitations.join(" ")).toMatch(/no military flag/i);
+  expect(e!.limitations.join(" ")).toMatch(/refreshed roughly every four minutes/i);
 });
 
 // --- 2. windy.ts: undisclosed cap --------------------------------------------


### PR DESCRIPTION
Two places kept crediting a feed that was removed months ago — and one of them wasn't a naming error, it was describing a mechanism that no longer exists.

## Pensábamos
That only two more spots needed the same swap #143 already made — replace "OpenSky" with "adsb.lol" in `lib/console/widgets/aviation.tsx:103` and three sentences in `lib/console/help.ts`, same as before.

## Medimos
- `grep -n "OpenSky" lib/console/widgets/aviation.tsx lib/console/help.ts` confirmed the exact lines.
- Read `lib/sources/adsb.ts`, `lib/sources/opensky.ts` and `app/api/planes/route.ts` in full to get the real mechanism, rather than assuming a word-swap would be honest: adsb.lol is reached as a **bounded grid sweep** (`SWEEP_CELLS`, 250 nm point+radius queries — no keyless global endpoint exists), paced against adsb.lol's own measured rate limit (a sweep typically completes 9-11 of ~38 planned cells inside a 14s budget). `REVALIDATE_S = 240` (4 min) is real and unchanged — its *comment* used to say this number came from OpenSky's anonymous credit cap; that reason is gone, the cadence itself isn't.

## Resultó
Two of the three flagged sentences only needed the provider's name swapped — the structural fact underneath ("no military flag", "refreshed roughly every four minutes") stayed true for adsb.lol too. The third ("Read from OpenSky's single global /states/all snapshot...") was describing a mechanism that is flatly false for a swept grid, and a plain find-replace would have produced a new, confident-sounding lie instead of fixing the old one.

**Scope note:** the same help-card object's `coverage` field (not in the original 3-sentence list) said *"Worldwide by construction — one global snapshot rather than a swept grid"* — the exact opposite of reality, and it would have directly contradicted the rewritten `method` sentence three lines above it in the same object. Fixed it too rather than ship a self-contradicting trust card; happy to split it out if you'd rather review it separately.

## Cambiamos
- `lib/console/widgets/aviation.tsx:103` — `help.source` now says `"adsb.lol community ADS-B receiver sweep (keyless)"`, matching the plain-mechanism-phrase convention every other widget's `help.source` already uses (checked `satellites.tsx`, `recon.tsx`, `headlines.tsx`) rather than reusing `ADSB_ATTRIBUTION` verbatim, which is a copyright-style string built for the catalog's legal-attribution UI, not this field.
- `lib/console/help.ts` — the aviation trust card's `method` and `coverage` rewritten to the real grid-sweep mechanism; both `limitations` sentences keep their structural claim, provider name swapped.
- `tests/unit/honest-strings.test.ts` — added a "1b" section, same pattern as #143's existing test: asserts `AVIATION_WIDGET.help.source` and the trust card both name adsb.lol and never OpenSky, that the false "single snapshot" framing is gone (`/grid sweep/i` in both `method` and `coverage`), that the real constraint is named (`/adsb\.lol rate-limits/i`), and that the two unchanged structural facts survived the edit.

## Todavía no sabemos
- `help.ts`'s TYPE sentence ("not broadcast and not looked up") is itself now partly inaccurate — `lib/planes/classify.ts` shows adsb.lol *does* broadcast a real ADS-B emitter category that `classifyPlane` prefers over the altitude/speed guess when present. Left untouched here (different sentence, different root cause, would be mixing two observations in one PR) — flagged as a follow-up.
- A few code comments in `aviation.tsx` (not user-visible strings) still talk about `opensky.ts` as if it's on the live path. Same reasoning — not touched here.
- `CLAUDE.md`'s own "Live-source notes" section (dated 2026-08-10) still says *"Aircraft come from OpenSky, not adsb.lol"* and describes `/api/planes` as returning `{count:0}` in prod — both are the same underlying drift this PR and #143 have been chasing, just in your doc instead of the app. Not edited (standing rule: never touch `CLAUDE.md`) — your call.

## Verification
- `npx tsc --noEmit`: clean.
- Full suite: **306 test files / 2,885 tests, all green** — re-run independently, not just trusted from the fix pass.
- Rebased onto `main` @ `09257a6` (#163 landed mid-review; confirmed it doesn't touch any file this PR changes).
- No UI layout changed, only help-popover copy + a test file — no new screenshots needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
