### PR TITLE
Invite people to the Discord, once, from the corner of the console

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -225,6 +225,9 @@ export default async function Landing() {
             <a href="/app">Open the map</a>
             <a href="#sources">All {total} sources</a>
             <a href="#ledger">Live layer status</a>
+            <a href={BRAND.discordUrl} target="_blank" rel="noreferrer noopener">
+              Discord
+            </a>
             <a href="/privacy">Privacy</a>
           </div>
           <div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -5759,6 +5759,93 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
 .tn-fb-btn.is-ghost:hover:not(:disabled) { color: var(--tn-text); background: var(--tn-surface-2); }
 @media (prefers-reduced-motion: reduce) { .tn-fb-card { animation: none; } }
 
+/* ── The Discord invitation ─────────────────────────────────────────────────
+   A corner note, not a banner and not a modal: no veil, no focus trap, nothing
+   behind it goes inert. It takes the console's own card surface, border and
+   radius so it reads as a panel that appeared rather than an ad that arrived.
+
+   BOTTOM-LEFT, ABOVE THE ATTRIBUTION. Every other corner is spoken for — the map
+   rail is centred on the right, the toast is bottom-centre at z 1200, and the
+   header owns the top. Bottom-left holds only MapLibre's attribution control,
+   which `.tn-terminal` pins at `left: 8px; bottom: 28px`, so the note sits above
+   it on the same left margin and the two read as one stack rather than a
+   collision.
+
+   Z-INDEX 1050 IS DELIBERATE AND SITS BELOW `.tn-fb` (1100). If the feedback
+   modal opens while this is still up, the modal's veil covers this card too and
+   the modal is unambiguously the live thing. See CommunityNote.tsx. */
+/* The always-mounted live region. It carries no box of its own — the card inside
+   is itself position:fixed — so it is zero-sized whether or not it holds anything,
+   and needs no `:empty` rule. It must NOT be display:none or visibility:hidden,
+   which would take it out of the accessibility tree and lose the announcement. */
+.tn-note-live { position: fixed; left: 0; bottom: 0; z-index: 1050; }
+.tn-note {
+  position: fixed; left: 8px; bottom: 52px;
+  /* 400, not 360. At 360 the text column is ~269px after the mark, the gutters and
+     the ✕, which wrapped two short sentences onto five lines — a wall of reading
+     for something that has to be taken in at a glance. 400 takes it to four and
+     still leaves the note plainly a corner card rather than a panel. */
+  width: min(400px, calc(100vw - 16px));
+  display: flex; align-items: flex-start; gap: 11px;
+  padding: 13px 14px;
+  background: var(--tn-surface-solid); color: var(--tn-text);
+  border: 1px solid var(--tn-border); border-radius: 14px; box-shadow: var(--tn-shadow);
+  animation: tn-note-in .2s ease-out;
+}
+/* Discord blurple, and the ONE place in the console it is allowed. The calm
+   olive identity carries everything else; a chat server is recognised by its
+   colour and its mark before it is read, and this note has about a second to be
+   recognised. Measured: #ffffff on #5865f2 is 4.61:1, which clears AA for normal
+   text — so the button below can carry white copy without an exception. */
+.tn-note-icon {
+  flex: none; width: 28px; height: 28px; border-radius: 8px;
+  display: grid; place-items: center;
+  background: #5865f2; color: #fff;
+}
+.tn-note-body { flex: 1; min-width: 0; }
+/* fs-lg over fs-md, and the reason is Sam's ~80% browser zoom rather than taste:
+   this card has about a second to be recognised, and at that zoom fs-md lands near
+   11 device pixels — legible, but not a headline. fs-lg renders at roughly 13.6 and
+   gives the two lines an actual hierarchy instead of a flat block. */
+.tn-note-title { margin: 0; font-size: var(--tnx-fs-lg); font-weight: 700; color: var(--tn-text); }
+.tn-note-text { margin: 5px 0 0; font-size: var(--tnx-fs-md); line-height: 1.5; color: var(--tn-text-muted); }
+.tn-note-actions { display: flex; align-items: center; gap: 8px; margin-top: 11px; }
+.tn-note-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font: inherit; font-size: var(--tnx-fs-md); font-weight: 600;
+  padding: 7px 13px; border-radius: 8px; border: 1px solid transparent;
+  cursor: pointer; text-decoration: none; white-space: nowrap;
+}
+.tn-note-btn.is-primary { background: #5865f2; color: #fff; }
+.tn-note-btn.is-primary:hover { background: #4752c4; }
+.tn-note-btn.is-ghost { background: none; color: var(--tn-text-faint); font-weight: 400; }
+.tn-note-btn.is-ghost:hover { color: var(--tn-text); background: var(--tn-surface-2); }
+.tn-note-btn:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: 1px; }
+.tn-note-x {
+  flex: none; width: 24px; height: 24px; margin: -3px -4px 0 0; border-radius: 7px;
+  border: 1px solid transparent; background: none; color: var(--tn-text-faint);
+  font-size: var(--tnx-fs-lg); line-height: 1; cursor: pointer;
+}
+.tn-note-x:hover { color: var(--tn-text); border-color: var(--tn-border-strong); }
+.tn-note-x:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: 1px; }
+@keyframes tn-note-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .tn-note { animation: none; } }
+/* On a phone the note spans the width it can get, and it has to sit ABOVE the
+   Sources FAB rather than on top of it.
+
+   THAT OVERLAP WAS REAL AND IT MATTERED. `.tn-rail-fab` is pinned to
+   `bottom: calc(var(--tn-ticker-h) + 12px)` under 720px and measures 44px tall, so
+   a note at the bottom margin covered its top half — and on a phone that button is
+   the console's main menu, the only way into the sources rail and the board list.
+   An invitation that hides the navigation is worse than no invitation.
+
+   The offset is written in the FAB's own terms (its 12px inset + its 44px height +
+   a 16px gap) so it tracks `--tn-ticker-h` instead of freezing one measurement
+   taken on one screen. Measured at 390 wide: note bottom 772, FAB top 788. */
+@media (max-width: 720px) {
+  .tn-note { left: 8px; right: 8px; width: auto; bottom: calc(var(--tn-ticker-h) + 72px); }
+}
+
 /* ── A widget that has just been added ───────────────────────────────────────
    Adding a camera wall to a full board places it below the fold (the wall is
    tiled to cover every column, so findFreeSpot falls through to the row under

--- a/components/brand/DiscordMark.tsx
+++ b/components/brand/DiscordMark.tsx
@@ -1,0 +1,27 @@
+// The Discord wordmark's glyph, monochrome, as an inline SVG.
+//
+// WHY A GLYPH AND NOT AN EMOJI. Every other button in the console header's right
+// cluster uses a text glyph (☕, <>, ⚙) because at 34px a glyph is the fastest way
+// to tell same-shaped segments apart. Discord has no such character — the closest
+// is 🎮, which names a category rather than the product and would read as "games".
+// The real mark is the thing people recognise, so it is worth the ~700 bytes.
+//
+// It inherits `currentColor` and takes its size from the caller, so it tracks the
+// header's hover/focus ink and the invitation card's accent without a second rule.
+// `aria-hidden` is unconditional: every caller already labels itself in text, and a
+// logo announced as "Discord" beside the word "Discord" is a stutter, not a label.
+
+export default function DiscordMark({ size = 13 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M20.317 4.3698a19.7913 19.7913 0 0 0-4.8851-1.5152.0741.0741 0 0 0-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 0 0-.0785-.037 19.7363 19.7363 0 0 0-4.8852 1.515.0699.0699 0 0 0-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 0 0 .0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 0 0 .0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 0 0-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 0 1-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 0 1 .0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 0 1 .0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 0 1-.0066.1276 12.2986 12.2986 0 0 1-1.873.8914.0766.0766 0 0 0-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 0 0 .0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 0 0 .0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 0 0-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189z" />
+    </svg>
+  );
+}

--- a/components/shell/CommunityNote.tsx
+++ b/components/shell/CommunityNote.tsx
@@ -1,0 +1,181 @@
+"use client";
+// The Discord invitation — a small card in the bottom-left corner of the console,
+// shown once to anyone who has stayed about a minute, and never again after they
+// answer it either way.
+//
+// IT IS A NOTE, NOT A MODAL, AND THAT IS THE WHOLE DESIGN. FeedbackPrompt next
+// door dims the console, traps focus and asks four questions, because it is asking
+// for work and has to be answered to be got rid of. This is asking for nothing: it
+// is a door being pointed at. So it takes no veil, no focus trap and no
+// aria-modal, it never moves focus, and every control behind it stays live while
+// it is on screen. A person who ignores it entirely loses nothing.
+//
+// Every decision about WHETHER to show lives in lib/shell/community.ts as pure
+// functions over an injectable store, so the gate is unit-tested in the node
+// environment. This file is the thin shell around it: a ticker, a card, two
+// buttons.
+//
+// ON STACKING WITH THE FEEDBACK PROMPT — deliberately NOT wired together. `.tn-note`
+// sits at z-index 1050, below `.tn-fb`'s 1100, so if the feedback modal does open
+// while this is still up, its veil dims this card along with the rest of the
+// console and the modal reads as the one live thing. That is the correct outcome
+// and it falls out of the z-order, so there is no cross-component subscription to
+// keep in sync and no ordering bug to have.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BRAND } from "@/lib/brand";
+import { BOOT_FADE_MS, BOOT_MS } from "@/lib/terminal/boot";
+import { cinematic } from "@/lib/cinematic/store";
+import DiscordMark from "@/components/brand/DiscordMark";
+import {
+  type CommunityState,
+  addActiveMs,
+  forcedFromSearch,
+  loadCommunityState,
+  markResolved,
+  recordVisit,
+  saveCommunityState,
+  shouldInvite,
+} from "@/lib/shell/community";
+
+/** Long enough for the cold-start plate and its fade to be gone. BOOT_MS is the
+ *  boot's ceiling — the plate usually leaves sooner, when the map is ready — so
+ *  this holds for the worst case and is never early. Same reasoning, and the same
+ *  constants, as FeedbackPrompt's hold. */
+const INITIAL_HOLD_MS = BOOT_MS + BOOT_FADE_MS + 500;
+/** Small enough that someone crossing the 40-second mark is asked during that
+ *  visit rather than several seconds late. */
+const TICK_MS = 5_000;
+
+/**
+ * `?discord=1`, read AT MODULE SCOPE rather than inside the mount effect.
+ *
+ * THE QUERY STRING DOES NOT SURVIVE TO FIRST EFFECT. The map syncs its camera into
+ * the URL (`?lat=…&lon=…&z=…&layers=&base=…`) with a history replace, which drops
+ * every param it does not own — `discord=1` included. Read from inside useEffect,
+ * the override therefore worked or did not depending on which effect ran first,
+ * which is the kind of bug that looks like "the flag is broken sometimes".
+ *
+ * Module bodies evaluate at import time, strictly before React renders anything and
+ * so strictly before any effect can rewrite the URL. Capturing here removes the race
+ * rather than winning it. Guarded for SSR, where there is no window at all.
+ */
+const FORCED = typeof window === "undefined" ? false : forcedFromSearch(window.location.search);
+
+export default function CommunityNote() {
+  const [open, setOpen] = useState(false);
+
+  const state = useRef<CommunityState | null>(null);
+
+  /* ── The gate ─────────────────────────────────────────────────────────── */
+
+  useEffect(() => {
+    const s = recordVisit(loadCommunityState());
+    state.current = s;
+    saveCommunityState(s);
+
+    let last = Date.now();
+    const started = last;
+
+    const tick = () => {
+      const now = Date.now();
+      const elapsed = now - last;
+      last = now;
+
+      // Only VISIBLE time counts — see the note in lib/shell/community.ts about
+      // why a background tab must not burn a one-shot impression.
+      if (document.visibilityState === "visible" && state.current) {
+        state.current = addActiveMs(state.current, elapsed);
+        saveCommunityState(state.current);
+      }
+
+      if (now - started < INITIAL_HOLD_MS) return;
+      const cur = state.current;
+      if (!cur) return;
+
+      const ctx = {
+        bootPlaying: false, // held out by INITIAL_HOLD_MS above, not by a racy read
+        diveActive: cinematic.get().phase !== "idle",
+      };
+
+      // The override forces the card for review but still respects a recorded
+      // resolution, so a review pass cannot silently re-ask someone who said no.
+      const show = FORCED ? !cur.resolved && !ctx.diveActive : shouldInvite(cur, ctx);
+      if (show) setOpen(true);
+    };
+
+    const timer = window.setInterval(tick, TICK_MS);
+    // One early evaluation so a forced review does not wait a full tick past the
+    // hold. A normal visitor cannot qualify this early — the hold is under six
+    // seconds and the bar is forty — so this costs nothing.
+    const first = window.setTimeout(tick, INITIAL_HOLD_MS + 100);
+    return () => {
+      window.clearInterval(timer);
+      window.clearTimeout(first);
+    };
+  }, []);
+
+  /* ── Resolution ───────────────────────────────────────────────────────── */
+
+  const resolve = useCallback((how: "joined" | "dismissed") => {
+    if (state.current) {
+      state.current = markResolved(state.current, how);
+      saveCommunityState(state.current);
+    }
+    setOpen(false);
+  }, []);
+
+  /* ── Render ───────────────────────────────────────────────────────────── */
+
+  // THE LIVE REGION IS MOUNTED ALWAYS, EMPTY WHEN IDLE, for the reason the toast
+  // in ConsoleShell.tsx documents: a live region has to already be in the
+  // accessibility tree when its content changes for the change to be announced,
+  // and one that arrives *carrying* its message is announced inconsistently across
+  // browser/screen-reader pairs. `.tn-note-live:empty` has no box, so the idle
+  // wrapper costs nothing visually — but it must NOT be display:none, which would
+  // take it back out of the tree and undo the fix.
+  return (
+    <div className="tn-note-live" role="status" aria-live="polite">
+      {open && (
+        <div className="tn-note">
+          <div className="tn-note-icon" aria-hidden>
+            <DiscordMark size={16} />
+          </div>
+          <div className="tn-note-body">
+            <p className="tn-note-title">Join our Discord!</p>
+            <p className="tn-note-text">
+              Ask for a camera or a layer, say what is broken, or watch what gets built. It is
+              new and quiet — come and make it less so.
+            </p>
+            <div className="tn-note-actions">
+              <a
+                className="tn-note-btn is-primary"
+                href={BRAND.discordUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                onClick={() => resolve("joined")}
+              >
+                <DiscordMark size={13} />
+                <span>Join the Discord</span>
+              </a>
+              <button type="button" className="tn-note-btn is-ghost" onClick={() => resolve("dismissed")}>
+                No thanks
+              </button>
+            </div>
+          </div>
+          {/* A second way out, in the corner, because the card is dismissible and a
+              ✕ is where a hand goes first. It resolves identically to "No thanks" —
+              there is no quiet third state. */}
+          <button
+            type="button"
+            className="tn-note-x"
+            onClick={() => resolve("dismissed")}
+            aria-label="Close, and do not show this again"
+          >
+            ×
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -31,6 +31,7 @@ import { pickStore } from "@/lib/console/widgets/camslot.pick";
 import SkipLink from "@/components/shell/SkipLink";
 import CommandPalette from "@/components/shell/CommandPalette";
 import FeedbackPrompt from "@/components/shell/FeedbackPrompt";
+import CommunityNote from "@/components/shell/CommunityNote";
 import { FeedOverlay } from "@/components/FeedOverlay";
 import { CinematicDive } from "@/components/CinematicDive";
 import { scopeStore } from "@/lib/shell/scope";
@@ -322,6 +323,11 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
       {/* Gates itself entirely (lib/shell/feedback.ts) and renders null until it
           decides to ask, so mounting it unconditionally costs one interval. */}
       <FeedbackPrompt />
+      {/* Gates itself the same way (lib/shell/community.ts) and renders an empty
+          live region until it decides to ask, so this also costs one interval.
+          Mounted AFTER FeedbackPrompt for readability only — the two are ordered by
+          z-index (1050 under 1100), not by DOM position. */}
+      <CommunityNote />
       {/* The toast is now mounted ALWAYS, empty when idle, instead of appearing and
           disappearing with its text. A live region has to already be in the
           accessibility tree when its content changes for the change to be

--- a/components/terminal/TerminalHeader.tsx
+++ b/components/terminal/TerminalHeader.tsx
@@ -108,6 +108,7 @@ import { isBoardEdited } from "@/lib/console/boards";
 import { useShellLayout } from "@/lib/console/store";
 import { appStatusLine } from "@/components/shell/a11y";
 import Mark from "@/components/brand/Mark";
+import DiscordMark from "@/components/brand/DiscordMark";
 import SettingsPanel from "@/components/shell/SettingsPanel";
 import { BRAND } from "@/lib/brand";
 
@@ -304,6 +305,25 @@ export default function TerminalHeader({ onOpenPalette }: { onOpenPalette: () =>
           cannot be a room with no door. `.tn-settings-trigger` came back with it.
         */}
         <div className="tnx-hdr-right">
+          {/* THE PERMANENT DOOR TO THE DISCORD, and the reason CommunityNote's
+              dismissal is allowed to be permanent. That card asks once and then
+              never again; without a standing link, "No thanks" would close the
+              only route rather than just the prompt. It joins this cluster because
+              it is the same kind of control as the two beside it — a way OUT of the
+              console — and it uses `.tnx-hdr-btn-label` (as SHORTCUTS and SETTINGS
+              do, and SUPPORT and SOURCE do not) so it collapses to the mark alone
+              under 720px and adds no width on a phone. */}
+          <a
+            className="tnx-hdr-btn"
+            href={BRAND.discordUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            title={`Join the ${BRAND.name} Discord`}
+          >
+            <DiscordMark size={12} />
+            <span className="tnx-hdr-btn-label">DISCORD</span>
+          </a>
+
           {/* Buy Me a Coffee (Ko-fi) — the app is free + keyless; this is a calm,
               opt-in way to support it. */}
           <a

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -23,6 +23,23 @@ export const BRAND = {
   ink: "#0b1016",
   /** Ko-fi support link (the calm, opt-in "Support" button). */
   kofiUrl: "https://ko-fi.com/opendata",
+  /**
+   * The Discord server.
+   *
+   * A DISCORD INVITE CAN EXPIRE, AND THAT IS THE ONLY DANGEROUS THING ABOUT THIS
+   * LINE. Invites are created with an expiry by default (7 days, or a custom one),
+   * and an expired invite does not fail loudly — it serves a normal-looking
+   * "Invite Invalid" page, so the console, the site footer and every shared link
+   * keep pointing at a dead end with nothing in this repo going red. Nothing here
+   * can detect it either: no test can reach discord.gg, and a link check would only
+   * tell you it was already broken.
+   *
+   * So the rule is a SETTING on Discord's side, not a check on ours: this must be a
+   * "never expire" invite (server → Invites → Edit → Expire After: Never, max uses
+   * unlimited). Verified against Discord's invite API on 2026-09-07 — server
+   * "Provenance", guild 1539313032801423441.
+   */
+  discordUrl: "https://discord.gg/H5vB8TsVK",
   /** Canonical public repository. */
   repo: "011-sam-110/Provenance",
   repoUrl: "https://github.com/011-sam-110/Provenance",

--- a/lib/shell/community.ts
+++ b/lib/shell/community.ts
@@ -1,0 +1,129 @@
+// The Discord invitation's gate. PURE: no React, no DOM, no "use client" — the
+// same reason lib/shell/feedback.ts is pure, and the same payoff: the interesting
+// behaviour (who is asked, when, and what makes it stop forever) is testable in the
+// node vitest environment with no window.
+//
+// HOW THIS DIFFERS FROM THE FEEDBACK GATE, AND WHY. Both are one-time asks over a
+// persisted envelope, so the shape is deliberately the same. Two rules are not:
+//
+//   (a) NO SAMPLING ROLL. Feedback samples one in three because it is a survey, and
+//       a survey wants a representative slice rather than every voice. An invitation
+//       is not a survey — sampling it would simply throw away two thirds of the
+//       reach for nothing in return.
+//
+//   (b) A MUCH SHORTER QUALIFYING TIME: 40 seconds of visible time, against
+//       feedback's fifteen minutes. Feedback has to be earned — you cannot usefully
+//       rate a thing you have not used. An invitation does not: the cost of asking
+//       early is one dismissed card, and the cost of asking late is that the person
+//       has already gone. Forty seconds is still long enough that a bounce (open,
+//       glance, close) never sees it.
+//
+// WHAT IS THE SAME, AND IS LOAD-BEARING: resolving is PERMANENT. Nobody who has
+// joined or said no is asked twice. The console header carries a DISCORD button, so
+// a permanent "no" here closes the prompt and not the door — which is what makes a
+// permanent no defensible rather than a one-way loss.
+
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export const COMMUNITY_KEY = "tn.community.v1";
+export const COMMUNITY_VERSION = 1;
+
+/**
+ * 40 seconds of VISIBLE time before the invitation appears.
+ *
+ * Visible rather than wall clock, for the reason feedback.ts gives: this is a live
+ * map, so a tab left open in the background is the normal case and means nobody
+ * looked at it. A background tab must not burn through the qualifying time and
+ * surface a card the person never sees, because the card would then be spent —
+ * `resolved` is permanent, and an unseen impression is the worst way to spend it.
+ */
+export const QUALIFY_ACTIVE_MS = 40_000;
+
+export type CommunityResolution = "joined" | "dismissed";
+
+export interface CommunityState {
+  /** Distinct page loads, incremented once per visit. Not a gate arm today — kept
+   *  because it is the one number that says whether the ask is reaching new people
+   *  or the same person repeatedly, and it costs one integer to have it later. */
+  visits: number;
+  /** Cumulative VISIBLE milliseconds across all visits. */
+  activeMs: number;
+  /** Set once, forever. Its presence is the permanent stop. */
+  resolved?: CommunityResolution;
+}
+
+export const EMPTY_COMMUNITY_STATE: CommunityState = { visits: 0, activeMs: 0 };
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function loadCommunityState(storage?: StorageLike): CommunityState {
+  const raw = loadPersisted<CommunityState>(COMMUNITY_KEY, COMMUNITY_VERSION, storage);
+  if (!raw || typeof raw !== "object") return { ...EMPTY_COMMUNITY_STATE };
+  // A hand-edited or half-written envelope must not become NaN maths downstream.
+  const visits = Number.isFinite(raw.visits) && raw.visits > 0 ? Math.floor(raw.visits) : 0;
+  const activeMs = Number.isFinite(raw.activeMs) && raw.activeMs > 0 ? raw.activeMs : 0;
+  const resolved = raw.resolved === "joined" || raw.resolved === "dismissed" ? raw.resolved : undefined;
+  return resolved ? { visits, activeMs, resolved } : { visits, activeMs };
+}
+
+export function saveCommunityState(state: CommunityState, storage?: StorageLike): void {
+  savePersisted<CommunityState>(COMMUNITY_KEY, COMMUNITY_VERSION, state, storage);
+}
+
+/* ── Pure state transitions ─────────────────────────────────────────────── */
+
+export function recordVisit(state: CommunityState): CommunityState {
+  return { ...state, visits: state.visits + 1 };
+}
+
+export function addActiveMs(state: CommunityState, ms: number): CommunityState {
+  if (!Number.isFinite(ms) || ms <= 0) return state;
+  return { ...state, activeMs: state.activeMs + ms };
+}
+
+export function markResolved(state: CommunityState, how: CommunityResolution): CommunityState {
+  return { ...state, resolved: how };
+}
+
+/* ── The gate ───────────────────────────────────────────────────────────── */
+
+export function qualifies(state: CommunityState): boolean {
+  return state.activeMs >= QUALIFY_ACTIVE_MS;
+}
+
+export interface CommunityGateContext {
+  /** The cold-start plate is still on screen. */
+  bootPlaying: boolean;
+  /** A cinematic dive is flying or landed. A dive is the one deliberately
+   *  immersive thing the console does; interrupting it with an ad for a chat
+   *  server is the single worst moment available. */
+  diveActive: boolean;
+}
+
+/** Why the card is being withheld, or null if nothing is withholding it. Returned
+ *  as a reason rather than a boolean so a test names the arm it is exercising. */
+export function blockedBy(state: CommunityState, ctx: CommunityGateContext): string | null {
+  if (state.resolved) return state.resolved;
+  if (ctx.bootPlaying) return "boot";
+  if (ctx.diveActive) return "dive";
+  return null;
+}
+
+export function shouldInvite(state: CommunityState, ctx: CommunityGateContext): boolean {
+  if (blockedBy(state, ctx) !== null) return false;
+  return qualifies(state);
+}
+
+/**
+ * `?discord=1` forces the invitation open for review — the same override precedent
+ * `?feedback=1` and `?boot=1` set. It bypasses the qualifying time; it does NOT
+ * bypass a recorded resolution, so a review pass cannot silently re-ask someone who
+ * has already said no.
+ */
+export function forcedFromSearch(search: string): boolean {
+  try {
+    return new URLSearchParams(search).get("discord") === "1";
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/community.test.ts
+++ b/tests/unit/community.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "vitest";
+import {
+  COMMUNITY_KEY,
+  COMMUNITY_VERSION,
+  EMPTY_COMMUNITY_STATE,
+  QUALIFY_ACTIVE_MS,
+  addActiveMs,
+  blockedBy,
+  forcedFromSearch,
+  loadCommunityState,
+  markResolved,
+  qualifies,
+  recordVisit,
+  saveCommunityState,
+  shouldInvite,
+  type CommunityState,
+} from "@/lib/shell/community";
+import { BRAND } from "@/lib/brand";
+
+/** A stand-in for window.localStorage, so the round trip and the version guard are
+ *  testable in the node environment. Same trick tests/unit/feedback.test.ts uses. */
+function memoryStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    raw: map,
+  };
+}
+
+const OPEN_CTX = { bootPlaying: false, diveActive: false };
+
+function stateWith(over: Partial<CommunityState> = {}): CommunityState {
+  return { ...EMPTY_COMMUNITY_STATE, ...over };
+}
+
+describe("community state persistence", () => {
+  test("round-trips through the versioned envelope", () => {
+    const store = memoryStorage();
+    const state = stateWith({ visits: 3, activeMs: 90_000, resolved: "joined" });
+    saveCommunityState(state, store);
+    expect(loadCommunityState(store)).toEqual(state);
+  });
+
+  test("an absent key loads the empty state rather than throwing", () => {
+    expect(loadCommunityState(memoryStorage())).toEqual(EMPTY_COMMUNITY_STATE);
+  });
+
+  test("a hand-edited envelope cannot become NaN maths downstream", () => {
+    const store = memoryStorage();
+    store.setItem(
+      COMMUNITY_KEY,
+      JSON.stringify({ v: COMMUNITY_VERSION, d: { visits: "lots", activeMs: -5, resolved: "maybe" } }),
+    );
+    const loaded = loadCommunityState(store);
+    expect(loaded).toEqual({ visits: 0, activeMs: 0 });
+    // The junk `resolved` must not survive as a truthy stop — the person has not
+    // actually answered, so they are still eligible to be asked.
+    expect(loaded.resolved).toBeUndefined();
+  });
+
+  test("a stale version is discarded, not migrated", () => {
+    const store = memoryStorage();
+    store.setItem(
+      COMMUNITY_KEY,
+      JSON.stringify({ v: COMMUNITY_VERSION + 1, d: { visits: 9, activeMs: 999_999 } }),
+    );
+    expect(loadCommunityState(store)).toEqual(EMPTY_COMMUNITY_STATE);
+  });
+});
+
+describe("pure transitions", () => {
+  test("recordVisit increments and does not mutate", () => {
+    const before = stateWith({ visits: 1 });
+    const after = recordVisit(before);
+    expect(after.visits).toBe(2);
+    expect(before.visits).toBe(1);
+  });
+
+  test("addActiveMs ignores a non-finite or negative delta", () => {
+    const before = stateWith({ activeMs: 1_000 });
+    expect(addActiveMs(before, Number.NaN)).toBe(before);
+    expect(addActiveMs(before, -1)).toBe(before);
+    expect(addActiveMs(before, 0)).toBe(before);
+    expect(addActiveMs(before, 500).activeMs).toBe(1_500);
+  });
+
+  test("markResolved records which way it went", () => {
+    expect(markResolved(stateWith(), "joined").resolved).toBe("joined");
+    expect(markResolved(stateWith(), "dismissed").resolved).toBe("dismissed");
+  });
+});
+
+describe("the gate", () => {
+  test("does not qualify below the visible-time bar", () => {
+    expect(qualifies(stateWith({ activeMs: QUALIFY_ACTIVE_MS - 1 }))).toBe(false);
+    expect(qualifies(stateWith({ activeMs: QUALIFY_ACTIVE_MS }))).toBe(true);
+  });
+
+  test("a bounce is never asked", () => {
+    expect(shouldInvite(stateWith({ visits: 1, activeMs: 5_000 }), OPEN_CTX)).toBe(false);
+  });
+
+  test("someone who has stayed is asked", () => {
+    expect(shouldInvite(stateWith({ visits: 1, activeMs: QUALIFY_ACTIVE_MS }), OPEN_CTX)).toBe(true);
+  });
+
+  test("EVERY qualifying visitor is asked — there is no sampling roll", () => {
+    // The distinguishing rule against the feedback gate, which samples one in
+    // three. If a roll is ever added here this test is the thing that should be
+    // argued with first: an invitation loses two thirds of its reach to sampling
+    // and gains nothing, because it is not a survey.
+    const qualified = stateWith({ visits: 1, activeMs: QUALIFY_ACTIVE_MS });
+    for (let i = 0; i < 50; i++) expect(shouldInvite(qualified, OPEN_CTX)).toBe(true);
+  });
+
+  test("resolving is permanent, either way", () => {
+    const long = { visits: 9, activeMs: QUALIFY_ACTIVE_MS * 100 };
+    expect(shouldInvite({ ...long, resolved: "dismissed" }, OPEN_CTX)).toBe(false);
+    expect(shouldInvite({ ...long, resolved: "joined" }, OPEN_CTX)).toBe(false);
+  });
+
+  test("the boot plate and a cinematic dive each hold it back", () => {
+    const qualified = stateWith({ activeMs: QUALIFY_ACTIVE_MS });
+    expect(blockedBy(qualified, { bootPlaying: true, diveActive: false })).toBe("boot");
+    expect(blockedBy(qualified, { bootPlaying: false, diveActive: true })).toBe("dive");
+    expect(blockedBy(qualified, OPEN_CTX)).toBeNull();
+    expect(shouldInvite(qualified, { bootPlaying: true, diveActive: false })).toBe(false);
+    expect(shouldInvite(qualified, { bootPlaying: false, diveActive: true })).toBe(false);
+  });
+
+  test("a recorded resolution outranks every other reason", () => {
+    expect(blockedBy(stateWith({ resolved: "joined" }), { bootPlaying: true, diveActive: true })).toBe("joined");
+  });
+});
+
+describe("the ?discord=1 review override", () => {
+  test("reads the flag, and only that flag", () => {
+    expect(forcedFromSearch("?discord=1")).toBe(true);
+    expect(forcedFromSearch("?foo=bar&discord=1")).toBe(true);
+    expect(forcedFromSearch("?discord=0")).toBe(false);
+    expect(forcedFromSearch("?feedback=1")).toBe(false);
+    expect(forcedFromSearch("")).toBe(false);
+  });
+});
+
+describe("the invite URL", () => {
+  test("is a discord.gg invite, not a channel or a server-settings deep link", () => {
+    // A `discord.com/channels/<guild>/<channel>` URL is what the desktop app puts
+    // on the clipboard when you copy a channel, and it is NOT joinable — someone
+    // who is not already a member lands on their own last-used server instead.
+    expect(BRAND.discordUrl).toMatch(/^https:\/\/discord\.gg\/[A-Za-z0-9-]+$/);
+  });
+});


### PR DESCRIPTION
## What

A one-time card in the bottom-left of `/app` inviting people to the Discord, plus two standing routes that survive its dismissal: a `DISCORD` button in the console header and a link in the landing-page footer.

<img width="400" alt="The invitation card" src="https://github.com/user-attachments/assets/placeholder" />

> **Join our Discord!**
> Ask for a camera or a layer, say what is broken, or watch what gets built. It is new and quiet — come and make it less so.
> `[ Join the Discord ]  No thanks`

## Why it is a note and not a banner

`FeedbackPrompt` next door dims the console, traps focus and asks four questions, because it is asking for *work* and has to be answered to be got rid of. This asks for nothing — it points at a door. So it takes no veil, no focus trap and no `aria-modal`, it never moves focus, and everything behind it stays live. Ignoring it entirely costs the visitor nothing.

The two are ordered by z-index alone (`.tn-note` 1050 under `.tn-fb` 1100). If the feedback modal opens while the note is still up, its veil dims the note along with the rest of the console and the modal reads as the one live thing — which is the correct outcome and falls out of the stacking order, so there is no cross-component subscription to keep in sync. Confirmed in the browser; the two did collide during review and behaved as described.

## The gate

Pure, in `lib/shell/community.ts`, tested in the node environment — the same shape as `lib/shell/feedback.ts`. Two rules deliberately differ:

| | Feedback | This |
|---|---|---|
| Sampling | 1 in 3 | **none** — an invitation is not a survey, and sampling throws away two thirds of the reach for nothing |
| Qualifies at | 15 min visible, or a 2nd visit | **40 s visible** — feedback has to be earned, an invitation does not |

Resolving is permanent either way. That is only defensible because the header button exists: a "No thanks" closes the prompt, not the door.

## Two things found by looking rather than reasoning

- **`?discord=1` did not survive to first effect.** The map syncs its camera into the URL with a history replace that drops every param it does not own, so the review override worked or did not depending on which effect ran first. Now read at module scope, which is strictly before any effect can rewrite the URL.
- **On a phone the note covered the top half of `.tn-rail-fab`** — the only way into the sources rail and the board list at that width. An invitation that hides the navigation is worse than no invitation. The mobile offset is now written in that button's own terms so it tracks `--tn-ticker-h` rather than freezing one measurement.

## One thing for you, and it is not in the code

**The invite expires on 2026-10-06.** Verified against Discord's invite API on 2026-09-07 (server "Provenance", guild `1539313032801423441`). An expired invite does not fail loudly — it serves a normal-looking "Invite Invalid" page, and nothing in this repo can detect that: no test can reach discord.gg. Please reissue it as **Expire After: Never, max uses unlimited** and I will swap the code. The reasoning is written down in `lib/brand.ts` so the next person to touch that line knows what they are changing.

Two smaller ones, both your call and neither blocking:
- The invite currently lands people in `👋・joins-leaves`. An invite made from a welcome or general channel would drop them somewhere they can read.
- The server has membership screening on and verification level 2, so new arrivals hit a rules gate before they can post.

## Gate

`npx tsc --noEmit` clean. **3,142 tests across 322 files pass.** Reviewed at 1440×900 and 390×844.
