### PR TITLE
Say TYPE is sometimes broadcast, not always guessed, and retire the last opensky.ts comments in aviation.tsx

### DIFF
--- a/lib/console/help.ts
+++ b/lib/console/help.ts
@@ -127,7 +127,7 @@ const WIDGET_EXPLAINERS: WidgetExplainer[] = [
     whatItShows:
       "A row is an aircraft that was broadcasting an ADS-B position in the last snapshot, with its callsign, a guessed type and its reported altitude in kilometres.",
     method:
-      "Read from adsb.lol, a community ADS-B receiver network reached as a bounded grid sweep of point+radius queries rather than one global snapshot. Altitude and squawk are the aircraft's own reported values, and squawks 7500/7600/7700 raise a critical alert. The TYPE is not broadcast and not looked up — it is our own guess from altitude, speed and on-ground state, which is why the dossier renders it as \"· est.\".",
+      "Read from adsb.lol, a community ADS-B receiver network reached as a bounded grid sweep of point+radius queries rather than one global snapshot. Altitude and squawk are the aircraft's own reported values, and squawks 7500/7600/7700 raise a critical alert. TYPE is adsb.lol's own broadcast ADS-B emitter category when the aircraft transmits one we recognise — a transmitted fact, not a guess. Only when no usable category is present does it fall back to our own guess from altitude, speed and on-ground state; either way the dossier renders it with a \"· est.\" badge.",
     confidence: "measured",
     coverage:
       "NOT worldwide by construction — a bounded grid sweep of point+radius queries over the busiest airspace, capped by adsb.lol's rate limit to whichever cells answer inside the time budget, and only where volunteer receivers hear the aircraft. Dense over North America and Europe, thin to empty over oceans, deserts and much of Africa, Asia, South America and Oceania.",

--- a/lib/console/widgets/aviation.tsx
+++ b/lib/console/widgets/aviation.tsx
@@ -16,12 +16,17 @@ import AviationDetail from "./aviation.detail";
  * Field-mapping notes (real usePlanes() shape vs brief's assumed fields):
  * - usePlanes() returns PlanesLayer { objects: WorldObject[], trails: PlaneTrail[] }
  *   → we use .objects (not the top-level array the brief assumed).
- * - WorldObject.label  → callsign (opensky.ts sets label = callsign ?? icao24)
+ * - WorldObject.label  → callsign (lib/sources/adsb.ts sets label = the row's own
+ *   `flight` callsign, falling back to its `hex` ICAO24 address when there is no
+ *   callsign; opensky.ts's own version of this mapping is retained only as the
+ *   shared type-shape contract — see that module's docblock — it is not live)
  * - WorldObject.altKm  → altitude in km (NOT feet; brief used p.altitude)
  * - WorldObject.typeLabel → human type ("Airliner", "Regional / jet", etc.)
- * - squawk            — opensky.ts parseStates() captures the raw squawk code and
- *   planeToWorldObject() carries it on meta.squawk, so the emergency-squawk
- *   alerts are LIVE: a plane squawking 7500/7600/7700 raises a critical alert.
+ * - squawk            — lib/sources/adsb.ts reads the row's own `squawk` field
+ *   directly and carries it on meta.squawk (opensky.ts's parseStates()/
+ *   planeToWorldObject() defined this meta shape originally and are kept only as
+ *   that contract, not as a live path), so the emergency-squawk alerts are LIVE:
+ *   a plane squawking 7500/7600/7700 raises a critical alert.
  * - NO isMilitary     — classifyPlane() has no military category; military traffic
  *   comes from the separate military-air signal layer, not this civil feed.
  * - NO origin/destination — not present in the WorldObject schema (the dossier
@@ -55,8 +60,17 @@ function AviationBody({ config }: WidgetBodyProps) {
     return r.slice(0, 200);
   }, [planes, sortKey]);
 
-  // OpenSky is a 12s cadence, so a frozen feed shows drift within seconds of it
-  // happening — the case the old hardcoded "live" hid completely.
+  // The freshness chip's expected cadence for "planes" is 12s — this widget's own
+  // POLL_INTERVAL_MS in lib/planes/usePlanes.ts, mirrored in lib/freshness.ts's
+  // seed() and lib/sources/catalog.ts's "planes" entry. That is NOT an upstream
+  // cadence, and it is not OpenSky's — opensky.ts no longer contacts OpenSky at
+  // all; the sole source is adsb.lol's grid sweep (lib/sources/adsb.ts). It also
+  // only catches a poll that stops SUCCEEDING (e.g. /api/planes starts erroring),
+  // within ~24-72s of that happening. It does NOT catch a poll that keeps
+  // returning 200 with an unchanged snapshot: the sweep is cached for the whole
+  // deployment and revalidated at most every REVALIDATE_S=240s (4 min, see
+  // opensky.ts), so up to ~4 minutes of real staleness can hide behind an
+  // unbroken "live" chip.
   const fresh = useFreshness().find((r) => r.id === "planes");
 
   const report = useWidgetReport();
@@ -95,9 +109,11 @@ export const AVIATION_WIDGET = {
   component: AviationBody,
   detail: AviationDetail,
   // NOTE: this used to promise "military types … are flagged". It never happened —
-  // the PlaneLite mapping above sets no isMilitary because OpenSky carries no
-  // military classification, so that alert can't fire on this widget. The ? note
-  // now says where military traffic actually lives.
+  // the PlaneLite mapping above sets no isMilitary because this general planes feed
+  // (adsb.lol's grid sweep via lib/sources/adsb.ts, formerly OpenSky) carries no
+  // military classification either way; military traffic is a separate adsb.lol
+  // feed (lib/signals/military-air.ts), not this one. The ? note now says where
+  // military traffic actually lives.
   help: {
     what: "Aircraft airborne right now, from open ADS-B, listed by altitude. An emergency squawk (7500/7600/7700) raises a critical alert; military traffic is its own signal layer, not this one.",
     source: "adsb.lol community ADS-B receiver sweep (keyless)",

--- a/tests/unit/honest-strings.test.ts
+++ b/tests/unit/honest-strings.test.ts
@@ -17,6 +17,13 @@
 //                                 cause, later found: OpenSky was removed from the
 //                                 live fetch path entirely (lib/sources/opensky.ts),
 //                                 adsb.lol's bounded grid sweep is the sole source.
+//   6. lib/console/help.ts's aviation TYPE sentence claimed TYPE is "not broadcast
+//                                 and not looked up" — true for OpenSky (no category
+//                                 field at all) but not for adsb.lol, which broadcasts
+//                                 a real ADS-B emitter `category` that lib/planes/
+//                                 classify.ts trusts as a fact when present, only
+//                                 falling back to the altitude/speed/on-ground guess
+//                                 when it is absent or unrecognised.
 import { afterEach, expect, test } from "vitest";
 import { getCatalogSource } from "@/lib/sources/catalog";
 import {
@@ -87,6 +94,24 @@ test("the aviation trust card describes adsb.lol's real mechanism, not OpenSky's
   // These structural facts are unchanged by the fix and must still hold.
   expect(e!.limitations.join(" ")).toMatch(/no military flag/i);
   expect(e!.limitations.join(" ")).toMatch(/refreshed roughly every four minutes/i);
+});
+
+// --- 6. aviation trust card: TYPE is sometimes broadcast, not always guessed ---
+//
+// The TYPE sentence used to say TYPE is "not broadcast and not looked up" —
+// unconditionally a guess. That was true of OpenSky (no category field at all)
+// but is not true of adsb.lol: lib/planes/classify.ts trusts a broadcast ADS-B
+// emitter `category` as a fact when the row carries one it recognises, and only
+// falls back to the altitude/speed/on-ground heuristic otherwise. The sentence
+// must state both paths, not just the fallback.
+
+test("the aviation trust card's TYPE sentence states both the broadcast path and the guess fallback", () => {
+  const e = widgetExplainerFor("aviation");
+  expect(e).toBeDefined();
+  const method = e!.method;
+  expect(method).toMatch(/broadcast/i);
+  expect(method).not.toMatch(/type is not broadcast/i);
+  expect(method).toMatch(/guess/i);
 });
 
 // --- 2. windy.ts: undisclosed cap --------------------------------------------


### PR DESCRIPTION
The two leftovers #164 explicitly flagged as follow-ups ("Todavía no sabemos"), closed together since they're the same root cause (opensky.ts naming/mechanism drift, one PR's worth left over from the OpenSky→adsb.lol switch).

## Pensábamos
That the TYPE sentence just needed the same word-swap #164 already did elsewhere, and that the four `aviation.tsx` comments naming `opensky.ts` were stale but otherwise harmless.

## Medimos
- `lib/planes/classify.ts`'s own doc comment: "PREFERRED: the ADS-B emitter category (adsb.lol's `category`... an actual broadcast field, not a guess. FALLBACK: when no category is present we infer..." — confirmed against `classifyPlane()` and `ADSB_CATEGORY`.
- `lib/sources/adsb.ts`'s `adsbRowToWorldObject`: passes the row's own `category` into `classifyPlane`, and its own docblock states "CLASSIFICATION IS BETTER HERE... a transmitted fact, not a guess."
- Checked whether the dossier's `"· est."` badge (`components/PlaneDetail.tsx:246`) actually distinguishes the two paths — it does not. It renders whenever `object.typeLabel` is set, which is unconditional (every adsb.lol row gets a `PlaneCategory` → `PLANE_META[category].label`). So the *badge itself* doesn't currently tell broadcast from guessed. That's a real, separate finding — logged in `bitacora.md` as a new queue row rather than fixed here (different root cause, would be a second implementation in the same PR).
- For the four comments: `lib/sources/opensky.ts`'s own docblock ("RETAINED, NOT DEAD") confirms `parseStates`/`planeToWorldObject` are a type-shape contract only, not live. `lib/sources/catalog.ts`'s `"planes"` entry has `refreshMs: 12_000`; `opensky.ts`'s `REVALIDATE_S = 240`. Traced where `12_000` actually applies: `lib/planes/usePlanes.ts`'s `POLL_INTERVAL_MS`, and confirmed via `components/WorldMap.tsx:572` that `freshnessStore.record("planes", ...)` fires on every successful client poll regardless of whether the underlying cached snapshot changed — so the freshness chip's "live" state tracks "is `/api/planes` still responding," not "is the data itself fresh." The two cadences (12s client poll vs. 240s server cache) are genuinely different things, and the old comment's "OpenSky is a 12s cadence" conflated them under the wrong provider's name.
- Military: `lib/signals/military-air.ts` hits a separate adsb.lol endpoint for the unfiltered military set — the general planes feed never carried a military field, on either provider.

## Resultó
The TYPE sentence needed both paths stated, not a swap: broadcast category first (a transmitted fact) with the altitude/speed/on-ground guess as the fallback only. All four comments were correctable without touching behavior — none was describing a UI bug, just a stale narrator.

## Cambiamos
- `lib/console/help.ts` — aviation trust card's `method` TYPE sentence now states the broadcast path and the guess fallback, keeping the (accurate, unconditional) note that the `"· est."` badge renders either way.
- `lib/console/widgets/aviation.tsx` — four comments rewritten to name `lib/sources/adsb.ts` and the real cadences instead of `opensky.ts`/OpenSky:
  - label mapping (flight/hex, not "callsign ?? icao24")
  - squawk mapping (adsb.ts's own field, opensky.ts kept only as the meta-shape contract)
  - the freshness-cadence comment (12s client poll vs. 240s server cache — two different numbers, neither is upstream OpenSky)
  - the "no isMilitary" note (general feed has no military field on adsb.lol either, not an OpenSky-specific gap)
- `tests/unit/honest-strings.test.ts` — new "#6" test asserting the TYPE sentence mentions "broadcast" and drops the unconditional "not broadcast" claim, alongside the existing #5 coverage for the same trust card.

## Todavía no sabemos
- The `"· est."` badge in `components/PlaneDetail.tsx` doesn't distinguish broadcast-category planes from guessed ones — logged as a new queue item, not fixed here.
- `CLAUDE.md`'s "Live-source notes" section is still dated 2026-08-10 and says "Aircraft come from OpenSky, not adsb.lol" — same standing note as #164, not touched (your call, per the standing rule).

## Verification
- `npx tsc --noEmit`: clean.
- Full suite: 307 test files / 2,894 tests, all green.
- No UI layout changed — only trust-card copy and code comments, no new screenshots needed (same call as #164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)