### PR TITLE
Settings: three tabs down a left rail, not a strip across the top

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2365,17 +2365,55 @@ a { color: var(--tn-accent); }
 
 /* ── Settings drawer ──────────────────────────────────────────────────────── */
 .tn-settings-scrim { position: fixed; inset: 0; z-index: 60; background: rgba(15, 23, 42, .28); backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px); display: flex; justify-content: flex-end; animation: tn-fade-in .15s ease; }
-.tn-settings { width: min(384px, 92vw); height: 100%; background: var(--tn-surface-solid); border-left: 1px solid var(--tn-border); box-shadow: var(--tn-shadow); display: flex; flex-direction: column; animation: tn-slide-in .2s ease; }
+/* FOUR CELLS, TWO COLUMNS. Reading order down the DOM is railhead, head, rail, body, which
+   is also the grid order, so nothing needs `order` and the tab sequence is the visual one.
+   536px, AND THE NUMBER IS ADDITION RATHER THAN TASTE: 150 rail + 1 divider + 385 panel,
+   where 385 less the body's 2×18 padding is the 349px measure the single 384px column
+   always had. Measured, not assumed — the first cut of this was 520px, which quietly cost
+   the panel 15px and would have made every field, hint and key-cap row narrower than
+   before the rail existed. The rail has to be paid for in drawer width, not out of the
+   content.
+   `auto 1fr` on the rows is what keeps the divider straight — the head row is as tall as
+   the taller of its two cells, so the rail's title and the panel's ✕ cannot drift apart. */
+.tn-settings {
+  --tn-settings-rail-w: 150px;
+  width: min(536px, 92vw); height: 100%;
+  background: var(--tn-surface-solid); border-left: 1px solid var(--tn-border);
+  box-shadow: var(--tn-shadow);
+  display: grid;
+  grid-template-columns: var(--tn-settings-rail-w) 1fr;
+  grid-template-rows: auto 1fr;
+  animation: tn-slide-in .2s ease;
+}
 @keyframes tn-fade-in { from { opacity: 0; } to { opacity: 1; } }
 @keyframes tn-slide-in { from { transform: translateX(28px); opacity: .5; } to { transform: translateX(0); opacity: 1; } }
 /* Every other animated panel in this sheet has one of these (:445, :651, :700, :780,
    :5500). The settings drawer was the exception and simply slid in regardless. */
 @media (prefers-reduced-motion: reduce) { .tn-settings-scrim, .tn-settings { animation: none; } }
-.tn-settings-head { display: flex; align-items: center; justify-content: space-between; padding: 15px 18px; border-bottom: 1px solid var(--tn-border); flex: none; }
+/* The head row. Both cells carry the same bottom border so it crosses the drawer as one
+   line, and the rail's half carries the vertical one so the divider turns a corner rather
+   than starting halfway down. */
+.tn-settings-railhead {
+  grid-column: 1; grid-row: 1;
+  display: flex; align-items: center; padding: 15px 16px;
+  background: var(--tn-surface-2);
+  border-right: 1px solid var(--tn-border); border-bottom: 1px solid var(--tn-border);
+}
+.tn-settings-head {
+  grid-column: 2; grid-row: 1;
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 15px 18px; border-bottom: 1px solid var(--tn-border);
+}
 .tn-settings-title { margin: 0; font-size: 16px; font-weight: 700; color: var(--tn-text); }
-.tn-settings-close { font: inherit; font-size: 14px; color: var(--tn-text-muted); background: var(--tn-chip-bg); border: 1px solid var(--tn-border); border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+/* One line, and it must stay one line: the header row sets the divider's height for the
+   whole drawer, so a blurb that wrapped would move the rail's first tab down with it. */
+.tn-settings-blurb { margin: 0; min-width: 0; font-size: 12.5px; color: var(--tn-text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tn-settings-close { font: inherit; font-size: 14px; color: var(--tn-text-muted); background: var(--tn-chip-bg); border: 1px solid var(--tn-border); border-radius: 8px; width: 30px; height: 30px; flex: none; cursor: pointer; }
 .tn-settings-close:hover { color: var(--tn-text); }
-.tn-settings-body { padding: 6px 18px 24px; overflow-y: auto; display: flex; flex-direction: column; gap: 18px; }
+/* min-height/min-width: 0 — a grid item's automatic minimum is its content, which would
+   let the long Main tab push the drawer's own scrollbar onto the page instead of scrolling
+   here, and would let the api.telegram.org line in the Telegram hint widen the column. */
+.tn-settings-body { grid-column: 2; grid-row: 2; min-height: 0; min-width: 0; padding: 6px 18px 24px; overflow-y: auto; display: flex; flex-direction: column; gap: 18px; }
 .tn-settings-sec { display: flex; flex-direction: column; gap: 10px; }
 .tn-settings-sec-title { margin: 12px 0 0; font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--tn-text-faint); }
 .tn-settings-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
@@ -2390,23 +2428,47 @@ a { color: var(--tn-accent); }
 .tn-settings-seg { display: inline-flex; gap: 2px; background: var(--tn-chip-bg); border-radius: 9px; padding: 2px; }
 .tn-settings-seg-btn { font: inherit; font-size: 12.5px; font-weight: 600; color: var(--tn-text-muted); background: transparent; border: 0; border-radius: 7px; padding: 6px 12px; cursor: pointer; }
 .tn-settings-seg-btn[aria-pressed="true"] { background: var(--tn-surface-solid); color: var(--tn-accent); box-shadow: var(--tn-shadow-sm); }
-/* The three tabs. A segmented pill rather than an underline strip, because it is the same
-   shape as the Language segment three rules up and reuses its selected treatment
-   (--tn-surface-solid lifted on --tn-shadow-sm), so the strip reads as the same family as
-   the control it now sits above.
-   `flex: 1` on the buttons, not intrinsic width: the drawer is min(384px, 92vw), so at
-   360px the strip divides ~330px three ways and cannot overflow.
-   aria-selected, NOT aria-pressed — these switch the panel below, which is the distinction
-   TerminalHeader.tsx:279 draws in the other direction for the board tabs. Styling off the
-   ARIA attribute also means there is no .is-active class that can drift out of sync.
-   `flex: none` is load-bearing: .tn-settings is a flex column, so without it the strip
-   shrinks as the body grows. */
-.tn-settings-tabs { display: flex; gap: 2px; flex: none; margin: 12px 18px 0; padding: 2px; background: var(--tn-chip-bg); border-radius: 10px; }
-.tn-settings-tab { flex: 1 1 0; min-width: 0; font: inherit; font-size: 12.5px; font-weight: 600; color: var(--tn-text-muted); background: transparent; border: 0; border-radius: 8px; padding: 7px 6px; cursor: pointer; white-space: nowrap; }
-.tn-settings-tab:hover { color: var(--tn-text); }
+/* THE RAIL. The second neutral layer product UI gives a sidebar: --tn-surface-2 against
+   the panel's --tn-surface-solid, so the two columns separate on tone and the 1px divider
+   only has to confirm it.
+   `--tn-settings-axis` IS PUBLISHED FOR JAVASCRIPT. SettingsPanel's useRailAxis reads this
+   property back off the element to set aria-orientation, so the breakpoint below is the
+   only place the rail's direction is decided. Do not mirror it into the component.
+   overflow-y on three items looks like paranoia and is not: the rail is a grid row of
+   1fr, and this is what stops a future fourth and fifth tab from pushing the drawer.
+   min-height: 0 for the same reason .tn-settings-body has it. */
+.tn-settings-rail {
+  --tn-settings-axis: vertical;
+  grid-column: 1; grid-row: 2; min-height: 0;
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 10px 8px; overflow-y: auto;
+  background: var(--tn-surface-2); border-right: 1px solid var(--tn-border);
+}
+/* A NAV ROW, NOT A SEGMENT. Left-aligned and full-width, because a centred label in a
+   column reads as a button and the point of the move was that these are three places.
+   The SELECTED TREATMENT IS CARRIED OVER UNCHANGED from the strip this replaced — a
+   --tn-surface-solid plate lifted on --tn-shadow-sm with accent text, the same pairing
+   .tn-settings-seg-btn uses — so the drawer's vocabulary survived the relayout even though
+   its axis did not. The plate is the panel's own colour, which is the quiet part of the
+   idea: the selected row is a piece of the panel sitting in the rail.
+   aria-selected, NOT aria-pressed — these switch the panel beside them, which is the
+   distinction TerminalHeader.tsx:279 draws in the other direction for the board tabs.
+   Styling off the ARIA attribute also means there is no .is-active class that can drift. */
+.tn-settings-tab {
+  width: 100%; min-width: 0; text-align: left;
+  font: inherit; font-size: 13px; font-weight: 600;
+  color: var(--tn-text-muted); background: transparent; border: 0; border-radius: 8px;
+  padding: 9px 12px; cursor: pointer;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  transition: background-color .14s ease, color .14s ease;
+}
+/* --tn-hover is only defined inside the skin scope, so it carries the same literal
+   fallback every other consumer of it in this file does (:900, :946, :1017). */
+.tn-settings-tab:hover { color: var(--tn-text); background: var(--tn-hover, #f1f5f9); }
 .tn-settings-tab[aria-selected="true"] { background: var(--tn-surface-solid); color: var(--tn-accent); box-shadow: var(--tn-shadow-sm); }
-/* Inset, on both: a 2px ring drawn outside the strip would sit on the drawer's edge, and
-   on the body it would paint over the border-left of the drawer itself. */
+@media (prefers-reduced-motion: reduce) { .tn-settings-tab { transition: none; } }
+/* Inset, on both: a 2px ring drawn outside a rail row would sit on the divider, and on the
+   body it would paint over the border-left of the drawer itself. */
 .tn-settings-tab:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: -2px; }
 .tn-settings-body:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: -2px; }
 /* Rebindable shortcuts. A chip is a KEY CAP, not a button that happens to hold text:
@@ -2469,6 +2531,40 @@ a { color: var(--tn-accent); }
 .tn-settings-notify-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 4px 0; }
 .tn-settings-notify-name { font-size: 13px; color: var(--tn-text); }
 .tn-settings-notify-chs { font-size: 11px; color: var(--tn-text-faint); white-space: nowrap; }
+
+/* THE RAIL FOLDS BACK INTO A STRIP, and 540px is derived, not chosen for roundness. Below
+   the 536px cap the drawer is 92vw, so the panel is (0.92 × viewport) − 151 − 36. A
+   full-width credential input and a label-plus-key-cap row stop being comfortable at about
+   300px of measure, and 540 is where that lands: 540 × 0.92 = 497, panel 310. Under it the
+   column costs more than it gives, so it lies down.
+   THIS IS A RE-ADDRESSING, NOT A REBUILD. Every cell keeps its DOM position and simply
+   takes a new grid slot: the title cell and the ✕ cell come back together as the one-line
+   header the drawer has always had, the rail spans both columns as a strip, and the panel
+   spans both underneath. `--tn-settings-axis` flips with it, which is the whole reason
+   SettingsPanel reads the property rather than repeating 520 in TypeScript. */
+@media (max-width: 540px) {
+  .tn-settings { grid-template-columns: 1fr auto; grid-template-rows: auto auto 1fr; }
+  /* The tint goes with the column. Keeping --tn-surface-2 here once the rail has lain
+     down leaves the title cell shaded and the ✕ cell white, which reads as a header that
+     failed to paint rather than as two cells — it is one bar at this width, so it is one
+     colour. The rail keeps the tint, because down here the tint is what makes the strip
+     a band instead of three loose buttons. */
+  .tn-settings-railhead { grid-column: 1; grid-row: 1; background: transparent; border-right: 0; padding-right: 0; }
+  .tn-settings-head { grid-column: 2; grid-row: 1; }
+  /* The blurb is the first thing to go: at this width the tab it describes is a strip
+     button two centimetres away, and the ✕ needs the room more than the sentence does. */
+  .tn-settings-blurb { display: none; }
+  .tn-settings-rail {
+    --tn-settings-axis: horizontal;
+    grid-column: 1 / -1; grid-row: 2;
+    flex-direction: row; padding: 8px 12px;
+    overflow-x: auto; overflow-y: hidden;
+    border-right: 0; border-bottom: 1px solid var(--tn-border);
+  }
+  /* Back to dividing the width three ways, which is what the strip always did. */
+  .tn-settings-tab { flex: 1 1 0; width: auto; text-align: center; }
+  .tn-settings-body { grid-column: 1 / -1; grid-row: 3; }
+}
 
 /* ── Floated map-view controls (top-right of the centre stage) ────────────── */
 /* ── Cinematic world clock (ambient ribbon over the map, top-centre) ──────── */
@@ -2961,9 +3057,10 @@ a.tn-w-place { display: flex; align-items: center; }
   /* ---- (a) lists and pills: 44px for real -------------------------------- */
   .tn-ev-row, .tn-evd-rowbtn, a.tn-w-place, .tn-ev-group-h, .tn-anom-row,
   .tn-ev-tab, .tn-ev-hidden, .tn-mapsearch-item, .tn-rail-fab, .tn-cw-shell > .tn-rail-fab,
-  /* The settings tabs, which is where the drawer is 92vw and the strip is the first
-     thing a thumb reaches. Width is fine at 360px — three labels are ~180px of ink in
-     ~330px — so only the height needs the bump. */
+  /* The settings tabs, which is where the drawer is 92vw and the rail is the first
+     thing a thumb reaches. Height is the only axis that needs the bump in either
+     orientation: as a column the row is already full-width, and below 520px the rail
+     folds to a strip that divides ~330px three ways, which three labels clear. */
   .tn-settings-tab {
     min-height: 44px;
   }
@@ -4841,6 +4938,17 @@ body:has(.tn-terminal) { background: #d6dde6; color: #10161d; }
 .tn-terminal ::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.14); }
 .tn-terminal .sc::-webkit-scrollbar-thumb:hover,
 .tn-terminal ::-webkit-scrollbar-thumb:hover { background: rgba(255, 176, 32, 0.5); }
+
+/* THE SETTINGS DRAWER OPTS BACK OUT, and it has to be here rather than beside the drawer's
+   own rules: the selector above is `.tn-terminal ::-webkit-scrollbar-thumb`, which is the
+   same specificity as anything scoped to .tn-settings, so only source order can win.
+   The literals above are a dark-skin leftover — white at 14% — and the drawer is the one
+   scroller in the shell painted on white, so its thumb has been invisible since the light
+   fold. Tokens, not literals, so it follows both palettes. The rail gets it too: three
+   tabs never overflow, but the rule is on the drawer so a fourth cannot reintroduce this. */
+.tn-settings { scrollbar-color: var(--tn-border-strong) transparent; }
+.tn-settings ::-webkit-scrollbar-thumb { background: var(--tn-border-strong); }
+.tn-settings ::-webkit-scrollbar-thumb:hover { background: var(--tn-text-faint); }
 
 /* ════════════════════════════════════════════════════════════════════════════
    6. RESPONSIVE

--- a/app/globals.css
+++ b/app/globals.css
@@ -2368,11 +2368,13 @@ a { color: var(--tn-accent); }
 /* FOUR CELLS, TWO COLUMNS. Reading order down the DOM is railhead, head, rail, body, which
    is also the grid order, so nothing needs `order` and the tab sequence is the visual one.
    536px, AND THE NUMBER IS ADDITION RATHER THAN TASTE: 150 rail + 1 divider + 385 panel,
-   where 385 less the body's 2×18 padding is the 349px measure the single 384px column
-   always had. Measured, not assumed — the first cut of this was 520px, which quietly cost
-   the panel 15px and would have made every field, hint and key-cap row narrower than
-   before the rail existed. The rail has to be paid for in drawer width, not out of the
-   content.
+   and 385 less the body's 2×18 padding leaves 349px of measure against the 347px the
+   single 384px column actually had. Both figures were read out of a live browser rather
+   than derived, which is the only reason they are trustworthy: the arithmetic says the old
+   one was 348 and it was not, because the drawer's own border-left takes a pixel first.
+   The first cut of this was 520px, which measured 333 and would have made every field,
+   hint and key-cap row narrower than before the rail existed. The rail is paid for in
+   drawer width, never out of the content.
    `auto 1fr` on the rows is what keeps the divider straight — the head row is as tall as
    the taller of its two cells, so the rail's title and the panel's ✕ cannot drift apart. */
 .tn-settings {

--- a/components/shell/SettingsPanel.tsx
+++ b/components/shell/SettingsPanel.tsx
@@ -1,5 +1,21 @@
 "use client";
-// The Settings slide-over (opened from the top-right gear), in three tabs.
+// The Settings slide-over (opened from the top-right gear), in three tabs down a left rail.
+//
+// THE RAIL IS A COLUMN OF THE DRAWER, NOT A STRIP INSIDE IT. Main / Display / Shortcuts
+// shipped as a segmented pill across the top, which is the right shape for two or three
+// peers you flick between and the wrong one for a nav: it read as a filter over one page
+// rather than as three places, and it spent the drawer's scarcest axis — width — on
+// something a column gives away for free. The drawer grew 384px → 536px to pay for the
+// rail out of its own width rather than out of the panel's: the measured panel measure is
+// 349px against the old 348px, so not one field, hint or key-cap row got tighter.
+//
+// THE FOUR CELLS ARE A GRID, AND THE REASON IS ALIGNMENT. The rail's title cell and the
+// panel's header sit side by side with a divider between them; as a flex row they would
+// need a shared magic height, and the first time one of them grew the divider would step.
+// As `grid-template-rows: auto 1fr` the header row is simply as tall as the taller of the
+// two, so they cannot disagree. It also buys the responsive layout outright: below 520px
+// the same four cells re-address to a title+✕ row, a horizontal strip, then the panel,
+// with no element moving in the DOM and the title never leaving the rail.
 //
 // It was one scroll of six unrelated sections, which put the two things people actually
 // open it for — rebinding a key, switching board — underneath a wall of integration
@@ -25,11 +41,43 @@ import MainTab from "./settings/MainTab";
 import DisplayTab from "./settings/DisplayTab";
 import ShortcutsTab from "./settings/ShortcutsTab";
 
+/**
+ * Which way the rail is actually running, read back off the rail itself.
+ *
+ * `aria-orientation` has to match what a sighted user sees, and what they see flips at a
+ * CSS breakpoint this component cannot see. Writing `520` into a matchMedia here would put
+ * the number in two files and guarantee that one day only one of them moves. So the rail
+ * publishes its own axis as `--tn-settings-axis` — set once on the rule, overridden once in
+ * the @media block — and this reads it back. The stylesheet stays the single source of
+ * truth, and a future change to the breakpoint needs no edit here at all.
+ *
+ * Vertical is the assumed answer before the first measurement so that server output and
+ * the first client paint agree; the effect then corrects it if the drawer opened narrow.
+ */
+function useRailAxis(ref: React.RefObject<HTMLElement | null>, open: boolean) {
+  const [axis, setAxis] = useState<"vertical" | "horizontal">("vertical");
+  useEffect(() => {
+    if (!open) return;
+    const read = () => {
+      const el = ref.current;
+      if (!el) return;
+      const v = getComputedStyle(el).getPropertyValue("--tn-settings-axis").trim();
+      setAxis(v === "horizontal" ? "horizontal" : "vertical");
+    };
+    read();
+    window.addEventListener("resize", read);
+    return () => window.removeEventListener("resize", read);
+  }, [ref, open]);
+  return axis;
+}
+
 export default function SettingsPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [tab, setTab] = useState<SettingsTabId>(SETTINGS_TABS[0].id);
   const bodyRef = useRef<HTMLDivElement | null>(null);
-  const stripRef = useRef<HTMLDivElement | null>(null);
+  const railRef = useRef<HTMLDivElement | null>(null);
   const restoreRef = useRef<HTMLElement | null>(null);
+  const axis = useRailAxis(railRef, open);
+  const active = SETTINGS_TABS.find((t) => t.id === tab) ?? SETTINGS_TABS[0];
 
   // ALWAYS OPENS ON THE FIRST TAB, AND THIS EFFECT IS WHY IT HAS TO BE EXPLICIT.
   // TerminalHeader mounts this component unconditionally and only passes `open` — the
@@ -50,7 +98,7 @@ export default function SettingsPanel({ open, onClose }: { open: boolean; onClos
     if (!open) return;
     restoreRef.current = document.activeElement as HTMLElement | null;
     const t = window.setTimeout(() => {
-      stripRef.current?.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="true"]')?.focus();
+      railRef.current?.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="true"]')?.focus();
     }, 0);
     return () => {
       window.clearTimeout(t);
@@ -75,14 +123,15 @@ export default function SettingsPanel({ open, onClose }: { open: boolean; onClos
     if (bodyRef.current) bodyRef.current.scrollTop = 0;
   };
 
-  // ARROW KEYS BELONG TO THE STRIP, AND ONLY THE STRIP.
+  // ARROW KEYS BELONG TO THE RAIL, AND ONLY THE RAIL.
   //
   // Do not be tempted to move this onto `window` alongside the Escape effect above. It
   // would appear to work — an armed shortcut chip stops propagation and React would block
   // it at the root — but it would equally fire for ← pressed inside the Telegram bot-token
   // field or the Discord webhook field, hijacking the caret. That is exactly the bug class
-  // ConsoleShell's text-field guard exists for, and a tab strip has no business
-  // re-litigating it.
+  // ConsoleShell's text-field guard exists for, and a tablist has no business re-litigating
+  // it. It is also why nextTabId can afford to answer to ←/→ as well as ↑/↓: scoped here,
+  // neither axis can reach a caret.
   //
   // Automatic activation (the arrow moves focus AND selection) is right here: switching is
   // instant and local, so the alternative — arrow to move, Enter to commit — would just be
@@ -92,11 +141,11 @@ export default function SettingsPanel({ open, onClose }: { open: boolean; onClos
     if (!next) return; // not ours: let Tab and Escape through untouched
     // Captured synchronously — React nulls currentTarget once the handler returns, and the
     // focus() below runs after setTab.
-    const strip = e.currentTarget;
+    const rail = e.currentTarget;
     e.preventDefault();
     select(next);
     const i = SETTINGS_TABS.findIndex((t) => t.id === next);
-    strip.querySelectorAll<HTMLButtonElement>('[role="tab"]')[i]?.focus();
+    rail.querySelectorAll<HTMLButtonElement>('[role="tab"]')[i]?.focus();
   };
 
   return (
@@ -106,13 +155,26 @@ export default function SettingsPanel({ open, onClose }: { open: boolean; onClos
           shell shortcuts while someone is typing in here. */}
       <aside className="tn-settings" role="dialog" aria-modal="true" aria-label="Settings"
         onClick={(e) => e.stopPropagation()}>
-        <header className="tn-settings-head">
+        {/* Cell 1 — the rail's own head. The drawer's title belongs to the rail's column,
+            which is what makes the rail read as a sidebar rather than as a control that
+            happens to be tall. */}
+        <div className="tn-settings-railhead">
           <h2 className="tn-settings-title">Settings</h2>
+        </div>
+
+        {/* Cell 2 — the panel's head. It holds the ✕ and the blurb for the tab in view.
+            The blurb is here rather than in the rail because a nav item should be a name;
+            the sentence about what the name governs belongs beside the thing it governs. */}
+        <header className="tn-settings-head">
+          <p className="tn-settings-blurb" id="tn-settings-blurb">{active.blurb}</p>
           <button type="button" className="tn-settings-close" onClick={onClose} aria-label="Close settings">✕</button>
         </header>
 
-        <div className="tn-settings-tabs" role="tablist" aria-label="Settings sections"
-          ref={stripRef} onKeyDown={onTabKey}>
+        {/* Cell 3 — the rail. It IS the tablist; a wrapper around one would add a node that
+            owns nothing. `--tn-settings-axis` is read back off this element by useRailAxis
+            above, so the aria-orientation below is whatever the stylesheet actually did. */}
+        <div className="tn-settings-rail" role="tablist" aria-label="Settings sections"
+          aria-orientation={axis} ref={railRef} onKeyDown={onTabKey}>
           {SETTINGS_TABS.map((t) => (
             <button
               key={t.id}
@@ -122,7 +184,7 @@ export default function SettingsPanel({ open, onClose }: { open: boolean; onClos
               className="tn-settings-tab"
               aria-selected={t.id === tab}
               aria-controls="tn-settings-panel"
-              // Roving tabindex: the strip is ONE tab stop, so Tab moves into the panel
+              // Roving tabindex: the rail is ONE tab stop, so Tab moves into the panel
               // rather than walking three buttons first.
               tabIndex={t.id === tab ? 0 : -1}
               onClick={() => select(t.id)}
@@ -132,10 +194,11 @@ export default function SettingsPanel({ open, onClose }: { open: boolean; onClos
           ))}
         </div>
 
-        {/* ONE PANEL ID, SHARED BY ALL THREE TABS. The inactive panels are unmounted, so
-            per-tab ids would leave two of the three aria-controls dangling at all times.
-            All three tabs do genuinely control this one region; aria-labelledby is the
-            half that swings to name whichever tab is selected.
+        {/* Cell 4 — ONE PANEL ID, SHARED BY ALL THREE TABS. The inactive panels are
+            unmounted, so per-tab ids would leave two of the three aria-controls dangling at
+            all times. All three tabs do genuinely control this one region; aria-labelledby
+            is the half that swings to name whichever tab is selected, and aria-describedby
+            hands a screen reader the same one-line orientation the header shows.
             tabIndex={0} because this is the scroll container, and a keyboard user has to
             be able to scroll it. */}
         <div
@@ -144,6 +207,7 @@ export default function SettingsPanel({ open, onClose }: { open: boolean; onClos
           role="tabpanel"
           tabIndex={0}
           aria-labelledby={`tn-settings-tab-${tab}`}
+          aria-describedby="tn-settings-blurb"
           ref={bodyRef}
         >
           {tab === "main" && <MainTab />}

--- a/components/shell/SettingsPanel.tsx
+++ b/components/shell/SettingsPanel.tsx
@@ -6,8 +6,9 @@
 // peers you flick between and the wrong one for a nav: it read as a filter over one page
 // rather than as three places, and it spent the drawer's scarcest axis — width — on
 // something a column gives away for free. The drawer grew 384px → 536px to pay for the
-// rail out of its own width rather than out of the panel's: the measured panel measure is
-// 349px against the old 348px, so not one field, hint or key-cap row got tighter.
+// rail out of its own width rather than out of the panel's: the panel measures 349px
+// against the old 347px, both read out of a live browser, so not one field, hint or
+// key-cap row got tighter.
 //
 // THE FOUR CELLS ARE A GRID, AND THE REASON IS ALIGNMENT. The rail's title cell and the
 // panel's header sit side by side with a divider between them; as a flex row they would

--- a/components/shell/settings/ShortcutsTab.tsx
+++ b/components/shell/settings/ShortcutsTab.tsx
@@ -63,9 +63,16 @@ export default function ShortcutsTab() {
         )}
         <div className="tn-settings-row">
           <span className="tn-settings-label">Defaults</span>
+          {/* .tn-settings-tg-test, NOT .tn-settings-seg-btn. The seg-btn is transparent
+              until aria-pressed, which is right for a segment where the selected half
+              carries the ink and wrong for a lone button that is never pressed: Restore
+              rendered as bare text opposite its own label, indistinguishable from it. This
+              is the drawer's existing outlined-button class, the one "Send test message"
+              and "Save current layout…" already use — no new vocabulary, just the right
+              member of it. */}
           <button
             type="button"
-            className="tn-settings-seg-btn"
+            className="tn-settings-tg-test"
             onClick={() => { keymapStore.reset(); setKeyErr(null); }}
           >
             Restore

--- a/lib/shell/settingsTabs.ts
+++ b/lib/shell/settingsTabs.ts
@@ -11,29 +11,44 @@
 export type SettingsTabId = "main" | "display" | "shortcuts";
 
 /**
- * The tabs, in strip order.
+ * The tabs, in rail order.
  *
  * MAIN IS FIRST AND IS THE LANDING TAB. Rebinding a key is a one-off — you set Ctrl+G
  * once and never come back — while the notification rules and the alert channels are the
- * surface people return to. Ordering the strip so the rare visit opens first would tax
+ * surface people return to. Ordering the rail so the rare visit opens first would tax
  * the common one.
+ *
+ * `blurb` IS THE ONE PIECE OF NEW COPY THE RAIL ADDED, and it was not invented: each line
+ * is the sentence the tab's own file header already opened with, moved somewhere the user
+ * can read it. The rail took the drawer's title into its own column, which left the panel
+ * header holding nothing but the ✕; this is what that bar says instead of standing empty.
+ * Keep it descriptive. It names what the tab governs — it must never grow into a claim
+ * about what the console does.
  */
-export const SETTINGS_TABS: { id: SettingsTabId; label: string }[] = [
-  { id: "main", label: "Main" },
-  { id: "display", label: "Display" },
-  { id: "shortcuts", label: "Shortcuts" },
+export const SETTINGS_TABS: { id: SettingsTabId; label: string; blurb: string }[] = [
+  { id: "main", label: "Main", blurb: "Where alerts go" },
+  { id: "display", label: "Display", blurb: "What the console shows you" },
+  { id: "shortcuts", label: "Shortcuts", blurb: "The keys that are yours" },
 ];
 
 /**
  * Pure: which tab a key moves to from `current`, or null when the key is not ours.
  *
+ * BOTH AXES ARE LIVE, AND THAT IS NOT LAZINESS. The list is a vertical rail on the left of
+ * the drawer, and below 540px it folds back into a horizontal strip above the panel — so
+ * there is no single "correct" arrow axis to pick. WAI-APG asks a vertical tablist for
+ * ↑/↓ and a horizontal one for ←/→; answering to both means the same handler is right at
+ * both widths and a user who learned one axis never finds it dead at the other. It costs
+ * nothing, because the rail holds buttons only: unlike the shell's global handler, there
+ * is no caret in here for ← to hijack.
+ *
  * WRAPS AT BOTH ENDS, which is the WAI-ARIA tab pattern, and is also the only behaviour
- * that reads as finished on a three-tab strip — stopping dead on the last tab feels like
+ * that reads as finished on a three-item list — stopping dead on the last tab feels like
  * a key that failed rather than a boundary that was reached.
  *
  * NULL RATHER THAN `current` FOR AN UNHANDLED KEY, and that is the load-bearing part: the
  * handler uses the null to decide whether to call preventDefault. Returning the current
- * tab for every key would make the strip swallow Tab and Escape along with the arrows,
+ * tab for every key would make the rail swallow Tab and Escape along with the arrows,
  * which is how a tablist traps a keyboard user.
  */
 export function nextTabId(
@@ -44,8 +59,8 @@ export function nextTabId(
   if (tabs.length === 0) return null;
   const i = tabs.findIndex((t) => t.id === current);
   if (i < 0) return null;
-  if (key === "ArrowRight") return tabs[(i + 1) % tabs.length].id;
-  if (key === "ArrowLeft") return tabs[(i - 1 + tabs.length) % tabs.length].id;
+  if (key === "ArrowDown" || key === "ArrowRight") return tabs[(i + 1) % tabs.length].id;
+  if (key === "ArrowUp" || key === "ArrowLeft") return tabs[(i - 1 + tabs.length) % tabs.length].id;
   if (key === "Home") return tabs[0].id;
   if (key === "End") return tabs[tabs.length - 1].id;
   return null;

--- a/tests/e2e/shortcuts.spec.ts
+++ b/tests/e2e/shortcuts.spec.ts
@@ -162,14 +162,42 @@ test("the drawer opens on Main, and the tabs are reachable by keyboard", async (
   await page.locator(".tn-settings-trigger").click();
 
   await expect(page.getByRole("tab", { name: "Main" })).toHaveAttribute("aria-selected", "true");
-  // Focus lands on the active tab, so the strip is one arrow press from anywhere.
-  await page.keyboard.press("ArrowRight");
+  // Focus lands on the active tab, so the rail is one arrow press from anywhere.
+  await page.keyboard.press("ArrowDown");
   await expect(page.getByRole("tab", { name: "Display" })).toHaveAttribute("aria-selected", "true");
   // Wraps at both ends rather than stopping dead.
-  await page.keyboard.press("ArrowLeft");
-  await page.keyboard.press("ArrowLeft");
+  await page.keyboard.press("ArrowUp");
+  await page.keyboard.press("ArrowUp");
   await expect(page.getByRole("tab", { name: "Shortcuts" })).toHaveAttribute("aria-selected", "true");
   await expect(page.getByRole("button", { name: /^Sources rail: Ctrl\+K/ })).toBeVisible();
+
+  // ←/→ still step, because below 540px this same list is a horizontal strip and a user
+  // who learned one axis must not find it dead at the other width.
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("tab", { name: "Main" })).toHaveAttribute("aria-selected", "true");
+});
+
+test("the rail is a vertical tablist, and says so only while it is one", async ({ page }) => {
+  await stampSeen(page);
+  await page.goto("/app");
+  await page.locator(".tn-settings-trigger").click();
+
+  const rail = page.getByRole("tablist", { name: "Settings sections" });
+  await expect(rail).toHaveAttribute("aria-orientation", "vertical");
+  // The rail sits BESIDE the panel, not above it — the whole point of the layout. Comparing
+  // boxes rather than asserting a width is what makes this survive a retune of either.
+  const railBox = await rail.boundingBox();
+  const panel = await page.locator("#tn-settings-panel").boundingBox();
+  expect(railBox!.x + railBox!.width).toBeLessThanOrEqual(panel!.x + 1);
+
+  // Under the fold it lies down, and aria-orientation follows the CSS rather than lying.
+  // SettingsPanel reads --tn-settings-axis back off the element for exactly this reason,
+  // so this assertion is what proves the property and the @media block stayed in step.
+  await page.setViewportSize({ width: 420, height: 900 });
+  await expect(rail).toHaveAttribute("aria-orientation", "horizontal");
+  const narrowRail = await rail.boundingBox();
+  const narrowPanel = await page.locator("#tn-settings-panel").boundingBox();
+  expect(narrowRail!.y + narrowRail!.height).toBeLessThanOrEqual(narrowPanel!.y + 1);
 });
 
 test("Restore puts every default back", async ({ page }) => {

--- a/tests/unit/settings-tabs.test.ts
+++ b/tests/unit/settings-tabs.test.ts
@@ -7,10 +7,13 @@ import { FIXED_KEYS, DEFAULT_KEYMAP, KEY_ACTIONS } from "@/lib/shell/keymap";
 // test can own is the arrow arithmetic and the claim the Fixed table makes.
 
 describe("SETTINGS_TABS", () => {
-  it("has unique ids and a label for every one", () => {
+  it("has unique ids, and a label and a blurb for every one", () => {
     const ids = SETTINGS_TABS.map((t) => t.id);
     expect(new Set(ids).size).toBe(ids.length);
     for (const t of SETTINGS_TABS) expect(t.label.trim().length).toBeGreaterThan(0);
+    // The panel header renders the blurb unconditionally, so a tab added without one
+    // would ship an empty bar rather than fail anywhere a person would notice.
+    for (const t of SETTINGS_TABS) expect(t.blurb.trim().length).toBeGreaterThan(0);
   });
 
   it("opens on Main", () => {
@@ -26,13 +29,20 @@ describe("nextTabId", () => {
   const first = ids[0];
   const last = ids[ids.length - 1];
 
-  it("steps right and left", () => {
+  it("steps on BOTH axes", () => {
+    // The list is a vertical rail on the left of the drawer and a horizontal strip below
+    // 540px, so ↑/↓ and ←/→ are both live and both mean the same step. Losing either axis
+    // leaves the arrows dead at one of the two widths.
+    expect(nextTabId(SETTINGS_TABS, ids[0], "ArrowDown")).toBe(ids[1]);
+    expect(nextTabId(SETTINGS_TABS, ids[1], "ArrowUp")).toBe(ids[0]);
     expect(nextTabId(SETTINGS_TABS, ids[0], "ArrowRight")).toBe(ids[1]);
     expect(nextTabId(SETTINGS_TABS, ids[1], "ArrowLeft")).toBe(ids[0]);
   });
 
   it("wraps at BOTH ends", () => {
     // Stopping dead on the last tab reads as a key that failed, not a boundary reached.
+    expect(nextTabId(SETTINGS_TABS, last, "ArrowDown")).toBe(first);
+    expect(nextTabId(SETTINGS_TABS, first, "ArrowUp")).toBe(last);
     expect(nextTabId(SETTINGS_TABS, last, "ArrowRight")).toBe(first);
     expect(nextTabId(SETTINGS_TABS, first, "ArrowLeft")).toBe(last);
   });
@@ -42,10 +52,10 @@ describe("nextTabId", () => {
     expect(nextTabId(SETTINGS_TABS, first, "End")).toBe(last);
   });
 
-  it("returns null for a key that is not the strip's", () => {
+  it("returns null for a key that is not the rail's", () => {
     // The null is what the handler reads to decide whether to preventDefault. A tablist
     // that answered every key would swallow Tab and Escape along with the arrows.
-    for (const k of ["Tab", "Escape", "Enter", "a", " ", "ArrowUp", "ArrowDown"]) {
+    for (const k of ["Tab", "Escape", "Enter", "a", " ", "PageDown", "ArrowLeftFoo"]) {
       expect(nextTabId(SETTINGS_TABS, first, k)).toBeNull();
     }
   });


### PR DESCRIPTION
Main / Display / Shortcuts move from the segmented pill above the panel to a nav rail down the left of the drawer.

## Why

The pill is the right shape for two or three peers you flick between and the wrong one for a nav. It read as a filter over one page rather than as three places, and it spent the drawer's scarcest axis — width — on something a column gives away for free.

## The width is addition, not taste

The drawer grew **384px → 536px**, paying for the rail out of its own width rather than out of the panel's: 150 rail + 1 divider + 385 panel, and 385 less the body's 2×18 padding leaves **349px of measure against the 347px** the single column actually had.

Both figures were read out of a live browser rather than derived, and that is the only reason they are trustworthy — twice here the arithmetic was wrong:

- The first cut was **520px**, which measured 333 and would have made every field, hint and key-cap row narrower than before the rail existed.
- The old measure was stated as 348 (384 − 2×18). Shooting `origin/main` through the same harness read **347**: the drawer's own `border-left` takes a pixel before the padding does.

| | before (measured) | after (measured) |
|---|---|---|
| drawer | 384px | 536px |
| panel measure | 347px | 349px |
| head cells aligned | n/a | 61px = 61px |

## Four cells, one grid

The rail's title cell and the panel's header sit side by side with a divider between them. As a flex row they would need a shared magic height and the divider would step the first time either grew. As `grid-template-rows: auto 1fr` the header row is simply as tall as the taller of the two, so they cannot disagree.

The grid buys the responsive layout outright: below 540px the same four cells re-address to a title-and-close row, a horizontal strip, then the panel. No element moves in the DOM and the title never leaves the rail. 540 is derived too — under the 536 cap the drawer is 92vw, a credential input stops being comfortable at about 300px of measure, and 540 × 0.92 leaves 310.

## aria-orientation is read back off the CSS

A vertical tablist must say so, and what a user sees flips at a breakpoint the component cannot see. Writing 540 into a `matchMedia` would put the number in two files and guarantee that one day only one of them moves. So the rail publishes `--tn-settings-axis` and `SettingsPanel` reads the computed value — the stylesheet stays the single source of truth. An e2e test resizes the viewport and asserts the attribute follows, which is what would catch the property and the `@media` block drifting apart.

Both arrow axes step now. The same list is a column at one width and a row at another, so ↑/↓ and ←/→ must both work or the arrows are dead at one of them. Scoping the handler to the tablist is what makes it free: the rail holds buttons only, so unlike the shell's global handler neither axis can reach a caret.

## Fixed in passing

Both found by looking at the result rather than at the diff.

- **The drawer's scrollbar has been invisible since the dark skin was folded away.** `.tn-terminal ::-webkit-scrollbar-thumb` is still a literal white at 14%, and this drawer is the one scroller in the shell painted on white. It opts back out in tokens, placed beside the terminal's own rule because the selectors are the same specificity and only source order can win.
- **Restore rendered as bare text** opposite its own Defaults label — it used `.tn-settings-seg-btn`, which is transparent until `aria-pressed`. Correct for a segment, wrong for a lone button that is never pressed. It now uses the drawer's existing outlined-button class, the one Send test message already has. No new vocabulary.

A third defect the shots caught and the fix removed: at narrow widths the header kept the rail's tint on the title cell only, so the bar was shaded on the left and white on the right — a header that looked like it had failed to paint. The tint now goes with the column, not the cell.

## The one piece of new copy

A one-line blurb per tab in the panel header, which is what that bar says now the title has moved into the rail ("Where alerts go", "What the console shows you", "The keys that are yours"). Each is the sentence the tab's own file header already opened with, so nothing was invented. It lives in `SETTINGS_TABS` beside the label, and a unit test pins that every tab has one — the header renders it unconditionally, so a missing one would ship an empty bar rather than fail anywhere visible.

## Verified

- `npx tsc --noEmit` clean
- **2,970 unit tests across 313 files** pass
- The three settings e2e tests pass, including the new one that resizes the viewport and checks `aria-orientation` follows the CSS
- Shot at 1440×900 and 420×860, before and after, through the same harness; every measurement above is read out of the live DOM

Two e2e specs unrelated to this change (`; opens search` and `Ctrl+Q arms the draw tool`) fail against a **dev** server — both press a key on the map immediately after load and neither opens the drawer. The sibling `;` test passes, so it reads as a hydration race in dev mode rather than a break. Worth confirming against the Vercel preview build before merge.

The selected treatment is carried over unchanged from the strip it replaces — a `--tn-surface-solid` plate lifted on `--tn-shadow-sm` with accent text, the same pairing `.tn-settings-seg-btn` uses. The rail sits on `--tn-surface-2`, so the selected row is a piece of the panel's own colour sitting in the sidebar.