### PR TITLE
Arming the camera picker turns its own pins on, and wears its marks

### DIFF
--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -403,7 +403,12 @@ function pickBoxSelection(bounds: ReturnType<typeof normalizeBounds>, webcams: W
   if (rows.length === 0 && webcams.length === 0) {
     // The store is populated only while the camera layer is on (WorldMap:1859), so an
     // empty result here means "we were not looking", not "there is nothing there".
-    toast("No camera pins are loaded, so a box has nothing to select. Turn on the Cameras layer.");
+    //
+    // It no longer means the layer is OFF, though, which is what this used to say.
+    // A box-drag only reaches here while picking is armed, and arming now switches
+    // the camera and webcam layers on itself (lib/console/widgets/camslot.layers.ts),
+    // so "Turn on the Cameras layer" would point at a toggle that is already lit.
+    toast("No camera pins have loaded yet, so a box has nothing to select. Give the pins a moment and drag again.");
     return;
   }
   if (cams.length === 0 && cover.length === 0) {

--- a/components/console/maprail/CamerasFlyout.tsx
+++ b/components/console/maprail/CamerasFlyout.tsx
@@ -11,12 +11,30 @@
 // chips, Send to wall, Clear and Stop picking, and it appears the moment picking
 // starts. A second Clear would put two controls for one action on screen at once,
 // which is the thing the rail exists to remove.
+//
+// NEW WALL IS NOT HERE EITHER, AND IT USED TO BE. Removing it was asked for, but
+// it had a recorded reason to exist and that reason has to be answered rather than
+// deleted with it. It was added after Sam reported a dead end — "after doing this I
+// then can't add a camera as there isn't a widget to add it to" — i.e. delete your
+// last camera wall and the board had no way back to one.
+//
+// That dead end is gone, and CHECKED rather than assumed. Two other routes create a
+// camera wall today: "Send to wall" offers a NEW wall as a destination whether or
+// not one exists (camslot.send.ts, SendTarget = "new"), and `camslot` is in
+// POPULAR_WIDGET_IDS (paletteGroups.ts:101), so ⌘K adds an empty one directly.
+// Both call the same createCamslot() this button did. A third control for a thing
+// two controls already do is the duplication the rail exists to remove — and this
+// one cost a chip of strip width on the flyout that had the most buttons.
+//
+// If both of those routes are ever removed, the dead end comes back and this button
+// is the fix. That is the condition to check, not the button to miss.
 
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { MIN_VERTICES, cancelDraw, useAoiDraw } from "@/lib/map/aoi";
 import { pickStore, usePicks } from "@/lib/console/widgets/camslot.pick";
 import { areaPickStore, startAreaPick } from "@/lib/console/widgets/camslot.area";
-import { createCamslot } from "@/lib/console/widgets/camslot.create";
+import { armPicking } from "@/lib/console/widgets/camslot.layers";
+import { BoundingBoxGlyph, CameraPlusGlyph } from "./RailIcons";
 
 export default function CamerasFlyout() {
   const { mode, picks } = usePicks();
@@ -30,13 +48,6 @@ export default function CamerasFlyout() {
     const t = setTimeout(() => setNote(null), 3500);
     return () => clearTimeout(t);
   }, [note]);
-
-  const onNewWall = useCallback(() => {
-    const r = createCamslot();
-    // createCamslot scrolls to and flashes the card it made, so a success needs no
-    // note of its own — saying "added" beside a card that has just lit up is noise.
-    if (!r.ok) setNote(r.reason ?? "Could not add a camera wall.");
-  }, []);
 
   const onArea = useCallback(() => {
     const r = startAreaPick();
@@ -71,40 +82,34 @@ export default function CamerasFlyout() {
 
   return (
     <>
+      {/* Arming goes through armPicking(), NOT pickStore.setMode — that is what
+          switches the camera and webcam pins on. Stopping is a plain setMode: the
+          layers stay up, deliberately. See camslot.layers.ts. */}
       <button
         type="button"
-        className="tnx-maprail-act"
+        className="tnx-maprail-act tnx-maprail-act-icon"
         aria-pressed={picking}
-        onClick={() => pickStore.setMode(picking ? "off" : "picking")}
+        onClick={() => (picking ? pickStore.setMode("off") : armPicking())}
         title={
           picking
             ? "Stop picking. What you have already picked stays in the tray."
-            : "Click camera pins, or shift-drag a box, to collect them for a wall"
+            : "Click camera pins, or shift-drag a box, to collect them for a wall. Turns the camera and webcam pins on."
         }
       >
-        {picking ? "Picking cameras" : "Pick cameras"}
+        <CameraPlusGlyph />
+        <span>{picking ? "Picking cameras" : "Pick cameras"}</span>
       </button>
 
       <button
         type="button"
-        className="tnx-maprail-act"
+        className="tnx-maprail-act tnx-maprail-act-icon"
         onClick={onArea}
-        // Honest about the side effect: this draws a shape AND turns picking on.
-        title="Draw a shape; every camera inside it is picked, and picking stays on"
+        // Honest about the side effects, both of them: this draws a shape, turns
+        // picking on, AND brings the pins it will read up.
+        title="Draw a shape; every camera inside it is picked, and picking stays on. Turns the camera and webcam pins on."
       >
-        By area
-      </button>
-
-      {/* The always-available way to get an empty wall, so removing the last one is
-          never a dead end. Sam's report: "after doing this I then can't add a
-          camera as there isn't a widget to add it to." */}
-      <button
-        type="button"
-        className="tnx-maprail-act"
-        onClick={onNewWall}
-        title="Add an empty camera wall to this board"
-      >
-        New wall
+        <BoundingBoxGlyph />
+        <span>By area</span>
       </button>
 
       {picks.length > 0 ? (

--- a/components/console/maprail/RailIcons.tsx
+++ b/components/console/maprail/RailIcons.tsx
@@ -179,8 +179,13 @@ export function PinGearGlyph() {
  * Pick cameras — a camera with a ＋ badge. The flyout mark for arming the picker.
  *
  * Traced from Sam's reference (selectcamerasicon.png). Same redraw-don't-embed
- * rule this file opens with: the reference is an opaque black raster, and the
- * flyout sits on --tnx-panel, so a PNG would be a black square on a dark skin.
+ * rule this file opens with, though NOT for the reason that rule was written: the
+ * console is light now (--tnx-panel is #ffffff), so a black raster would be
+ * visible rather than invisible. Two things still make stroke geometry the only
+ * option. The mark has to take --tnx-accent (#464b37) when the button is pressed,
+ * and a raster cannot be recoloured; and at rest it has to be the same olive ink
+ * as the word beside it, not pure black, or the two halves of one button are
+ * different colours. currentColor gives both for free.
  *
  * THE BODY IS AN OPEN PATH, NOT A RECT, and that is the whole trick. The badge
  * overlaps the camera's bottom-right corner, so the outline STOPS on both sides
@@ -205,7 +210,8 @@ export function CameraPlusGlyph() {
 /**
  * By area — a bounding box with square corner handles.
  *
- * Traced from Sam's reference (pickcamerasbyarea.png). Deliberately built on
+ * Traced from Sam's reference (pickcamerasbyarea.png), redrawn for the same
+ * currentColor reasons as CameraPlusGlyph above. Deliberately built on
  * PolygonGlyph's geometry — same corner centres (4/20), same trimmed edges — so
  * the two area marks read as one family. It is told apart from PolygonGlyph by
  * the two things the references themselves differ on: SQUARE handles rather than

--- a/components/console/maprail/RailIcons.tsx
+++ b/components/console/maprail/RailIcons.tsx
@@ -174,3 +174,59 @@ export function PinGearGlyph() {
     </svg>
   );
 }
+
+/**
+ * Pick cameras — a camera with a ＋ badge. The flyout mark for arming the picker.
+ *
+ * Traced from Sam's reference (selectcamerasicon.png). Same redraw-don't-embed
+ * rule this file opens with: the reference is an opaque black raster, and the
+ * flyout sits on --tnx-panel, so a PNG would be a black square on a dark skin.
+ *
+ * THE BODY IS AN OPEN PATH, NOT A RECT, and that is the whole trick. The badge
+ * overlaps the camera's bottom-right corner, so the outline STOPS on both sides
+ * of it (x=11.5 along the bottom, y=9.5 down the right edge) instead of running
+ * underneath. Those two numbers are the badge circle grown by 0.9 — the cut is
+ * wider than the badge so there is a visible gap rather than a kiss. Same
+ * reasoning as PolygonGlyph's trimmed edges: at 18px two strokes of one colour
+ * that touch read as a smudge, and one drawn through another reads as a blot.
+ */
+export function CameraPlusGlyph() {
+  return (
+    <svg {...BASE} strokeWidth={1.9}>
+      <path d="M11.5 16.4H3.6A1.6 1.6 0 0 1 2 14.8V8.2A1.6 1.6 0 0 1 3.6 6.6H6L7 4.6h3.4l1 2h3.2A1.6 1.6 0 0 1 16.2 8.2V9.5" />
+      <circle cx={9.1} cy={11.5} r={2.9} />
+      <circle cx={17.4} cy={15.4} r={5.1} />
+      <line x1={17.4} y1={12.9} x2={17.4} y2={17.9} />
+      <line x1={14.9} y1={15.4} x2={19.9} y2={15.4} />
+    </svg>
+  );
+}
+
+/**
+ * By area — a bounding box with square corner handles.
+ *
+ * Traced from Sam's reference (pickcamerasbyarea.png). Deliberately built on
+ * PolygonGlyph's geometry — same corner centres (4/20), same trimmed edges — so
+ * the two area marks read as one family. It is told apart from PolygonGlyph by
+ * the two things the references themselves differ on: SQUARE handles rather than
+ * round, and a closed rectangle rather than an irregular five-vertex ring. That
+ * distinction has to survive 18px, which is why the handles are not merely
+ * smaller circles.
+ *
+ * The edges run handle-edge to handle-edge (6.1 → 17.9, the centres ± 2.1) so no
+ * line is drawn through the inside of a handle.
+ */
+export function BoundingBoxGlyph() {
+  return (
+    <svg {...BASE} strokeWidth={1.9}>
+      <line x1={6.1} y1={4} x2={17.9} y2={4} />
+      <line x1={6.1} y1={20} x2={17.9} y2={20} />
+      <line x1={4} y1={6.1} x2={4} y2={17.9} />
+      <line x1={20} y1={6.1} x2={20} y2={17.9} />
+      <rect x={1.9} y={1.9} width={4.2} height={4.2} rx={0.7} />
+      <rect x={17.9} y={1.9} width={4.2} height={4.2} rx={0.7} />
+      <rect x={1.9} y={17.9} width={4.2} height={4.2} rx={0.7} />
+      <rect x={17.9} y={17.9} width={4.2} height={4.2} rx={0.7} />
+    </svg>
+  );
+}

--- a/lib/console/widgets/camslot.area.ts
+++ b/lib/console/widgets/camslot.area.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { getMapInstance } from "@/lib/map/instance";
+import { revealPickLayers } from "@/lib/console/widgets/camslot.layers";
 import { aoiDrawStore, startDraw } from "@/lib/map/aoi";
 import { loadedCamerasStore } from "@/lib/cameras/loaded";
 import { loadedWebcamsStore } from "@/lib/webcams/loaded";
@@ -86,11 +87,18 @@ aoiDrawStore.subscribe(() => {
  * Turns picking mode on as a side effect, deliberately: someone who has just drawn
  * a ring around Soho is picking cameras whether or not they pressed the toggle
  * first, and making them press it afterwards to see the tray would be a riddle.
+ *
+ * And it brings the pins up for the same reason — see camslot.layers.ts. Drawing a
+ * ring is an unambiguous statement that you want the cameras inside it, so a ring
+ * that closes onto an empty result because a layer was off is the tool refusing a
+ * request it understood. `revealPickLayers` is called here rather than only in the
+ * flyout so the guarantee belongs to the GESTURE, not to one button that starts it.
  */
 export function startAreaPick(): AreaPickOutcome {
   const map = getMapInstance();
   if (!map) return { kind: "no-map" };
 
+  revealPickLayers();
   pickStore.setMode("picking");
   setForPick(true);
   const ok = startDraw(map, { onFinish: (ring) => { setForPick(false); pickRing(ring); } });
@@ -119,9 +127,15 @@ export function pickRing(ring: readonly [number, number][]): RingPickResult {
   const webcams = loadedWebcamsStore.get();
 
   if (rows.length === 0 && webcams.length === 0) {
-    // Neither layer is on. Saying "no cameras in that area" here would be a
+    // Nothing has ARRIVED yet. Saying "no cameras in that area" here would be a
     // confident wrong answer to a question we never actually asked.
-    const message = "No camera pins are loaded, so an area has nothing to select. Turn on the Cameras or Webcams layer and draw it again.";
+    //
+    // This used to read "Turn on the Cameras or Webcams layer and draw it again",
+    // and that instruction is now false: startAreaPick switched both layers on
+    // before the draw began, so it would send the user to a toggle that is already
+    // lit. Reaching here means the feeds are still in flight (or have failed), which
+    // is a wait, not a setting.
+    const message = "No camera pins have loaded yet, so an area has nothing to select. Give the pins a moment and draw it again.";
     toast(message);
     return { message, found: 0, added: 0 };
   }

--- a/lib/console/widgets/camslot.layers.ts
+++ b/lib/console/widgets/camslot.layers.ts
@@ -1,0 +1,80 @@
+"use client";
+// ── Arming the picker turns its pins on ──────────────────────────────────────
+//
+// Picking cameras off a map with no camera pins on it is not a hard mode to get
+// into — until now it was the DEFAULT one for webcams, which ship off. The tool
+// then failed in the one way this codebase works hardest to avoid: it answered a
+// question it had never asked. `camslot.area.ts` and `WorldMap.pickBoxSelection`
+// both had to carry a branch distinguishing "your ring is empty" from "we were
+// not looking", and the best either could do was tell the user to go and find a
+// layer toggle and then repeat the gesture.
+//
+// So the arming step switches the layers on itself. Asked for directly: "make it
+// so the pick cameras for a wall automatically turns on cameras and webcams".
+//
+// WHY A MODULE AND NOT A LINE IN EACH BUTTON. Three separate controls arm
+// picking — the map rail's Cameras flyout, its By area button (via
+// startAreaPick), and "◎ Pick cameras on the map" inside an empty camera wall.
+// The trap is identical from all three, so the fix has to be. `armPicking()` is
+// the one door, and a fourth entry point added later gets the behaviour by using
+// the same function rather than by remembering this.
+//
+// WHY NOT INSIDE pickStore.setMode(). That was the first shape and it is wrong.
+// camslot.pick.ts is the basket MODEL: it is imported by node unit tests, and
+// layersStore.set persists through localStorage on every emit, so the store would
+// have grown a jsdom dependency to serve a concern that is not its own. Arming is
+// a UI act; the basket is a data structure.
+//
+// WHY IT DOES NOT PUT THE LAYERS BACK. Stopping picking leaves them on. Turning
+// off a layer the user can currently see is a bigger surprise than leaving one
+// on, and it would also be a guess: nothing records whether the user had cameras
+// on before they started, so "restore" would mean "turn off", which is a
+// different thing and wrong for anyone who had them on all along.
+//
+// THE COST, STATED RATHER THAN BURIED. `webcams` defaults to false on purpose and
+// is deliberately excluded from the layer presets — lib/layers.ts explains why it
+// is a keyed, rate-limited global sample that stays opt-in. This reverses that for
+// one gesture, and that is a real trade, not an oversight. What keeps it honest is
+// WHERE the call sits: it fires on the arming action, never on mount and never on
+// opening the flyout, so nothing fetches Windy until someone has deliberately
+// pressed a button that says it is about to collect cameras. The opt-in did not
+// disappear; it moved from a toggle users could not find to the gesture they
+// actually performed.
+
+import { layersStore, type LayerKey } from "@/lib/layers";
+import { pickStore } from "@/lib/console/widgets/camslot.pick";
+
+/**
+ * The core layers a camera pick draws from.
+ *
+ * These are exactly the two stores the pick paths read — `loadedCamerasStore`
+ * (road cameras) and `loadedWebcamsStore` (the Windy sample) — and each is
+ * populated only while its layer is on, because WorldMap gates the feed
+ * component itself (`{layers.webcams && <WebcamsFeed …/>}`). Switching the layer
+ * on is therefore what starts the fetch, not merely what reveals it.
+ *
+ * Exported so a test can assert the list rather than restate it.
+ */
+export const PICK_LAYERS: readonly LayerKey[] = ["cameras", "webcams"];
+
+/**
+ * Switch on every layer a pick can draw from. Idempotent — `layersStore.set`
+ * early-returns when the value is unchanged, so this neither re-emits nor
+ * re-persists for a layer that was already on.
+ */
+export function revealPickLayers(): void {
+  for (const key of PICK_LAYERS) layersStore.set(key, true);
+}
+
+/**
+ * Arm picking: the pins come on, then the mode goes on.
+ *
+ * ORDER MATTERS, though only by a frame. The feed components mount off the layer
+ * state, so switching the layers first means the fetch is already in flight by the
+ * time the tray appears — rather than the user seeing "SELECTED 0" over an empty
+ * map for a beat and concluding the tool is broken.
+ */
+export function armPicking(): void {
+  revealPickLayers();
+  pickStore.setMode("picking");
+}

--- a/lib/console/widgets/camslot.tsx
+++ b/lib/console/widgets/camslot.tsx
@@ -25,6 +25,7 @@ import CamslotDetail from "@/lib/console/widgets/camslot.detail";
 import { useHistoryRecorder } from "@/lib/cameras/history";
 import { streamHealth, useStreamHealth, liveStreams, benchedNote } from "@/lib/console/widgets/camslot.health";
 import { pickStore } from "@/lib/console/widgets/camslot.pick";
+import { armPicking } from "@/lib/console/widgets/camslot.layers";
 import { shellLayoutStore } from "@/lib/console/store";
 import {
   sanitizeCamslotConfig,
@@ -212,7 +213,11 @@ function CamslotBody({ instanceId, config }: WidgetBodyProps) {
   // basket, which is what lets the user choose the destination at send time rather
   // than committing to one before they have found anything.
   const openPicker = useCallback(() => setPicking(true), []);
-  const pickOnMap = useCallback(() => pickStore.setMode("picking"), []);
+  // armPicking, not pickStore.setMode: this route hits the same trap as the map
+  // rail's, so it gets the same fix — the camera and webcam pins come on with the
+  // mode. Sending someone to a selection surface with nothing selectable on it is
+  // the failure this slot's empty state is already apologising for.
+  const pickOnMap = useCallback(() => armPicking(), []);
 
   // Names and cadences come from the shared camera poller — ref-counted, so several
   // slots share one 60s poll instead of each starting their own.

--- a/tests/e2e/map-rail.spec.ts
+++ b/tests/e2e/map-rail.spec.ts
@@ -248,6 +248,58 @@ test("Radius: two clicks set a circular scope, and the readout names the radius"
   await expect(pop.getByRole("button", { name: RADIUS_TOOL })).toBeVisible();
 });
 
+test("Cameras: two buttons with marks, no New wall, and arming turns the pins on", async ({ page }) => {
+  // THE ONE THING THE NODE TESTS CANNOT SAY. tests/unit/camslot-layers.test.ts pins
+  // the store contract that armPicking() honours, but vitest here is environment:
+  // "node" and collects .ts only -- nothing there can see a button, so nothing there
+  // can catch the flyout being wired to pickStore.setMode again, or New wall coming
+  // back. That is what this covers.
+  const rail = page.locator(RAIL);
+  await mapReady(page);
+
+  // A COLD layer state, so "arming turned them on" is an observation and not a value
+  // that was already true. Written before the click, through the same persisted key
+  // lib/layers.ts uses, and read back the same way.
+  await page.evaluate(() => {
+    window.localStorage.setItem("tn.layers.v1", JSON.stringify({
+      v: 1,
+      d: { cameras: false, satellites: false, planes: false, ships: false, webcams: false, weather: false, countries: true },
+    }));
+  });
+  await page.reload();
+  await mapReady(page);
+
+  await rail.getByRole("button", { name: CAMERAS }).click();
+  const pop = page.locator(".tnx-maprail-pop");
+  await expect(pop).toBeVisible();
+
+  // TWO buttons, not three. Asserted on the count as well as on the absent name,
+  // because a New wall button that had merely been renamed would still be a third
+  // control for a thing two other routes already do.
+  await expect(pop.getByRole("button")).toHaveCount(2);
+  await expect(pop.getByRole("button", { name: /new wall/i })).toHaveCount(0);
+
+  // Both marks render. They are aria-hidden, so they are counted rather than
+  // queried by role -- an icon a screen reader can see would be the bug.
+  await expect(pop.locator("button svg")).toHaveCount(2);
+
+  const layers = () =>
+    page.evaluate(() => JSON.parse(window.localStorage.getItem("tn.layers.v1") || "{}").d ?? {});
+  expect(await layers()).toMatchObject({ cameras: false, webcams: false });
+
+  await pop.getByRole("button", { name: /^Pick cameras$/ }).click();
+  await expect(pop.getByRole("button", { name: /Picking cameras/ })).toHaveAttribute("aria-pressed", "true");
+
+  // The point of the change: the picker switched on the layers it reads from.
+  await expect.poll(layers).toMatchObject({ cameras: true, webcams: true });
+
+  // And stopping leaves them up -- deliberate, see camslot.layers.ts. Nothing
+  // records what was on beforehand, so "restore" could only mean "turn off".
+  await pop.getByRole("button", { name: /Picking cameras/ }).click();
+  await expect(pop.getByRole("button", { name: /^Pick cameras$/ })).toHaveAttribute("aria-pressed", "false");
+  expect(await layers()).toMatchObject({ cameras: true, webcams: true });
+});
+
 test("the zoom cluster is gone and the ⓘ attribution is not", async ({ page }) => {
   // Two assertions that have to travel together. The zoom/compass cluster was
   // removed because the rail replaces it; the attribution was NOT, because

--- a/tests/unit/camslot-layers.test.ts
+++ b/tests/unit/camslot-layers.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { layersStore } from "@/lib/layers";
+import { pickStore } from "@/lib/console/widgets/camslot.pick";
+import { PICK_LAYERS, armPicking, revealPickLayers } from "@/lib/console/widgets/camslot.layers";
+
+// What this file is for, and what it deliberately cannot say.
+//
+// It pins ONE promise: arming the camera picker switches on the layers the picker
+// reads from. That promise is worth a test rather than a comment because it is
+// invisible in the UI — the button that arms picking is not the control that shows
+// the layers, so nothing on screen goes red if the wiring is dropped, and the bug
+// it prevents ("no cameras in that area") reads as a truthful answer rather than
+// as a failure.
+//
+// The node environment bounds the claim. Nothing here renders, so this does NOT
+// cover the flyout's buttons, the WorldMap feed components that mount off the
+// layer state, or whether Windy actually answers. It covers the store contract the
+// three arming routes share.
+
+// Both stores are module singletons, so state leaks between tests unless it is
+// reset. "none" is the honest baseline here rather than "all": it is the only
+// preset that leaves BOTH cameras and webcams off, which is the state the change
+// exists to fix. (webcams is false in every preset — see lib/layers.ts — so an
+// "all" baseline would make the webcams assertions pass for the wrong reason.)
+beforeEach(() => {
+  layersStore.applyPreset("none");
+  pickStore.setMode("off");
+});
+afterEach(() => {
+  layersStore.applyPreset("none");
+  pickStore.setMode("off");
+});
+
+test("the picker draws from exactly the cameras and webcams layers", () => {
+  // Pinned as a list, not asserted loosely, because it is the whole contract: if a
+  // third source of pins is added to the pick paths and not added here, arming will
+  // silently stop covering it.
+  expect(PICK_LAYERS).toEqual(["cameras", "webcams"]);
+});
+
+test("revealPickLayers switches both pick layers on from cold", () => {
+  expect(layersStore.get().cameras).toBe(false);
+  expect(layersStore.get().webcams).toBe(false);
+
+  revealPickLayers();
+
+  expect(layersStore.get().cameras).toBe(true);
+  expect(layersStore.get().webcams).toBe(true);
+});
+
+test("armPicking turns the pins on as well as the mode", () => {
+  // The regression this exists to catch: arming through pickStore.setMode alone,
+  // which is what all three entry points used to do. Picking would be ON with
+  // nothing on the map to pick, and the area path would then report "no cameras in
+  // that area" — a confident wrong answer to a question never asked.
+  armPicking();
+
+  expect(pickStore.get().mode).toBe("picking");
+  expect(layersStore.get().cameras).toBe(true);
+  expect(layersStore.get().webcams).toBe(true);
+});
+
+test("arming leaves the other core layers alone", () => {
+  // It reveals what the picker reads and nothing else. A camera pick is not a
+  // reason to start the planes or satellites feeds ticking.
+  armPicking();
+
+  expect(layersStore.get().planes).toBe(false);
+  expect(layersStore.get().satellites).toBe(false);
+  // The base reference layer is untouched either way — "none" leaves it on.
+  expect(layersStore.get().countries).toBe(true);
+});
+
+test("stopping picking leaves the layers up", () => {
+  // Deliberate, and the reason is in camslot.layers.ts: nothing records what was on
+  // before arming, so "restore" could only mean "turn off", which is a different
+  // thing and wrong for a user who had cameras on all along.
+  armPicking();
+  pickStore.setMode("off");
+
+  expect(pickStore.get().mode).toBe("off");
+  expect(layersStore.get().cameras).toBe(true);
+  expect(layersStore.get().webcams).toBe(true);
+});
+
+test("arming twice is idempotent", () => {
+  armPicking();
+  armPicking();
+
+  expect(layersStore.get().cameras).toBe(true);
+  expect(layersStore.get().webcams).toBe(true);
+  expect(pickStore.get().mode).toBe("picking");
+});
+
+test("arming does not disturb a layer the user already turned on", () => {
+  layersStore.set("planes", true);
+
+  armPicking();
+
+  expect(layersStore.get().planes).toBe(true);
+});


### PR DESCRIPTION
Three things asked for on the map rail's **Cameras** flyout ("Pick cameras for a wall"): picking should switch the cameras and webcams layers on by itself, the two buttons should carry the icons from Sam's downloads, and **New wall** should go.

## The layers were a real bug, not a convenience

`loadedCamerasStore` and `loadedWebcamsStore` are populated **only while their layer is on** — WorldMap gates the feed component itself (`{layers.webcams && <WebcamsFeed …/>}`). Webcams ship **off** by default, so the common case was a tool that could not see what it had been asked to collect.

Both pick paths had already grown a branch apologising for it. `camslot.area.ts` and `WorldMap.pickBoxSelection` each distinguish *"your ring is empty"* from *"we were not looking"*, and the best either could do was send the user off to find a layer toggle and repeat the gesture.

`armPicking()` in the new `lib/console/widgets/camslot.layers.ts` switches the layers on **and then** sets the mode, so the question gets asked before it is answered.

- **One door, not three lines.** Three controls arm picking: the flyout's *Pick cameras*, its *By area* (via `startAreaPick`), and *"Pick cameras on the map"* inside an empty camera wall. The trap was identical from all three, so the fix is.
- **Not inside `pickStore.setMode`.** `camslot.pick.ts` is the basket *model*, imported by node unit tests, and `layersStore` persists through `localStorage` on every emit. Arming is a UI act; the basket is a data structure.
- **It does not put the layers back.** Nothing records what was on beforehand, so "restore" could only mean "turn off" — wrong for anyone who had cameras on all along.

### The cost, stated rather than buried

`webcams` is opt-in on purpose and deliberately excluded from the layer presets (`lib/layers.ts` gives the reason: a keyed, rate-limited global sample). **This reverses that for one gesture, and that is a real trade.** It was raised on the agent bus by the peer reworking the layer registry, and it is recorded in the module header rather than left to be rediscovered.

What keeps it honest is *where* the call sits: on the **arming action**, never on mount and never on opening the flyout. Nothing fetches Windy until someone has deliberately pressed a button that says it is about to collect cameras.

## Two toasts were made false by this, and are fixed with it

Both told the user to turn on a layer that is now already on by the time they can read the sentence. They now say the pins have not landed yet — which is what reaching that branch actually means. A wait, not a setting.

## The marks are redrawn, not embedded

`RailIcons.tsx`'s standing rule: the references are opaque black rasters and the flyout sits on a dark panel, so shipping the PNGs would be a black square on the skin.

- `CameraPlusGlyph` draws the camera body as an **open path** that stops on both sides of the ＋ badge rather than running underneath it — the cut is the badge grown by 0.9, so there is a visible gap rather than a kiss.
- `BoundingBoxGlyph` is built on `PolygonGlyph`'s geometry so the two area marks read as one family, and is told apart by the things the references themselves differ on: **square** handles, and a closed rectangle rather than an irregular five-vertex ring.

Both were checked **as rendered** at 72 / 27 / 18px against the reference art and against `PolygonGlyph`, not just read in source.

No CSS change — `.tnx-maprail-act-icon` already existed for the Draw flyout's glyphs.

## New wall is gone, and the dead end is not back

That button existed for a **reported** reason: delete your last camera wall and the board had no way to another. So the reason is answered in the file header rather than deleted along with the button. Two routes still create one, both checked:

- **Send to wall** offers a *new* wall as a destination whether or not one exists (`camslot.send.ts`, `SendTarget = "new"`).
- `camslot` is in `POPULAR_WIDGET_IDS` (`paletteGroups.ts:101`), so ⌘K adds an empty one.

Both call the same `createCamslot()` this button did. If either is ever removed the dead end returns, and that is the condition to check.

## Gate

- `npx tsc --noEmit` — exit 0
- `npm test` — **323 files / 3,149 tests pass**, exit 0
- `tests/unit/camslot-layers.test.ts` (7 new tests) was **watched go red first** — 3 of 7 fail with the reveal unwired — because a pinning test nobody saw fail is decoration.

Not covered: the node test environment has no renderer, so this pins the store contract the three arming routes share, not the flyout's buttons or whether Windy answers.

> Built alongside three other agents on the shared bus; paths were claimed up front and the one overlap (`WorldMap.tsx`, a single toast string, far from the country-click line another agent is taking) was declared before it was written.
