### PR TITLE
Send the cache TTL under the header Vercel actually reads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# The Vercel ignore step runs this on Linux; CRLF would break the shebang line.
+*.sh text eol=lf

--- a/app/api/cameras/route.ts
+++ b/app/api/cameras/route.ts
@@ -1,5 +1,5 @@
 import { getRegistry } from "@/lib/sources/registry";
-import { camerasBody, camerasCacheControl } from "@/lib/cameras/body";
+import { camerasBody, camerasCacheHeaders } from "@/lib/cameras/body";
 
 export const dynamic = "force-dynamic";
 
@@ -12,7 +12,7 @@ export async function GET() {
   return new Response(camerasBody(await getRegistry()), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": camerasCacheControl(),
+      ...camerasCacheHeaders(),
     },
   });
 }

--- a/app/api/coverage/route.ts
+++ b/app/api/coverage/route.ts
@@ -1,6 +1,6 @@
 import { getRegistry, feedHealth, CAMERA_FEED_COUNT } from "@/lib/sources/registry";
 import { groupCoverage } from "@/lib/coverage";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +42,6 @@ export async function GET() {
         detail: health,
       },
     },
-    { headers: { "Cache-Control": edgeCacheControl(COVERAGE_TTL_MS, 300_000) } },
+    { headers: edgeCacheHeaders(COVERAGE_TTL_MS, 300_000) },
   );
 }

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -9,6 +9,7 @@
 import { ImageResponse } from "next/og";
 import type { ReactElement } from "react";
 import { BRAND, siteUrl } from "@/lib/brand";
+import { browserAndEdgeHeaders } from "@/lib/http/cache";
 
 export const runtime = "nodejs";
 
@@ -17,7 +18,7 @@ const HEIGHT = 630;
 // Identical params always render the identical card and the route is CPU-heavy
 // (Satori + rasterise), so cache hard: stops load amplification via varied t/s/c and
 // lets the CDN serve crawlers instantly.
-const CACHE = "public, max-age=86400, s-maxage=604800";
+const CACHE = browserAndEdgeHeaders(86_400, 604_800);
 
 /** Code-point-aware clamp so truncating never splits an emoji / surrogate pair. */
 function clamp(s: string, n: number): string {
@@ -118,7 +119,7 @@ export function GET(req: Request): ImageResponse {
     /* keep fallback host */
   }
 
-  const opts = { width: WIDTH, height: HEIGHT, headers: { "Cache-Control": CACHE } };
+  const opts = { width: WIDTH, height: HEIGHT, headers: CACHE };
   try {
     return new ImageResponse(card(title, subtitle, accent, host), opts);
   } catch {

--- a/app/api/planes/route.ts
+++ b/app/api/planes/route.ts
@@ -1,6 +1,6 @@
 import { fetchAircraftSnapshot } from "@/lib/sources/opensky";
 import { describeCoverage } from "@/lib/signals/coverage";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -84,6 +84,6 @@ export async function GET() {
       ...(staleness ? { staleness } : {}),
       planes,
     },
-    { headers: { "Cache-Control": edgeCacheControl(PLANES_TTL_MS) } },
+    { headers: edgeCacheHeaders(PLANES_TTL_MS) },
   );
 }

--- a/app/api/point-weather/route.ts
+++ b/app/api/point-weather/route.ts
@@ -7,7 +7,7 @@ import {
   type Coord,
 } from "@/lib/weather/pointWeather";
 import { readOutcome } from "@/lib/signals/outcome";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 import { cacheTtlMs } from "@/lib/signals/cacheTtl";
 
 export const dynamic = "force-dynamic";
@@ -84,7 +84,7 @@ export async function GET(req: Request) {
 
     return Response.json(
       { ok: true, observedAt: now, count: points.length, points },
-      { headers: { "Cache-Control": edgeCacheControl(cacheTtlMs(TTL_MS, points.length === 0), TTL_MS) } },
+      { headers: edgeCacheHeaders(cacheTtlMs(TTL_MS, points.length === 0), TTL_MS) },
     );
   } catch (err) {
     console.warn("[point-weather] handler threw:", err);

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -3,6 +3,7 @@ import { getCameraById } from "@/lib/sources/registry";
 import { isAllowed } from "@/lib/proxy/allowlist";
 import { extractScotlandImage } from "@/lib/sources/trafficscotland";
 import { needsH2, h2Fetch } from "@/lib/http/h2";
+import { frameCacheHeaders } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -54,7 +55,7 @@ export async function GET(req: NextRequest) {
     headers: {
       "Content-Type": contentType,
       // Never serve a camera faster than the source refresh (TfL = 300s).
-      "Cache-Control": `public, max-age=${cam.refreshSeconds}, s-maxage=${cam.refreshSeconds}`,
+      ...frameCacheHeaders(cam.refreshSeconds),
     },
   });
 }
@@ -80,7 +81,7 @@ async function proxyOverH2(target: URL, refreshSeconds: number): Promise<Respons
     status: 200,
     headers: {
       "Content-Type": ct && ct.startsWith("image/") ? ct : "image/jpeg",
-      "Cache-Control": `public, max-age=${refreshSeconds}, s-maxage=${refreshSeconds}`,
+      ...frameCacheHeaders(refreshSeconds),
     },
   });
 }
@@ -108,7 +109,7 @@ async function proxyTrafficScotland(target: URL, refreshSeconds: number): Promis
     status: 200,
     headers: {
       "Content-Type": img.contentType,
-      "Cache-Control": `public, max-age=${refreshSeconds}, s-maxage=${refreshSeconds}`,
+      ...frameCacheHeaders(refreshSeconds),
     },
   });
 }

--- a/app/api/signals/[id]/route.ts
+++ b/app/api/signals/[id]/route.ts
@@ -2,7 +2,7 @@ import { getSignal } from "@/lib/signals/registry";
 import { describeCoverage, readCoverage } from "@/lib/signals/coverage";
 import type { SignalFeature } from "@/lib/signals/types";
 import { cacheTtlMs } from "@/lib/signals/cacheTtl";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 import { publishOutcome } from "@/lib/signals/outcome";
 
 export const dynamic = "force-dynamic";
@@ -86,9 +86,7 @@ function cacheHeaders(refreshMs: number, features: SignalFeature[], ok: boolean)
   // minutes after it ended. no-store means the next request re-asks upstream and the
   // layer recovers as soon as the upstream does.
   if (!ok) return { "Cache-Control": "no-store" };
-  return {
-    "Cache-Control": edgeCacheControl(cacheTtlMs(refreshMs, features.length === 0)),
-  };
+  return edgeCacheHeaders(cacheTtlMs(refreshMs, features.length === 0));
 }
 
 export async function GET(

--- a/app/api/webcam-image/route.ts
+++ b/app/api/webcam-image/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server";
 import { fetchWebcamById, WINDY_SOURCE } from "@/lib/sources/windy";
 import { isAllowed } from "@/lib/proxy/allowlist";
+import { frameCacheHeaders } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -49,7 +50,7 @@ export async function GET(req: NextRequest) {
     headers: {
       "Content-Type": contentType,
       // Bounded by the source refresh — never re-pull faster than the token cadence.
-      "Cache-Control": `public, max-age=${WINDY_SOURCE.refreshSeconds}, s-maxage=${WINDY_SOURCE.refreshSeconds}`,
+      ...frameCacheHeaders(WINDY_SOURCE.refreshSeconds),
     },
   });
 }

--- a/app/api/webcam-place/route.ts
+++ b/app/api/webcam-place/route.ts
@@ -1,5 +1,5 @@
 import { fetchWebcamById } from "@/lib/sources/windy";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -19,8 +19,10 @@ type Place = { id: string; lat: number | null; lon: number | null };
 type CacheEntry = { at: number; value: Place };
 const cache = new Map<string, CacheEntry>();
 
-function placeCacheControl(place: Place): string {
-  return place.lat !== null && place.lon !== null ? edgeCacheControl(TTL_MS, TTL_MS) : "no-store";
+function placeCacheHeaders(place: Place): Record<string, string> {
+  return place.lat !== null && place.lon !== null
+    ? edgeCacheHeaders(TTL_MS, TTL_MS)
+    : { "Cache-Control": "no-store" };
 }
 
 export async function GET(req: Request) {
@@ -36,7 +38,7 @@ export async function GET(req: Request) {
 
     const hit = cache.get(id);
     if (hit && Date.now() - hit.at < TTL_MS) {
-      return Response.json(hit.value, { headers: { "Cache-Control": placeCacheControl(hit.value) } });
+      return Response.json(hit.value, { headers: placeCacheHeaders(hit.value) });
     }
 
     const webcam = await fetchWebcamById(id);
@@ -48,7 +50,7 @@ export async function GET(req: Request) {
       if (oldest !== undefined) cache.delete(oldest);
     }
 
-    return Response.json(value, { headers: { "Cache-Control": placeCacheControl(value) } });
+    return Response.json(value, { headers: placeCacheHeaders(value) });
   } catch (err) {
     console.warn("[webcam-place] handler threw:", err);
     return Response.json({ id: "", lat: null, lon: null }, { headers: { "Cache-Control": "no-store" } });

--- a/app/api/webcams/route.ts
+++ b/app/api/webcams/route.ts
@@ -1,5 +1,5 @@
 import { getWebcams } from "@/lib/webcams/registry";
-import { webcamsBody, webcamsCacheControl } from "@/lib/webcams/body";
+import { webcamsBody, webcamsCacheHeaders } from "@/lib/webcams/body";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +14,7 @@ export async function GET() {
   return new Response(webcamsBody(await getWebcams()), {
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": webcamsCacheControl(),
+      ...webcamsCacheHeaders(),
     },
   });
 }

--- a/lib/cameras/body.ts
+++ b/lib/cameras/body.ts
@@ -1,6 +1,6 @@
 import type { Camera } from "@/lib/types";
 import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 
 // The body of GET /api/cameras, and its edge-cache policy.
 //
@@ -80,7 +80,7 @@ export function __resetCamerasBody(): void {
   serialised = null;
 }
 
-/** The Cache-Control this route answers with. Lives beside the TTL it is derived from. */
-export function camerasCacheControl(): string {
-  return edgeCacheControl(CAMERAS_TTL_MS, 300_000);
+/** The cache headers this route answers with. Live beside the TTL they are derived from. */
+export function camerasCacheHeaders(): Record<string, string> {
+  return edgeCacheHeaders(CAMERAS_TTL_MS, 300_000);
 }

--- a/lib/http/cache.ts
+++ b/lib/http/cache.ts
@@ -48,3 +48,78 @@ export function toSeconds(ms: number): number {
   if (!Number.isFinite(ms) || ms <= 0) return MIN_TTL_SECONDS;
   return Math.max(MIN_TTL_SECONDS, Math.floor(ms / 1000));
 }
+
+// ---------------------------------------------------------------------------
+// WHY THERE ARE TWO HEADERS AND NOT ONE.
+//
+// The comment above says `s-maxage` is one header rather than a Cache-Control /
+// CDN-Cache-Control pair. That was wrong, and production had been proving it wrong
+// for the whole life of the file. Measured against prod on 2026-09-06:
+//
+//   /api/proxy    sent `public, max-age=300, s-maxage=300`
+//                 served `public, max-age=300`                    <- s-maxage gone
+//   /api/signals  sent `public, s-maxage=60, stale-while-revalidate=60`
+//                 served `public`                                 <- both gone
+//
+// `max-age` arrives untouched; the SHARED-cache directives do not. Checked on five
+// routes (signals, cameras, planes, webcams, coverage), all five `X-Vercel-Cache:
+// MISS`, and the one thing all of them share is `dynamic = "force-dynamic"`.
+//
+// So every helper below was computing a correct TTL and handing it to the one header
+// that gets rewritten before it leaves. The edge answered nobody; each visitor cost
+// an invocation, which is the exact charge the file was written to stop. Measured
+// over one day at the time of the fix: 108,344 invocations, 12.4 per page load.
+//
+// `Vercel-CDN-Cache-Control` is read by the Vercel CDN itself and is NOT rewritten.
+// Sending the same value under both names is what makes the policy take effect.
+//
+// THE TTLs ARE UNCHANGED BY THIS. Nothing here caches for longer than it already
+// claimed to — the freshness rule at the top of this file still holds, because every
+// value still comes from the source's own declared refresh interval.
+
+/** The header name the Vercel CDN reads. Not rewritten by the framework. */
+export const CDN_HEADER = "Vercel-CDN-Cache-Control";
+
+/**
+ * Cache headers for a read-only JSON response: `edgeCacheControl`'s policy, sent
+ * under both names so it reaches the CDN as well as any cache in front of it.
+ *
+ * Spread this into a `headers` object. Prefer it over calling `edgeCacheControl`
+ * directly — a lone `Cache-Control` is the defect this pair exists to prevent.
+ */
+export function edgeCacheHeaders(ttlMs: number, staleForMs?: number): Record<string, string> {
+  const value = edgeCacheControl(ttlMs, staleForMs);
+  return { "Cache-Control": value, [CDN_HEADER]: value };
+}
+
+/**
+ * Cache headers where the browser and the shared caches get DIFFERENT lifetimes.
+ *
+ * @param browserSeconds  `max-age` — what the visitor's own cache may keep.
+ * @param sharedSeconds   `s-maxage` — what the CDN may keep. Usually the longer one.
+ */
+export function browserAndEdgeHeaders(
+  browserSeconds: number,
+  sharedSeconds: number,
+): Record<string, string> {
+  const browser = toSeconds(browserSeconds * 1000);
+  const shared = toSeconds(sharedSeconds * 1000);
+  return {
+    "Cache-Control": `public, max-age=${browser}, s-maxage=${shared}`,
+    [CDN_HEADER]: `public, s-maxage=${shared}`,
+  };
+}
+
+/**
+ * Cache headers for an IMAGE frame (the camera proxies).
+ *
+ * Differs from `edgeCacheHeaders` in keeping a browser `max-age`: a frame is bytes
+ * the same tab re-requests on a timer, so the visitor's own cache should answer it
+ * and not just the CDN's. `stale-while-revalidate` is deliberately absent — a stale
+ * frame is a stale PICTURE of a road and must not outlive its cadence at all.
+ *
+ * @param ttlSeconds the source's own refresh cadence, in seconds.
+ */
+export function frameCacheHeaders(ttlSeconds: number): Record<string, string> {
+  return browserAndEdgeHeaders(ttlSeconds, ttlSeconds);
+}

--- a/lib/seo/xml.ts
+++ b/lib/seo/xml.ts
@@ -17,6 +17,7 @@
 // rather than something you have to deploy to inspect.
 
 import type { SitemapEntry } from "@/lib/seo/directory";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 
 /** Where the browser-facing stylesheet lives (served from `public/`). */
 export const SITEMAP_STYLESHEET_PATH = "/sitemap.xsl";
@@ -138,6 +139,6 @@ ${body}
 export function sitemapHeaders(): HeadersInit {
   return {
     "Content-Type": "application/xml; charset=utf-8",
-    "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+    ...edgeCacheHeaders(86_400_000, 604_800_000),
   };
 }

--- a/lib/webcams/body.ts
+++ b/lib/webcams/body.ts
@@ -1,7 +1,7 @@
 import { describeWebcamSample, type WebcamSample } from "@/lib/webcams/fetch";
 import { WINDY_SOURCE } from "@/lib/sources/windy";
 import { describeCoverage } from "@/lib/signals/coverage";
-import { edgeCacheControl } from "@/lib/http/cache";
+import { edgeCacheHeaders } from "@/lib/http/cache";
 
 // The body of GET /api/webcams, and its edge-cache policy.
 //
@@ -130,7 +130,7 @@ export function __resetWebcamsBody(): void {
   serialised = null;
 }
 
-/** The Cache-Control this route answers with. Lives beside the TTL it is derived from. */
-export function webcamsCacheControl(): string {
-  return edgeCacheControl(WEBCAMS_TTL_MS, 300_000);
+/** The cache headers this route answers with. Live beside the TTL they are derived from. */
+export function webcamsCacheHeaders(): Record<string, string> {
+  return edgeCacheHeaders(WEBCAMS_TTL_MS, 300_000);
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,50 @@ const nextConfig: NextConfig = {
   },
   // Allow an isolated build dir so a verification `next build` doesn't fight a
   // concurrently-running `next dev` over `.next` (defaults to `.next`).
+  /**
+   * CACHE POLICY FOR `public/`.
+   *
+   * MEASURED, 2026-09-06, one production day: 1,083,357 static-asset requests against
+   * 8,717 `/app` loads — 124 per page load, and 78% of ALL traffic to the site.
+   * `/icons/icon-192.png` alone was fetched 22,242 times.
+   *
+   * The cause is that Vercel serves `public/` with `max-age=0, must-revalidate`, so a
+   * browser re-asks for every asset on every load. It gets a 304 and no bytes move,
+   * which is why this never showed up as bandwidth — but each conditional request is
+   * still a billed edge request AND a billed observability event, and observability
+   * was 46% of the bill.
+   *
+   * WHY `stale-while-revalidate` AND NOT `immutable`. Nothing under `public/` is
+   * content-hashed — `/webcams/t/r01332311.json` keeps its name when the harvest is
+   * re-run — so `immutable` would pin a stale file for the whole max-age with no way
+   * to push a correction. SWR gets essentially the same saving (the traffic is repeat
+   * loads and long-lived tabs, all inside a day) while a change still propagates.
+   *
+   * `/sw.js` is deliberately ABSENT: a service worker that a browser will not re-check
+   * cannot be updated, and this one owns the offline shell.
+   */
+  async headers() {
+    // Assets that change only on deploy and whose staleness is cosmetic.
+    const assets = "public, max-age=86400, stale-while-revalidate=604800";
+    // Harvested data. Same mechanism, shorter leash: a re-harvest should land the
+    // same day, not the same week.
+    const data = "public, max-age=3600, stale-while-revalidate=86400";
+
+    const rule = (source: string, value: string) => ({
+      source,
+      headers: [{ key: "Cache-Control", value }],
+    });
+
+    return [
+      rule("/icons/:path*", assets),
+      rule("/textures/:path*", assets),
+      rule("/sky/:path*", assets),
+      rule("/brand/:path*", assets),
+      rule("/favicon.svg", assets),
+      rule("/geo/:path*", data),
+      rule("/webcams/:path*", data),
+    ];
+  },
   distDir: process.env.TN_DIST_DIR || ".next",
   webpack: (config, { isServer, webpack }) => {
     if (!isServer) {

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step". Wired up by `ignoreCommand` in vercel.json.
+#
+#   exit 0  ->  SKIP this build
+#   exit 1  ->  RUN this build
+#
+# WHY. 200+ deployments in the 23 Aug - 6 Sep cycle burned 14 hours of build CPU
+# ($3.09, 13.5% of the infra bill). Preview builds are a genuinely useful review
+# surface and are worth keeping -- but a commit that only edits a doc, a test or a
+# screenshot cannot change what `next build` emits, and paying four minutes of CPU
+# to rebuild it byte-for-byte buys nothing.
+#
+# FAIL-SAFE BY CONSTRUCTION, and this is the whole design. A wrong answer in the
+# SKIP direction is silent: production keeps serving the old build and nothing
+# anywhere says the deploy did not happen. So this script does not try to list the
+# paths that matter. It lists the paths that provably CANNOT matter, and skips only
+# when every changed file is one of them. A new top-level directory, a new config
+# file, an unfamiliar path -- all of them fall through to "build".
+#
+# It also builds whenever it cannot see the history it needs to decide, which on a
+# shallow clone is a real case rather than a theoretical one.
+
+set -u
+
+# A change confined to these cannot alter the output of `next build`:
+#   docs/, *.md, LICENSE   documentation
+#   tests/                 vitest suite -- `npm run build` is `next build`, no tests
+#   persona-shots/         Playwright UI evidence, committed as review artefacts
+#   .github/               CI config, not shipped
+#   *.config.ts for test runners only (playwright, vitest -- NOT next.config.ts)
+IGNORABLE='^(docs/|tests/|persona-shots/|launch-shots/|\.github/|scratchpad/)|(^|/)[^/]*\.md$|^LICENSE$|^\.gitignore$|^(playwright|playwright\.preview|vitest)\.config\.ts$'
+
+base="${VERCEL_GIT_PREVIOUS_SHA:-}"
+[ -z "$base" ] && base="HEAD^"
+
+if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+  echo "ignore-build: base '${base}' is not in this clone - building."
+  exit 1
+fi
+
+changed="$(git diff --name-only "$base" HEAD 2>/dev/null)"
+if [ $? -ne 0 ]; then
+  echo "ignore-build: could not diff against '${base}' - building."
+  exit 1
+fi
+
+if [ -z "$changed" ]; then
+  # No diff at all is not "nothing to do" -- it usually means the base is wrong, or
+  # this is a redeploy of the same tree. Neither is a safe reason to skip.
+  echo "ignore-build: no diff against '${base}' - building."
+  exit 1
+fi
+
+relevant=0
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  if ! echo "$file" | grep -Eq "$IGNORABLE"; then
+    echo "ignore-build: '${file}' can affect the build."
+    relevant=1
+    break
+  fi
+done <<EOF
+$changed
+EOF
+
+if [ "$relevant" -eq 0 ]; then
+  echo "ignore-build: every change since ${base} is documentation, tests or screenshots - skipping."
+  exit 0
+fi
+
+echo "ignore-build: building."
+exit 1

--- a/tests/unit/http-cache.test.ts
+++ b/tests/unit/http-cache.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { edgeCacheControl, toSeconds, MIN_TTL_SECONDS } from "@/lib/http/cache";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  browserAndEdgeHeaders,
+  edgeCacheControl,
+  edgeCacheHeaders,
+  frameCacheHeaders,
+  toSeconds,
+  MIN_TTL_SECONDS,
+} from "@/lib/http/cache";
 
 describe("toSeconds", () => {
   it("floors milliseconds to whole seconds", () => {
@@ -49,5 +58,97 @@ describe("edgeCacheControl", () => {
     expect(edgeCacheControl(0)).toBe(
       `public, s-maxage=${MIN_TTL_SECONDS}, stale-while-revalidate=${MIN_TTL_SECONDS}`,
     );
+  });
+});
+
+/**
+ * MEASURED DEFECT, 2026-09-06. Every read route already asked the CDN to cache, and
+ * the CDN never did. Against production:
+ *
+ *   /api/proxy   code sends `public, max-age=300, s-maxage=300`
+ *                wire returns `public, max-age=300`          <- s-maxage gone
+ *   /api/signals code sends `public, s-maxage=60, stale-while-revalidate=60`
+ *                wire returns `public`                       <- both gone
+ *
+ * `max-age` survives and the SHARED-cache directives do not, on all five routes
+ * checked, every one of them `dynamic = "force-dynamic"`. So `X-Vercel-Cache: MISS`
+ * on 100% of requests and every poll from every open tab was a cold invocation.
+ *
+ * The fix does not depend on pinning which layer strips them: `Vercel-CDN-Cache-Control`
+ * is read by the Vercel CDN directly and is not rewritten, so the TTL sent under that
+ * name arrives. These tests exist so the pair can never drift apart again.
+ */
+describe("edgeCacheHeaders", () => {
+  it("sends the SAME policy twice — once for any CDN, once under the name Vercel reads", () => {
+    const headers = edgeCacheHeaders(60_000);
+    expect(headers["Cache-Control"]).toBe("public, s-maxage=60, stale-while-revalidate=60");
+    expect(headers["Vercel-CDN-Cache-Control"]).toBe(headers["Cache-Control"]);
+  });
+
+  it("carries an explicit stale window into both headers", () => {
+    const headers = edgeCacheHeaders(20_000, 60_000);
+    expect(headers["Vercel-CDN-Cache-Control"]).toBe(
+      "public, s-maxage=20, stale-while-revalidate=60",
+    );
+  });
+
+  it("never invents a TTL — it is edgeCacheControl's value, unchanged", () => {
+    for (const ttl of [1_000, 20_000, 300_000, 86_400_000]) {
+      expect(edgeCacheHeaders(ttl)["Vercel-CDN-Cache-Control"]).toBe(edgeCacheControl(ttl));
+    }
+  });
+});
+
+describe("frameCacheHeaders", () => {
+  it("keeps the browser max-age a camera frame needs AND reaches the CDN", () => {
+    const headers = frameCacheHeaders(300);
+    expect(headers["Cache-Control"]).toBe("public, max-age=300, s-maxage=300");
+    expect(headers["Vercel-CDN-Cache-Control"]).toBe("public, s-maxage=300");
+  });
+
+  it("floors a zero or fractional cadence rather than emitting max-age=0", () => {
+    expect(frameCacheHeaders(0)["Cache-Control"]).toBe(
+      `public, max-age=${MIN_TTL_SECONDS}, s-maxage=${MIN_TTL_SECONDS}`,
+    );
+    expect(frameCacheHeaders(2.7)["Cache-Control"]).toBe("public, max-age=2, s-maxage=2");
+  });
+
+  it("lets the CDN hold a rasterised card longer than the visitor's own tab", () => {
+    const headers = browserAndEdgeHeaders(86_400, 604_800);
+    expect(headers["Cache-Control"]).toBe("public, max-age=86400, s-maxage=604800");
+    expect(headers["Vercel-CDN-Cache-Control"]).toBe("public, s-maxage=604800");
+  });
+});
+
+describe("no route may hand-roll a shared-cache directive", () => {
+  // Synchronous on purpose: this walks every .ts/.tsx under app/ and lib/, and the
+  // promise-based version timed out at 5s when the full suite ran it under load —
+  // a guard that fails only when the machine is busy is worse than no guard.
+  it("keeps every s-maxage in the codebase behind lib/http/cache.ts", () => {
+    function walk(dir: string): string[] {
+      const out: string[] = [];
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walk(full));
+        else if (/\.tsx?$/.test(entry.name)) out.push(full);
+      }
+      return out;
+    }
+
+    const files = [...walk("app"), ...walk("lib")];
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      if (file.endsWith(join("lib", "http", "cache.ts"))) continue;
+      // Strip comments — several files DISCUSS s-maxage, which is fine.
+      const code = readFileSync(file, "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/.*$/gm, "");
+      if (code.includes("s-maxage")) offenders.push(file);
+    }
+
+    // A route that writes its own s-maxage writes it into the ONE header production
+    // strips, which is exactly how this defect shipped and stayed invisible.
+    expect(offenders).toEqual([]);
   });
 });

--- a/tests/unit/static-asset-caching.test.ts
+++ b/tests/unit/static-asset-caching.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { readdir } from "node:fs/promises";
+import nextConfig from "../../next.config";
+
+/**
+ * Guards the `public/` cache policy added on 2026-09-06.
+ *
+ * MEASURED over one production day: 1,083,357 static-asset requests against 8,717
+ * `/app` loads — 124 per load, 78% of all traffic to the site, because Vercel serves
+ * `public/` with `max-age=0, must-revalidate` and every browser re-asks every time.
+ * No bytes move on a 304, so this never looked like a bandwidth problem; it is a
+ * request-count problem, and request count is what observability events are billed on.
+ *
+ * These tests exist because the failure is INVISIBLE from inside the app: a missing
+ * rule costs nothing that a page-load timing or a test suite can see, it just quietly
+ * turns every returning visitor back into a billed round trip per asset.
+ */
+
+async function headerRules() {
+  const rules = await nextConfig.headers!();
+  return rules.map((rule) => ({
+    source: rule.source,
+    cacheControl: rule.headers.find((h) => h.key === "Cache-Control")?.value ?? "",
+  }));
+}
+
+/** Top-level entries of `public/`, which is what the rules have to cover. */
+async function publicEntries() {
+  return readdir("public", { withFileTypes: true });
+}
+
+describe("public/ cache policy", () => {
+  it("gives every served directory a lifetime a browser will actually honour", async () => {
+    const rules = await headerRules();
+    const dirs = (await publicEntries()).filter((e) => e.isDirectory()).map((e) => e.name);
+
+    for (const dir of dirs) {
+      const rule = rules.find((r) => r.source.startsWith(`/${dir}/`));
+      expect(rule, `public/${dir}/ has no Cache-Control rule in next.config.ts`).toBeDefined();
+
+      const maxAge = Number(/max-age=(\d+)/.exec(rule!.cacheControl)?.[1] ?? 0);
+      expect(maxAge, `public/${dir}/ is cached for ${maxAge}s — a browser re-asks every load`)
+        .toBeGreaterThan(0);
+    }
+  });
+
+  it("never pins a file it cannot later correct", async () => {
+    // Nothing under public/ is content-hashed: /webcams/t/r01332311.json keeps its
+    // name across a re-harvest. `immutable` on a stable filename is unrecallable.
+    for (const rule of await headerRules()) {
+      expect(rule.cacheControl, `${rule.source} is immutable but its URL is not versioned`)
+        .not.toContain("immutable");
+    }
+  });
+
+  it("leaves the service worker revalidating on every load", async () => {
+    // A service worker the browser will not re-check cannot be updated, and this one
+    // owns the offline shell (public/sw.js).
+    for (const rule of await headerRules()) {
+      expect(rule.source).not.toMatch(/^\/sw\.js/);
+      expect(rule.source).not.toBe("/:path*");
+      expect(rule.source).not.toBe("/(.*)");
+    }
+  });
+
+  it("gives harvested data a shorter leash than branding", async () => {
+    const rules = await headerRules();
+    const ageOf = (prefix: string) =>
+      Number(/max-age=(\d+)/.exec(rules.find((r) => r.source.startsWith(prefix))!.cacheControl)![1]);
+
+    // A stale icon is cosmetic; a stale webcam tile is wrong data.
+    expect(ageOf("/webcams/")).toBeLessThan(ageOf("/icons/"));
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
+}


### PR DESCRIPTION
## The finding

`lib/http/cache.ts` was written so that "each visitor" does not "cost a serverless invocation". Measured against production on 2026-09-06, every visitor still did.

| Route | Code sends | Wire returns |
|---|---|---|
| `/api/proxy` | `public, max-age=300, s-maxage=300` | `public, max-age=300` |
| `/api/signals/*` | `public, s-maxage=60, stale-while-revalidate=60` | `public` |

`max-age` arrives untouched. The **shared**-cache directives do not. Checked on five routes — signals, cameras, planes, webcams, coverage — `X-Vercel-Cache: MISS` on all five, and the one thing all of them share is `dynamic = "force-dynamic"`.

So the edge cache this repo deliberately built has never once been used in production.

**One production day, measured:** 1.39M requests · 108,344 function invocations · 8,717 `/app` loads — **12.4 invocations per page load**, because every poll from every open tab was a cold origin hit.

## What changed

**1 — `Vercel-CDN-Cache-Control`.** Read by the Vercel CDN directly, not rewritten. `edgeCacheHeaders()` sends the same policy under both names.

**No TTL changes.** Every value still comes from the source's own declared refresh interval, so the freshness rule at the top of `cache.ts` still holds — this is the existing policy finally taking effect, not a new one. `/api/planes` stays at 20s, which is what its relative `staleness.ageMs` requires.

The affected routes — signals, advisory, planes, cameras, webcams, satellites — are **65% of invocations and 77% of origin transfer**, and none of them varies by visitor. `/api/cameras` alone moved 2.09 GB/day serving the same registry snapshot 2,735 times.

**2 — `public/` cache policy.** Vercel serves `public/` with `max-age=0, must-revalidate`, so browsers re-ask for every asset every load: **1,083,357 static requests/day, 124 per page load, 78% of all traffic.** `/icons/icon-192.png` alone was fetched 22,242 times for 8,717 loads. No bytes move on a 304, which is why this never looked like bandwidth — but each conditional request is a billed edge request *and* a billed observability event, and observability was 46% of the bill.

Uses `stale-while-revalidate`, **not** `immutable`: nothing under `public/` is content-hashed (`/webcams/t/r01332311.json` keeps its name across a re-harvest), so `immutable` would pin a stale file with no way to correct it. `/sw.js` is deliberately excluded — a service worker the browser won't re-check can't be updated.

**3 — Ignored Build Step.** 200+ deployments in the cycle, 14 hours of build CPU. A commit touching only docs, tests or screenshots cannot change what `next build` emits.

The script skips only when **every** changed file is on an allowlist of provably-ignorable paths, and builds on anything it doesn't recognise or can't diff. A wrong skip is silent — production keeps serving the old build and nothing says the deploy didn't happen — so the default has to be "build".

## Guards

Both were watched go red before being made to pass:

- `http-cache.test.ts` fails if any route hand-rolls an `s-maxage` outside `lib/http/cache.ts` — that is exactly how this shipped invisibly.
- `static-asset-caching.test.ts` fails if a `public/` directory has no rule, if a rule is `immutable`, or if `/sw.js` ever gets caught by one.

## Gate

`npx tsc --noEmit` clean · **3022/3022 tests** · `npm run build` clean.

## Not in this PR

`/camera/[id]` regenerates every 300s across 18,766 URLs — the cycle wrote 2.7x more ISR than it read (398.81K writes vs 148.89K reads). Left alone deliberately: `revalidate` is pinned to `REGISTRY_TTL_MS` by `seo-page-caching.test.ts`, so moving it means moving all three together. Worth a separate look.