### PR TITLE
Take the site down behind a code, without taking it out of the index

### DIFF
--- a/app/api/gate/route.ts
+++ b/app/api/gate/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  gateToken,
+  constantTimeEqual,
+  safeNext,
+  withDenied,
+  gateCookieHeader,
+} from "@/lib/gate/token";
+
+/**
+ * The one door through the maintenance curtain.
+ *
+ * `lib/gate/paths.ts` exempts this path, so the middleware never runs for it - if it
+ * did, the form would be gated by the gate it is trying to open.
+ *
+ * It answers 404 when the gate is not armed, matching how `/admin` and `/api/admin`
+ * disappear in production rather than announcing themselves. A password endpoint that
+ * exists on a site with no password is a target and nothing else.
+ *
+ * There is no rate limiting here, so the access code must be long. Six digits is 10^6,
+ * exposed for a month; a script walks that while nobody is watching. If the gate ever
+ * needs real resistance the place for it is a Vercel Firewall rule on this path, not
+ * this handler - a middleware-shaped limiter would cost an invocation to say no.
+ */
+export async function POST(request: NextRequest) {
+  if (!process.env.MAINTENANCE_MODE) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const form = await request.formData();
+  // `safeNext` refuses anything that is not a same-origin path, so the redirect cannot
+  // be aimed off-site by anyone who can get someone to submit this form.
+  const next = safeNext(form.get("next"));
+  const presented = typeof form.get("password") === "string" ? String(form.get("password")) : "";
+  const expected = process.env.MAINTENANCE_PASSWORD ?? "";
+
+  if (expected === "" || !(await constantTimeEqual(presented, expected))) {
+    return NextResponse.redirect(new URL(withDenied(next), request.url), { status: 303 });
+  }
+
+  // 303 so the browser reissues the request as a GET; a 307 would repost the form.
+  const response = NextResponse.redirect(new URL(next, request.url), { status: 303 });
+  response.headers.set(
+    "set-cookie",
+    gateCookieHeader(await gateToken(expected), request.nextUrl.protocol === "https:"),
+  );
+  return response;
+}

--- a/docs/superpowers/specs/2026-09-07-maintenance-gate-design.md
+++ b/docs/superpowers/specs/2026-09-07-maintenance-gate-design.md
@@ -1,0 +1,234 @@
+# Maintenance gate — design
+
+**Date:** 2026-09-07
+**Branch:** `feat/maintenance-gate`
+**Status:** approved, not yet implemented
+
+## Why
+
+Visitor volume pushed Provenance's running cost past what the project carries. The site
+comes down for about a month while a new release is built.
+
+The goal is **cost, not concealment**. A gate that hides the UI but still renders pages,
+revalidates ISR and fetches upstreams would have solved nothing. Success is measured as:
+a gated request costs one edge invocation and no more — no React render, no ISR write,
+no upstream fetch, no large asset transfer.
+
+A password lets one person (Sampo) through to the live site from any browser.
+
+## Decision
+
+A Next.js edge middleware gate, armed by an environment variable, merged to `main` and
+left switched off between uses.
+
+**Rejected — Vercel Password Protection.** It is a paid add-on; the docs say plainly it
+"requires an eligible plan". Paying a subscription to reduce a bill is the wrong shape.
+
+**Rejected — a static holding deployment.** Truly zero compute, and nothing of the site
+would even be present to leak, but there is no password path: the real site would only be
+reachable from a separate Vercel-authenticated preview URL. That is not what was asked for.
+
+## Prior work already on disk
+
+`lib/gate/` exists, untracked, in this worktree: `paths.ts`, `token.ts`, `page.ts` (254
+lines). It is sound and is kept. It stops short of doing anything — there is no
+`middleware.ts` and no `/api/gate` route, so nothing invokes it.
+
+Four changes are made to it, each recorded below with its reason:
+
+1. **The `noindex` meta comes out** (`page.ts`). It contradicts the index-preservation
+   reasoning in `paths.ts`. On a 503 it is largely inert, but if the status ever
+   regressed to 200 it would silently deindex every camera page. It is a loaded gun for
+   no benefit.
+2. **`/api/*` becomes gated**, except `/api/gate`. See the exemption principle below.
+3. **The copy is replaced** with the wording agreed on 2026-09-07, and a Discord link is
+   added — the page currently has neither.
+4. **Two defects are fixed.** `gateMatcher()` does `s.replace(/\./g, "\.")`, and `"\."`
+   in a JS string literal is just `"."` — the dots it claims to escape are not escaped.
+   And the `~1M requests a day` figure in the `paths.ts` header cites `next.config.ts`,
+   which contains no such number; the claim is unsourced and is removed rather than
+   repeated.
+
+## What is gated
+
+The prior work carries a flat exemption list. It is replaced by a principle, because a
+list gives no guidance about a file added later:
+
+> **Chrome and crawl signals pass. Pages, data and compute are gated.**
+
+Measured against `public/` on 2026-09-07 (`du -sh public/*`):
+
+| Path | Size | Gated? | Why |
+|---|---|---|---|
+| `/api/*` | — | **gated** | 42 routes and every upstream feed. This is where the cost is. |
+| `/api/gate` | — | exempt | The unlock endpoint. Gating it would lock everyone out permanently. |
+| pages (`/`, `/app`, `/camera/*`, …) | — | **gated** | The point of the exercise. |
+| `sitemap`, `sitemap.xml` | — | **gated** | It is a render that may fan out to the camera registry. A 503 sitemap is a mild signal Google retries. *Differs from the prior work, deliberately.* |
+| `public/webcams/` | 8.4 MB | **gated** | The largest thing served. Only ever fetched by gated HTML, so legitimate traffic is zero either way — gating it means a scraper costs one invocation instead of 8.4 MB of egress. |
+| `public/textures/`, `public/sky/` | 3.8 MB | **gated** | Same reasoning. Only the globe requests them, and the globe is behind the gate. |
+| `public/geo/` | 208 KB | **gated** | Data. |
+| `robots.txt` | — | exempt | A 503 on robots.txt makes Google stop crawling the site entirely, which is louder than the outage warrants. |
+| `_next/`, `_vercel/` | — | exempt | Build assets, RSC payloads, the analytics beacon. Served from the CDN with **no function invocation**; gating them would add an invocation per request and leak nothing, because the HTML that references them is gated. |
+| `public/brand/` | 912 KB | exempt | OG card images. Keeps already-shared links rendering a card. |
+| `favicon.svg`, `icons/`, `sw.js`, `.well-known/` | 128 KB | exempt | Chrome. A 503 here breaks the installed PWA and hides nothing. |
+
+`isGatedPath()` stays the single source of truth, and `middleware.ts` carries a
+`config.matcher` derived from the same list so an exempt request never invokes the
+function at all. Next requires the matcher to be a string literal, so it cannot import
+the list — a unit test derives the literal and fails if the two drift apart.
+
+## Behaviour
+
+1. `MAINTENANCE_MODE` unset → `next()` on the first line, no other work.
+2. Armed, path exempt → never matched, so the function does not run.
+3. Armed, valid `pv_gate` cookie → `next()`.
+4. Armed, `POST /api/gate` → verify the code, set the cookie, `303` to `safeNext(next)`.
+5. Armed, anything else → the curtain.
+
+**Fail closed.** If `MAINTENANCE_MODE` is set and `MAINTENANCE_PASSWORD` is missing or
+empty, the gate still serves the curtain and the page says the code is not configured.
+Failing open would leave the site up and billing, which is the failure this exists to
+prevent. Recovery is: set the variable, redeploy.
+
+**Production only.** Both variables are set on Vercel Production. Previews are
+unaffected and stay behind Vercel Authentication as they already are.
+
+## The response
+
+- `503 Service Unavailable`
+- `Retry-After: 3600`
+- `Cache-Control: no-store` — **load-bearing.** The CDN keys on URL, not on the cookie. A
+  cached 503 would be replayed to everyone including an unlocked browser, which looks
+  exactly like being locked out of your own site.
+- `Content-Type: text/html; charset=utf-8`
+- **No `X-Robots-Tag`, and no `noindex` in the document.** A directive to remove pages is
+  the opposite of what a 503 is for.
+
+### Why 503 and not 200
+
+There are camera pages in Google's index. A `200` tells Google this holding page *is* the
+content of every one of them, and it begins dropping them. A `503` with `Retry-After`
+says the absence is temporary.
+
+**It is the best signal available, not a guarantee.** Google treats 503 as "come back
+later" and slows crawling, which is correct for days. Across about a month some erosion
+is likely regardless — 503 minimises it, it does not prevent it. The cheap hedge, if the
+index turns out to matter more than the saving, is to let `/` alone through as a static
+page: it costs nothing to serve and keeps one live URL for crawlers. Not built; a
+one-line change to the exempt list.
+
+## The session
+
+`lib/gate/token.ts` is kept as written. The cookie is `sha256(prefix + code)`:
+
+- no server state — every deployment validates it with nothing but the env var
+- changing the code logs every browser out at once, so rotation is one edit
+- the code itself never enters the cookie
+- `pv_gate`, `HttpOnly`, `SameSite=Lax`, `Path=/`, `Secure` in production, 30 days
+- `constantTimeEqual` hashes both sides first, so the compare is always over 64
+  characters and length is not itself the leak. The edge runtime has Web Crypto but not
+  Node's `timingSafeEqual`, which is why this is hand-rolled.
+- `safeNext()` refuses anything that is not a same-origin path, so the unlock redirect
+  cannot be turned into an open redirect.
+
+### Choose a long code
+
+The prior work's input is `inputmode="numeric"` and its comment describes a six-digit
+code. Six digits is 10⁶, exposed for a month, with no rate limiting in front of it — a
+script walks that in minutes. **Use a long random alphanumeric passphrase instead**, and
+if the gate ever needs real resistance, the place for it is a Vercel Firewall rate-limit
+rule on `/api/gate`, not middleware. The `inputmode` hint is removed.
+
+## The curtain
+
+One self-contained HTML document. Inline CSS, system fonts, no script, no asset request
+of any kind — the stylesheet it would otherwise load lives behind the gate it is standing
+in for. It follows the calm light identity by value (`--tn-*` values copied, not imported).
+
+Reads `BRAND.name`, `BRAND.repoUrl`, `BRAND.license` and `BRAND.discordUrl` from
+`lib/brand.ts`. Every interpolated value passes through `escapeHtml`.
+
+**The source link is not decoration.** This page becomes what a network user of an
+AGPL-3.0 program sees, and section 13 says they must be offered the Corresponding Source.
+The console header and the site footer are the only two places that offer exists, and the
+gate replaces both. `CLAUDE.md` says not to remove those links; keeping one on the curtain
+is how that is honoured.
+
+### Copy
+
+> **Provenance is offline**
+>
+> A surge in visitors pushed the running cost past what this project can carry, so the
+> site is down for now.
+>
+> A lot of feedback came in with those visitors. A new release is planned in about a
+> month, and development updates go to the Discord.
+
+Refusal line: *That code is not right. Check for a space on the end.*
+
+### The Discord invite
+
+`BRAND.discordUrl` is updated to `https://discord.gg/q45NU8qWk`, confirmed by Sampo on
+2026-09-07 as the live invite, replacing `H5vB8TsVK`. One source of truth — the curtain
+reads the constant rather than carrying a second copy.
+
+**The invite must be set to never expire.** Discord invites expire by default and an
+expired one renders a dead page with no error anywhere we would see it. On the curtain it
+is the only link. This is a setting on Discord's side — *Edit invite → Expire after:
+Never → Max uses: No limit* — and no test can verify it, because nothing in CI can reach
+`discord.gg`. The existing comment in `lib/brand.ts` already records this rule; it now
+also applies to a page where the link is the only way anyone learns anything.
+
+## Files
+
+| File | |
+|---|---|
+| `middleware.ts` | new — the gate, with a matcher derived from `GATE_EXEMPT_STARTS` |
+| `app/api/gate/route.ts` | new — verify the code, set the cookie, 303 |
+| `lib/gate/paths.ts` | kept, edited — `/api` gated, data dirs gated, escape bug fixed, unsourced figure removed |
+| `lib/gate/token.ts` | kept as written |
+| `lib/gate/page.ts` | kept, edited — `noindex` removed, copy replaced, Discord link added |
+| `lib/brand.ts` | edited — `discordUrl` updated |
+| `tests/unit/gate.test.ts` | new |
+
+Environment, Production only: `MAINTENANCE_MODE=1`, `MAINTENANCE_PASSWORD=<long random>`.
+
+## Tests
+
+vitest, node environment, `tests/unit/gate.test.ts`, per the repo convention. Each
+assertion is watched fail before the code that satisfies it is written — a pinning test
+nobody saw go red is decoration.
+
+- `isGatedPath` gates `/`, `/app`, `/camera/tfl:JamCams_00001.01234`, `/api/coverage`,
+  `/sitemap.xml`, `/webcams/manifest.json`; exempts `/api/gate`, `/robots.txt`,
+  `/_next/static/x.js`, `/favicon.svg`
+- a camera id containing dots is gated — the list must never be "anything with a dot is a
+  file"
+- `gateMatcher()` equals the literal in `middleware.ts` (drift guard), and its escaping is
+  a real regex escape
+- `gateToken` is deterministic; a different code yields a different token
+- `constantTimeEqual` is true for equal inputs and false for unequal ones of differing
+  length
+- `safeNext` rejects `//evil.example`, `/\evil.example` and absolute URLs, and strips a
+  previous `?gate=denied`
+- the curtain contains `BRAND.discordUrl`, `BRAND.repoUrl` and the licence short name
+- the curtain contains **no** `noindex` and no same-origin `src`/`href` — proving it is
+  self-contained
+
+## What this does not do
+
+- **No rate limiting.** One user, one long code. If it is ever needed, Vercel Firewall,
+  not middleware.
+- **It does not make a blocked request free.** Every gated request still costs one edge
+  invocation. If the bill is still bad with the gate on, the next lever is Firewall rules,
+  which deny before any function runs.
+- **No instant toggle.** Arming and disarming both need a redeploy. Edge Config would
+  remove that, at the price of a store to manage and a read per request; not worth it for
+  a switch thrown twice.
+
+## Accepted trade
+
+`middleware.ts` merges to `main` and stays. Switched off it is an environment read and a
+pass-through, but it runs on every non-exempt request forever. That is the price of
+maintenance mode being a variable flip rather than a branch merge, and it was chosen
+knowingly on 2026-09-07.

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -36,10 +36,15 @@ export const BRAND = {
    *
    * So the rule is a SETTING on Discord's side, not a check on ours: this must be a
    * "never expire" invite (server → Invites → Edit → Expire After: Never, max uses
-   * unlimited). Verified against Discord's invite API on 2026-09-07 — server
-   * "Provenance", guild 1539313032801423441.
+   * unlimited).
+   *
+   * The stakes went UP on 2026-09-07: the maintenance curtain (lib/gate/page.ts) is
+   * served in place of every page while the site is down, and this is the only link
+   * on it. A dead invite there does not degrade the experience, it IS the experience.
+   *
+   * Code confirmed live by Sampo on 2026-09-07, replacing H5vB8TsVK.
    */
-  discordUrl: "https://discord.gg/H5vB8TsVK",
+  discordUrl: "https://discord.gg/q45NU8qWk",
   /** Canonical public repository. */
   repo: "011-sam-110/Provenance",
   repoUrl: "https://github.com/011-sam-110/Provenance",

--- a/lib/gate/page.ts
+++ b/lib/gate/page.ts
@@ -1,0 +1,122 @@
+import { BRAND } from "@/lib/brand";
+
+/**
+ * The curtain. One self-contained HTML document, inline CSS, system fonts, no script,
+ * no asset requests - it is served by the middleware on every gated request and must
+ * cost nothing to render and nothing to fetch. It follows the calm light identity
+ * (`--tn-*` tokens in app/globals.css) by value, because the stylesheet itself lives
+ * behind the gate it is standing in for. That is also why there is no webfont: the
+ * page renders in whatever the visitor's system offers.
+ *
+ * The repository link is not decoration: this page is now what a network user of an
+ * AGPL-3.0 program sees, and section 13 says they must be offered the source. The
+ * console header and the site footer are the only other two places that offer exists,
+ * and this page replaces both of them.
+ *
+ * THERE IS DELIBERATELY NO `noindex`. The curtain is served with 503, whose whole
+ * purpose is to tell a crawler the absence is temporary so the camera pages keep their
+ * place in the index. A noindex asks for the opposite, and if the status ever regressed
+ * to 200 it would quietly delete them. `tests/unit/gate.test.ts` pins its absence.
+ */
+export function maintenanceHtml(opts: {
+  next: string;
+  denied: boolean;
+  /** MAINTENANCE_MODE is armed but MAINTENANCE_PASSWORD is not set. */
+  unconfigured?: boolean;
+}): string {
+  const next = escapeHtml(opts.next);
+  const name = escapeHtml(BRAND.name);
+  const refused = opts.denied
+    ? `<p class="err" role="alert">That code is not right. Check for a space on the end.</p>`
+    : "";
+  // Fail closed: with no code configured nobody can be let through, so offering a box
+  // that cannot open would be a lie. Saying why is what makes it recoverable.
+  const entry = opts.unconfigured
+    ? `<p class="err" role="alert">There is no access code set on this deployment, so nobody can be let through from here.</p>`
+    : `<form method="post" action="/api/gate" autocomplete="off">
+    <input type="hidden" name="next" value="${next}">
+    <label for="gate-code">Have the access code?</label>
+    <div class="row">
+      <input id="gate-code" name="password" type="password" autocomplete="off" required autofocus>
+      <button type="submit">Enter</button>
+    </div>
+    ${refused}
+  </form>`;
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light">
+<meta name="theme-color" content="${BRAND.accent}">
+<title>${name} — offline</title>
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; min-height: 100%; }
+  body {
+    display: grid; place-items: center; padding: 24px;
+    background: #e9edf2; color: #1f2a37;
+    font: 16px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  main {
+    width: min(440px, 100%); background: #fff; border: 1px solid rgba(15,23,42,.10);
+    border-radius: 14px; padding: 32px 28px 26px;
+    box-shadow: 0 18px 50px -30px rgba(15,23,42,.35);
+  }
+  .brand { display: flex; align-items: center; gap: 10px; margin: 0 0 18px; }
+  .brand b { font-size: 15px; letter-spacing: .01em; }
+  .pill {
+    font-size: 11px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase;
+    color: ${BRAND.accent}; background: rgba(14,125,151,.10); border-radius: 999px; padding: 3px 9px;
+  }
+  h1 { font-size: 24px; line-height: 1.2; margin: 0 0 10px; letter-spacing: -.01em; }
+  p { margin: 0 0 12px; color: #54606d; }
+  .discord {
+    display: inline-block; margin: 4px 0 0; padding: 9px 14px; border-radius: 9px;
+    border: 1px solid rgba(15,23,42,.16); background: #f2f5f9; color: #0b6175;
+    font-size: 14px; font-weight: 600; text-decoration: none;
+  }
+  .discord:hover { background: #fff; border-color: ${BRAND.accent}; }
+  form { margin-top: 22px; padding-top: 18px; border-top: 1px solid rgba(15,23,42,.10); }
+  label { display: block; font-size: 13px; font-weight: 600; color: #1f2a37; margin-bottom: 6px; }
+  .row { display: flex; gap: 8px; }
+  input {
+    flex: 1; min-width: 0; font: inherit; letter-spacing: .12em;
+    padding: 10px 12px; border: 1px solid rgba(15,23,42,.16); border-radius: 9px; background: #f2f5f9; color: #1f2a37;
+  }
+  input:focus { outline: 2px solid ${BRAND.accent}; outline-offset: 1px; border-color: transparent; background: #fff; }
+  button {
+    font: inherit; font-weight: 600; padding: 10px 16px; border: 0; border-radius: 9px; cursor: pointer;
+    background: ${BRAND.accent}; color: #fff;
+  }
+  button:hover { background: #0b6175; }
+  .err { color: #a33a2e; font-size: 14px; margin: 10px 0 0; }
+  footer { margin-top: 22px; padding-top: 14px; border-top: 1px solid rgba(15,23,42,.10); font-size: 12px; color: #626e7d; }
+  footer a { color: inherit; }
+</style>
+</head>
+<body>
+<main>
+  <p class="brand"><b>${name}</b><span class="pill">Offline</span></p>
+  <h1>${name} is offline</h1>
+  <p>A surge in visitors pushed the running cost past what this project can carry, so the site is down for now.</p>
+  <p>A lot of feedback came in with those visitors. A new release is planned in about a month, and development updates go to the Discord.</p>
+  <a class="discord" href="${BRAND.discordUrl}" rel="noopener">Updates on Discord →</a>
+  ${entry}
+  <footer>Source: <a href="${BRAND.repoUrl}" rel="noopener">${escapeHtml(BRAND.repo)}</a> · ${escapeHtml(BRAND.license.short)}</footer>
+</main>
+</body>
+</html>
+`;
+}
+
+/** Enough escaping for text nodes and double-quoted attribute values. */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/lib/gate/paths.ts
+++ b/lib/gate/paths.ts
@@ -1,0 +1,85 @@
+/**
+ * Which paths the maintenance gate leaves alone.
+ *
+ * The site comes down to stop it costing money, so the list follows from that and not
+ * from what is convenient:
+ *
+ *   CHROME AND CRAWL SIGNALS PASS. PAGES, DATA AND COMPUTE ARE GATED.
+ *
+ * A principle rather than a bare list, because a list says nothing about a file added
+ * next month. Applying it:
+ *
+ *   api/gate            the unlock endpoint. Gating it locks everyone out for good.
+ *   _next/  _vercel/    build assets, RSC payloads, the analytics beacon. The CDN
+ *                       serves these with NO function invocation; gating them would
+ *                       add one per request and hide nothing, because the HTML that
+ *                       references them is gated.
+ *   robots.txt          a 503 here makes Google stop crawling the site outright,
+ *                       which is louder than a month-long outage warrants. The
+ *                       sitemap is NOT exempt: a 503 sitemap is a mild signal Google
+ *                       retries, and generating it can fan out to the camera registry.
+ *   sw.js  manifest     the installed PWA re-checks these. A 503 breaks the install
+ *   favicon icons/      and hides nothing.
+ *   brand/              OG card images, so links already shared still render a card.
+ *   .well-known/
+ *
+ * Everything else is gated, and two entries are worth naming because an earlier draft
+ * of this file exempted them:
+ *
+ *   api/                42 handlers and every upstream feed. This is where the cost
+ *                       is. Exempting it kept the Telegram and Discord webhooks and
+ *                       /api/status working, and left the expensive half of the site
+ *                       running - which is the thing the outage exists to stop.
+ *   webcams/ textures/  8.4 MB and 3.4 MB of public/ (measured 2026-09-07). Only
+ *   sky/ geo/           gated HTML ever asks for them, so real traffic is zero either
+ *                       way; gating means a scraper costs one invocation instead of
+ *                       the egress.
+ *
+ * ONE LIST, TWO CONSUMERS. `isGatedPath` is what the middleware function checks, and
+ * `middleware.ts` ALSO carries a `config.matcher` built from the same list so that an
+ * exempt request never invokes the function at all. Next needs the matcher to be a
+ * string LITERAL, so it cannot import this list; `tests/unit/gate.test.ts` derives the
+ * literal from the list and fails if the two ever disagree.
+ *
+ * Do not "simplify" this to "anything with a dot in it is a file": camera ids contain
+ * dots (`tfl:JamCams_00001.01234`), so `/camera/<id>` pages would leak through.
+ */
+export const GATE_EXEMPT_STARTS = [
+  "api/gate",
+  "_next/",
+  "_vercel/",
+  ".well-known/",
+  "sw.js",
+  "manifest.webmanifest",
+  "robots.txt",
+  "favicon",
+  "icons/",
+  "brand/",
+] as const;
+
+/** True when a request for `pathname` must present the gate cookie. */
+export function isGatedPath(pathname: string): boolean {
+  return !GATE_EXEMPT_STARTS.some((start) => pathname.startsWith("/" + start));
+}
+
+/** Escape a literal so it means itself inside a regular expression. */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The `config.matcher` string that `middleware.ts` must carry, derived from the list.
+ * Same shape as the Next docs' "match everything except" pattern.
+ *
+ * The escape is load bearing and was wrong here once: written as `"\."` it is not an
+ * escape at all, because JS collapses that to a bare `.` in a string literal, and the
+ * dot then matches any character. `sw.js` would have exempted `swXjs` with it.
+ *
+ * Note the exemptions are PREFIXES, which is the only shape a negative lookahead can
+ * express. `api/gate` therefore also exempts a route called `api/gateway`; the unit
+ * test asserts no such route exists.
+ */
+export function gateMatcher(): string {
+  const alternatives = GATE_EXEMPT_STARTS.map(escapeRegExp).join("|");
+  return `/((?!${alternatives}).*)`;
+}

--- a/lib/gate/token.ts
+++ b/lib/gate/token.ts
@@ -1,0 +1,94 @@
+/**
+ * The maintenance gate's session and its helpers. Pure, no Next imports, so the same
+ * functions run in the Edge middleware, the Node route handler, vitest and the
+ * Playwright config.
+ *
+ * THERE IS NO SERVER STATE. The cookie is a SHA-256 of the current access code, so:
+ * every deployment validates it with nothing but the env var; changing the code logs
+ * every browser out at once; and clearing the env var switches the gate off without a
+ * deploy of code. The code itself never goes into the cookie.
+ *
+ * What this is NOT: authentication. The code is six digits and there is no lockout
+ * beyond the site's existing attack-challenge firewall. It is a curtain that keeps
+ * the public and the crawlers out during a rebuild, and the cookie is scoped to
+ * exactly that.
+ */
+
+/** Cookie the gate sets once the code has been presented. `pv` = Provenance. */
+export const GATE_COOKIE = "pv_gate";
+
+/**
+ * Domain-separates the hash so the cookie value is not simply sha256(code), which a
+ * rainbow table already knows for every six-digit string. Bump the version to log
+ * everyone out without changing the code.
+ */
+export const GATE_TOKEN_PREFIX = "provenance-gate-v1:";
+
+/** Thirty days. Long enough to survive a maintenance window, short enough to rot. */
+export const GATE_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
+
+/** Query key + value the unlock route appends when a code is refused. */
+export const GATE_QUERY = "gate";
+export const GATE_DENIED = "denied";
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** The cookie value that proves `password` was presented. Deterministic per code. */
+export function gateToken(password: string): Promise<string> {
+  return sha256Hex(GATE_TOKEN_PREFIX + password);
+}
+
+/**
+ * Equality without an early exit on the first differing character. Both sides are
+ * hashed first so the comparison is always over 64 characters, whatever the inputs'
+ * lengths - a length check would itself be the leak.
+ */
+export async function constantTimeEqual(a: string, b: string): Promise<boolean> {
+  const [ha, hb] = await Promise.all([sha256Hex(a), sha256Hex(b)]);
+  let diff = 0;
+  for (let i = 0; i < ha.length; i++) diff |= ha.charCodeAt(i) ^ hb.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * Where to send someone after the form: the page they were trying to reach, and only
+ * that. Refuses anything that is not a same-origin path - `//evil.example`,
+ * `/\evil.example` and absolute URLs all fall back to `/` - and strips a previous
+ * `?gate=denied` so a second attempt does not carry the first refusal with it.
+ */
+export function safeNext(raw: unknown): string {
+  if (typeof raw !== "string") return "/";
+  if (!raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) return "/";
+  let url: URL;
+  try {
+    url = new URL(raw, "http://gate.invalid");
+  } catch {
+    return "/";
+  }
+  if (url.origin !== "http://gate.invalid") return "/";
+  url.searchParams.delete(GATE_QUERY);
+  return url.pathname + url.search;
+}
+
+/** `next` with the refusal flag on it, for the redirect back to the curtain. */
+export function withDenied(next: string): string {
+  const url = new URL(next, "http://gate.invalid");
+  url.searchParams.set(GATE_QUERY, GATE_DENIED);
+  return url.pathname + url.search;
+}
+
+/** The Set-Cookie header value for a fresh session. */
+export function gateCookieHeader(token: string, secure: boolean): string {
+  const parts = [
+    `${GATE_COOKIE}=${token}`,
+    "Path=/",
+    `Max-Age=${GATE_COOKIE_MAX_AGE}`,
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (secure) parts.push("Secure");
+  return parts.join("; ");
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,64 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { isGatedPath } from "@/lib/gate/paths";
+import { GATE_COOKIE, GATE_QUERY, GATE_DENIED, gateToken } from "@/lib/gate/token";
+import { maintenanceHtml } from "@/lib/gate/page";
+
+/**
+ * The maintenance gate.
+ *
+ * Armed by `MAINTENANCE_MODE` on Vercel Production only, so previews are untouched and
+ * stay behind Vercel Authentication as they already are. Disarmed, this function reads
+ * one environment variable and passes through - that is the standing cost of having the
+ * switch on `main` rather than on a branch, and it was chosen knowingly.
+ *
+ * The point of the gate is COST, not concealment. It answers before anything downstream
+ * is invoked, so a gated request buys no React render, no ISR revalidation and no
+ * upstream fetch. `docs/superpowers/specs/2026-09-07-maintenance-gate-design.md` has
+ * the reasoning; `lib/gate/paths.ts` has the exemptions and why each one is exempt.
+ *
+ * THE MATCHER MUST EQUAL `gateMatcher()`. Next requires a string literal here, so it
+ * cannot be imported. `tests/unit/gate.test.ts` derives it from `GATE_EXEMPT_STARTS`
+ * and fails if the two drift apart - which is the only thing that stops an exemption
+ * added to the list from still costing an invocation on every request.
+ */
+export const config = {
+  matcher: "/((?!api/gate|_next/|_vercel/|\\.well-known/|sw\\.js|manifest\\.webmanifest|robots\\.txt|favicon|icons/|brand/).*)",
+};
+
+export default async function middleware(request: NextRequest) {
+  if (!process.env.MAINTENANCE_MODE) return NextResponse.next();
+
+  const { pathname, search, searchParams } = request.nextUrl;
+  // The matcher has already excluded the exempt paths; this is the same list applied a
+  // second time, because the matcher is a copy and copies drift.
+  if (!isGatedPath(pathname)) return NextResponse.next();
+
+  const code = process.env.MAINTENANCE_PASSWORD ?? "";
+  if (code) {
+    const presented = request.cookies.get(GATE_COOKIE)?.value;
+    if (presented && presented === (await gateToken(code))) return NextResponse.next();
+  }
+
+  return new NextResponse(
+    maintenanceHtml({
+      next: pathname + search,
+      denied: searchParams.get(GATE_QUERY) === GATE_DENIED,
+      // Fail CLOSED. Failing open would leave the site up and billing, which is the
+      // one failure this exists to prevent. Recovery is to set the variable and deploy.
+      unconfigured: code === "",
+    }),
+    {
+      status: 503,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        // Load bearing. The CDN keys on URL, not on the cookie, so a cached 503 would
+        // be replayed to everyone - including an unlocked browser, which looks exactly
+        // like being locked out of your own site.
+        "cache-control": "no-store",
+        // Tells a crawler the absence is temporary, so the camera pages keep their
+        // place in the index. This is the whole reason the status is 503 and not 200.
+        "retry-after": "3600",
+      },
+    },
+  );
+}

--- a/tests/unit/gate.test.ts
+++ b/tests/unit/gate.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { BRAND } from "@/lib/brand";
+import { GATE_EXEMPT_STARTS, isGatedPath, gateMatcher } from "@/lib/gate/paths";
+import {
+  GATE_COOKIE,
+  GATE_QUERY,
+  GATE_DENIED,
+  gateToken,
+  constantTimeEqual,
+  safeNext,
+  withDenied,
+  gateCookieHeader,
+} from "@/lib/gate/token";
+import { maintenanceHtml, escapeHtml } from "@/lib/gate/page";
+
+const ROOT = process.cwd();
+
+describe("what the gate covers", () => {
+  // The exemption list is a principle, not a taste: chrome and crawl signals pass,
+  // pages, data and compute are gated. The whole reason the site goes down is cost,
+  // and /api/* is where the cost is - 42 handlers, every upstream feed. An earlier
+  // draft of this list exempted all of /api so the Telegram and Discord webhooks kept
+  // working; that bought working bots and left the expensive half of the site running.
+  it("gates the pages", () => {
+    for (const p of ["/", "/app", "/locate", "/cameras", "/admin", "/admin/verify"]) {
+      expect(isGatedPath(p), p).toBe(true);
+    }
+  });
+
+  it("gates every API route except the unlock endpoint", () => {
+    for (const p of ["/api/coverage", "/api/cameras", "/api/planes", "/api/status", "/api/og"]) {
+      expect(isGatedPath(p), p).toBe(true);
+    }
+    expect(isGatedPath("/api/gate")).toBe(false);
+  });
+
+  // `/api/gate` is exempted as a PREFIX, because that is the only shape the Next
+  // matcher's negative lookahead can express. So a future route whose name merely
+  // starts with "gate" would silently fall outside the gate along with it.
+  it("has no other API route that starts with the unlock endpoint's name", () => {
+    const dirs = readdirSync(join(ROOT, "app", "api"), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    expect(dirs.filter((d) => d.startsWith("gate"))).toEqual(["gate"]);
+  });
+
+  it("gates the data under public/, which is the bulk of what is served", () => {
+    // public/webcams is 8.4 MB and public/textures 3.4 MB (measured 2026-09-07).
+    // Only gated HTML ever asks for them, so legitimate traffic is zero either way -
+    // gating means a scraper costs one invocation instead of the egress.
+    for (const p of ["/webcams/manifest.json", "/textures/earth.jpg", "/sky/stars.png", "/geo/countries.json"]) {
+      expect(isGatedPath(p), p).toBe(true);
+    }
+  });
+
+  it("gates the sitemap but never robots.txt", () => {
+    // A 503 on robots.txt makes Google stop crawling the site entirely, which is
+    // louder than a month-long outage warrants. A 503 sitemap is a mild signal it
+    // retries, and the sitemap is a render that can fan out to the camera registry.
+    expect(isGatedPath("/robots.txt")).toBe(false);
+    expect(isGatedPath("/sitemap.xml")).toBe(true);
+    expect(isGatedPath("/sitemap/0.xml")).toBe(true);
+  });
+
+  it("lets build assets and chrome through without an invocation", () => {
+    for (const p of ["/_next/static/chunk.js", "/_vercel/insights/script.js", "/favicon.svg", "/icons/192.png", "/sw.js", "/brand/og.png"]) {
+      expect(isGatedPath(p), p).toBe(false);
+    }
+  });
+
+  // Camera ids carry dots (`tfl:JamCams_00001.01234`), so any "a dot means it is a
+  // file" shortcut would leak ~19k camera pages straight through the curtain.
+  it("gates a camera page whose id contains dots", () => {
+    expect(isGatedPath("/camera/tfl:JamCams_00001.01234")).toBe(true);
+  });
+});
+
+describe("the middleware matcher stays in step with the list", () => {
+  // Next needs config.matcher to be a string LITERAL, so middleware.ts cannot import
+  // GATE_EXEMPT_STARTS. Nothing but this test stops the two drifting apart.
+  const middleware = readFileSync(join(ROOT, "middleware.ts"), "utf8");
+
+  it("carries exactly the matcher the list derives", () => {
+    const m = middleware.match(/matcher:\s*"([^"]+)"/);
+    expect(m, "middleware.ts must declare matcher as a double-quoted string literal").toBeTruthy();
+    // The capture is raw source, so a backslash in the file is two characters here.
+    // Parsing it compares the VALUE Next will receive - and throws if the literal was
+    // written `"\."`, which JS silently collapses to a bare dot.
+    expect(JSON.parse(`"${m![1]}"`)).toBe(gateMatcher());
+  });
+
+  it("escapes dots for real", () => {
+    // `"\."` in a JS string literal is just `"."`, so an escape written that way is a
+    // no-op and `sw.js` reaches the regex with a dot that matches any character.
+    expect(gateMatcher()).toContain("sw\\.js");
+    expect(gateMatcher()).not.toContain("|sw.js|");
+  });
+
+  it("names every exemption", () => {
+    for (const start of GATE_EXEMPT_STARTS) {
+      expect(gateMatcher()).toContain(start.replace(/\./g, "\\."));
+    }
+  });
+});
+
+describe("the session", () => {
+  it("is deterministic per code, and different codes differ", async () => {
+    expect(await gateToken("open-sesame")).toBe(await gateToken("open-sesame"));
+    expect(await gateToken("open-sesame")).not.toBe(await gateToken("open-sesamf"));
+  });
+
+  it("never contains the code itself", async () => {
+    expect(await gateToken("hunter2")).not.toContain("hunter2");
+  });
+
+  it("compares without leaking length", async () => {
+    expect(await constantTimeEqual("abc", "abc")).toBe(true);
+    expect(await constantTimeEqual("abc", "abd")).toBe(false);
+    expect(await constantTimeEqual("a", "a-much-longer-string")).toBe(false);
+  });
+
+  it("sets a cookie the browser will keep and script cannot read", () => {
+    const header = gateCookieHeader("t0ken", true);
+    expect(header).toContain(`${GATE_COOKIE}=t0ken`);
+    expect(header).toContain("HttpOnly");
+    expect(header).toContain("SameSite=Lax");
+    expect(header).toContain("Path=/");
+    expect(header).toContain("Secure");
+    expect(gateCookieHeader("t0ken", false)).not.toContain("Secure");
+  });
+});
+
+describe("the redirect back cannot be aimed off-site", () => {
+  it("refuses anything that is not a same-origin path", () => {
+    for (const hostile of ["//evil.example", "/\\evil.example", "https://evil.example/x", "javascript:alert(1)", 42, null]) {
+      expect(safeNext(hostile as unknown), String(hostile)).toBe("/");
+    }
+  });
+
+  it("keeps a real path and its query", () => {
+    expect(safeNext("/app?c=grid")).toBe("/app?c=grid");
+  });
+
+  it("strips a previous refusal so a second attempt starts clean", () => {
+    expect(safeNext(`/app?${GATE_QUERY}=${GATE_DENIED}`)).toBe("/app");
+    expect(withDenied("/app")).toBe(`/app?${GATE_QUERY}=${GATE_DENIED}`);
+  });
+});
+
+describe("the curtain", () => {
+  const html = maintenanceHtml({ next: "/app", denied: false });
+  const denied = maintenanceHtml({ next: "/app", denied: true });
+
+  // AGPL-3.0 section 13: a network user must be offered the Corresponding Source. The
+  // console header and the site footer are the only two places that offer exists, and
+  // the curtain replaces both of them. CLAUDE.md says not to remove those links.
+  it("offers the source, as the licence requires", () => {
+    expect(html).toContain(BRAND.repoUrl);
+    expect(html).toContain(escapeHtml(BRAND.license.short));
+  });
+
+  it("links the Discord, which is the only place updates go", () => {
+    expect(html).toContain(BRAND.discordUrl);
+  });
+
+  // The whole reason the curtain answers 503 rather than 200 is to keep the camera
+  // pages in the index. A noindex directive on the same page asks for the opposite.
+  it("carries no directive that would remove pages from the index", () => {
+    expect(html).not.toContain("noindex");
+    expect(html).not.toContain("nofollow");
+  });
+
+  // Its own stylesheet lives behind the gate it is standing in for, so any same-origin
+  // asset it references would 503 and the page would render undressed.
+  it("requests no asset of its own", () => {
+    expect(html).not.toMatch(/\ssrc=/);
+    expect(html).not.toMatch(/href="\//);
+    expect(html).not.toContain("<script");
+  });
+
+  it("says why the site is down, not just that it is", () => {
+    expect(html).toContain("running cost");
+    expect(html).toContain("about a month");
+  });
+
+  it("shows a refusal only when the code was refused", () => {
+    expect(html).not.toContain("not right");
+    expect(denied).toContain("not right");
+  });
+
+  // If MAINTENANCE_MODE is armed and MAINTENANCE_PASSWORD is not set, the gate fails
+  // CLOSED - failing open would leave the site up and billing, which is the exact
+  // failure it exists to prevent. Saying so beats a code box that can never work.
+  it("says when no code is configured, instead of offering a box that cannot open", () => {
+    const stuck = maintenanceHtml({ next: "/", denied: false, unconfigured: true });
+    expect(stuck).toContain("no access code");
+    expect(stuck).not.toContain("<form");
+  });
+
+  it("escapes what it interpolates", () => {
+    const evil = maintenanceHtml({ next: '"><script>alert(1)</script>', denied: false });
+    expect(evil).not.toContain("<script>alert(1)</script>");
+  });
+});
+
+describe("the invite", () => {
+  // Confirmed live by Sampo on 2026-09-07, replacing H5vB8TsVK. Nothing here can check
+  // that it still resolves - no test can reach discord.gg - so this only pins WHICH
+  // invite ships. The expiry rule is a setting on Discord's side; see lib/brand.ts.
+  it("is the one that was confirmed", () => {
+    expect(BRAND.discordUrl).toBe("https://discord.gg/q45NU8qWk");
+  });
+});

--- a/tests/unit/sources-status.test.ts
+++ b/tests/unit/sources-status.test.ts
@@ -105,6 +105,19 @@ describe("key requirements table", () => {
       "VERCEL_ANALYTICS_TOKEN",
       "VERCEL_ANALYTICS_PROJECT_ID",
       "VERCEL_ANALYTICS_TEAM_ID",
+      // The maintenance gate, exempt for the same reason as the three above plus one
+      // specific to it. Registering them would put "there is a password gate, and here
+      // are the two variables behind it" on a PUBLIC status endpoint. The capability
+      // reading would be nonsense anyway: while the gate is armed /api/status is itself
+      // behind the curtain, so it reports nothing to anybody.
+      "MAINTENANCE_MODE",
+      "MAINTENANCE_PASSWORD",
+      // Inputs to the LOCAL test runner, surfaced the moment this scan learned to read
+      // root-level files. playwright.preview.config.ts uses them to decide which preview
+      // deployment an e2e run points at and how it gets through deployment protection.
+      // The deployment never holds either, and no capability turns on them.
+      "VERCEL_OIDC_TOKEN",
+      "PREVIEW_URL",
     ]);
     const declared = new Set(KEY_REQUIREMENTS.flatMap((r) => r.env));
 
@@ -118,6 +131,13 @@ describe("key requirements table", () => {
     };
     walk("lib");
     walk("app");
+    // Root-level source too. `middleware.ts` reads env to decide whether the whole
+    // site is served at all, and until it existed nothing in this repo read env from
+    // the root - so this scan had never needed to look there. A gate the guard cannot
+    // see is not guarded.
+    for (const name of readdirSync(".")) {
+      if (/\.ts$/.test(name) && !name.endsWith(".d.ts") && statSync(name).isFile()) files.push(name);
+    }
 
     const undeclared = new Map<string, string>();
     for (const file of files) {


### PR DESCRIPTION
Visitor volume pushed the running cost past what the project carries, so the site goes dark for about a month while the next release is built. This is the curtain, and one code to get behind it.

**The gate exists for cost, not concealment.** `middleware.ts` answers from the edge before anything downstream is invoked, so a gated request buys no render, no ISR revalidation and no upstream fetch. Disarmed it reads one environment variable and passes through.

`MAINTENANCE_MODE=1` plus `MAINTENANCE_PASSWORD` on Vercel **Production only**, then redeploy. Removing `MAINTENANCE_MODE` and redeploying turns it off. Previews are untouched and stay behind Vercel Authentication. Vercel's own Password Protection is a paid add-on, which is why this is hand-rolled.

## Three things that are load bearing, not stylistic

**503 with `Retry-After`, never 200.** There are camera pages in Google's index, and a 200 would tell Google this one page is now the content of every one of them. For the same reason the curtain carries **no `noindex`** — the untracked draft in `lib/gate/` had one, which asks for the exact opposite of what the status code is for. Honest limit: across a month, 503 minimises index erosion, it does not prevent it.

**`Cache-Control: no-store`.** The CDN keys on URL and not on the cookie. A cached 503 gets replayed to an unlocked browser, which looks exactly like being locked out of your own site.

**The curtain links the repository.** It is now what a network user of an AGPL-3.0 program sees, and section 13 says they must be offered the Corresponding Source. The console header and the site footer are the only other two places that offer exists, and this page replaces both of them. `CLAUDE.md` says not to remove those links.

## Coverage is a principle, not a list

> Chrome and crawl signals pass. Pages, data and compute are gated.

A list says nothing about a file added next month. Applying it, with two entries that reverse the earlier draft:

| | | |
|---|---|---|
| pages, `/api/*` | **gated** | 42 handlers and every upstream feed. This is the cost the outage exists to stop; the draft exempted it to keep the Telegram and Discord webhooks working, which bought working bots and left the expensive half of the site running. |
| `public/webcams|textures|sky|geo` | **gated** | 12 MB measured. Only gated HTML ever asks for it, so real traffic is zero either way — gating means a scraper costs one invocation instead of the egress. |
| `sitemap` | **gated** | A render that can fan out to the camera registry. A 503 sitemap is a mild signal Google retries. |
| `_next/`, `_vercel/` | exempt | The CDN serves these with **no function invocation**. Gating them would *add* one per request and hide nothing, since the HTML referencing them is gated. |
| `robots.txt` | exempt | A 503 here makes Google stop crawling the site outright, louder than a month-long outage warrants. |
| `favicon`, `icons/`, `brand/`, `sw.js` | exempt | Chrome. A 503 breaks the installed PWA and already-shared link cards. |
| `/api/gate` | exempt | The unlock endpoint. Gating it locks everyone out for good. |

`isGatedPath()` is the single source of truth and `config.matcher` is derived from the same list, so an exempt request never invokes the function at all. Next needs the matcher to be a string literal, so a unit test derives it and fails if the two drift.

## Also fixed

An escape in the draft that was not one: `"\."` in a JS string literal is a bare dot, so `sw.js` would have exempted `swXjs`. And an unsourced `~1M requests a day` figure that cited `next.config.ts`, which contains no such number.

The `process.env` scan in `sources-status.test.ts` now reads root-level files. `middleware.ts` decides whether the site is served at all, and until it existed nothing in this repo read env from the root, so that guard had never needed to look there — a gate the guard cannot see is not guarded. It immediately surfaced two reads in `playwright.preview.config.ts` that nobody had classified.

`BRAND.discordUrl` moves to the reissued invite, which also lands people in announcements rather than joins-leaves.

## Gate

`npx tsc --noEmit` clean. **3,148 tests across 320 files pass**, 26 of them new, each watched fail before the code that satisfies it was written.

Unit tests prove the pure functions; they cannot prove a middleware intercepts anything. Measured against a running server, both ways:

| request | armed | disarmed |
|---|---|---|
| `GET /` | 503, `no-store`, `retry-after: 3600` | 200 |
| `GET /api/coverage` | 503, no upstream fetch | 200 |
| `GET /robots.txt` | 200 | 200 |
| `POST /api/gate` wrong code | 303 to `/app?gate=denied` | 404 |
| `POST /api/gate` right code | 303 to `/app?c=grid`, sets `pv_gate` HttpOnly | 404 |
| `POST` with `next=//evil.example` | 303 to `/`, refused | 404 |

## Two things this does not do

**No rate limiting**, so the access code must be long — six digits is 10^6 exposed for a month. If the gate ever needs real resistance the place for it is a Vercel Firewall rule on `/api/gate`, not middleware.

**It does not make a blocked request free.** Every gated request still costs one edge invocation. If the bill is still bad with the gate on, Firewall rules deny before any function runs — that is the next lever, not this.

## Before deploying

**The Discord invite expires 2026-10-07 02:37 UTC**, checked against Discord's public invite API. That is the same week the release is planned, and it is the only link on the curtain. It needs Expire After: Never, max uses unlimited — a setting on Discord's side that no test in this repo can reach.

Design and reasoning: `docs/superpowers/specs/2026-09-07-maintenance-gate-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPc6asqo4ePhWJF684Ccuz
