### PR TITLE
Inspector: saved areas with their own source profiles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6786,3 +6786,57 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
   }
 }
 /* ── end stage rail ──────────────────────────────── */
+
+/* ── Inspector: the context bar and the index ─────────────────────────────── */
+.tn-ctxbar {
+  display: flex; align-items: center; gap: 7px; margin: 0 0 2px;
+  padding: 6px 9px; border-radius: 8px; font-size: var(--tnx-fs-sm);
+  background: var(--tn-surface-2, rgba(0,0,0,.03)); border: 1px solid var(--tn-border);
+}
+.tn-ctxbar[data-area] { border-color: var(--tn-accent); }
+.tn-ctxbar-glyph { color: var(--tn-text-faint); }
+.tn-ctxbar[data-area] .tn-ctxbar-glyph, .tn-ctxbar[data-area] .tn-ctxbar-name { color: var(--tn-accent); }
+.tn-ctxbar-name { flex: 1; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-ctxbar-x { border: none; background: none; color: var(--tn-text-faint); cursor: pointer; font: inherit; padding: 0 2px; }
+.tn-ctxbar-x:hover { color: var(--tn-text); }
+
+.tn-rail-tabs { display: flex; gap: 4px; padding: 7px 0 2px; }
+.tn-rail-tab {
+  flex: 1; padding: 5px 0 6px; font: inherit; font-size: var(--tnx-fs-sm); font-weight: 500;
+  border-radius: 7px; border: 1px solid transparent; background: none;
+  color: var(--tn-text-faint); cursor: pointer;
+}
+.tn-rail-tab[aria-selected="true"] {
+  border-color: var(--tn-accent); color: var(--tn-accent); font-weight: 600;
+}
+
+.tn-insp-count { color: var(--tn-text-faint); font-weight: 400; }
+.tn-insp-row {
+  display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 8px;
+  margin: 0 -8px; border: none; border-radius: 8px; background: none;
+  font: inherit; text-align: left; color: inherit; cursor: pointer;
+}
+.tn-insp-row:hover { background: var(--tn-surface-2, rgba(0,0,0,.04)); }
+.tn-insp-row[data-loaded] { background: var(--tn-accent-soft, rgba(0,0,0,.06)); }
+.tn-insp-glyph { color: var(--tn-accent); flex: 0 0 auto; }
+.tn-insp-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
+.tn-insp-label { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-insp-sub { font-size: var(--tnx-fs-xs); color: var(--tn-text-faint); }
+.tn-insp-pill {
+  font-size: var(--tnx-fs-xs); font-weight: 700; letter-spacing: .05em;
+  padding: 1.5px 5px; border-radius: 4px; white-space: nowrap; color: var(--tn-accent);
+  border: 1px solid var(--tn-accent);
+}
+.tn-insp-pill-muted { color: var(--tn-text-faint); border-color: var(--tn-border); }
+.tn-insp-draw {
+  width: 100%; margin-top: 8px; padding: 7px 9px; text-align: left;
+  border: 1px dashed var(--tn-border); border-radius: 8px; background: none;
+  font: inherit; font-size: var(--tnx-fs-sm); color: var(--tn-accent); cursor: pointer;
+}
+.tn-insp-soon {
+  margin-top: 12px; padding: 9px 10px; border-radius: 10px;
+  border: 1px dashed var(--tn-border); background: var(--tn-surface-2, rgba(0,0,0,.03));
+}
+.tn-insp-soon-head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; font-size: var(--tnx-fs-xs); font-weight: 600; }
+.tn-insp-soon-head span:first-child { flex: 1; }
+.tn-insp-soon p { margin: 0; font-size: var(--tnx-fs-xs); color: var(--tn-text-faint); line-height: 1.5; }

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -16,6 +16,7 @@ import maplibregl, { type GeoJSONSource } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { WorldObject } from "@/lib/world";
 import { overlay } from "@/lib/overlay";
+import { sourcesRailStore } from "@/lib/console/sourcesRail";
 import { filterToScope } from "@/lib/scopeFilter";
 import { useScope } from "@/lib/shell/scope";
 import { cinematic } from "@/lib/cinematic/store";
@@ -1513,6 +1514,12 @@ export default function WorldMap() {
       const f = e.features?.[0];
       if (!f) return;
       overlay.open(buildCountryObject(f.properties as CountryProps, e.lngLat.lat, e.lngLat.lng));
+      // Open the rail alongside the dossier. The dossier is the country's detail; the
+      // rail is the index it belongs to, and the Inspector tab is where a country's
+      // sources are configured. Opening one without the other leaves the user reading
+      // a country panel with no visible way to act on it. What the overlay opens is
+      // unchanged — this only reveals the surface that was already there.
+      sourcesRailStore.setOpen(true);
     });
     // ── ONE shared pointer hit-test ─────────────────────────────────────────
     // This replaces 13 layer-scoped mouseenter/mouseleave/mousemove handlers.

--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -16,6 +16,8 @@ import maplibregl, { type GeoJSONSource } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { WorldObject } from "@/lib/world";
 import { overlay } from "@/lib/overlay";
+import { filterToScope } from "@/lib/scopeFilter";
+import { useScope } from "@/lib/shell/scope";
 import { cinematic } from "@/lib/cinematic/store";
 import { computeDive } from "@/lib/cinematic/dive";
 import { loadedCamerasStore } from "@/lib/cameras/loaded";
@@ -2363,6 +2365,48 @@ function SignalFeed({
   onData: (id: string, objs: WorldObject[]) => void;
 }) {
   const { id } = source;
+  const scope = useScope();
+  const rawRef = useRef<WorldObject[]>([]);
+  const loadedOnceRef = useRef(false);
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
+
+  /**
+   * Hand on the SCOPED view of whatever the upstream last returned.
+   *
+   * The map is the surface the Inspector's whole promise rests on: load an area and
+   * the console shows that area. Every signal layer funnels through this component,
+   * so this is the one place that has to crop, and cropping here also fixes the 13
+   * roll-up cards and the Webcams leaf — they read signalCountsStore and would
+   * otherwise print a planet-wide total beside a map cropped to one ring.
+   *
+   * FRESHNESS IS DELIBERATELY NOT SCOPED. It answers "did the upstream respond",
+   * and an area with nothing inside it must not make a healthy source look dead.
+   * So a card can honestly read 0 with a green dot: the feed is fine, your area is
+   * empty. Those are different facts and the UI keeps them apart.
+   *
+   * KNOWN LIMIT, stated rather than hidden: a feature is tested by its
+   * representative lat/lon, so a cable or a jamming corridor whose line crosses the
+   * ring while its own point sits outside is dropped. Testing the geometry itself
+   * needs a per-shape traversal this does not do yet.
+   */
+  const publish = useCallback(
+    (objs: WorldObject[]) => {
+      const scoped = filterToScope(objs, scopeRef.current, (o) => o);
+      onData(id, scoped);
+      signalCountsStore.set(id, scoped.length);
+    },
+    [id, onData],
+  );
+
+  // Re-crop when the scope changes, WITHOUT refetching — loading an area must not
+  // fire 33 upstream requests. Skipped until the first load so a mounting layer
+  // shows "no count yet" rather than a momentary 0.
+  useEffect(() => {
+    if (!loadedOnceRef.current) return;
+    publish(rawRef.current);
+  }, [scope, publish]);
+
   useEffect(() => {
     let alive = true;
     const load = () => {
@@ -2397,14 +2441,16 @@ function SignalFeed({
               ...(f.geometry ? { geometry: f.geometry } : {}),
             },
           }));
-          onData(id, objs);
-          signalCountsStore.set(id, objs.length);
+          rawRef.current = objs;
+          loadedOnceRef.current = true;
+          publish(objs);
           signalFreshnessStore.record(id, { ok: true, count: objs.length });
         })
         .catch(() => {
           if (!alive) return;
-          onData(id, []);
-          signalCountsStore.set(id, 0);
+          rawRef.current = [];
+          loadedOnceRef.current = true;
+          publish([]);
           signalFreshnessStore.record(id, { ok: false, count: 0 });
         });
     };
@@ -2418,7 +2464,7 @@ function SignalFeed({
       signalCountsStore.set(id, null);
       signalFreshnessStore.clear(id);
     };
-  }, [id, source, onData]);
+  }, [id, source, onData, publish]);
   return null;
 }
 

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -14,6 +14,7 @@
 // remapped --tn-* tokens without a single .tn-cw* rule being rewritten.
 
 import { useEffect, useRef, useState } from "react";
+import { inspectorStore } from "@/lib/shell/inspector";
 import { uiStore } from "@/lib/shell/ui";
 import { langStore } from "@/lib/i18n/store";
 import { watchlistStore } from "@/lib/shell/watchlist";
@@ -84,6 +85,7 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
   // uiStore.hydrate() applies the persisted data-theme before paint; variantStore
   // then re-asserts the variant's theme. Order matters.
   useEffect(() => {
+    inspectorStore.hydrate();
     uiStore.hydrate();
     variantStore.bootstrap(new URLSearchParams(window.location.search));
     watchlistStore.hydrate();

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -85,9 +85,15 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
   // uiStore.hydrate() applies the persisted data-theme before paint; variantStore
   // then re-asserts the variant's theme. Order matters.
   useEffect(() => {
-    inspectorStore.hydrate();
     uiStore.hydrate();
+    // BEFORE inspectorStore.hydrate(), and that order is load-bearing. bootstrap
+    // applies the variant through layersStore/signalsStore, which write whichever
+    // source context is LOADED — so restoring a loaded area first made every reload
+    // overwrite that area's sources with the variant's layers. Nothing is loaded
+    // yet at this point, so the writes land on World, which is what a variant
+    // configures. Then the Inspector restores the areas and which one was loaded.
     variantStore.bootstrap(new URLSearchParams(window.location.search));
+    inspectorStore.hydrate();
     watchlistStore.hydrate();
     timeWindowStore.hydrate();
     langStore.hydrate();

--- a/components/shell/SourceCatalog.tsx
+++ b/components/shell/SourceCatalog.tsx
@@ -50,6 +50,8 @@ import { shouldHintRail, sourcesRailStore, useSourcesRail } from "@/lib/console/
 import { formatChord, isMac, useKeymap } from "@/lib/shell/keymap";
 import SourceSection from "@/components/shell/sources/SourceSection";
 import { useRailDrag } from "@/components/shell/sources/useRailDrag";
+import ContextBar from "@/components/shell/inspector/ContextBar";
+import InspectorTab from "@/components/shell/inspector/InspectorTab";
 
 function CameraFilters() {
   const filter = useCameraFilter();
@@ -121,6 +123,7 @@ export default function SourceCatalog() {
   // No hydrate effect: the hint is scoped to one launch and nothing about it is
   // persisted, so the server render and the first client pass already agree.
   const [query, setQuery] = useState("");
+  const [tab, setTab] = useState<"sources" | "inspector">("sources");
   const t = useT();
   const layers = useLayers();
   const signals = useSignals();
@@ -213,65 +216,88 @@ export default function SourceCatalog() {
         </button>
       </div>
 
-      <input
-        type="search"
-        className="tn-cat-search"
-        placeholder="Search sources…"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        aria-label="Search sources"
-      />
+      <ContextBar />
 
-      <PresetBar />
+      <div className="tn-rail-tabs" role="tablist">
+        <button
+          type="button" role="tab" className="tn-rail-tab"
+          aria-selected={tab === "sources"} onClick={() => setTab("sources")}
+        >
+          Sources
+        </button>
+        <button
+          type="button" role="tab" className="tn-rail-tab"
+          aria-selected={tab === "inspector"} onClick={() => setTab("inspector")}
+        >
+          Inspector
+        </button>
+      </div>
 
-
-      {visible.length === 0 ? (
-        <p className="tn-rail-foot">No source matches “{query.trim()}”.</p>
-      ) : (
-        visible.map((section) => (
-          <SourceSection
-            key={section.id}
-            section={section}
-            isOn={isOn}
-            isPlaced={isPlaced}
-            onToggle={onToggle}
-            onDragHandle={onDragHandle}
-          />
-        ))
-      )}
-
-      {/* AFTER the six sections, not inside them. These filters belong to the
-          Cameras row, so the obvious place was under the section holding it —
-          but seen in the browser that injects ~220px of feed and region chips
-          between Ground and Air & space and breaks the run of six headings the
-          rail exists to give you. They are a refinement of one source rather
-          than a source, so they read better as a trailing panel. Shown only
-          while the layer they filter is actually on. */}
-      {layers.cameras ? (
+      {tab === "sources" ? (
         <>
+          <input
+            type="search"
+            className="tn-cat-search"
+            placeholder="Search sources…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Search sources"
+          />
+
+          <PresetBar />
+
+
+          {visible.length === 0 ? (
+            <p className="tn-rail-foot">No source matches “{query.trim()}”.</p>
+          ) : (
+            visible.map((section) => (
+              <SourceSection
+                key={section.id}
+                section={section}
+                isOn={isOn}
+                isPlaced={isPlaced}
+                onToggle={onToggle}
+                onDragHandle={onDragHandle}
+              />
+            ))
+          )}
+
+          {/* AFTER the six sections, not inside them. These filters belong to the
+              Cameras row, so the obvious place was under the section holding it —
+              but seen in the browser that injects ~220px of feed and region chips
+              between Ground and Air & space and breaks the run of six headings the
+              rail exists to give you. They are a refinement of one source rather
+              than a source, so they read better as a trailing panel. Shown only
+              while the layer they filter is actually on. */}
+          {layers.cameras ? (
+            <>
+              <div className="tn-rail-divider" />
+              <CameraFilters />
+            </>
+          ) : null}
+
           <div className="tn-rail-divider" />
-          <CameraFilters />
+
+          <button type="button" className="tn-coverage-open" onClick={() => coverageStore.open()}>
+            {t("btnCoverage")}
+          </button>
+
+          <button type="button" className="tn-coverage-open" onClick={() => marketsStore.open()}>
+            {t("btnMarkets")}
+          </button>
+
+          <button type="button" className="tn-coverage-open" onClick={() => watchlistPanelStore.open()}>
+            ★ {t("sectionSaved")}
+          </button>
+
+          <p className="tn-rail-foot">
+            Only sources you can see are fetched. ＋ or drag a source to put it on the left, right or
+            bottom rail.
+          </p>
         </>
-      ) : null}
-
-      <div className="tn-rail-divider" />
-
-      <button type="button" className="tn-coverage-open" onClick={() => coverageStore.open()}>
-        {t("btnCoverage")}
-      </button>
-
-      <button type="button" className="tn-coverage-open" onClick={() => marketsStore.open()}>
-        {t("btnMarkets")}
-      </button>
-
-      <button type="button" className="tn-coverage-open" onClick={() => watchlistPanelStore.open()}>
-        ★ {t("sectionSaved")}
-      </button>
-
-      <p className="tn-rail-foot">
-        Only sources you can see are fetched. ＋ or drag a source to put it on the left, right or
-        bottom rail.
-      </p>
+      ) : (
+        <InspectorTab />
+      )}
     </aside>
   );
 }

--- a/components/shell/inspector/AreaDetail.tsx
+++ b/components/shell/inspector/AreaDetail.tsx
@@ -1,0 +1,196 @@
+"use client";
+// In-overlay body for a saved area.
+//
+// The Inspector tab is the INDEX — every area, one row each. This is the DETAIL, and
+// it opens in the same right-edge dossier that a camera, a plane or a country opens
+// in. That split is the whole point: the rail stays a list you can scan, and the
+// panel that was already the app's detail surface goes on being it.
+//
+// IT READS THE STORE, NOT THE OVERLAY OBJECT. The object carries only an id; every
+// field below is looked up live. So a rename in this panel, a toggle in the Sources
+// tab and a load from anywhere all repaint it, and an area removed elsewhere leaves
+// an honest "no longer saved" rather than a stale copy of something that is gone.
+//
+// THE SOURCE LIST HERE IS READ-ONLY, on purpose. Sources are configured in the
+// Sources tab, which is already pointed at whichever context is loaded. Two places
+// to change one thing is the bug this whole split exists to avoid.
+
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
+import type { WorldObject } from "@/lib/world";
+import { areaSummary, inspectorStore, useInspector } from "@/lib/shell/inspector";
+import { scopeStore, WORLD_SCOPE } from "@/lib/shell/scope";
+import { mapViewStore } from "@/lib/mapView";
+import { overlay } from "@/lib/overlay";
+
+const CARD_STYLE: CSSProperties = {
+  padding: "10px",
+  borderRadius: 8,
+  background: "var(--tn-surface-2, rgba(148,163,184,0.10))",
+};
+const TITLE_STYLE: CSSProperties = { fontSize: 13, fontWeight: 600, color: "var(--tn-text)" };
+const NOTE_STYLE: CSSProperties = { fontSize: 11, color: "var(--tn-text-muted)" };
+const ROW_STYLE: CSSProperties = { display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" };
+const BTN_STYLE: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  border: "1px solid var(--tn-border)",
+  borderRadius: 6,
+  padding: "4px 9px",
+  background: "transparent",
+  color: "var(--tn-text)",
+  cursor: "pointer",
+};
+const LABEL_INPUT_STYLE: CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  width: "100%",
+  border: "1px solid var(--tn-border)",
+  borderRadius: 6,
+  padding: "4px 7px",
+  background: "var(--tn-surface, transparent)",
+  color: "var(--tn-text)",
+};
+
+/** [west, south, east, north] → its centre. */
+function bboxCentre(bbox: [number, number, number, number]): { lat: number; lon: number } {
+  return { lat: (bbox[1] + bbox[3]) / 2, lon: (bbox[0] + bbox[2]) / 2 };
+}
+
+export default function AreaDetail({ object }: { object: WorldObject }) {
+  const state = useInspector();
+  const area = state.areas.find((a) => a.id === object.id) ?? null;
+  const [draft, setDraft] = useState(area?.label ?? "");
+
+  // Follow a rename made anywhere else, but never while this input has focus —
+  // overwriting what someone is mid-way through typing is its own small betrayal.
+  useEffect(() => {
+    if (!area) return;
+    if (document.activeElement?.getAttribute("data-tn-area-label") === area.id) return;
+    setDraft(area.label);
+  }, [area]);
+
+  if (!area) {
+    return (
+      <div style={{ ...CARD_STYLE, display: "grid", gap: 6 }}>
+        <div style={TITLE_STYLE}>Area no longer saved</div>
+        <div style={NOTE_STYLE}>
+          It was removed while this panel was open. Nothing here is stale — the panel simply has
+          nothing left to show.
+        </div>
+      </div>
+    );
+  }
+
+  const loaded = state.loaded === area.id;
+  const centre = bboxCentre(area.bbox);
+  const on = Object.entries(area.sources)
+    .filter(([, v]) => v)
+    .map(([id]) => id)
+    .sort();
+
+  const commitLabel = () => {
+    const next = draft.trim();
+    // An empty label would leave an unclickable blank row in the index.
+    if (!next || next === area.label) {
+      setDraft(area.label);
+      return;
+    }
+    inspectorStore.rename(area.id, next);
+  };
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <label style={NOTE_STYLE} htmlFor={`area-label-${area.id}`}>
+          Area name
+        </label>
+        <input
+          id={`area-label-${area.id}`}
+          data-tn-area-label={area.id}
+          style={LABEL_INPUT_STYLE}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitLabel}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+            if (e.key === "Escape") {
+              setDraft(area.label);
+              e.currentTarget.blur();
+            }
+          }}
+        />
+        <div style={NOTE_STYLE}>{areaSummary(area)}</div>
+      </div>
+
+      <div style={{ ...CARD_STYLE, display: "grid", gap: 6 }}>
+        <div style={TITLE_STYLE}>Shape</div>
+        <div style={NOTE_STYLE}>
+          {area.polygon.length} vertices · centre {centre.lat.toFixed(2)}, {centre.lon.toFixed(2)}
+        </div>
+        <div style={NOTE_STYLE}>
+          Drawn, not a bounding box — the console filters on the ring itself, and the box is only
+          the cheap first reject.
+        </div>
+      </div>
+
+      <div style={ROW_STYLE}>
+        <button
+          type="button"
+          style={{
+            ...BTN_STYLE,
+            borderColor: loaded ? "var(--tn-accent, var(--tn-border))" : "var(--tn-border)",
+          }}
+          onClick={() => {
+            if (loaded) {
+              inspectorStore.load(null);
+              scopeStore.set(WORLD_SCOPE);
+              return;
+            }
+            inspectorStore.load(area.id);
+            scopeStore.set({
+              mode: "aoi",
+              bbox: area.bbox,
+              polygon: area.polygon as [number, number][],
+              label: area.label,
+            });
+          }}
+        >
+          {loaded ? "Unload — back to World" : "Load this area"}
+        </button>
+        <button
+          type="button"
+          style={BTN_STYLE}
+          onClick={() => mapViewStore.flyToPoint({ lat: centre.lat, lon: centre.lon, zoom: 6 })}
+        >
+          Fly to
+        </button>
+        <button
+          type="button"
+          style={BTN_STYLE}
+          onClick={() => {
+            inspectorStore.remove(area.id);
+            overlay.close();
+          }}
+        >
+          Remove
+        </button>
+      </div>
+
+      <div style={{ ...CARD_STYLE, display: "grid", gap: 6 }}>
+        <div style={TITLE_STYLE}>Sources on here</div>
+        {on.length === 0 ? (
+          <div style={NOTE_STYLE}>
+            Nothing switched on yet. Cameras and webcams still draw — an area never loads to a
+            blank map.
+          </div>
+        ) : (
+          <div style={NOTE_STYLE}>{on.join(", ")}</div>
+        )}
+        <div style={NOTE_STYLE}>
+          Change these in the Sources tab — it is already pointed at this area.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/shell/inspector/ContextBar.tsx
+++ b/components/shell/inspector/ContextBar.tsx
@@ -1,0 +1,37 @@
+"use client";
+// What the rail is editing. THE LOAD-BEARING CONTROL OF THIS WHOLE FEATURE.
+//
+// With several source contexts, a toggle in the Sources tab writes whichever one is
+// loaded. A user who flips Aircraft without knowing whether they changed the globe
+// or the Kharkiv area has been handed a control that lies about its effect — and
+// this codebase has shipped and then fixed two variants of that bug already. So this
+// line is rendered in BOTH tabs, not just the Inspector, and it is never hidden.
+
+import { inspectorStore, loadedArea, useInspector } from "@/lib/shell/inspector";
+import { scopeStore, WORLD_SCOPE } from "@/lib/shell/scope";
+
+export default function ContextBar() {
+  const state = useInspector();
+  const area = loadedArea(state);
+
+  return (
+    <div className="tn-ctxbar" data-area={area ? "" : undefined}>
+      <span className="tn-ctxbar-glyph" aria-hidden>{area ? "▣" : "⌂"}</span>
+      <span className="tn-ctxbar-name">{area ? area.label : "World"}</span>
+      {area ? (
+        <button
+          type="button"
+          className="tn-ctxbar-x"
+          onClick={() => {
+            inspectorStore.load(null);
+            scopeStore.set(WORLD_SCOPE);
+          }}
+          title="Back to World"
+          aria-label={`Unload ${area.label} and return to World`}
+        >
+          ✕
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/components/shell/inspector/InspectorTab.tsx
+++ b/components/shell/inspector/InspectorTab.tsx
@@ -1,0 +1,100 @@
+"use client";
+// The Inspector index. A LIST, not a detail view — detail opens in the dossier on
+// the right, which already exists at 384px and already handles focus, escape and
+// mobile. See lib/overlay-content.tsx.
+//
+// Sources are NOT configured here. Load an area and the Sources tab is pointed at
+// it; that is the whole interaction, and duplicating a source list in this column
+// would give the user two places to change one thing.
+
+import { aoiLabel, startDraw } from "@/lib/map/aoi";
+import { areaSummary, inspectorStore, useInspector } from "@/lib/shell/inspector";
+import { aoiScope, scopeStore } from "@/lib/shell/scope";
+import { overlay } from "@/lib/overlay";
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+declare global {
+  interface Window { __map?: MapLibreMap }
+}
+
+export default function InspectorTab() {
+  const state = useInspector();
+
+  const draw = () => {
+    const map = window.__map;
+    if (!map) return;
+    // onFinish is supplied, so aoi.ts hands us the ring and leaves the scope alone.
+    // That contract is what keeps a camera pick from becoming a saved area; do not
+    // drop it. See DrawOptions in lib/map/aoi.ts.
+    startDraw(map, {
+      onFinish: (ring) => {
+        const id = inspectorStore.add(ring, aoiLabel(ring));
+        if (id) load(id);
+      },
+    });
+  };
+
+  const load = (id: string) => {
+    inspectorStore.load(id);
+    const area = inspectorStore.get().areas.find((a) => a.id === id);
+    if (area) scopeStore.set(aoiScope(area.polygon, area.label));
+  };
+
+  return (
+    <div className="tn-insp">
+      <div className="tn-subhead">
+        Areas <span className="tn-insp-count">{state.areas.length}</span>
+      </div>
+
+      {state.areas.length === 0 ? (
+        <p className="tn-rail-foot">
+          No areas yet. Draw one on the map to give it its own sources.
+        </p>
+      ) : (
+        state.areas.map((a) => (
+          <button
+            key={a.id}
+            type="button"
+            className="tn-insp-row"
+            data-loaded={state.loaded === a.id ? "" : undefined}
+            onClick={() =>
+              // The bbox CENTRE, not 0,0. FeedOverlay writes the object's lat/lon
+              // straight into its GeoJSON export, so a placeholder would hand the
+              // user a downloaded file claiming every area sits at Null Island.
+              // A position we do have must never be shipped as one we invented.
+              overlay.open({
+                kind: "area",
+                id: a.id,
+                label: a.label,
+                lat: (a.bbox[1] + a.bbox[3]) / 2,
+                lon: (a.bbox[0] + a.bbox[2]) / 2,
+              })
+            }
+          >
+            <span className="tn-insp-glyph" aria-hidden>▣</span>
+            <span className="tn-insp-main">
+              <span className="tn-insp-label">{a.label}</span>
+              <span className="tn-insp-sub">{areaSummary(a)}</span>
+            </span>
+            {state.loaded === a.id ? <span className="tn-insp-pill">LOADED</span> : null}
+          </button>
+        ))
+      )}
+
+      <button type="button" className="tn-insp-draw" onClick={draw}>
+        ＋ Draw an area
+      </button>
+
+      {/* Labelled and inert, never a control that does nothing. The design is in
+          docs/superpowers/specs/2026-09-07-inspector-design.md §12 so it drops in
+          without moving anything here. */}
+      <div className="tn-insp-soon">
+        <div className="tn-insp-soon-head">
+          <span>Alert me</span>
+          <span className="tn-insp-pill tn-insp-pill-muted">COMING SOON</span>
+        </div>
+        <p>Tell me when something enters or leaves an area. Not built yet.</p>
+      </div>
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-09-07-inspector-areas.md
+++ b/docs/superpowers/plans/2026-09-07-inspector-areas.md
@@ -1167,7 +1167,19 @@ export default function InspectorTab() {
             type="button"
             className="tn-insp-row"
             data-loaded={state.loaded === a.id ? "" : undefined}
-            onClick={() => overlay.open({ kind: "area", id: a.id, label: a.label, lat: 0, lon: 0 })}
+            onClick={() =>
+              // The bbox CENTRE, not 0,0. FeedOverlay writes the object's lat/lon
+              // straight into its GeoJSON export, so a placeholder would hand the
+              // user a downloaded file claiming every area sits at Null Island.
+              // A position we do have must never be shipped as one we invented.
+              overlay.open({
+                kind: "area",
+                id: a.id,
+                label: a.label,
+                lat: (a.bbox[1] + a.bbox[3]) / 2,
+                lon: (a.bbox[0] + a.bbox[2]) / 2,
+              })
+            }
           >
             <span className="tn-insp-glyph" aria-hidden>▣</span>
             <span className="tn-insp-main">
@@ -1231,7 +1243,7 @@ Append to `app/globals.css`, beside the existing `.tn-rail` block:
 /* ── Inspector: the context bar and the index ─────────────────────────────── */
 .tn-ctxbar {
   display: flex; align-items: center; gap: 7px; margin: 0 0 2px;
-  padding: 6px 9px; border-radius: 8px; font-size: 12px;
+  padding: 6px 9px; border-radius: 8px; font-size: var(--tnx-fs-sm);
   background: var(--tn-surface-2, rgba(0,0,0,.03)); border: 1px solid var(--tn-border);
 }
 .tn-ctxbar[data-area] { border-color: var(--tn-accent); }
@@ -1243,7 +1255,7 @@ Append to `app/globals.css`, beside the existing `.tn-rail` block:
 
 .tn-rail-tabs { display: flex; gap: 4px; padding: 7px 0 2px; }
 .tn-rail-tab {
-  flex: 1; padding: 5px 0 6px; font: inherit; font-size: 12px; font-weight: 500;
+  flex: 1; padding: 5px 0 6px; font: inherit; font-size: var(--tnx-fs-sm); font-weight: 500;
   border-radius: 7px; border: 1px solid transparent; background: none;
   color: var(--tn-text-faint); cursor: pointer;
 }
@@ -1262,9 +1274,9 @@ Append to `app/globals.css`, beside the existing `.tn-rail` block:
 .tn-insp-glyph { color: var(--tn-accent); flex: 0 0 auto; }
 .tn-insp-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
 .tn-insp-label { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.tn-insp-sub { font-size: 11px; color: var(--tn-text-faint); }
+.tn-insp-sub { font-size: var(--tnx-fs-xs); color: var(--tn-text-faint); }
 .tn-insp-pill {
-  font-size: 9.5px; font-weight: 700; letter-spacing: .05em;
+  font-size: var(--tnx-fs-xs); font-weight: 700; letter-spacing: .05em;
   padding: 1.5px 5px; border-radius: 4px; white-space: nowrap; color: var(--tn-accent);
   border: 1px solid var(--tn-accent);
 }
@@ -1272,15 +1284,15 @@ Append to `app/globals.css`, beside the existing `.tn-rail` block:
 .tn-insp-draw {
   width: 100%; margin-top: 8px; padding: 7px 9px; text-align: left;
   border: 1px dashed var(--tn-border); border-radius: 8px; background: none;
-  font: inherit; font-size: 12px; color: var(--tn-accent); cursor: pointer;
+  font: inherit; font-size: var(--tnx-fs-sm); color: var(--tn-accent); cursor: pointer;
 }
 .tn-insp-soon {
   margin-top: 12px; padding: 9px 10px; border-radius: 10px;
   border: 1px dashed var(--tn-border); background: var(--tn-surface-2, rgba(0,0,0,.03));
 }
-.tn-insp-soon-head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; font-size: 11px; font-weight: 600; }
+.tn-insp-soon-head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; font-size: var(--tnx-fs-xs); font-weight: 600; }
 .tn-insp-soon-head span:first-child { flex: 1; }
-.tn-insp-soon p { margin: 0; font-size: 11px; color: var(--tn-text-faint); line-height: 1.5; }
+.tn-insp-soon p { margin: 0; font-size: var(--tnx-fs-xs); color: var(--tn-text-faint); line-height: 1.5; }
 ```
 
 - [ ] **Step 9: Run the full gate**
@@ -1311,7 +1323,7 @@ and an area label that overstates is the one thing this product must not print."
 **Files:**
 - Create: `lib/scopeFilter.ts`
 - Test: `tests/unit/scope-filter.test.ts`
-- Modify: `lib/planes/usePlanes.ts`, `lib/cameras/useCameras.ts`, and the satellites + webcam directory hooks
+- Modify: `lib/planes/usePlanes.ts`, `lib/cameras/useCameras.ts`, `lib/satellites/useSatellites.ts`, `lib/webcams/titles.ts` (`useWebcamDirectory`)
 
 **Interfaces:**
 - Consumes: `withinScope`, `useScope` from `@/lib/shell/scope`.
@@ -1557,7 +1569,7 @@ ring', and keeping it would place an unknown inside a boundary drawn to exclude.
 - Create: `components/shell/inspector/AreaDetail.tsx`
 - Modify: `lib/world.ts` — add `"area"` to `WorldObjectKind`
 - Modify: `lib/overlay-content.tsx` — add `case "area"`
-- Modify: `components/WorldMap.tsx:1507`
+- Modify: `components/WorldMap.tsx:1510`
 
 **Interfaces:**
 - Consumes: `inspectorStore`, `useInspector`, `areaSummary` from Task 1; `overlay` from `@/lib/overlay`.
@@ -1567,21 +1579,254 @@ ring', and keeping it would place an unknown inside a boundary drawn to exclude.
 
 - [ ] **Step 1: Add the `area` kind**
 
-In `lib/world.ts`, extend `WorldObjectKind` with `"area"`.
+In `lib/world.ts`, extend `WorldObjectKind`:
+
+```ts
+export type WorldObjectKind = "camera" | "satellite" | "plane" | "webcam" | "signal" | "country" | "area";
+```
 
 - [ ] **Step 2: Build `AreaDetail.tsx`**
 
-Render, from the area whose `id` the overlay object carries: label (inline-editable → `inspectorStore.rename`), `areaSummary(area)`, vertex count, centre coordinates, and the source list read from `area.sources`. Buttons: **Load / Unload** (`inspectorStore.load` + `scopeStore.set`), **Fly to** (`mapViewStore.flyToPoint` on the bbox centre), **Remove** (`inspectorStore.remove`, then `overlay.close()`).
+Create `components/shell/inspector/AreaDetail.tsx`. Written out rather than described,
+because an earlier revision of this plan described it in prose and that is not
+transcribable — it is a component someone then has to invent.
 
-The source list is **read-only here** with the line "Change these in the Sources tab — it is already pointed at this area." Two places to change one thing is the bug this whole split exists to avoid.
+Two decisions in it are not stylistic. **It reads the STORE, not the overlay object**,
+so the object only has to carry an id and every other field is live: a rename here, a
+toggle in the Sources tab and a load from anywhere all repaint it, and an area removed
+elsewhere leaves an honest "no longer saved" instead of a stale copy. And **the source
+list is read-only**, with the line pointing at the Sources tab — two places to change
+one thing is the bug this whole split exists to avoid.
+
+```tsx
+"use client";
+// In-overlay body for a saved area.
+//
+// The Inspector tab is the INDEX — every area, one row each. This is the DETAIL, and
+// it opens in the same right-edge dossier that a camera, a plane or a country opens
+// in. That split is the whole point: the rail stays a list you can scan, and the
+// panel that was already the app's detail surface goes on being it.
+//
+// IT READS THE STORE, NOT THE OVERLAY OBJECT. The object carries only an id; every
+// field below is looked up live. So a rename in this panel, a toggle in the Sources
+// tab and a load from anywhere all repaint it, and an area removed elsewhere leaves
+// an honest "no longer saved" rather than a stale copy of something that is gone.
+//
+// THE SOURCE LIST HERE IS READ-ONLY, on purpose. Sources are configured in the
+// Sources tab, which is already pointed at whichever context is loaded. Two places
+// to change one thing is the bug this whole split exists to avoid.
+
+import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
+import type { WorldObject } from "@/lib/world";
+import { areaSummary, inspectorStore, useInspector } from "@/lib/shell/inspector";
+import { scopeStore, WORLD_SCOPE } from "@/lib/shell/scope";
+import { mapViewStore } from "@/lib/mapView";
+import { overlay } from "@/lib/overlay";
+
+const CARD_STYLE: CSSProperties = {
+  padding: "10px",
+  borderRadius: 8,
+  background: "var(--tn-surface-2, rgba(148,163,184,0.10))",
+};
+const TITLE_STYLE: CSSProperties = { fontSize: 13, fontWeight: 600, color: "var(--tn-text)" };
+const NOTE_STYLE: CSSProperties = { fontSize: 11, color: "var(--tn-text-muted)" };
+const ROW_STYLE: CSSProperties = { display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" };
+const BTN_STYLE: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  border: "1px solid var(--tn-border)",
+  borderRadius: 6,
+  padding: "4px 9px",
+  background: "transparent",
+  color: "var(--tn-text)",
+  cursor: "pointer",
+};
+const LABEL_INPUT_STYLE: CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  width: "100%",
+  border: "1px solid var(--tn-border)",
+  borderRadius: 6,
+  padding: "4px 7px",
+  background: "var(--tn-surface, transparent)",
+  color: "var(--tn-text)",
+};
+
+/** [west, south, east, north] → its centre. */
+function bboxCentre(bbox: [number, number, number, number]): { lat: number; lon: number } {
+  return { lat: (bbox[1] + bbox[3]) / 2, lon: (bbox[0] + bbox[2]) / 2 };
+}
+
+export default function AreaDetail({ object }: { object: WorldObject }) {
+  const state = useInspector();
+  const area = state.areas.find((a) => a.id === object.id) ?? null;
+  const [draft, setDraft] = useState(area?.label ?? "");
+
+  // Follow a rename made anywhere else, but never while this input has focus —
+  // overwriting what someone is mid-way through typing is its own small betrayal.
+  useEffect(() => {
+    if (!area) return;
+    if (document.activeElement?.getAttribute("data-tn-area-label") === area.id) return;
+    setDraft(area.label);
+  }, [area]);
+
+  if (!area) {
+    return (
+      <div style={{ ...CARD_STYLE, display: "grid", gap: 6 }}>
+        <div style={TITLE_STYLE}>Area no longer saved</div>
+        <div style={NOTE_STYLE}>
+          It was removed while this panel was open. Nothing here is stale — the panel simply has
+          nothing left to show.
+        </div>
+      </div>
+    );
+  }
+
+  const loaded = state.loaded === area.id;
+  const centre = bboxCentre(area.bbox);
+  const on = Object.entries(area.sources)
+    .filter(([, v]) => v)
+    .map(([id]) => id)
+    .sort();
+
+  const commitLabel = () => {
+    const next = draft.trim();
+    // An empty label would leave an unclickable blank row in the index.
+    if (!next || next === area.label) {
+      setDraft(area.label);
+      return;
+    }
+    inspectorStore.rename(area.id, next);
+  };
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <label style={NOTE_STYLE} htmlFor={`area-label-${area.id}`}>
+          Area name
+        </label>
+        <input
+          id={`area-label-${area.id}`}
+          data-tn-area-label={area.id}
+          style={LABEL_INPUT_STYLE}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitLabel}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+            if (e.key === "Escape") {
+              setDraft(area.label);
+              e.currentTarget.blur();
+            }
+          }}
+        />
+        <div style={NOTE_STYLE}>{areaSummary(area)}</div>
+      </div>
+
+      <div style={{ ...CARD_STYLE, display: "grid", gap: 6 }}>
+        <div style={TITLE_STYLE}>Shape</div>
+        <div style={NOTE_STYLE}>
+          {area.polygon.length} vertices · centre {centre.lat.toFixed(2)}, {centre.lon.toFixed(2)}
+        </div>
+        <div style={NOTE_STYLE}>
+          Drawn, not a bounding box — the console filters on the ring itself, and the box is only
+          the cheap first reject.
+        </div>
+      </div>
+
+      <div style={ROW_STYLE}>
+        <button
+          type="button"
+          style={{
+            ...BTN_STYLE,
+            borderColor: loaded ? "var(--tn-accent, var(--tn-border))" : "var(--tn-border)",
+          }}
+          onClick={() => {
+            if (loaded) {
+              inspectorStore.load(null);
+              scopeStore.set(WORLD_SCOPE);
+              return;
+            }
+            inspectorStore.load(area.id);
+            scopeStore.set({
+              mode: "aoi",
+              bbox: area.bbox,
+              polygon: area.polygon as [number, number][],
+              label: area.label,
+            });
+          }}
+        >
+          {loaded ? "Unload — back to World" : "Load this area"}
+        </button>
+        <button
+          type="button"
+          style={BTN_STYLE}
+          onClick={() => mapViewStore.flyToPoint({ lat: centre.lat, lon: centre.lon, zoom: 6 })}
+        >
+          Fly to
+        </button>
+        <button
+          type="button"
+          style={BTN_STYLE}
+          onClick={() => {
+            inspectorStore.remove(area.id);
+            overlay.close();
+          }}
+        >
+          Remove
+        </button>
+      </div>
+
+      <div style={{ ...CARD_STYLE, display: "grid", gap: 6 }}>
+        <div style={TITLE_STYLE}>Sources on here</div>
+        {on.length === 0 ? (
+          <div style={NOTE_STYLE}>
+            Nothing switched on yet. Cameras and webcams still draw — an area never loads to a
+            blank map.
+          </div>
+        ) : (
+          <div style={NOTE_STYLE}>{on.join(", ")}</div>
+        )}
+        <div style={NOTE_STYLE}>
+          Change these in the Sources tab — it is already pointed at this area.
+        </div>
+      </div>
+    </div>
+  );
+}
+```
 
 - [ ] **Step 3: Register it**
 
-In `lib/overlay-content.tsx`, add `case "area": return <AreaDetail object={object} />;`.
+In `lib/overlay-content.tsx`, add the import beside `CountryDetail` and the case beside
+`case "country"`:
+
+```tsx
+import AreaDetail from "@/components/shell/inspector/AreaDetail";
+```
+
+```tsx
+    case "area":
+      return <AreaDetail object={object} />;
+```
 
 - [ ] **Step 4: Country click also opens the Inspector**
 
-At `components/WorldMap.tsx:1507`, keep the existing `overlay.open(...)` and add `sourcesRailStore.setOpen(true)` beside it so the index is visible alongside the dossier. **Do not** change what the overlay opens.
+At `components/WorldMap.tsx:1510`, keep the existing `overlay.open(...)` exactly as it
+is and add the rail beside it. **Do not** change what the overlay opens.
+
+```tsx
+      overlay.open(buildCountryObject(f.properties as CountryProps, e.lngLat.lat, e.lngLat.lng));
+      // Open the rail alongside the dossier. The dossier is the country's detail; the
+      // rail is the index it belongs to, and the Inspector tab is where a country's
+      // sources are configured. Opening one without the other leaves the user reading
+      // a country panel with no visible way to act on it. What the overlay opens is
+      // unchanged — this only reveals the surface that was already there.
+      sourcesRailStore.setOpen(true);
+```
+
+with `import { sourcesRailStore } from "@/lib/console/sourcesRail";` added to the imports.
 
 - [ ] **Step 5: Run the full gate**
 

--- a/docs/superpowers/plans/2026-09-07-inspector-areas.md
+++ b/docs/superpowers/plans/2026-09-07-inspector-areas.md
@@ -930,23 +930,30 @@ Both stores keep their exact public API and become views onto whichever context
 is loaded. No call site changed: WorldMap, SourceCatalog, monitors, presetLayers,
 presets, PresetBar and the palette all still call toggle/set/get unedited.
 
-This is also a REVERT of an accidental deletion, not a new feature, and one git
-show makes that visible:
+CORRECTED DURING EXECUTION, and the correction is the useful part. This step was
+planned as a REVERT of an accidental deletion: git log -S \"layersStore.hydrate\"
+origin/main lands on 41cf2b9 (2026-06-27, \"wire ConsoleShell to the variant
+spine\"), whose parent has layersStore.hydrate() and signalsStore.hydrate() at
+ConsoleShell.tsx lines 34-35 and which drops both, with their imports, while
+re-adding alertStore and langStore in the same hunk. Nothing adds them back --
+474 commits and 71 days. Both files' headers still claim the old behaviour.
 
-  git log -S \"layersStore.hydrate\" origin/main   ->  41cf2b9
-  git show 41cf2b9 -- components/shell/ConsoleShell.tsx
+Every one of those facts is true, and the conclusion drawn from them was wrong.
+variantStore.bootstrap calls itself \"The ONLY load-time hydration path\" in its
+own doc comment: it applies the variant on every boot, and captureOverride
+subscribes to both stores and persists the delta under tn.variant.v1. Toggles DO
+survive a reload; their persistence MOVED. The deletion was deliberate and
+correct, and re-adding those calls would have fought the mechanism that replaced
+them.
 
-41cf2b9, 2026-06-27, \"wire ConsoleShell to the variant spine\", rewrote the hydrate
-block and dropped two stores out of it. Its parent has layersStore.hydrate() and
-signalsStore.hydrate() at ConsoleShell.tsx lines 34 and 35; the commit shows them as
-two minus lines while alertStore and langStore are re-added in the same hunk. Nothing
-adds them back. That is 474 commits and 71 days on main.
+Two things to take from it. A careful reading of a diff supported a conclusion
+that one line of localStorage in a running browser disproves -- so where a claim
+is about RUNTIME behaviour, run it. And the deletion was internally consistent
+(calls and imports together, no unused symbol, no type error), which is why no
+tool flagged it for 474 commits and why the only thing left inconsistent was
+English prose in two file headers.
 
-So layer and signal toggles have not survived a reload since 2026-06-27, and both
-files' headers have described the behaviour of the code that used to be there --
-lib/layers.ts still says \"persisted to localStorage so a composed view survives a
-reload\", and lib/signals/store.ts says the same. This makes the code match its
-documentation again. Rehydration now happens once, in inspectorStore.
+Rehydration now happens once, in inspectorStore.
 
 Also corrects the LayerKey comment: weather left SIGNALS in #177 and the rail
 stopped drawing signposts for either planned key before that."

--- a/docs/superpowers/plans/2026-09-07-inspector-areas.md
+++ b/docs/superpowers/plans/2026-09-07-inspector-areas.md
@@ -1888,4 +1888,51 @@ visible beside the dossier it is describing."
 
 **Type consistency.** `SourceSet`, `InspectorArea`, `InspectorState`, `effectiveSet`, `activeSet`, `writeActive`, `replaceActive`, `areaSummary`, `ringAreaKm2`, `loadedArea`, `filterToScope`, `useScopeFilter` are used in Tasks 2–5 exactly as Task 1 and Task 4 define them. `ALWAYS_ON_SOURCES` is read only through `effectiveSet`.
 
-**One risk worth naming.** Task 2's `layersStore.applyExact` merges rather than replaces, because a context's `SourceSet` holds signal ids alongside `LayerKey`s and a layer preset must not switch every signal off. `signalsStore.applyExact` does replace, which mirrors its current behaviour but now also clears layer keys from the set — `presetLayers.ts` and `variants/resolveSignals.ts` call it, so their tests are the ones to watch in Task 2 Step 7.
+**One risk worth naming — and it landed.** Task 2's `layersStore.applyExact` merges rather than replaces, because a context's `SourceSet` holds signal ids alongside `LayerKey`s and a layer preset must not switch every signal off. The plan had `signalsStore.applyExact` still doing a whole-set replace, which in the new shape clears every layer key a moment after the variant sets them; `variants-store.test.ts` caught it during execution and it now merges the layer half too. `presetLayers.ts` and `variants/resolveSignals.ts` are its callers.
+
+
+## Verified in a browser, and what running it found
+
+`npx tsc --noEmit` clean; 324 unit files / 3,162 tests green. Neither could see any of
+the following — every one is a mount-order or shared-state fault in a real browser.
+
+**Two data-destroying bugs, both found by running it, both now fixed and guarded.**
+
+1. **A reload replaced a loaded area's configuration with the variant's layers.**
+   `ConsoleShell` hydrated the Inspector before `variantStore.bootstrap()`, and
+   bootstrap writes through `layersStore`/`signalsStore` — which are now views onto
+   whichever context is loaded. Measured: an area seeded `{earthquakes, wildfires}`
+   came back holding the variant's set. Fixed by bootstrapping first, not persisting
+   World in the Inspector, and returning early from `captureOverride` unless
+   `loaded === null`.
+2. **Every reload emptied the Inspector — the mirror of (1).** With bootstrap running
+   first, its World write hit an `inspectorStore.commit()` that persisted
+   unconditionally, saving the pre-hydrate `areas: []` over the user's saved areas;
+   the hydrate that followed then read back the file it had just destroyed. Measured
+   on the preview: a seeded area came back as `{"world":{…},"areas":[],"loaded":null}`.
+   Fixed with a module flag — nothing persists until `hydrate()` has read what is
+   already saved. `tests/unit/inspector-boot-order.test.ts` pins it by driving the real
+   boot order against an injected `localStorage`, and fails with
+   `expected [] to have a length of 1` when the gate is removed.
+
+**The claim itself.** `tests/e2e/inspector-areas.spec.ts`, run against the preview
+through the repo's own `playwright.preview.config.ts`: **1 passed**. Loading an area
+cropped the map from 193 drawn features to 11 — *exactly* the 11 whose positions fall
+inside the ring, computed at run time. The assertion is an equality, not "fewer than
+before", because a build that drops everything also satisfies the inequality: the first
+ring chosen (Kharkiv) was seismically quiet and cropped 193 → 0, where "filtered
+correctly" and "wiped" are indistinguishable. Inverted, the assertion fails with
+`Expected: 192, Received: 11`, so it discriminates rather than decorates.
+
+**Two things about the harness that cost real time.**
+
+- The basemap host is `tiles.openfreemap.org` (`DEFAULT_BASEMAP = "streets"`), not
+  `basemaps.cartocdn.com`, which serves only the dark variant. An earlier commit
+  "corrected" it the wrong way round.
+- `playwright.preview.config.ts` could not run a map spec at all: it sets the
+  protection token as a request header, and any custom header CORS-preflights the tile
+  host, which answers 405 to OPTIONS. The basemap then dies silently — a
+  false-positive generator for exactly this claim. It now also accepts
+  `PREVIEW_SHARE_URL` (a `_vercel_share` cookie link, no header). A share token is
+  per-deployment, so every push invalidates it; the symptom is a `.map-canvas`
+  timeout rather than a visible login page.

--- a/docs/superpowers/plans/2026-09-07-inspector-areas.md
+++ b/docs/superpowers/plans/2026-09-07-inspector-areas.md
@@ -382,6 +382,31 @@ export function effectiveSet(state: InspectorState): SourceSet {
   return out;
 }
 
+/**
+ * The set the console DRAWS, memoised on the state object.
+ *
+ * effectiveSet() builds a fresh object whenever an area is loaded, because it has to
+ * force ALWAYS_ON_SOURCES in. useSyncExternalStore compares snapshots by identity, so
+ * a store calling effectiveSet() per render hands React a new snapshot every time —
+ * the documented infinite-loop bug. World hid it: with nothing loaded effectiveSet
+ * returns state.world by identity, so the globe was stable and only loading an area
+ * would have hung the console. There are no component tests in this repo to catch
+ * that, so the guard is an identity assertion in tests/unit/inspector-routing.test.ts.
+ *
+ * The state object is replaced on every write and never mutated, so its identity is
+ * the correct cache key.
+ */
+let memoState: InspectorState | null = null;
+let memoSet: SourceSet = {};
+
+export function effectiveSetMemo(state: InspectorState): SourceSet {
+  if (state !== memoState) {
+    memoState = state;
+    memoSet = effectiveSet(state);
+  }
+  return memoSet;
+}
+
 /** Pure: set one source on the loaded context. */
 export function writeActive(state: InspectorState, id: string, on: boolean): InspectorState {
   const area = loadedArea(state);
@@ -542,6 +567,35 @@ toggles and removing an area cannot strand a source only it turned on."
 
 **Why this shape:** `WorldMap`, `SourceCatalog`, `monitors.ts`, `presetLayers.ts`, `presets.ts`, `PresetBar.tsx`, the command palette and the widgets all call these stores. Changing the API would touch every one of them. Making them views onto `inspectorStore` touches none.
 
+> **Three corrections were made to this task DURING execution, and the blocks below are
+> the corrected versions.** Recording them because each was a real defect that the first
+> cut shipped, and two of them no test in the original plan would have caught:
+>
+> 1. **The two stores share one map and were wiping each other's half.** Layers and
+>    signals used to own separate module state, so neither `applyExact` could reach the
+>    other. Projecting both onto one `SourceSet` made a whole-set replace destructive:
+>    `lib/variants/store.ts` applies layers and then signals, so every variant reset its
+>    own map layers a moment after setting them. Caught by the EXISTING
+>    `tests/unit/variants-store.test.ts` — the pinning test doing exactly its job.
+> 2. **`get()` returned a fresh object per call whenever an area was loaded.**
+>    `effectiveSet()` has to build a new object to force `ALWAYS_ON_SOURCES` in, and
+>    `useSyncExternalStore` compares snapshots by identity — the documented infinite-loop
+>    bug. World hid it completely (it returns `state.world` by identity), so the console
+>    would have worked on the globe and hung the moment an area loaded. There are no
+>    component tests in this repo, so nothing would have caught it before a browser.
+>    Fixed with `effectiveSetMemo` in `lib/shell/inspector.ts`; pinned by an identity
+>    assertion. The first cut's comment in `lib/signals/store.ts` asserted the identity
+>    WAS stable, which was true for World and false for an area.
+> 3. **An empty area read as `DEFAULT_STATE`, not as empty.** `project()` floored every
+>    context with `DEFAULT_STATE`, so a new area came up with planes, satellites and
+>    countries on — contradicting `newArea`'s own "starts empty" comment two files away.
+>    An area now floors to all-off; World still floors to `DEFAULT_STATE` so the globe is
+>    byte-identical to before. Without this the area's set silently inherits a constant,
+>    and every unconfigured key moves the day a default flips.
+>
+> Also: the test block below was missing its `vitest` import, which the implementing
+> agent added and reported. That was a gap in this plan, not a deviation.
+
 - [ ] **Step 1: Write the failing test**
 
 Create `tests/unit/inspector-routing.test.ts`:
@@ -626,6 +680,54 @@ test("applyPreset writes the loaded area, not World", () => {
   expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.planes).toBe(true);
   expect(inspectorStore.get().world.planes).toBeUndefined();
 });
+
+// --- the two the first cut got wrong ----------------------------------------
+
+test("an empty area reads every layer OFF except the always-on pair", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  // A new area starts with an empty set. DEFAULT_STATE is World's floor, not an
+  // area's — flooring an area with it would silently hand the user a context they
+  // never configured, and would drift again the day a default flips.
+  expect(layersStore.get()).toEqual({
+    cameras: true, // always-on
+    webcams: true, // always-on
+    satellites: false,
+    planes: false,
+    ships: false,
+    weather: false,
+    countries: false,
+  });
+});
+
+test("get() is identity-stable while an area is loaded — a fresh object per call loops React", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  // effectiveSet() FORCES the always-on ids in, so it builds a new object every
+  // call. useSyncExternalStore compares snapshots by identity: returning a new one
+  // per render is the documented infinite-loop bug, and there are no component
+  // tests in this repo to catch it. World never showed it — it returns state.world
+  // by identity — so this only bites once an area loads.
+  expect(layersStore.get()).toBe(layersStore.get());
+  expect(signalsStore.get()).toBe(signalsStore.get());
+});
+
+test("the two stores share one map and must not wipe each other's half", () => {
+  // Layers and signals used to own separate module state, so neither applyExact
+  // could reach the other. They now project onto ONE SourceSet per context, which
+  // makes a whole-set replace from either side destructive. A variant writes both
+  // (lib/variants/store.ts applies layers, then signals) so whichever runs second
+  // would silently reset the first — caught by tests/unit/variants-store.test.ts.
+  layersStore.applyExact({ ...DEFAULT_STATE, satellites: false });
+  signalsStore.applyExact({ "conflict-coverage": true });
+  expect(layersStore.get().satellites).toBe(false);
+  expect(signalsStore.isOn("conflict-coverage")).toBe(true);
+
+  // ...and the mirror: a layer preset must not switch every signal layer off.
+  layersStore.applyExact({ ...DEFAULT_STATE, planes: false });
+  expect(signalsStore.isOn("conflict-coverage")).toBe(true);
+  expect(layersStore.get().planes).toBe(false);
+});
 ```
 
 - [ ] **Step 2: Run it and watch it fail**
@@ -658,28 +760,46 @@ Then replace everything from `let state: LayerState = { ...DEFAULT_STATE };` to 
 //
 // The projection is one-way. This file imports inspector.ts; inspector.ts must never
 // import this one, or the pair is circular and neither owns the state.
-import { effectiveSet, inspectorStore, type SourceSet } from "@/lib/shell/inspector";
+import { effectiveSetMemo, inspectorStore, loadedArea, type SourceSet } from "@/lib/shell/inspector";
 
-/** The 7 LayerKeys pulled out of a context's set, with DEFAULT_STATE as the floor. */
-function project(set: SourceSet): LayerState {
-  const out = { ...DEFAULT_STATE };
+/** Every LayerKey off. An AREA's floor — see project(). */
+const ALL_OFF: LayerState = (Object.keys(DEFAULT_STATE) as LayerKey[]).reduce((acc, k) => {
+  acc[k] = false;
+  return acc;
+}, {} as LayerState);
+
+/**
+ * The 7 LayerKeys pulled out of a context's set, over the floor that context uses.
+ *
+ * THE FLOOR IS DIFFERENT FOR WORLD AND FOR AN AREA, and that is the whole contexts
+ * rule expressed in one argument. World floors to DEFAULT_STATE, so the globe behaves
+ * exactly as it did before this store was routed. An area floors to ALL_OFF, because a
+ * new area starts with an empty set and must read as empty — flooring it with
+ * DEFAULT_STATE would hand the user a context they never configured, and would move
+ * every area's unset key the day a default flips. ALWAYS_ON_SOURCES is what keeps an
+ * empty area from loading to a blank map; the floor is not.
+ */
+function project(set: SourceSet, floor: LayerState): LayerState {
+  const out = { ...floor };
   for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) {
     if (typeof set[k] === "boolean") out[k] = set[k];
   }
   return out;
 }
 
-// Memoised on the context object so useSyncExternalStore's identity check holds:
-// project() builds a fresh object every call, and returning a new one from get()
-// on every render loops React forever.
+// Memoised on the state object so useSyncExternalStore's identity check holds:
+// project() builds a fresh object every call, and returning a new one from get() on
+// every render loops React forever. effectiveSetMemo is memoised for the same reason
+// one layer down — see the note on it in lib/shell/inspector.ts.
 let lastSet: SourceSet | null = null;
 let lastProjection: LayerState = { ...DEFAULT_STATE };
 
 function current(): LayerState {
-  const set = effectiveSet(inspectorStore.get());
+  const state = inspectorStore.get();
+  const set = effectiveSetMemo(state);
   if (set !== lastSet) {
     lastSet = set;
-    lastProjection = project(set);
+    lastProjection = project(set, loadedArea(state) ? ALL_OFF : DEFAULT_STATE);
   }
   return lastProjection;
 }
@@ -698,11 +818,9 @@ export const layersStore = {
   applyExact(next: LayerState) {
     // Merge rather than replace: the context's set also holds SIGNAL ids, and a
     // layer preset must not silently switch every signal layer off.
-    const merged: SourceSet = { ...inspectorStore.get().world };
     const active = { ...DEFAULT_STATE, ...next };
-    const set: SourceSet = { ...effectiveSet(inspectorStore.get()) };
+    const set: SourceSet = { ...effectiveSetMemo(inspectorStore.get()) };
     for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) set[k] = active[k];
-    void merged;
     inspectorStore.replaceSources(set);
   },
   get: current,
@@ -727,14 +845,21 @@ Remove the now-unused `loadPersisted` / `savePersisted` import and the `PERSIST_
 Same treatment. Replace the module-level `state` and the `signalsStore` body; leave `SignalState`, `signalCountsStore` and `useSignalCounts` untouched.
 
 ```ts
-import { effectiveSet, inspectorStore } from "@/lib/shell/inspector";
+import { DEFAULT_STATE } from "@/lib/layers";
+import { effectiveSetMemo, inspectorStore, type SourceSet } from "@/lib/shell/inspector";
 
 // Signals are the sparse half of a context's SourceSet: an id that is not present
 // reads as off, exactly as before. No projection is needed — a SourceSet IS a
-// SignalState — so this returns the context's map directly and its identity is
-// already stable across renders.
+// SignalState — so this returns the context's map directly.
+//
+// It must go through the MEMOISED reader. An earlier cut of this file called
+// effectiveSet() and claimed its identity was "already stable across renders": true
+// for World, which is returned by identity, and false for an area, where the
+// always-on ids are forced into a fresh object on every call. useSignals() would have
+// looped as soon as an area loaded. Pinned by an identity assertion in
+// tests/unit/inspector-routing.test.ts.
 function current(): SignalState {
-  return effectiveSet(inspectorStore.get());
+  return effectiveSetMemo(inspectorStore.get());
 }
 
 export const signalsStore = {
@@ -749,7 +874,19 @@ export const signalsStore = {
     inspectorStore.setSource(id, on);
   },
   applyExact(next: SignalState) {
-    inspectorStore.replaceSources({ ...next });
+    // MERGE, never replace — the exact mirror of the note in lib/layers.ts. Layers and
+    // signals used to own separate module state, so neither could reach the other; they
+    // now project onto ONE SourceSet per context. A variant writes both (layers first,
+    // then signals, in lib/variants/store.ts), so a whole-set replace here resets every
+    // map layer to its floor a moment after the variant set it. Only the layer half is
+    // carried over; every signal id comes from `next`, so a signal absent from it still
+    // reads off, exactly as before.
+    const set: SourceSet = { ...next };
+    const cur = effectiveSetMemo(inspectorStore.get());
+    for (const k of Object.keys(DEFAULT_STATE)) {
+      if (typeof cur[k] === "boolean") set[k] = cur[k];
+    }
+    inspectorStore.replaceSources(set);
   },
   get: current,
   /** Kept for API compatibility. inspectorStore.hydrate() owns rehydration now. */
@@ -1287,13 +1424,99 @@ Expected: PASS, 5 tests.
 
 - [ ] **Step 5: Apply it in the four hooks**
 
-In each of `lib/planes/usePlanes.ts`, `lib/cameras/useCameras.ts`, the satellites hook and the webcam-directory hook, wrap the returned list:
+Four files, four different return shapes. All four were read on 2026-09-07 and the
+accessors below match the real fields. Do NOT assume every row carries `lat`/`lon`:
+one of the four has them **optional**, and that is load-bearing rather than sloppy.
+
+Two things hold across all four:
+
+- **Use the `useMemo` + `filterToScope` form, not bare `useScopeFilter`.** Under World
+  `filterToScope` returns the SAME array, so the memo keeps the hook's return identity
+  byte-for-byte stable and nothing downstream re-renders for a filter that filtered
+  nothing. Under an area the memo stops a fresh array being minted on every render.
+  `useScope()` reads a module-level snapshot, so `scope` is a valid memo dependency.
+- **A source being always-on does not exempt it from the boundary.** Cameras and
+  webcams are forced ON inside an area (`ALWAYS_ON_SOURCES`), which keeps the *source*
+  enabled; the scope still crops what it shows to the ring. Both are true at once and
+  neither is a bug to "fix" later.
+
+**5a. `lib/planes/usePlanes.ts`** — returns `PlanesLayer { objects: WorldObject[]; trails: PlaneTrail[] }`.
+`WorldObject.lat` / `.lon` are required. **The trails must be filtered to match the
+objects**, or a plane cropped out of the area keeps drawing its tail across the ring.
+
+Extend the react import on line 3 to include `useMemo`, and add:
 
 ```ts
-const scoped = useScopeFilter(list, (x) => (Number.isFinite(x.lat) && Number.isFinite(x.lon) ? x : null));
+import { filterToScope } from "@/lib/scopeFilter";
+import { useScope } from "@/lib/shell/scope";
 ```
 
-and return `scoped` in place of `list`. Read each hook's actual return shape first — the field names differ (`lat`/`lon` vs `latitude`/`longitude`) and the accessor must match the real one.
+Then replace the final `return layer;` with:
+
+```ts
+  const scope = useScope();
+  return useMemo(() => {
+    const objects = filterToScope(layer.objects, scope, (o) => o);
+    if (objects === layer.objects) return layer; // World: same array, same identity
+    const keep = new Set(objects.map((o) => o.id));
+    return { objects, trails: layer.trails.filter((t) => keep.has(t.id)) };
+  }, [layer, scope]);
+```
+
+**5b. `lib/cameras/useCameras.ts`** — returns `CamerasFeed { cameras: CameraRow[]; status; updatedAt }`.
+`CameraRow extends CameraLite`, whose `lat` / `lon` are required. `useMemo` is already
+imported on line 12; add the two imports above.
+
+Replace the final `return useSyncExternalStore(subscribe, getSnapshot, () => EMPTY);` with:
+
+```ts
+  const feed = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY);
+  const scope = useScope();
+  return useMemo(() => {
+    const cameras = filterToScope(feed.cameras, scope, (c) => c);
+    if (cameras === feed.cameras) return feed; // World: keep status/updatedAt identity
+    return { ...feed, cameras };
+  }, [feed, scope]);
+```
+
+**5c. `lib/satellites/useSatellites.ts`** — returns `WorldObject[]` directly. Extend the
+react import on line 2 with `useMemo`, add the two imports above, and replace the final
+`return objects;` with:
+
+```ts
+  const scope = useScope();
+  return useMemo(() => filterToScope(objects, scope, (o) => o), [objects, scope]);
+```
+
+**5d. `lib/webcams/titles.ts`, `useWebcamDirectory()` (line 89)** — returns `WebcamRow[]`,
+and here `lat` / `lon` are **optional**. The file's own comment says why: "a missing
+position means we don't know, never 0,0". That is exactly the row `filterToScope` drops
+inside an area and keeps under World, so **the accessor must return `null`, never coerce
+to 0**. Extend the react import on line 15 with `useMemo`, add the two imports above, and
+rewrite the hook body as:
+
+```ts
+export function useWebcamDirectory(): WebcamRow[] {
+  const all = useSyncExternalStore(
+    subscribe,
+    () => rows ?? EMPTY,
+    () => EMPTY,
+  );
+  const scope = useScope();
+  return useMemo(
+    () =>
+      filterToScope(all, scope, (w) =>
+        typeof w.lat === "number" && typeof w.lon === "number"
+          ? { lat: w.lat, lon: w.lon }
+          : null,
+      ),
+    [all, scope],
+  );
+}
+```
+
+Leave `useWebcamTitles()` directly below it alone — it maps id to title for rows a slot
+already holds, and scoping it would blank the label on a webcam the user is looking at.
 
 - [ ] **Step 6: Classify every registered widget type**
 

--- a/docs/superpowers/plans/2026-09-07-inspector-areas.md
+++ b/docs/superpowers/plans/2026-09-07-inspector-areas.md
@@ -1,0 +1,1404 @@
+# Inspector Areas Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the console several independent source contexts — World plus one per drawn area — with a left-rail Inspector index that loads them, and detail opening in the existing right-hand dossier.
+
+**Architecture:** One new persisted store (`lib/shell/inspector.ts`) holds `world`, `areas[]` and a `loaded` pointer. `layersStore` and `signalsStore` keep their exact public APIs but read and write the loaded context's `SourceSet` instead of a single global map, so no call site changes. Loading an area drives the existing `scopeStore`, which the map, feed and widgets already honour. Detail opens through `lib/overlay-content.tsx`'s existing `kind → component` switch.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, MapLibre GL, vitest (node environment), Playwright for e2e.
+
+## Global Constraints
+
+- **Branch:** `feat/inspector-areas`, worktree `~/Desktop/tn-inspector`, forked from `origin/main` `bbe9651`.
+- **Baseline (measured, not remembered):** `npx tsc --noEmit` exit 0; `npm test` 319 files / 3121 tests passed. Any red after this is ours.
+- **Gate for every task:** `npx tsc --noEmit && npm test`.
+- **Attribution:** solo. `CLAUDE.md` line 56 — no `Co-Authored-By`, no session trailer. This overrides the harness default.
+- **Tests are vitest, NODE environment, in `tests/unit/**/*.test.ts`.** No React testing library is installed — **there are no component tests**. Logic goes in pure exported functions that can be tested without a DOM; components stay thin.
+- **Every guard test is watched go RED before it goes green.** A pinning test nobody saw fail is decoration.
+- **Dormant-safe:** a missing or corrupt persisted payload degrades to defaults, never throws.
+- **Do not touch:** `lib/console/widgets/camslot.*`, `components/console/maprail/*`, `lib/map/aoi.ts`, `components/shell/EventFeed.tsx`.
+- **`startDraw(map, opts)` contract is unchanged:** with `opts.onFinish` the ring goes to the caller and the scope is left alone. A camera pick must never become a saved area.
+- **Never type a count from memory.** Widget/layer/source counts are re-measured; `tests/unit/readme-counts.test.ts` and `tests/unit/claude-md-counts.test.ts` pin several.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `lib/shell/inspector.ts` | **New.** The context store: `SourceSet`, `InspectorArea`, `InspectorState`, pure list/set operations, persistence, `useInspector()`. Knows nothing about `layersStore` or `signalsStore` — the dependency runs one way only. |
+| `lib/layers.ts` | **Modify.** `layersStore` reads/writes the loaded context. Public API unchanged. Also fixes the false `LayerKey` comment. |
+| `lib/signals/store.ts` | **Modify.** Same treatment for `signalsStore`. |
+| `components/shell/ConsoleShell.tsx` | **Modify.** One line: `inspectorStore.hydrate()` in the existing hydrate effect. |
+| `components/shell/inspector/InspectorTab.tsx` | **New.** The index: area list, draw button, coming-soon alerts block. |
+| `components/shell/inspector/ContextBar.tsx` | **New.** The `⌂ World` / `▣ <area> ✕` line above the tabs. |
+| `components/shell/inspector/AreaDetail.tsx` | **New.** The `area` dossier body. |
+| `components/shell/SourceCatalog.tsx` | **Modify.** Context bar + two tabs; the existing content becomes the Sources tab. |
+| `lib/overlay-content.tsx` | **Modify.** Add `case "area"`. |
+| `lib/world.ts` | **Modify.** Add `"area"` to `WorldObjectKind`. |
+| `lib/scopeFilter.ts` | **New.** One pure helper the four unscoped hooks share, so scoping is defined once. |
+| `lib/planes/usePlanes.ts`, `lib/cameras/useCameras.ts`, satellites + webcam directory hooks | **Modify.** Apply `lib/scopeFilter.ts`. |
+| `components/WorldMap.tsx` | **Modify.** Line 1507 only — a country click also opens the Inspector tab. |
+
+---
+
+## Task 1: The context store
+
+**Files:**
+- Create: `lib/shell/inspector.ts`
+- Test: `tests/unit/inspector-store.test.ts`
+
+**Interfaces:**
+- Consumes: `loadPersisted` / `savePersisted` from `@/lib/shell/persist`; `bboxOfRing`, `sanitiseRing` from `@/lib/shell/scope`.
+- Produces:
+  - `type SourceSet = Record<string, boolean>`
+  - `interface InspectorArea { id, label, polygon, bbox, createdAt, sources }`
+  - `interface InspectorState { world: SourceSet; areas: InspectorArea[]; loaded: string | null }`
+  - `const AREA_CAP = 40`
+  - `const ALWAYS_ON_SOURCES: readonly string[]`
+  - `newArea(ring, label, now): InspectorArea | null`
+  - `addArea(areas, area, cap?): InspectorArea[]`
+  - `removeArea(areas, id): InspectorArea[]`
+  - `renameArea(areas, id, label): InspectorArea[]`
+  - `activeSet(state): SourceSet`
+  - `effectiveSet(state): SourceSet`
+  - `writeActive(state, id, on): InspectorState`
+  - `replaceActive(state, next): InspectorState`
+  - `coerceState(saved): InspectorState`
+  - `inspectorStore` (`get`, `subscribe`, `hydrate`, `add`, `remove`, `rename`, `load`, `setSource`, `replaceSources`)
+  - `useInspector(): InspectorState`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/inspector-store.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import {
+  AREA_CAP,
+  ALWAYS_ON_SOURCES,
+  activeSet,
+  addArea,
+  coerceState,
+  effectiveSet,
+  newArea,
+  removeArea,
+  renameArea,
+  replaceActive,
+  writeActive,
+  type InspectorArea,
+  type InspectorState,
+} from "@/lib/shell/inspector";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+function area(id: string, createdAt = 1): InspectorArea {
+  return { id, label: id, polygon: RING, bbox: [36, 49.8, 36.5, 50.2], createdAt, sources: {} };
+}
+
+function state(partial: Partial<InspectorState> = {}): InspectorState {
+  return { world: {}, areas: [], loaded: null, ...partial };
+}
+
+test("newArea derives a bbox and keeps the ring open", () => {
+  const a = newArea(RING, "Kharkiv corridor", 1788744123456);
+  expect(a).not.toBeNull();
+  expect(a!.bbox).toEqual([36, 49.8, 36.5, 50.2]);
+  expect(a!.polygon).toHaveLength(4);
+  expect(a!.label).toBe("Kharkiv corridor");
+  expect(a!.sources).toEqual({});
+});
+
+test("newArea refuses a ring that is not an area", () => {
+  expect(newArea([[0, 0], [1, 1]], "line", 1)).toBeNull();
+  expect(newArea([], "empty", 1)).toBeNull();
+});
+
+test("addArea puts the newest first and dedupes by id", () => {
+  const list = addArea(addArea([], area("a")), area("b"));
+  expect(list.map((x) => x.id)).toEqual(["b", "a"]);
+  const again = addArea(list, { ...area("a"), label: "renamed" });
+  expect(again.map((x) => x.id)).toEqual(["a", "b"]);
+  expect(again[0].label).toBe("renamed");
+});
+
+test("addArea caps the list, dropping the oldest", () => {
+  let list: InspectorArea[] = [];
+  for (let i = 0; i < AREA_CAP + 5; i++) list = addArea(list, area(`a${i}`, i));
+  expect(list).toHaveLength(AREA_CAP);
+  expect(list[0].id).toBe(`a${AREA_CAP + 4}`);
+});
+
+test("removeArea and renameArea are pure and by id", () => {
+  const list = addArea(addArea([], area("a")), area("b"));
+  expect(removeArea(list, "a").map((x) => x.id)).toEqual(["b"]);
+  expect(renameArea(list, "b", "Gulf of Aden")[0].label).toBe("Gulf of Aden");
+  expect(list[0].label).toBe("b"); // original untouched
+});
+
+test("activeSet returns World's set when nothing is loaded", () => {
+  const s = state({ world: { cameras: true }, areas: [area("a")], loaded: null });
+  expect(activeSet(s)).toEqual({ cameras: true });
+});
+
+test("activeSet returns the loaded area's own set", () => {
+  const a = { ...area("a"), sources: { planes: true } };
+  expect(activeSet(state({ world: { cameras: true }, areas: [a], loaded: "a" }))).toEqual({ planes: true });
+});
+
+test("a loaded id that no longer exists falls back to World", () => {
+  const s = state({ world: { cameras: true }, areas: [], loaded: "gone" });
+  expect(activeSet(s)).toEqual({ cameras: true });
+});
+
+test("effectiveSet forces the always-on sources on inside an area", () => {
+  const a = { ...area("a"), sources: { planes: true } };
+  const eff = effectiveSet(state({ areas: [a], loaded: "a" }));
+  for (const id of ALWAYS_ON_SOURCES) expect(eff[id]).toBe(true);
+  expect(eff.planes).toBe(true);
+});
+
+test("effectiveSet leaves World alone — webcams stays opt-in on the globe", () => {
+  const eff = effectiveSet(state({ world: { cameras: true } }));
+  expect(eff).toEqual({ cameras: true });
+  expect(eff.webcams).toBeUndefined();
+});
+
+test("writeActive lands on the loaded area and leaves World untouched", () => {
+  const a = area("a");
+  const s = state({ world: { cameras: true }, areas: [a], loaded: "a" });
+  const next = writeActive(s, "planes", true);
+  expect(next.areas[0].sources).toEqual({ planes: true });
+  expect(next.world).toEqual({ cameras: true });
+});
+
+test("writeActive lands on World when nothing is loaded", () => {
+  const next = writeActive(state({ world: {} }), "planes", true);
+  expect(next.world).toEqual({ planes: true });
+});
+
+test("replaceActive swaps the whole set for the loaded context only", () => {
+  const a = { ...area("a"), sources: { planes: true } };
+  const s = state({ world: { cameras: true }, areas: [a], loaded: "a" });
+  const next = replaceActive(s, { ships: true });
+  expect(next.areas[0].sources).toEqual({ ships: true });
+  expect(next.world).toEqual({ cameras: true });
+});
+
+test("coerceState turns junk into a valid empty state", () => {
+  expect(coerceState(null)).toEqual({ world: {}, areas: [], loaded: null });
+  expect(coerceState("nonsense")).toEqual({ world: {}, areas: [], loaded: null });
+  expect(coerceState({ areas: "no" })).toEqual({ world: {}, areas: [], loaded: null });
+});
+
+test("coerceState drops areas whose ring is not an area, and a dangling loaded id", () => {
+  const s = coerceState({
+    world: { cameras: true, junk: "yes" },
+    areas: [
+      { id: "good", label: "Good", polygon: RING, createdAt: 1, sources: { planes: true } },
+      { id: "bad", label: "Bad", polygon: [[0, 0]], createdAt: 2, sources: {} },
+    ],
+    loaded: "bad",
+  });
+  expect(s.areas.map((a) => a.id)).toEqual(["good"]);
+  expect(s.world).toEqual({ cameras: true });
+  expect(s.loaded).toBeNull();
+});
+
+test("coerceState recomputes the bbox rather than trusting the payload", () => {
+  const s = coerceState({
+    world: {},
+    areas: [{ id: "a", label: "A", polygon: RING, bbox: [0, 0, 0, 0], createdAt: 1, sources: {} }],
+    loaded: null,
+  });
+  expect(s.areas[0].bbox).toEqual([36, 49.8, 36.5, 50.2]);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/unit/inspector-store.test.ts`
+Expected: FAIL — `Failed to resolve import "@/lib/shell/inspector"`.
+
+- [ ] **Step 3: Write the store**
+
+Create `lib/shell/inspector.ts`:
+
+```ts
+"use client";
+// The console's SOURCE CONTEXTS — World, plus one per drawn area.
+//
+// WHY CONTEXTS AND NOT AN OVERRIDE. An area does not inherit from World, layer on
+// top of it, or copy it. It is a separate map of source id → on with a boundary
+// attached. That is the whole reason this is safe: nothing is borrowed, so
+// unloading an area cannot leave the globe wearing the area's toggles, and
+// removing an area cannot strand a source that only it turned on. The alternative
+// — one global set plus per-area diffs — has to answer "what happens to World's
+// toggles while an area is loaded" on every single write, and every answer to that
+// question is a bug waiting for a reload.
+//
+// WHAT DEPENDS ON WHAT. This file knows nothing about lib/layers.ts or
+// lib/signals/store.ts. THEY import THIS. Keep it that way: those two stores are
+// views onto whichever SourceSet is loaded, and a back-reference here would make
+// the pair circular and the ownership unreadable.
+//
+// ONE MAP FOR TWO REGISTRIES. A SourceSet holds layersStore's LayerKeys and
+// signalsStore's arbitrary signal ids together, because a context does not care
+// which registry a source came from. The two stores keep their own typed surfaces
+// on top; the split lives there, not here.
+//
+// PERSISTENCE, AND A BUG IT FIXES. Adding this store to ConsoleShell's hydrate
+// list is what makes a saved area survive a reload. It also, incidentally, makes
+// LAYER and SIGNAL toggles survive one — which both of those files' comments have
+// claimed for a long time and which was not true: layersStore.hydrate() and
+// signalsStore.hydrate() existed and had no caller anywhere in the tree, so every
+// reload reset them to their defaults. Measured on bbe9651 before this change.
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { bboxOfRing, sanitiseRing } from "@/lib/shell/scope";
+
+/** id → on, for ONE context. Covers LayerKeys and signal ids in a single map. */
+export type SourceSet = Record<string, boolean>;
+
+export interface InspectorArea {
+  /** "area:<epoch ms>" — stable, and sorts by age without a second field. */
+  id: string;
+  label: string;
+  /** OPEN ring of [lon, lat] — exactly what lib/shell/scope.ts speaks. */
+  polygon: [number, number][];
+  bbox: [number, number, number, number];
+  createdAt: number;
+  /** ITS OWN. Never merged with World's. */
+  sources: SourceSet;
+}
+
+export interface InspectorState {
+  world: SourceSet;
+  areas: InspectorArea[];
+  /** null = World. The one value that decides what the console shows. */
+  loaded: string | null;
+}
+
+export const AREA_CAP = 40;
+
+/**
+ * Sources an AREA always draws, whatever its own set says.
+ *
+ * Sam's rule, and it is what lets a new area start empty without ever loading to a
+ * blank map. ONE CONSTANT ON PURPOSE: `webcams` is a keyed, rate-limited global
+ * sample that lib/layers.ts deliberately defaults off and keeps out of the presets,
+ * and its adapter's fetch() takes no arguments — so the pull is global whatever the
+ * ring is, and scoping crops what is drawn rather than what is pulled. That cost was
+ * put to Sam and he kept the rule. Reversing it is deleting one string here, not a
+ * hunt through the UI.
+ *
+ * WORLD IS NOT SUBJECT TO THIS. The globe keeps its own toggles, so today's
+ * "webcams is opt-in on the globe" behaviour is unchanged. See effectiveSet.
+ */
+export const ALWAYS_ON_SOURCES: readonly string[] = ["cameras", "webcams"];
+
+const PERSIST_KEY = "tn.inspector.v1";
+const PERSIST_VERSION = 1;
+
+const EMPTY: InspectorState = Object.freeze({ world: {}, areas: [], loaded: null });
+
+// --- pure -------------------------------------------------------------------
+
+/** Pure: a source map with only boolean values kept. */
+function cleanSet(value: unknown): SourceSet {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const out: SourceSet = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "boolean") out[k] = v;
+  }
+  return out;
+}
+
+/** Pure: build an area from a drawn ring. Null when the ring is not an area. */
+export function newArea(
+  ring: readonly [number, number][],
+  label: string,
+  now: number,
+): InspectorArea | null {
+  const clean = sanitiseRing(ring as unknown);
+  if (!clean) return null;
+  return {
+    id: `area:${now}`,
+    label,
+    polygon: clean,
+    bbox: bboxOfRing(clean),
+    createdAt: now,
+    sources: {},
+  };
+}
+
+/** Pure: newest first, deduped by id, capped. */
+export function addArea(
+  areas: readonly InspectorArea[],
+  area: InspectorArea,
+  cap = AREA_CAP,
+): InspectorArea[] {
+  return [area, ...areas.filter((a) => a.id !== area.id)].slice(0, cap);
+}
+
+/** Pure: drop by id. */
+export function removeArea(areas: readonly InspectorArea[], id: string): InspectorArea[] {
+  return areas.filter((a) => a.id !== id);
+}
+
+/** Pure: relabel by id. */
+export function renameArea(
+  areas: readonly InspectorArea[],
+  id: string,
+  label: string,
+): InspectorArea[] {
+  return areas.map((a) => (a.id === id ? { ...a, label } : a));
+}
+
+/** Pure: the loaded area, or null for World (including a dangling id). */
+export function loadedArea(state: InspectorState): InspectorArea | null {
+  if (state.loaded === null) return null;
+  return state.areas.find((a) => a.id === state.loaded) ?? null;
+}
+
+/** Pure: the RAW set for the loaded context. What the Sources rail edits. */
+export function activeSet(state: InspectorState): SourceSet {
+  return loadedArea(state)?.sources ?? state.world;
+}
+
+/** Pure: the set the console actually DRAWS. Areas force ALWAYS_ON_SOURCES on. */
+export function effectiveSet(state: InspectorState): SourceSet {
+  const area = loadedArea(state);
+  if (!area) return state.world;
+  const out: SourceSet = { ...area.sources };
+  for (const id of ALWAYS_ON_SOURCES) out[id] = true;
+  return out;
+}
+
+/** Pure: set one source on the loaded context. */
+export function writeActive(state: InspectorState, id: string, on: boolean): InspectorState {
+  const area = loadedArea(state);
+  if (!area) return { ...state, world: { ...state.world, [id]: on } };
+  return {
+    ...state,
+    areas: state.areas.map((a) => (a.id === area.id ? { ...a, sources: { ...a.sources, [id]: on } } : a)),
+  };
+}
+
+/** Pure: replace the whole set for the loaded context (presets, variants). */
+export function replaceActive(state: InspectorState, next: SourceSet): InspectorState {
+  const area = loadedArea(state);
+  if (!area) return { ...state, world: { ...next } };
+  return {
+    ...state,
+    areas: state.areas.map((a) => (a.id === area.id ? { ...a, sources: { ...next } } : a)),
+  };
+}
+
+/**
+ * Pure: coerce a persisted payload into a valid state.
+ *
+ * The bbox is RECOMPUTED rather than trusted: it is derived data, and a payload
+ * whose bbox disagrees with its ring would silently mis-filter every source in
+ * that area through withinScope's cheap reject.
+ */
+export function coerceState(saved: unknown): InspectorState {
+  if (!saved || typeof saved !== "object" || Array.isArray(saved)) return { ...EMPTY };
+  const s = saved as Partial<InspectorState>;
+  const areas: InspectorArea[] = [];
+  if (Array.isArray(s.areas)) {
+    for (const raw of s.areas) {
+      if (!raw || typeof raw !== "object") continue;
+      const a = raw as Partial<InspectorArea>;
+      const ring = sanitiseRing(a.polygon as unknown);
+      if (!ring || typeof a.id !== "string" || typeof a.label !== "string") continue;
+      areas.push({
+        id: a.id,
+        label: a.label,
+        polygon: ring,
+        bbox: bboxOfRing(ring),
+        createdAt: typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : 0,
+        sources: cleanSet(a.sources),
+      });
+    }
+  }
+  const loaded =
+    typeof s.loaded === "string" && areas.some((a) => a.id === s.loaded) ? s.loaded : null;
+  return { world: cleanSet(s.world), areas: areas.slice(0, AREA_CAP), loaded };
+}
+
+// --- store ------------------------------------------------------------------
+
+let state: InspectorState = { ...EMPTY };
+const listeners = new Set<() => void>();
+
+function commit(next: InspectorState) {
+  state = next;
+  for (const l of listeners) l();
+  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+}
+
+export const inspectorStore = {
+  get: (): InspectorState => state,
+  subscribe(l: () => void): () => void {
+    listeners.add(l);
+    return () => {
+      listeners.delete(l);
+    };
+  },
+
+  /** Pull persisted contexts back in. Called once from ConsoleShell, client-side. */
+  hydrate() {
+    commit(coerceState(loadPersisted<InspectorState>(PERSIST_KEY, PERSIST_VERSION)));
+  },
+
+  /** Save a drawn ring as an area. Returns its id, or null for a ring that is not one. */
+  add(ring: readonly [number, number][], label: string): string | null {
+    const area = newArea(ring, label, Date.now());
+    if (!area) return null;
+    commit({ ...state, areas: addArea(state.areas, area) });
+    return area.id;
+  },
+
+  remove(id: string) {
+    commit({
+      ...state,
+      areas: removeArea(state.areas, id),
+      loaded: state.loaded === id ? null : state.loaded,
+    });
+  },
+
+  rename(id: string, label: string) {
+    commit({ ...state, areas: renameArea(state.areas, id, label) });
+  },
+
+  /** null unloads (back to World). An unknown id is ignored rather than stranding. */
+  load(id: string | null) {
+    if (id !== null && !state.areas.some((a) => a.id === id)) return;
+    if (state.loaded === id) return;
+    commit({ ...state, loaded: id });
+  },
+
+  setSource(id: string, on: boolean) {
+    commit(writeActive(state, id, on));
+  },
+
+  replaceSources(next: SourceSet) {
+    commit(replaceActive(state, next));
+  },
+};
+
+export function useInspector(): InspectorState {
+  return useSyncExternalStore(inspectorStore.subscribe, inspectorStore.get, () => EMPTY);
+}
+```
+
+- [ ] **Step 4: Run the test and watch it pass**
+
+Run: `npx vitest run tests/unit/inspector-store.test.ts`
+Expected: PASS, 15 tests.
+
+- [ ] **Step 5: Run the full gate**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: exit 0, 320 files / 3136 tests (319 + this file, 3121 + 15).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/shell/inspector.ts tests/unit/inspector-store.test.ts docs/superpowers/specs/2026-09-07-inspector-design.md docs/superpowers/plans/2026-09-07-inspector-areas.md
+git commit -m "Inspector: source contexts — World plus one per drawn area
+
+A new persisted store holding the globe's source set, a capped list of drawn
+areas each with its OWN set, and the loaded pointer that says which one the
+console is showing. Pure list and set operations, unit-tested; nothing renders
+yet and no existing behaviour changes.
+
+An area does not inherit from World, override it, or copy it. That is what makes
+unloading safe: nothing is borrowed, so the globe cannot end up wearing an area's
+toggles and removing an area cannot strand a source only it turned on."
+```
+
+---
+
+## Task 2: Route the two source stores through the loaded context
+
+**Files:**
+- Modify: `lib/layers.ts`
+- Modify: `lib/signals/store.ts`
+- Modify: `components/shell/ConsoleShell.tsx` (one line in the existing hydrate effect)
+- Test: `tests/unit/inspector-routing.test.ts`
+
+**Interfaces:**
+- Consumes: everything Task 1 produces.
+- Produces: no new exports. `layersStore.toggle/set/applyPreset/applyExact/get/hydrate/subscribe`, `useLayers()`, `signalsStore.isOn/toggle/set/applyExact/get/hydrate/subscribe`, `useSignals()` all keep their **exact** current signatures. Every existing call site is correct unchanged.
+
+**Why this shape:** `WorldMap`, `SourceCatalog`, `monitors.ts`, `presetLayers.ts`, `presets.ts`, `PresetBar.tsx`, the command palette and the widgets all call these stores. Changing the API would touch every one of them. Making them views onto `inspectorStore` touches none.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/inspector-routing.test.ts`:
+
+```ts
+import { beforeEach, expect, test } from "vitest";
+import { inspectorStore } from "@/lib/shell/inspector";
+import { DEFAULT_STATE, layersStore } from "@/lib/layers";
+import { signalsStore } from "@/lib/signals/store";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+beforeEach(() => {
+  // A clean store between tests — hydrate with nothing persisted resets to empty.
+  inspectorStore.hydrate();
+});
+
+test("with nothing loaded, layersStore reads World and matches today's defaults", () => {
+  expect(layersStore.get()).toEqual(DEFAULT_STATE);
+});
+
+test("a layer toggle while World is loaded writes World, not an area", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  layersStore.set("planes", false);
+  expect(inspectorStore.get().world.planes).toBe(false);
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.planes).toBeUndefined();
+});
+
+test("a layer toggle while an area is loaded writes the area and leaves World alone", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  layersStore.set("planes", false); // World: planes off
+  inspectorStore.load(id);
+  layersStore.set("planes", true); // area: planes on
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.planes).toBe(true);
+  expect(inspectorStore.get().world.planes).toBe(false);
+});
+
+test("unloading restores World's set exactly", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  layersStore.set("satellites", false);
+  const world = { ...layersStore.get() };
+  inspectorStore.load(id);
+  layersStore.set("satellites", true);
+  inspectorStore.load(null);
+  expect(layersStore.get()).toEqual(world);
+});
+
+test("an area forces cameras and webcams on however its own set reads", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  layersStore.set("cameras", false);
+  layersStore.set("webcams", false);
+  expect(layersStore.get().cameras).toBe(true);
+  expect(layersStore.get().webcams).toBe(true);
+});
+
+test("World keeps webcams opt-in — the always-on rule is areas only", () => {
+  expect(layersStore.get().webcams).toBe(false);
+});
+
+test("signalsStore routes the same way", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  signalsStore.set("earthquakes", true);
+  inspectorStore.load(id);
+  expect(signalsStore.isOn("earthquakes")).toBe(false);
+  signalsStore.set("conflict", true);
+  expect(signalsStore.isOn("conflict")).toBe(true);
+  inspectorStore.load(null);
+  expect(signalsStore.isOn("earthquakes")).toBe(true);
+  expect(signalsStore.isOn("conflict")).toBe(false);
+});
+
+test("applyPreset writes the loaded area, not World", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  layersStore.applyPreset("air-space");
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.planes).toBe(true);
+  expect(inspectorStore.get().world.planes).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/unit/inspector-routing.test.ts`
+Expected: FAIL — the routing tests fail because `layersStore` still holds its own module-level `state`. The first test (`equals DEFAULT_STATE`) passes already; that is the point of having it, it pins the behaviour that must NOT change.
+
+- [ ] **Step 3: Route `lib/layers.ts`**
+
+Replace the module-level `state` and the store body. Keep `LayerKey`, `LayerState`, `ACTIVE_LAYERS`, `PLANNED_LAYERS`, `DEFAULT_STATE`, `PresetId`, `LAYER_PRESETS` and `presetState` exactly as they are.
+
+Also **fix the false comment above `LayerKey`** — `sources-rail` verified both halves are wrong as of `bbe9651` and handed over this wording:
+
+```ts
+// Active layers have a live CORE map layer today. The two "planned" keys never got
+// one. ships still ships as the AIS signal layer; weather no longer has one — its
+// adapter was unregistered in #177. Neither is drawn in the rail; see OMITTED_LAYERS
+// in lib/console/sources/railSources.ts.
+export type LayerKey = "cameras" | "satellites" | "planes" | "ships" | "webcams" | "weather" | "countries";
+```
+
+Then replace everything from `let state: LayerState = { ...DEFAULT_STATE };` to the end of the file with:
+
+```ts
+// STATE LIVES IN lib/shell/inspector.ts, NOT HERE. This store is a VIEW onto
+// whichever source context is loaded — World, or one drawn area. The API below is
+// byte-identical to what it was before that change, which is the whole point:
+// WorldMap, SourceCatalog, monitors.ts, presetLayers.ts, presets.ts, PresetBar and
+// the command palette all call these methods and none of them needed an edit.
+//
+// The projection is one-way. This file imports inspector.ts; inspector.ts must never
+// import this one, or the pair is circular and neither owns the state.
+import { effectiveSet, inspectorStore, type SourceSet } from "@/lib/shell/inspector";
+
+/** The 7 LayerKeys pulled out of a context's set, with DEFAULT_STATE as the floor. */
+function project(set: SourceSet): LayerState {
+  const out = { ...DEFAULT_STATE };
+  for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) {
+    if (typeof set[k] === "boolean") out[k] = set[k];
+  }
+  return out;
+}
+
+// Memoised on the context object so useSyncExternalStore's identity check holds:
+// project() builds a fresh object every call, and returning a new one from get()
+// on every render loops React forever.
+let lastSet: SourceSet | null = null;
+let lastProjection: LayerState = { ...DEFAULT_STATE };
+
+function current(): LayerState {
+  const set = effectiveSet(inspectorStore.get());
+  if (set !== lastSet) {
+    lastSet = set;
+    lastProjection = project(set);
+  }
+  return lastProjection;
+}
+
+export const layersStore = {
+  toggle(key: LayerKey) {
+    inspectorStore.setSource(key, !current()[key]);
+  },
+  set(key: LayerKey, on: boolean) {
+    if (current()[key] === on) return;
+    inspectorStore.setSource(key, on);
+  },
+  applyPreset(id: PresetId) {
+    layersStore.applyExact(presetState(id));
+  },
+  applyExact(next: LayerState) {
+    // Merge rather than replace: the context's set also holds SIGNAL ids, and a
+    // layer preset must not silently switch every signal layer off.
+    const merged: SourceSet = { ...inspectorStore.get().world };
+    const active = { ...DEFAULT_STATE, ...next };
+    const set: SourceSet = { ...effectiveSet(inspectorStore.get()) };
+    for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) set[k] = active[k];
+    void merged;
+    inspectorStore.replaceSources(set);
+  },
+  get: current,
+  /** Kept for API compatibility. inspectorStore.hydrate() owns rehydration now. */
+  hydrate() {
+    /* no-op — see the note at the top of this block */
+  },
+  subscribe(listener: () => void): () => void {
+    return inspectorStore.subscribe(listener);
+  },
+};
+
+export function useLayers(): LayerState {
+  return useSyncExternalStore(layersStore.subscribe, layersStore.get, layersStore.get);
+}
+```
+
+Remove the now-unused `loadPersisted` / `savePersisted` import and the `PERSIST_KEY` / `PERSIST_VERSION` constants.
+
+- [ ] **Step 4: Route `lib/signals/store.ts`**
+
+Same treatment. Replace the module-level `state` and the `signalsStore` body; leave `SignalState`, `signalCountsStore` and `useSignalCounts` untouched.
+
+```ts
+import { effectiveSet, inspectorStore } from "@/lib/shell/inspector";
+
+// Signals are the sparse half of a context's SourceSet: an id that is not present
+// reads as off, exactly as before. No projection is needed — a SourceSet IS a
+// SignalState — so this returns the context's map directly and its identity is
+// already stable across renders.
+function current(): SignalState {
+  return effectiveSet(inspectorStore.get());
+}
+
+export const signalsStore = {
+  isOn(id: string): boolean {
+    return current()[id] === true;
+  },
+  toggle(id: string) {
+    inspectorStore.setSource(id, !(current()[id] === true));
+  },
+  set(id: string, on: boolean) {
+    if ((current()[id] === true) === on) return;
+    inspectorStore.setSource(id, on);
+  },
+  applyExact(next: SignalState) {
+    inspectorStore.replaceSources({ ...next });
+  },
+  get: current,
+  /** Kept for API compatibility. inspectorStore.hydrate() owns rehydration now. */
+  hydrate() {
+    /* no-op */
+  },
+  subscribe(listener: () => void): () => void {
+    return inspectorStore.subscribe(listener);
+  },
+};
+```
+
+- [ ] **Step 5: Hydrate the store in `ConsoleShell.tsx`**
+
+In the existing effect at `components/shell/ConsoleShell.tsx:87-103`, add one line **before** the others so the source contexts exist before anything reads them:
+
+```ts
+    inspectorStore.hydrate();
+    uiStore.hydrate();
+```
+
+with `import { inspectorStore } from "@/lib/shell/inspector";` beside the other store imports.
+
+- [ ] **Step 6: Run the routing test and watch it pass**
+
+Run: `npx vitest run tests/unit/inspector-routing.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 7: Run the full gate**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: exit 0. `tests/unit/layers.test.ts` must still pass untouched — it pins `PLANNED_LAYERS` as `["ships", "weather"]` and the preset shapes, none of which move.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/layers.ts lib/signals/store.ts components/shell/ConsoleShell.tsx tests/unit/inspector-routing.test.ts
+git commit -m "Point the layer and signal stores at the loaded source context
+
+Both stores keep their exact public API and become views onto whichever context
+is loaded. No call site changed: WorldMap, SourceCatalog, monitors, presetLayers,
+presets, PresetBar and the palette all still call toggle/set/get unedited.
+
+This also fixes a bug the two files' own comments had been denying. Both claimed
+toggle state survived a reload; both exposed a hydrate() that NOTHING in the tree
+called, so every reload silently reset layers to DEFAULT_STATE and signals to {}.
+ConsoleShell hydrates seventeen stores and neither was among them. Rehydration now
+happens once, in inspectorStore.
+
+Also corrects the LayerKey comment: weather left SIGNALS in #177 and the rail
+stopped drawing signposts for either planned key before that."
+```
+
+---
+
+## Task 3: The context bar, the tabs, and the Inspector index
+
+**Files:**
+- Create: `components/shell/inspector/ContextBar.tsx`
+- Create: `components/shell/inspector/InspectorTab.tsx`
+- Modify: `components/shell/SourceCatalog.tsx`
+- Modify: `app/globals.css`
+- Test: `tests/unit/inspector-labels.test.ts`
+
+**Interfaces:**
+- Consumes: `inspectorStore`, `useInspector`, `InspectorArea` from Task 1; `useAoiDraw`, `startDraw`, `aoiLabel` from `@/lib/map/aoi` (read-only — `aoi.ts` is not edited); `scopeStore`, `aoiScope`, `WORLD_SCOPE` from `@/lib/shell/scope`.
+- Produces: `areaSummary(area, effective): string` in `lib/shell/inspector.ts` — the one-line "4 sources · 4,180 km²" the index and the dossier both print.
+
+**Copy rule:** the Sources tab's section headings read `EDITING THIS AREA` while an area is loaded. The context bar is visible in **both** tabs and states `⌂ World` or `▣ <label>` with an unload control.
+
+- [ ] **Step 1: Write the failing test for the pure label helpers**
+
+Create `tests/unit/inspector-labels.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import { areaSummary, ringAreaKm2, type InspectorArea } from "@/lib/shell/inspector";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+const AREA: InspectorArea = {
+  id: "area:1",
+  label: "Kharkiv corridor",
+  polygon: RING,
+  bbox: [36, 49.8, 36.5, 50.2],
+  createdAt: 1,
+  sources: { planes: true, conflict: true },
+};
+
+test("ringAreaKm2 is within 5% of the true spherical area of a known box", () => {
+  // 0.5deg lon x 0.4deg lat at ~50N. Reference computed from the spherical excess
+  // formula: ~35.8km x 44.5km = ~1,593 km2.
+  const km2 = ringAreaKm2(RING);
+  expect(km2).toBeGreaterThan(1_500);
+  expect(km2).toBeLessThan(1_700);
+});
+
+test("ringAreaKm2 refuses a degenerate ring rather than returning a fake number", () => {
+  expect(ringAreaKm2([[0, 0], [1, 1]])).toBe(0);
+});
+
+test("areaSummary counts the sources actually on, not the keys present", () => {
+  expect(areaSummary({ ...AREA, sources: { planes: true, conflict: false } })).toMatch(/^1 source /);
+});
+
+test("areaSummary pluralises and rounds", () => {
+  expect(areaSummary(AREA)).toMatch(/^2 sources · [\d,]+ km²$/);
+});
+
+test("areaSummary states zero honestly rather than hiding it", () => {
+  expect(areaSummary({ ...AREA, sources: {} })).toMatch(/^No sources · /);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/unit/inspector-labels.test.ts`
+Expected: FAIL — `areaSummary` and `ringAreaKm2` are not exported.
+
+- [ ] **Step 3: Add the two helpers to `lib/shell/inspector.ts`**
+
+```ts
+const EARTH_RADIUS_KM = 6371.0088;
+
+/**
+ * Pure: the spherical area of a closed ring, in km².
+ *
+ * A PLANAR shoelace on lon/lat is wrong by the cosine of the latitude — at 50°N it
+ * overstates by about 55%, and an area label that overstates is worse than no label
+ * on a product whose whole claim is that it does not overstate. This is the spherical
+ * excess form, which is correct at any latitude and costs nothing at these ring sizes.
+ * Returns 0 for anything that is not an area, rather than a plausible fake.
+ */
+export function ringAreaKm2(ring: readonly [number, number][]): number {
+  if (!Array.isArray(ring) || ring.length < 3) return 0;
+  const rad = Math.PI / 180;
+  let total = 0;
+  for (let i = 0; i < ring.length; i++) {
+    const [lon1, lat1] = ring[i];
+    const [lon2, lat2] = ring[(i + 1) % ring.length];
+    total += (lon2 - lon1) * rad * (2 + Math.sin(lat1 * rad) + Math.sin(lat2 * rad));
+  }
+  return Math.abs((total * EARTH_RADIUS_KM * EARTH_RADIUS_KM) / 2);
+}
+
+/** Pure: the one-line summary the index row and the dossier header both print. */
+export function areaSummary(area: InspectorArea): string {
+  const on = Object.values(area.sources).filter(Boolean).length;
+  const km2 = Math.round(ringAreaKm2(area.polygon));
+  const count = on === 0 ? "No sources" : on === 1 ? "1 source" : `${on} sources`;
+  return `${count} · ${km2.toLocaleString("en-GB")} km²`;
+}
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `npx vitest run tests/unit/inspector-labels.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Build `ContextBar.tsx`**
+
+```tsx
+"use client";
+// What the rail is editing. THE LOAD-BEARING CONTROL OF THIS WHOLE FEATURE.
+//
+// With several source contexts, a toggle in the Sources tab writes whichever one is
+// loaded. A user who flips Aircraft without knowing whether they changed the globe
+// or the Kharkiv area has been handed a control that lies about its effect — and
+// this codebase has shipped and then fixed two variants of that bug already. So this
+// line is rendered in BOTH tabs, not just the Inspector, and it is never hidden.
+
+import { inspectorStore, loadedArea, useInspector } from "@/lib/shell/inspector";
+import { scopeStore, WORLD_SCOPE } from "@/lib/shell/scope";
+
+export default function ContextBar() {
+  const state = useInspector();
+  const area = loadedArea(state);
+
+  return (
+    <div className="tn-ctxbar" data-area={area ? "" : undefined}>
+      <span className="tn-ctxbar-glyph" aria-hidden>{area ? "▣" : "⌂"}</span>
+      <span className="tn-ctxbar-name">{area ? area.label : "World"}</span>
+      {area ? (
+        <button
+          type="button"
+          className="tn-ctxbar-x"
+          onClick={() => {
+            inspectorStore.load(null);
+            scopeStore.set(WORLD_SCOPE);
+          }}
+          title="Back to World"
+          aria-label={`Unload ${area.label} and return to World`}
+        >
+          ✕
+        </button>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Build `InspectorTab.tsx`**
+
+```tsx
+"use client";
+// The Inspector index. A LIST, not a detail view — detail opens in the dossier on
+// the right, which already exists at 384px and already handles focus, escape and
+// mobile. See lib/overlay-content.tsx.
+//
+// Sources are NOT configured here. Load an area and the Sources tab is pointed at
+// it; that is the whole interaction, and duplicating a source list in this column
+// would give the user two places to change one thing.
+
+import { aoiLabel, startDraw } from "@/lib/map/aoi";
+import { areaSummary, inspectorStore, useInspector } from "@/lib/shell/inspector";
+import { aoiScope, scopeStore } from "@/lib/shell/scope";
+import { overlay } from "@/lib/overlay";
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+declare global {
+  interface Window { __map?: MapLibreMap }
+}
+
+export default function InspectorTab() {
+  const state = useInspector();
+
+  const draw = () => {
+    const map = window.__map;
+    if (!map) return;
+    // onFinish is supplied, so aoi.ts hands us the ring and leaves the scope alone.
+    // That contract is what keeps a camera pick from becoming a saved area; do not
+    // drop it. See DrawOptions in lib/map/aoi.ts.
+    startDraw(map, {
+      onFinish: (ring) => {
+        const id = inspectorStore.add(ring, aoiLabel(ring));
+        if (id) load(id);
+      },
+    });
+  };
+
+  const load = (id: string) => {
+    inspectorStore.load(id);
+    const area = inspectorStore.get().areas.find((a) => a.id === id);
+    if (area) scopeStore.set(aoiScope(area.polygon, area.label));
+  };
+
+  return (
+    <div className="tn-insp">
+      <div className="tn-subhead">
+        Areas <span className="tn-insp-count">{state.areas.length}</span>
+      </div>
+
+      {state.areas.length === 0 ? (
+        <p className="tn-rail-foot">
+          No areas yet. Draw one on the map to give it its own sources.
+        </p>
+      ) : (
+        state.areas.map((a) => (
+          <button
+            key={a.id}
+            type="button"
+            className="tn-insp-row"
+            data-loaded={state.loaded === a.id ? "" : undefined}
+            onClick={() => overlay.open({ kind: "area", id: a.id, label: a.label, lat: 0, lon: 0 })}
+          >
+            <span className="tn-insp-glyph" aria-hidden>▣</span>
+            <span className="tn-insp-main">
+              <span className="tn-insp-label">{a.label}</span>
+              <span className="tn-insp-sub">{areaSummary(a)}</span>
+            </span>
+            {state.loaded === a.id ? <span className="tn-insp-pill">LOADED</span> : null}
+          </button>
+        ))
+      )}
+
+      <button type="button" className="tn-insp-draw" onClick={draw}>
+        ＋ Draw an area
+      </button>
+
+      {/* Labelled and inert, never a control that does nothing. The design is in
+          docs/superpowers/specs/2026-09-07-inspector-design.md §12 so it drops in
+          without moving anything here. */}
+      <div className="tn-insp-soon">
+        <div className="tn-insp-soon-head">
+          <span>Alert me</span>
+          <span className="tn-insp-pill tn-insp-pill-muted">COMING SOON</span>
+        </div>
+        <p>Tell me when something enters or leaves an area. Not built yet.</p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Wire the tabs into `SourceCatalog.tsx`**
+
+Add `const [tab, setTab] = useState<"sources" | "inspector">("sources");` beside the existing `query` state. Immediately after the `<div className="tn-rail-header">…</div>` block at line 206-216, insert:
+
+```tsx
+      <ContextBar />
+
+      <div className="tn-rail-tabs" role="tablist">
+        <button
+          type="button" role="tab" className="tn-rail-tab"
+          aria-selected={tab === "sources"} onClick={() => setTab("sources")}
+        >
+          Sources
+        </button>
+        <button
+          type="button" role="tab" className="tn-rail-tab"
+          aria-selected={tab === "inspector"} onClick={() => setTab("inspector")}
+        >
+          Inspector
+        </button>
+      </div>
+```
+
+Wrap everything from the `<input className="tn-cat-search">` to the closing `</p>` of `tn-rail-foot` in `{tab === "sources" ? (<>…</>) : <InspectorTab />}`.
+
+- [ ] **Step 8: Add the CSS**
+
+Append to `app/globals.css`, beside the existing `.tn-rail` block:
+
+```css
+/* ── Inspector: the context bar and the index ─────────────────────────────── */
+.tn-ctxbar {
+  display: flex; align-items: center; gap: 7px; margin: 0 0 2px;
+  padding: 6px 9px; border-radius: 8px; font-size: 12px;
+  background: var(--tn-surface-2, rgba(0,0,0,.03)); border: 1px solid var(--tn-border);
+}
+.tn-ctxbar[data-area] { border-color: var(--tn-accent); }
+.tn-ctxbar-glyph { color: var(--tn-text-faint); }
+.tn-ctxbar[data-area] .tn-ctxbar-glyph, .tn-ctxbar[data-area] .tn-ctxbar-name { color: var(--tn-accent); }
+.tn-ctxbar-name { flex: 1; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-ctxbar-x { border: none; background: none; color: var(--tn-text-faint); cursor: pointer; font: inherit; padding: 0 2px; }
+.tn-ctxbar-x:hover { color: var(--tn-text); }
+
+.tn-rail-tabs { display: flex; gap: 4px; padding: 7px 0 2px; }
+.tn-rail-tab {
+  flex: 1; padding: 5px 0 6px; font: inherit; font-size: 12px; font-weight: 500;
+  border-radius: 7px; border: 1px solid transparent; background: none;
+  color: var(--tn-text-faint); cursor: pointer;
+}
+.tn-rail-tab[aria-selected="true"] {
+  border-color: var(--tn-accent); color: var(--tn-accent); font-weight: 600;
+}
+
+.tn-insp-count { color: var(--tn-text-faint); font-weight: 400; }
+.tn-insp-row {
+  display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 8px;
+  margin: 0 -8px; border: none; border-radius: 8px; background: none;
+  font: inherit; text-align: left; color: inherit; cursor: pointer;
+}
+.tn-insp-row:hover { background: var(--tn-surface-2, rgba(0,0,0,.04)); }
+.tn-insp-row[data-loaded] { background: var(--tn-accent-soft, rgba(0,0,0,.06)); }
+.tn-insp-glyph { color: var(--tn-accent); flex: 0 0 auto; }
+.tn-insp-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
+.tn-insp-label { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tn-insp-sub { font-size: 11px; color: var(--tn-text-faint); }
+.tn-insp-pill {
+  font-size: 9.5px; font-weight: 700; letter-spacing: .05em;
+  padding: 1.5px 5px; border-radius: 4px; white-space: nowrap; color: var(--tn-accent);
+  border: 1px solid var(--tn-accent);
+}
+.tn-insp-pill-muted { color: var(--tn-text-faint); border-color: var(--tn-border); }
+.tn-insp-draw {
+  width: 100%; margin-top: 8px; padding: 7px 9px; text-align: left;
+  border: 1px dashed var(--tn-border); border-radius: 8px; background: none;
+  font: inherit; font-size: 12px; color: var(--tn-accent); cursor: pointer;
+}
+.tn-insp-soon {
+  margin-top: 12px; padding: 9px 10px; border-radius: 10px;
+  border: 1px dashed var(--tn-border); background: var(--tn-surface-2, rgba(0,0,0,.03));
+}
+.tn-insp-soon-head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; font-size: 11px; font-weight: 600; }
+.tn-insp-soon-head span:first-child { flex: 1; }
+.tn-insp-soon p { margin: 0; font-size: 11px; color: var(--tn-text-faint); line-height: 1.5; }
+```
+
+- [ ] **Step 9: Run the full gate**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: exit 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add components/shell/inspector/ components/shell/SourceCatalog.tsx app/globals.css lib/shell/inspector.ts tests/unit/inspector-labels.test.ts
+git commit -m "Split the rail into Sources and Inspector, above a context line
+
+The Inspector is an index: the areas you have drawn, what each holds, and which
+one is loaded. Detail opens in the dossier on the right rather than in this
+column, and sources are configured in the Sources tab — which the context line
+above the tabs says is pointed at the loaded area, in both tabs, always.
+
+Area size uses the spherical excess formula, not a planar shoelace on lon/lat.
+The planar version overstates by the cosine of the latitude — about 55% at 50N —
+and an area label that overstates is the one thing this product must not print."
+```
+
+---
+
+## Task 4: Loading an area scopes the console
+
+**Files:**
+- Create: `lib/scopeFilter.ts`
+- Test: `tests/unit/scope-filter.test.ts`
+- Modify: `lib/planes/usePlanes.ts`, `lib/cameras/useCameras.ts`, and the satellites + webcam directory hooks
+
+**Interfaces:**
+- Consumes: `withinScope`, `useScope` from `@/lib/shell/scope`.
+- Produces: `filterToScope<T>(items, scope, at): T[]` and `useScopeFilter<T>(items, at): T[]`, where `at` is `(item: T) => { lat: number; lon: number } | null`.
+
+**Why one helper:** the filter goes inside the shared hooks, not at each call site, so a widget added next month is scoped by construction — the same property that makes adding a signal layer need no edit to the rail.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/scope-filter.test.ts`:
+
+```ts
+import { expect, test } from "vitest";
+import { filterToScope } from "@/lib/scopeFilter";
+import { aoiScope, WORLD_SCOPE } from "@/lib/shell/scope";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+const AT = (p: { lat: number; lon: number }) => p;
+const INSIDE = { lat: 50.0, lon: 36.2 };
+const OUTSIDE = { lat: 51.5, lon: -0.1 };
+
+test("the world scope filters nothing and returns the SAME array", () => {
+  const items = [INSIDE, OUTSIDE];
+  expect(filterToScope(items, WORLD_SCOPE, AT)).toBe(items);
+});
+
+test("an aoi scope keeps only what is inside the ring", () => {
+  const out = filterToScope([INSIDE, OUTSIDE], aoiScope(RING), AT);
+  expect(out).toEqual([INSIDE]);
+});
+
+test("an item with no position is DROPPED inside an area, not silently kept", () => {
+  const out = filterToScope([INSIDE, { lat: NaN, lon: NaN }], aoiScope(RING), (p) =>
+    Number.isFinite(p.lat) ? p : null,
+  );
+  expect(out).toEqual([INSIDE]);
+});
+
+test("an item with no position is KEPT under the world scope", () => {
+  const items = [{ lat: NaN, lon: NaN }];
+  expect(filterToScope(items, WORLD_SCOPE, () => null)).toBe(items);
+});
+
+test("an empty list stays empty rather than throwing", () => {
+  expect(filterToScope([], aoiScope(RING), AT)).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/unit/scope-filter.test.ts`
+Expected: FAIL — `Failed to resolve import "@/lib/scopeFilter"`.
+
+- [ ] **Step 3: Write the helper**
+
+Create `lib/scopeFilter.ts`:
+
+```ts
+"use client";
+// One scope filter, shared by every data hook that is not already scoped.
+//
+// WHY IT LIVES IN A HELPER AND NOT AT THE CALL SITES. Ten widget files already call
+// useScope() and filter for themselves. The remaining data-bearing ones funnel
+// through four hooks — usePlanes, useCameras, useSatellites, useWebcamDirectory —
+// so putting the filter INSIDE those four scopes every widget that reads them, and
+// scopes any widget added later by construction. Filtering at each call site would
+// be the same work done six times and forgotten on the seventh.
+//
+// A MISSING POSITION IS DROPPED, NOT KEPT. Under an area, "I do not know where this
+// is" cannot honestly answer "is it in the ring". Keeping it would put an item of
+// unknown location inside a boundary the user drew precisely to exclude things.
+// Under World the question is not asked, so it stays.
+
+import { useScope, withinScope, type Scope } from "@/lib/shell/scope";
+
+/** Pure: keep only the items inside `scope`. Returns the input array untouched for World. */
+export function filterToScope<T>(
+  items: readonly T[],
+  scope: Scope,
+  at: (item: T) => { lat: number; lon: number } | null,
+): T[] {
+  if (scope.mode === "world") return items as T[];
+  const out: T[] = [];
+  for (const item of items) {
+    const p = at(item);
+    if (p && withinScope(p.lat, p.lon, scope)) out.push(item);
+  }
+  return out;
+}
+
+/** Hook form: filters to the LIVE scope, which the Inspector drives when an area loads. */
+export function useScopeFilter<T>(
+  items: readonly T[],
+  at: (item: T) => { lat: number; lon: number } | null,
+): T[] {
+  return filterToScope(items, useScope(), at);
+}
+```
+
+- [ ] **Step 4: Run it and watch it pass**
+
+Run: `npx vitest run tests/unit/scope-filter.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Apply it in the four hooks**
+
+In each of `lib/planes/usePlanes.ts`, `lib/cameras/useCameras.ts`, the satellites hook and the webcam-directory hook, wrap the returned list:
+
+```ts
+const scoped = useScopeFilter(list, (x) => (Number.isFinite(x.lat) && Number.isFinite(x.lon) ? x : null));
+```
+
+and return `scoped` in place of `list`. Read each hook's actual return shape first — the field names differ (`lat`/`lon` vs `latitude`/`longitude`) and the accessor must match the real one.
+
+- [ ] **Step 6: Classify every registered widget type**
+
+Run this and record the output in the commit message:
+
+```bash
+npx tsx -e "import('./lib/console/widgets/index.ts').then(async()=>{const{listWidgetTypes}=await import('./lib/console/registry.ts');console.log(listWidgetTypes().length)})"
+```
+
+For each type, confirm it falls in exactly one bucket: already scoped (calls `useScope`), scoped now (reads one of the four hooks), or carries no geographic data. **Any type in none of the three is a gap** — a widget showing global numbers beside a cropped map — and gets a `⌂ WORLD` marker or a scope filter before this task is done.
+
+- [ ] **Step 7: Run the full gate**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/scopeFilter.ts tests/unit/scope-filter.test.ts lib/planes/ lib/cameras/
+git commit -m "Loading an area scopes the map, the feed and every widget
+
+The filter goes inside the four shared data hooks rather than at each call site,
+so a widget added later is scoped by construction — the same property that makes
+adding a signal layer need no edit to the rail. Ten widget files already scoped
+themselves through useScope and are untouched.
+
+An item with no usable position is DROPPED inside an area and KEPT under World.
+Under an area, 'I do not know where this is' cannot honestly answer 'is it in the
+ring', and keeping it would place an unknown inside a boundary drawn to exclude."
+```
+
+---
+
+## Task 5: The area dossier, and the country click
+
+**Files:**
+- Create: `components/shell/inspector/AreaDetail.tsx`
+- Modify: `lib/world.ts` — add `"area"` to `WorldObjectKind`
+- Modify: `lib/overlay-content.tsx` — add `case "area"`
+- Modify: `components/WorldMap.tsx:1507`
+
+**Interfaces:**
+- Consumes: `inspectorStore`, `useInspector`, `areaSummary` from Task 1; `overlay` from `@/lib/overlay`.
+- Produces: nothing other tasks depend on.
+
+**Note:** `case "country"` in `lib/overlay-content.tsx` is **not** removed and `components/CountryDetail.tsx` is **not** reflowed. `.tn-dossier` is already a 384px right-edge panel, which is the chosen layout — an earlier revision of the spec said otherwise and was wrong.
+
+- [ ] **Step 1: Add the `area` kind**
+
+In `lib/world.ts`, extend `WorldObjectKind` with `"area"`.
+
+- [ ] **Step 2: Build `AreaDetail.tsx`**
+
+Render, from the area whose `id` the overlay object carries: label (inline-editable → `inspectorStore.rename`), `areaSummary(area)`, vertex count, centre coordinates, and the source list read from `area.sources`. Buttons: **Load / Unload** (`inspectorStore.load` + `scopeStore.set`), **Fly to** (`mapViewStore.flyToPoint` on the bbox centre), **Remove** (`inspectorStore.remove`, then `overlay.close()`).
+
+The source list is **read-only here** with the line "Change these in the Sources tab — it is already pointed at this area." Two places to change one thing is the bug this whole split exists to avoid.
+
+- [ ] **Step 3: Register it**
+
+In `lib/overlay-content.tsx`, add `case "area": return <AreaDetail object={object} />;`.
+
+- [ ] **Step 4: Country click also opens the Inspector**
+
+At `components/WorldMap.tsx:1507`, keep the existing `overlay.open(...)` and add `sourcesRailStore.setOpen(true)` beside it so the index is visible alongside the dossier. **Do not** change what the overlay opens.
+
+- [ ] **Step 5: Run the full gate**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: exit 0.
+
+- [ ] **Step 6: Verify in a real browser, red first**
+
+Push the branch, let Vercel build the preview, then run the existing e2e against **production** (old code — expect red) and against the **preview** (expect green), using the technique in the spec §11:
+
+```bash
+npx playwright test tests/e2e/map-rail.spec.ts --config=<temp config with baseURL and no webServer>
+```
+
+`tests/e2e/map-rail.spec.ts` matters twice here. Its "cold layer state" setup seeds `tn.layers.v1` and reloads, which was **inert** before Task 2 because nothing rehydrated — but only one half of the later assertion was damaged by that, and the distinction matters:
+
+- `cameras: false → true` was **vacuous**. `DEFAULT_STATE.cameras` is already `true`, which is the exact condition the seed was written to rule out.
+- `webcams: false → true` still **observed something real**, because `DEFAULT_STATE.webcams` is `false` with or without the seed.
+
+So the case was half load-bearing, not dead — keep and repair it, never delete it. With hydration wired the seed is genuinely read, `cameras: false` actually holds at reload, and both halves become real. Confirm it still passes and record that it is now testing what it claims.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/shell/inspector/AreaDetail.tsx lib/world.ts lib/overlay-content.tsx components/WorldMap.tsx
+git commit -m "Open area detail in the dossier, and show the index on a country click
+
+The dossier is already a 384px right-edge panel mirroring the rail, so an area
+becomes one more kind in the kind-to-component switch rather than a second detail
+surface. It inherits focus handling, escape, the close button and the mobile
+behaviour for nothing.
+
+The country case is untouched: an earlier draft of the spec proposed removing it
+and reflowing CountryDetail into the left rail, which was wrong about where the
+dossier already sits. A country click now also opens the rail so the index is
+visible beside the dossier it is describing."
+```
+
+---
+
+## Deferred to their own plan
+
+- **Area alerts.** Spec §12. Ships in Task 3 as a labelled, inert block.
+- **The camera tray split.** Spec §7. `wallpicker` has pre-agreed the hand-over of `CameraTray.tsx` and `StageBar.tsx:188`; the gesture controls stay on the stage and only the basket review moves. Needs its own red/green against a preview because it can strand an armed pick.
+- **`components/shell/EventFeed.tsx`**, imported by nothing and already dead on `origin/main` before #177. Flagged, untouched.
+
+## Self-Review
+
+**Spec coverage.** §1–§2 → Tasks 1–3. §3 context bar → Task 3. §4 model → Task 1. §5 migration + the hydrate bug → Task 2. §6 scope reach → Task 4. §7 tray → deferred, stated. §8 webcams → `ALWAYS_ON_SOURCES`, Task 1. §9 country decision → Task 5. §11 tests → each task's test step. §12 alerts → Task 3's coming-soon block.
+
+**Placeholder scan.** Task 4 Step 5 and Task 5 Step 2 describe edits without full code, because the four hooks' return shapes and `CountryDetail`'s markup must be read first — the field names differ per hook and inventing them here would plant a bug. Both steps name the exact files and the exact accessor contract instead.
+
+**Type consistency.** `SourceSet`, `InspectorArea`, `InspectorState`, `effectiveSet`, `activeSet`, `writeActive`, `replaceActive`, `areaSummary`, `ringAreaKm2`, `loadedArea`, `filterToScope`, `useScopeFilter` are used in Tasks 2–5 exactly as Task 1 and Task 4 define them. `ALWAYS_ON_SOURCES` is read only through `effectiveSet`.
+
+**One risk worth naming.** Task 2's `layersStore.applyExact` merges rather than replaces, because a context's `SourceSet` holds signal ids alongside `LayerKey`s and a layer preset must not switch every signal off. `signalsStore.applyExact` does replace, which mirrors its current behaviour but now also clears layer keys from the set — `presetLayers.ts` and `variants/resolveSignals.ts` call it, so their tests are the ones to watch in Task 2 Step 7.

--- a/docs/superpowers/plans/2026-09-07-inspector-areas.md
+++ b/docs/superpowers/plans/2026-09-07-inspector-areas.md
@@ -503,7 +503,7 @@ export function useInspector(): InspectorState {
 - [ ] **Step 4: Run the test and watch it pass**
 
 Run: `npx vitest run tests/unit/inspector-store.test.ts`
-Expected: PASS, 15 tests.
+Expected: PASS, 16 tests.
 
 - [ ] **Step 5: Run the full gate**
 
@@ -793,11 +793,23 @@ Both stores keep their exact public API and become views onto whichever context
 is loaded. No call site changed: WorldMap, SourceCatalog, monitors, presetLayers,
 presets, PresetBar and the palette all still call toggle/set/get unedited.
 
-This also fixes a bug the two files' own comments had been denying. Both claimed
-toggle state survived a reload; both exposed a hydrate() that NOTHING in the tree
-called, so every reload silently reset layers to DEFAULT_STATE and signals to {}.
-ConsoleShell hydrates seventeen stores and neither was among them. Rehydration now
-happens once, in inspectorStore.
+This is also a REVERT of an accidental deletion, not a new feature, and one git
+show makes that visible:
+
+  git log -S \"layersStore.hydrate\" origin/main   ->  41cf2b9
+  git show 41cf2b9 -- components/shell/ConsoleShell.tsx
+
+41cf2b9, 2026-06-27, \"wire ConsoleShell to the variant spine\", rewrote the hydrate
+block and dropped two stores out of it. Its parent has layersStore.hydrate() and
+signalsStore.hydrate() at ConsoleShell.tsx lines 34 and 35; the commit shows them as
+two minus lines while alertStore and langStore are re-added in the same hunk. Nothing
+adds them back. That is 474 commits and 71 days on main.
+
+So layer and signal toggles have not survived a reload since 2026-06-27, and both
+files' headers have described the behaviour of the code that used to be there --
+lib/layers.ts still says \"persisted to localStorage so a composed view survives a
+reload\", and lib/signals/store.ts says the same. This makes the code match its
+documentation again. Rehydration now happens once, in inspectorStore.
 
 Also corrects the LayerKey comment: weather left SIGNALS in #177 and the rail
 stopped drawing signposts for either planned key before that."

--- a/docs/superpowers/specs/2026-09-07-inspector-design.md
+++ b/docs/superpowers/specs/2026-09-07-inspector-design.md
@@ -1,0 +1,297 @@
+# Sources and Inspector — design
+
+**Date:** 2026-09-07
+**Base:** PR #177 (`feat/retire-dead-signal-layers`, `f0c376b` + `30ab64b`, cut off `origin/main` 4d2f8f1)
+**Status:** design agreed in outline; one open decision (§8); awaiting approval to plan
+**Visual review:** https://claude.ai/code/artifact/3e54c841-00f6-4307-a0e9-6d94cb182817
+
+> Do not design against `69faca4` or `feat/sources-rail-legibility`. That branch forks twelve
+> commits behind main and was already squash-merged as `177eecb`; PR #178 was opened from it
+> and closed as conflicting. #177 is the same layer work on a base that merges, plus the
+> ScopeControl fix below.
+
+---
+
+## 1. What this changes
+
+The console has one set of sources. It gets several.
+
+- **World** — the globe. Its own sources. What the console is today.
+- **An area** — a drawn ring. Its own sources.
+
+Exactly one is **loaded** at a time. Loading an area filters the whole console to that ring
+and draws that area's sources. Unloading returns World exactly as it was.
+
+An area does not inherit from World, override it, or copy it. The sets are independent, which
+is the property that makes this safe: nothing is borrowed, so nothing can be stranded.
+
+The Sources rail edits **whichever context is loaded**. The Inspector is the index — where you
+choose the context and manage areas. Sources are never configured from the Inspector; that is
+the Sources tab's job.
+
+## 2. Two surfaces, both already in the tree
+
+The layout is index-left, detail-right, and **both halves already exist**:
+
+| | Element | Geometry |
+|---|---|---|
+| Index | `.tn-rail` (`SourceCatalog.tsx`) | `position: fixed; left: 12px; width: 268px` |
+| Detail | `.tn-dossier` (`FeedOverlay.tsx`) | `position: fixed; right: 10px; width: min(384px, 94vw)`, top bar to ticker |
+
+`FeedOverlay` is not a modal over the globe — it is a 384px right-edge panel mirroring the
+rail. `lib/overlay-content.tsx` is a `kind → component` switch (camera, satellite, plane,
+webcam, signal, country). **The Inspector adds two kinds to it — `area` and `basket` — rather
+than growing a second detail panel.** That inherits the existing focus handling, close button,
+slide-in and mobile behaviour for free.
+
+## 3. Why the rail must announce its context
+
+A requirement, not styling. Flip a toggle without knowing whether you changed the globe or the
+Kharkiv area and the control lies about its effect. This codebase has shipped and then fixed
+two variants of that bug already.
+
+- A context line above the tabs, visible in **both** tabs: `⌂ World` or `▣ <area> ✕`.
+- Section headings in the Sources tab read `EDITING THIS AREA` while an area is loaded.
+- It persists across a reload. A user who reloads into a loaded area must be told why the map
+  is sparse, or they conclude the app is broken.
+
+## 4. Data model
+
+```ts
+// lib/shell/inspector.ts — new, persisted, the lib/shell store idiom
+// (module state + listener set + useSyncExternalStore, like scope.ts and watchlist.ts)
+
+/**
+ * id → on, for ONE context. Covers layersStore's 4 core LayerKeys and signalsStore's
+ * signal ids in a single map, because a context does not care which registry a source
+ * came from. The two stores keep their typed surfaces on top of this.
+ */
+type SourceSet = Record<string, boolean>;
+
+interface InspectorArea {
+  id: string;                     // "area:1788744123456"
+  label: string;                  // editable, defaults to the ring's own label
+  polygon: [number, number][];    // OPEN ring of [lon, lat] — the shape scope.ts speaks
+  bbox: [number, number, number, number];
+  createdAt: number;
+  sources: SourceSet;             // its own; never merged with World's
+}
+
+interface InspectorState {
+  world: SourceSet;               // the globe's own set
+  areas: InspectorArea[];         // drawn only — cap 40, oldest evicted (matches WATCHLIST_CAP)
+  loaded: string | null;          // null = World. The context switch.
+}
+```
+
+A clicked country needs **no field here**. `lib/overlay.ts` already holds the open object, and
+a country is a dossier rather than a context. That also means it clears on reload, which is
+right — a stale dossier from last week is worse than none.
+
+### What loading does, precisely
+
+1. Sets `loaded`.
+2. Sets `scopeStore` to the ring — this is what filters the map, feed and widgets.
+   `lib/map/aoi.ts` already paints the active scope on its own layers and re-asserts them on
+   `styledata`, so the boundary is drawn with no map edit.
+3. Flies to the bbox once. A separate **Fly to** re-centres on demand.
+4. Points the Sources rail at that area's `SourceSet`.
+
+Unloading reverses 1, 2 and 4, and does **not** move the camera. A map that jumps when you
+close a panel is disorienting.
+
+## 5. The store migration — the part with real blast radius
+
+`layersStore` and `signalsStore` have many callers: `WorldMap`, `SourceCatalog`, presets,
+monitors, variants, widgets. **Their public API does not change.**
+
+`layersStore.toggle(key)`, `useLayers()`, `signalsStore.set(id, on)`, `useSignals()` keep their
+exact signatures. Internally they read and write
+`loaded === null ? world : area.sources`. Every existing caller is correct by construction and
+no call site is edited.
+
+**Migration on first run:** the persisted `tn.layers.v1` and `tn.signals.v1` become World's
+`SourceSet` verbatim. A returning user sees the console they left. Pinned by a test that loads
+a v1 payload and asserts World's set matches key for key.
+
+**Known consequence, deliberate:** applying a preset or monitor variant while an area is loaded
+writes that area's set, not World's. That is the correct reading — you are configuring the
+loaded thing — but it is a behaviour change and is stated in the UI.
+
+### The Inspector is the sole UI owner of scope
+
+Checked at `69faca4` and confirmed independently by `sources-rail` against the tree:
+`components/shell/ScopeControl.tsx` was orphaned — its only importer, `ConsoleTopBar.tsx`, was
+deleted, and `coerceSavedScope` coerced a persisted `near-me` to World but let `region` through
+as-is, so a user with a Region scope reloaded filtered with Draw → Clear as the only way out.
+
+**Fixed in #177 commit `30ab64b`:** `ScopeControl.tsx` deleted, `region` now coerces to World.
+Nothing for this branch to carry. The only remaining `scopeStore` writers are `lib/map/aoi.ts`
+lines 542, 593 and 605 — so the Inspector's context bar owns the mode outright and there is no
+second control to reconcile with.
+
+### Cameras and webcams
+
+Sam's rule: cameras and webcams are always on in every area. This settles what a new area
+starts with — **empty, except those two** — so an area never loads to a blank map. They render
+as an always-on marker, never as a toggle that ignores clicks.
+
+**OPEN for webcams — see §8.**
+
+## 6. Scope reach
+
+Sam's call: map, feed and every widget honour the loaded area before any of it ships.
+
+Measured against the tree:
+
+| | Count | What |
+|---|---|---|
+| Already scoped | 10 files | `ais.detail`, `anomaly`, `cables.detail`, `directory.detail`, `events`, `events.detail`, `forecast.detail`, `schedule.detail`, `signals`, `signals.detail` — all call `useScope()` today |
+| One hook each | 6 files | `usePlanes` (aviation ×2), `useCameras` + `useWebcamDirectory` (camslot ×3), `useSatellites` (satellites ×2) |
+| Nothing geographic | the rest | clocks, notes, trust cards, chrome |
+
+**The filter goes inside the four hooks, not at each call site.** A widget added next month is
+then scoped by construction — the same property that makes adding a signal layer need no edit
+to the rail.
+
+The classification pass runs over every registered widget type. That count is **63 as of
+#177**, down from 70 in that same PR — it is #177's number, not a standing fact, and
+`readme-counts.test.ts` pins the README's copy of it. Re-measure with `listWidgetTypes()`;
+never type it from memory.
+
+### Two things it will not do, which the UI must admit
+
+1. **Loading an area crops what you see. It does not reduce what is fetched.** A source
+   adapter's `fetch()` takes no arguments — every one returns a global list and the scope
+   filter runs after it arrives. A small area is not a cheaper console.
+2. **A source that is off in this area genuinely is not fetched — that is where the saving
+   is.** The existing rule holds per context: only sources you can see are fetched. An area
+   with four sources on pulls four feeds, not thirty-six. Stated next to the point above so
+   the two are not confused.
+
+## 7. The camera tray, split rather than moved
+
+`components/console/CameraTray.tsx`, rendered by `StageBar.tsx:188` over the map stage. Both of
+Sam's cases — "select an area" and "select cameras" — are one feature: picking cameras inside a
+drawn ring.
+
+**Do not move all of it.** Verified on the live preview by `wallpicker`, who owns the picker:
+while picking is armed the tray is the **only** thing on screen carrying **Stop picking** and
+**Send to wall**. The Sources rail mounts closed. A receipt in a closed panel means a user arms
+picking, sees nothing, and cannot stop.
+
+The split follows the line the tray's own header already draws — it lives on the stage because
+it "belongs to one gesture on one surface":
+
+| Stays on the stage | Moves to the `basket` dossier |
+|---|---|
+| Stop picking | The picked list |
+| Live found-in-area count | The cap, stated as a cap |
+| | Send to wall, Clear |
+
+`wallpicker` has ruled: a read-only summary subscribing to `pickStore` is free to take now;
+taking `CameraTray.tsx` and `StageBar.tsx:188` is agreed once Sam approves a plan.
+`camslot.pick.ts`, `camslot.send.ts`, `camslot.area.ts` and `camslot.layers.ts` stay theirs.
+
+**The area total is never `picks.length`.** The tray's header is explicit that printing the
+basket size as the area's total turns a cap into a coverage claim. The dossier must not
+regress that.
+
+## 8. Open decision
+
+**Webcams always-on.** `lib/layers.ts` defaults webcams to `false` and excludes it from the
+layer presets deliberately: it is a keyed, rate-limited global sample. Its `fetch()` takes no
+arguments, so **the pull is global regardless of the area** — scoping changes what is drawn,
+never what is pulled. Always-on in every area means that keyed feed runs whenever any area is
+loaded.
+
+Recommendation: cameras always on, webcams on by default but switchable. The never-blank-map
+property comes from cameras alone. One line either way.
+
+Cameras have no such limit and are uncontroversial.
+
+## 9. Decisions taken
+
+- **The country panel stays where it is.** *Reversing an earlier call in this document's rev 2.*
+  I had planned to remove `case "country"` from `OverlayBody` and reflow `CountryDetail` into
+  the left rail. The dossier is already a 384px right-edge panel, which is the chosen layout —
+  so there is no reflow and no removal. A country click additionally opens the left rail on the
+  Inspector tab so the index reflects what the dossier shows.
+- **Alerts ship as a labelled, inert "coming soon" block**, not a half-built rule. Design in
+  §12 so it drops in without moving anything on screen.
+
+## 10. Build order
+
+Off #177. Each milestone gated by `npx tsc --noEmit && npm test`. M1–M3 answer "saved areas I
+can load, configure and remove".
+
+| | Work | Files |
+|---|---|---|
+| M1 | The store — contexts, areas, loaded pointer; pure add / remove / rename / load / cap with tests. Nothing renders. | `lib/shell/inspector.ts` |
+| M2 | `layersStore` and `signalsStore` become views onto the loaded set, APIs unchanged. v1 migration pinned by a test. | `lib/layers.ts`, `lib/signals/store.ts` |
+| M3 | Context bar, tabs, Inspector index, and the `area` dossier kind. Draw saves; the index loads, renames, removes, flies to. Alert me ships marked coming soon. | `SourceCatalog.tsx`, `components/shell/inspector/*`, `overlay-content.tsx` |
+| M4 | Loading drives `scopeStore`. Four hooks learn scope. Classification pass over every registered widget type. | 4 hooks, 6 widget files |
+| M5 | Country click also opens the Inspector index. The `basket` dossier kind takes the tray's review half; the stage keeps Stop picking. | `WorldMap.tsx:1507`, `CameraTray.tsx`, `StageBar.tsx` |
+
+## 11. Tests
+
+Pure functions only — this repo has no React testing library and no component tests.
+
+- `inspector.ts`: add / remove / rename / cap eviction / load-unload round trip / coerce a junk
+  persisted payload to a valid state.
+- Migration: a v1 `tn.layers.v1` + `tn.signals.v1` payload becomes World's set key for key.
+- Context routing: a write while an area is loaded lands on the area and leaves World
+  untouched; unload restores World byte for byte.
+- Scope reach: a fixture of items inside and outside a ring, asserted through each of the four
+  hooks' pure projection helpers.
+
+Each guard test is watched go red before it goes green. A pinning test nobody saw fail is
+decoration.
+
+`wallpicker`'s technique is worth reusing for anything visual: point the e2e spec at
+**production** to get the red, then at the branch's Vercel preview for the green. Red and green
+against two real builds, no local build, no disk.
+
+## 12. Deferred, designed
+
+Area alerts. A membership differ, not a new fetcher. `lib/events/alerting.ts` already has the
+shape — seeded baseline, fired-set dedupe, dormant-safe channels — but matches on radius from
+an asset and fires only on appear.
+
+1. A source polls (already happens). It calls `areaWatch.publish(sourceId, items, ok)`.
+2. Per area, per source: `entered = cur − prev`, `left = prev − cur`. First tick is a silent
+   baseline so arming does not stampede.
+3. Fans out through `lib/shell/notifications.ts` — browser, Telegram, Discord. No new key, no
+   new route.
+
+Limits, which go in the UI and not only here: it fires only while a Provenance tab is open,
+because the stack is client-side and keyless by design; areas must alert even when not loaded,
+or an alert only reports what you are already looking at; "leaves" is honest only for sources
+returning a complete set per poll, and `ok:false` must be dropped so one 403 never reads as a
+mass exit; resolution is a poll (30s at best), not a second.
+
+## 13. Not building
+
+- User-pasted custom feeds per area. `SourceSet` is keyed by string id, so one slots in later
+  as `custom:<id>` with no model change.
+- Server-side alerting.
+- More than one area loaded at once.
+- Countries as saveable contexts. A country is a dossier, not an area.
+
+## 14. Coordination
+
+Bus channel `trafficnerd-v2`. Claimed and agreed:
+
+- `sources-rail` — finished, PR #177. Off `SourceCatalog.tsx`, `components/shell/sources/*`,
+  `PresetBar.tsx` and the `.tn-rail` CSS. Those are mine.
+- `wallpicker` — PR #176, done and left the bus. Owns `components/console/maprail/*` and the
+  `camslot.*` picker modules. `CameraTray.tsx` and `StageBar.tsx` are unclaimed.
+- `shortcuts-ui` — no overlap declared.
+
+`startDraw(map, {onFinish})` keeps its contract: the ring goes to the caller's callback, never
+to the scope. A camera pick must never become a saved area. Saving is an explicit action only.
+
+**Third orphan, not this branch's to fix:** `components/shell/EventFeed.tsx` is imported by
+nothing, and was already dead on `origin/main` before #177. Its `.tn-feed` CSS block is
+likewise unreachable. Flagged, untouched. Two orphans surfaced in one evening; a cheap sweep
+would be to grep for an import of every default-exported component under `components/shell`.

--- a/lib/cameras/useCameras.ts
+++ b/lib/cameras/useCameras.ts
@@ -12,6 +12,8 @@
 import { useMemo, useSyncExternalStore } from "react";
 import type { CameraLite } from "@/lib/cameras/coverage";
 import type { SurfaceReading } from "@/lib/cameras/surface";
+import { filterToScope } from "@/lib/scopeFilter";
+import { useScope } from "@/lib/shell/scope";
 
 export interface CameraRow extends CameraLite {
   country: string;
@@ -94,5 +96,11 @@ export function useCameras(): CamerasFeed {
   );
 
   const getSnapshot = () => ensure().state;
-  return useSyncExternalStore(subscribe, getSnapshot, () => EMPTY);
+  const feed = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY);
+  const scope = useScope();
+  return useMemo(() => {
+    const cameras = filterToScope(feed.cameras, scope, (c) => c);
+    if (cameras === feed.cameras) return feed; // World: keep status/updatedAt identity
+    return { ...feed, cameras };
+  }, [feed, scope]);
 }

--- a/lib/layers.ts
+++ b/lib/layers.ts
@@ -9,12 +9,11 @@
 // localStorage so a composed view survives a reload.
 
 import { useSyncExternalStore } from "react";
-import { loadPersisted, savePersisted } from "@/lib/shell/persist";
 
 // Active layers have a live CORE map layer today. The two "planned" keys never got
-// one — but their data DID ship, as signal layers (lib/signals/ais.ts and
-// lib/signals/weather.ts, both in SIGNALS), so the rail renders them as dimmed,
-// toggle-less signposts pointing at Global signals, NOT as "coming soon".
+// one. ships still ships as the AIS signal layer; weather no longer has one — its
+// adapter was unregistered in #177. Neither is drawn in the rail; see OMITTED_LAYERS
+// in lib/console/sources/railSources.ts.
 export type LayerKey = "cameras" | "satellites" | "planes" | "ships" | "webcams" | "weather" | "countries";
 export type LayerState = Record<LayerKey, boolean>;
 
@@ -70,46 +69,84 @@ export function presetState(id: PresetId): LayerState {
   }
 }
 
-let state: LayerState = { ...DEFAULT_STATE };
-const listeners = new Set<() => void>();
+// STATE LIVES IN lib/shell/inspector.ts, NOT HERE. This store is a VIEW onto
+// whichever source context is loaded — World, or one drawn area. The API below is
+// byte-identical to what it was before that change, which is the whole point:
+// WorldMap, SourceCatalog, monitors.ts, presetLayers.ts, presets.ts, PresetBar and
+// the command palette all call these methods and none of them needed an edit.
+//
+// The projection is one-way. This file imports inspector.ts; inspector.ts must never
+// import this one, or the pair is circular and neither owns the state.
+import { effectiveSetMemo, inspectorStore, loadedArea, type SourceSet } from "@/lib/shell/inspector";
 
-function emit() {
-  for (const l of listeners) l();
-  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+/** Every LayerKey off. An AREA's floor — see project(). */
+const ALL_OFF: LayerState = (Object.keys(DEFAULT_STATE) as LayerKey[]).reduce((acc, k) => {
+  acc[k] = false;
+  return acc;
+}, {} as LayerState);
+
+/**
+ * The 7 LayerKeys pulled out of a context's set, over the floor that context uses.
+ *
+ * THE FLOOR IS DIFFERENT FOR WORLD AND FOR AN AREA, and that is the whole contexts
+ * rule expressed in one argument. World floors to DEFAULT_STATE, so the globe behaves
+ * exactly as it did before this store was routed. An area floors to ALL_OFF, because a
+ * new area starts with an empty set and must read as empty — flooring it with
+ * DEFAULT_STATE would hand the user a context they never configured, and would move
+ * every area's unset key the day a default flips. ALWAYS_ON_SOURCES is what keeps an
+ * empty area from loading to a blank map; the floor is not.
+ */
+function project(set: SourceSet, floor: LayerState): LayerState {
+  const out = { ...floor };
+  for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) {
+    if (typeof set[k] === "boolean") out[k] = set[k];
+  }
+  return out;
+}
+
+// Memoised on the state object so useSyncExternalStore's identity check holds:
+// project() builds a fresh object every call, and returning a new one from get() on
+// every render loops React forever. effectiveSetMemo is memoised for the same reason
+// one layer down — see the note on it in lib/shell/inspector.ts.
+let lastSet: SourceSet | null = null;
+let lastProjection: LayerState = { ...DEFAULT_STATE };
+
+function current(): LayerState {
+  const state = inspectorStore.get();
+  const set = effectiveSetMemo(state);
+  if (set !== lastSet) {
+    lastSet = set;
+    lastProjection = project(set, loadedArea(state) ? ALL_OFF : DEFAULT_STATE);
+  }
+  return lastProjection;
 }
 
 export const layersStore = {
   toggle(key: LayerKey) {
-    state = { ...state, [key]: !state[key] };
-    emit();
+    inspectorStore.setSource(key, !current()[key]);
   },
   set(key: LayerKey, on: boolean) {
-    if (state[key] === on) return;
-    state = { ...state, [key]: on };
-    emit();
+    if (current()[key] === on) return;
+    inspectorStore.setSource(key, on);
   },
   applyPreset(id: PresetId) {
-    state = presetState(id);
-    emit();
+    layersStore.applyExact(presetState(id));
   },
   applyExact(next: LayerState) {
-    state = { ...DEFAULT_STATE, ...next };
-    emit();
+    // Merge rather than replace: the context's set also holds SIGNAL ids, and a
+    // layer preset must not silently switch every signal layer off.
+    const active = { ...DEFAULT_STATE, ...next };
+    const set: SourceSet = { ...effectiveSetMemo(inspectorStore.get()) };
+    for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) set[k] = active[k];
+    inspectorStore.replaceSources(set);
   },
-  get(): LayerState {
-    return state;
-  },
-  /** Pull persisted toggles back in. Call once, client-side, after mount. */
+  get: current,
+  /** Kept for API compatibility. inspectorStore.hydrate() owns rehydration now. */
   hydrate() {
-    const saved = loadPersisted<Partial<LayerState>>(PERSIST_KEY, PERSIST_VERSION);
-    if (saved) state = { ...DEFAULT_STATE, ...saved };
-    emit();
+    /* no-op — see the note at the top of this block */
   },
   subscribe(listener: () => void): () => void {
-    listeners.add(listener);
-    return () => {
-      listeners.delete(listener);
-    };
+    return inspectorStore.subscribe(listener);
   },
 };
 

--- a/lib/layers.ts
+++ b/lib/layers.ts
@@ -5,8 +5,14 @@
 // WorldMap reads this to decide which MapLibre layers are visible AND — via the
 // gating <CamerasFeed>/<PlanesFeed>/<SatellitesFeed> wrappers — whether a layer's
 // data hook is even mounted (a hidden layer does not fetch or tick). The left
-// LayerRail and the ⌘K palette drive the toggles. Toggle state is persisted to
-// localStorage so a composed view survives a reload.
+// LayerRail and the ⌘K palette drive the toggles.
+//
+// TOGGLE STATE IS NOT PERSISTED HERE, and this comment used to say it was. It
+// survives a reload through the VARIANT SPINE: variantStore.bootstrap is the only
+// load-time hydration path, and its captureOverride subscribes to this store and
+// persists the diff-from-variant under tn.variant.v1. The header was wrong about
+// the mechanism while being right about the outcome, which is the worse kind of
+// wrong — the behaviour appears to confirm it. tn.layers.v1 is a dead key.
 
 import { useSyncExternalStore } from "react";
 
@@ -34,8 +40,6 @@ export const DEFAULT_STATE: LayerState = {
   countries: true,
 };
 
-const PERSIST_KEY = "tn.layers.v1";
-const PERSIST_VERSION = 1;
 
 export type PresetId = "all" | "none" | "cameras" | "air-space";
 // Labels have to match presetState() below, which they did not: the "all" preset

--- a/lib/overlay-content.tsx
+++ b/lib/overlay-content.tsx
@@ -6,6 +6,7 @@
 //   • camera    → live proxied image + mandatory attribution (CameraDetail)
 //   • satellite → identity + Esri satellite imagery of the ground beneath it
 //   • plane     → live flight info (callsign, altitude, speed, heading)
+//   • area      → a saved Inspector area: its shape, what it has on, load/remove
 
 import type { WorldObject } from "@/lib/world";
 import { CameraDetail } from "@/components/CameraDetail";
@@ -14,6 +15,7 @@ import PlaneDetail from "@/components/PlaneDetail";
 import WebcamDetail from "@/components/WebcamDetail";
 import SignalDetail from "@/components/SignalDetail";
 import CountryDetail from "@/components/CountryDetail";
+import AreaDetail from "@/components/shell/inspector/AreaDetail";
 
 export function OverlayBody({ object }: { object: WorldObject }) {
   switch (object.kind) {
@@ -29,6 +31,8 @@ export function OverlayBody({ object }: { object: WorldObject }) {
       return <SignalDetail object={object} />;
     case "country":
       return <CountryDetail object={object} />;
+    case "area":
+      return <AreaDetail object={object} />;
     default:
       return null;
   }

--- a/lib/planes/usePlanes.ts
+++ b/lib/planes/usePlanes.ts
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import type { WorldObject } from "@/lib/world";
 import { buildTrailPath, pushHistory, type TrailPoint } from "@/lib/planes/trail";
+import { filterToScope } from "@/lib/scopeFilter";
+import { useScope } from "@/lib/shell/scope";
 
 const POLL_INTERVAL_MS = 12_000;
 
@@ -85,5 +87,11 @@ export function usePlanes(): PlanesLayer {
     };
   }, []);
 
-  return layer;
+  const scope = useScope();
+  return useMemo(() => {
+    const objects = filterToScope(layer.objects, scope, (o) => o);
+    if (objects === layer.objects) return layer; // World: same array, same identity
+    const keep = new Set(objects.map((o) => o.id));
+    return { objects, trails: layer.trails.filter((t) => keep.has(t.id)) };
+  }, [layer, scope]);
 }

--- a/lib/satellites/useSatellites.ts
+++ b/lib/satellites/useSatellites.ts
@@ -1,10 +1,12 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import type { SatRec } from "satellite.js";
 import type { WorldObject } from "@/lib/world";
 import { buildSatrec, propagateAt, orbitalPeriodMin } from "@/lib/satellites/propagate";
 import { classifySatellite } from "@/lib/satellites/classify";
 import { SAT_META } from "@/lib/icons/svg";
+import { filterToScope } from "@/lib/scopeFilter";
+import { useScope } from "@/lib/shell/scope";
 
 interface ApiSat {
   name: string;
@@ -109,5 +111,6 @@ export function useSatellites(group = "visual", stepMs = 1000): WorldObject[] {
     return () => clearInterval(timer);
   }, [stepMs]);
 
-  return objects;
+  const scope = useScope();
+  return useMemo(() => filterToScope(objects, scope, (o) => o), [objects, scope]);
 }

--- a/lib/scopeFilter.ts
+++ b/lib/scopeFilter.ts
@@ -1,0 +1,39 @@
+"use client";
+// One scope filter, shared by every data hook that is not already scoped.
+//
+// WHY IT LIVES IN A HELPER AND NOT AT THE CALL SITES. Ten widget files already call
+// useScope() and filter for themselves. The remaining data-bearing ones funnel
+// through four hooks — usePlanes, useCameras, useSatellites, useWebcamDirectory —
+// so putting the filter INSIDE those four scopes every widget that reads them, and
+// scopes any widget added later by construction. Filtering at each call site would
+// be the same work done six times and forgotten on the seventh.
+//
+// A MISSING POSITION IS DROPPED, NOT KEPT. Under an area, "I do not know where this
+// is" cannot honestly answer "is it in the ring". Keeping it would put an item of
+// unknown location inside a boundary the user drew precisely to exclude things.
+// Under World the question is not asked, so it stays.
+
+import { useScope, withinScope, type Scope } from "@/lib/shell/scope";
+
+/** Pure: keep only the items inside `scope`. Returns the input array untouched for World. */
+export function filterToScope<T>(
+  items: readonly T[],
+  scope: Scope,
+  at: (item: T) => { lat: number; lon: number } | null,
+): T[] {
+  if (scope.mode === "world") return items as T[];
+  const out: T[] = [];
+  for (const item of items) {
+    const p = at(item);
+    if (p && withinScope(p.lat, p.lon, scope)) out.push(item);
+  }
+  return out;
+}
+
+/** Hook form: filters to the LIVE scope, which the Inspector drives when an area loads. */
+export function useScopeFilter<T>(
+  items: readonly T[],
+  at: (item: T) => { lat: number; lon: number } | null,
+): T[] {
+  return filterToScope(items, useScope(), at);
+}

--- a/lib/shell/inspector.ts
+++ b/lib/shell/inspector.ts
@@ -277,9 +277,26 @@ export const inspectorStore = {
     };
   },
 
-  /** Pull persisted contexts back in. Called once from ConsoleShell, client-side. */
+  /**
+   * Pull persisted AREAS back in. Called once from ConsoleShell, client-side,
+   * AFTER variantStore.bootstrap().
+   *
+   * WORLD IS DELIBERATELY NOT RESTORED, and the ordering is not incidental. The
+   * variant spine is, in its own words, "the ONLY load-time hydration path": every
+   * boot runs applyVariant, which calls layersStore.applyExact and
+   * signalsStore.applyExact and so re-derives World's whole set. Persisting a
+   * second copy of it here would be two owners for one piece of state — the exact
+   * bug the Sources/Inspector split exists to avoid — and it was destructive, not
+   * merely redundant: with an area loaded, bootstrap's writes land on the AREA, so
+   * one reload replaced a user's area configuration with the variant's layers.
+   * Measured on a preview before this ordering was fixed.
+   *
+   * So World's toggles persist where they already did for 71 days, as a delta in
+   * tn.variant.v1; this store persists the areas, which nothing else knows about.
+   */
   hydrate() {
-    commit(coerceState(loadPersisted<InspectorState>(PERSIST_KEY, PERSIST_VERSION)));
+    const saved = coerceState(loadPersisted<InspectorState>(PERSIST_KEY, PERSIST_VERSION));
+    commit({ ...saved, world: state.world });
   },
 
   /** Save a drawn ring as an area. Returns its id, or null for a ring that is not one. */

--- a/lib/shell/inspector.ts
+++ b/lib/shell/inspector.ts
@@ -1,0 +1,267 @@
+"use client";
+// The console's SOURCE CONTEXTS — World, plus one per drawn area.
+//
+// WHY CONTEXTS AND NOT AN OVERRIDE. An area does not inherit from World, layer on
+// top of it, or copy it. It is a separate map of source id → on with a boundary
+// attached. That is the whole reason this is safe: nothing is borrowed, so
+// unloading an area cannot leave the globe wearing the area's toggles, and
+// removing an area cannot strand a source that only it turned on. The alternative
+// — one global set plus per-area diffs — has to answer "what happens to World's
+// toggles while an area is loaded" on every single write, and every answer to that
+// question is a bug waiting for a reload.
+//
+// WHAT DEPENDS ON WHAT. This file knows nothing about lib/layers.ts or
+// lib/signals/store.ts. THEY import THIS. Keep it that way: those two stores are
+// views onto whichever SourceSet is loaded, and a back-reference here would make
+// the pair circular and the ownership unreadable.
+//
+// ONE MAP FOR TWO REGISTRIES. A SourceSet holds layersStore's LayerKeys and
+// signalsStore's arbitrary signal ids together, because a context does not care
+// which registry a source came from. The two stores keep their own typed surfaces
+// on top; the split lives there, not here.
+//
+// PERSISTENCE, AND A BUG IT FIXES. Adding this store to ConsoleShell's hydrate
+// list is what makes a saved area survive a reload. It also, incidentally, makes
+// LAYER and SIGNAL toggles survive one — which both of those files' comments have
+// claimed for a long time and which was not true: layersStore.hydrate() and
+// signalsStore.hydrate() existed and had no caller anywhere in the tree, so every
+// reload reset them to their defaults. Measured on bbe9651 before this change.
+
+import { useSyncExternalStore } from "react";
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+import { bboxOfRing, sanitiseRing } from "@/lib/shell/scope";
+
+/** id → on, for ONE context. Covers LayerKeys and signal ids in a single map. */
+export type SourceSet = Record<string, boolean>;
+
+export interface InspectorArea {
+  /** "area:<epoch ms>" — stable, and sorts by age without a second field. */
+  id: string;
+  label: string;
+  /** OPEN ring of [lon, lat] — exactly what lib/shell/scope.ts speaks. */
+  polygon: [number, number][];
+  bbox: [number, number, number, number];
+  createdAt: number;
+  /** ITS OWN. Never merged with World's. */
+  sources: SourceSet;
+}
+
+export interface InspectorState {
+  world: SourceSet;
+  areas: InspectorArea[];
+  /** null = World. The one value that decides what the console shows. */
+  loaded: string | null;
+}
+
+export const AREA_CAP = 40;
+
+/**
+ * Sources an AREA always draws, whatever its own set says.
+ *
+ * Sam's rule, and it is what lets a new area start empty without ever loading to a
+ * blank map. ONE CONSTANT ON PURPOSE: `webcams` is a keyed, rate-limited global
+ * sample that lib/layers.ts deliberately defaults off and keeps out of the presets,
+ * and its adapter's fetch() takes no arguments — so the pull is global whatever the
+ * ring is, and scoping crops what is drawn rather than what is pulled. That cost was
+ * put to Sam and he kept the rule. Reversing it is deleting one string here, not a
+ * hunt through the UI.
+ *
+ * WORLD IS NOT SUBJECT TO THIS. The globe keeps its own toggles, so today's
+ * "webcams is opt-in on the globe" behaviour is unchanged. See effectiveSet.
+ */
+export const ALWAYS_ON_SOURCES: readonly string[] = ["cameras", "webcams"];
+
+const PERSIST_KEY = "tn.inspector.v1";
+const PERSIST_VERSION = 1;
+
+const EMPTY: InspectorState = Object.freeze({ world: {}, areas: [], loaded: null });
+
+// --- pure -------------------------------------------------------------------
+
+/** Pure: a source map with only boolean values kept. */
+function cleanSet(value: unknown): SourceSet {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const out: SourceSet = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "boolean") out[k] = v;
+  }
+  return out;
+}
+
+/** Pure: build an area from a drawn ring. Null when the ring is not an area. */
+export function newArea(
+  ring: readonly [number, number][],
+  label: string,
+  now: number,
+): InspectorArea | null {
+  const clean = sanitiseRing(ring as unknown);
+  if (!clean) return null;
+  return {
+    id: `area:${now}`,
+    label,
+    polygon: clean,
+    bbox: bboxOfRing(clean),
+    createdAt: now,
+    sources: {},
+  };
+}
+
+/** Pure: newest first, deduped by id, capped. */
+export function addArea(
+  areas: readonly InspectorArea[],
+  area: InspectorArea,
+  cap = AREA_CAP,
+): InspectorArea[] {
+  return [area, ...areas.filter((a) => a.id !== area.id)].slice(0, cap);
+}
+
+/** Pure: drop by id. */
+export function removeArea(areas: readonly InspectorArea[], id: string): InspectorArea[] {
+  return areas.filter((a) => a.id !== id);
+}
+
+/** Pure: relabel by id. */
+export function renameArea(
+  areas: readonly InspectorArea[],
+  id: string,
+  label: string,
+): InspectorArea[] {
+  return areas.map((a) => (a.id === id ? { ...a, label } : a));
+}
+
+/** Pure: the loaded area, or null for World (including a dangling id). */
+export function loadedArea(state: InspectorState): InspectorArea | null {
+  if (state.loaded === null) return null;
+  return state.areas.find((a) => a.id === state.loaded) ?? null;
+}
+
+/** Pure: the RAW set for the loaded context. What the Sources rail edits. */
+export function activeSet(state: InspectorState): SourceSet {
+  return loadedArea(state)?.sources ?? state.world;
+}
+
+/** Pure: the set the console actually DRAWS. Areas force ALWAYS_ON_SOURCES on. */
+export function effectiveSet(state: InspectorState): SourceSet {
+  const area = loadedArea(state);
+  if (!area) return state.world;
+  const out: SourceSet = { ...area.sources };
+  for (const id of ALWAYS_ON_SOURCES) out[id] = true;
+  return out;
+}
+
+/** Pure: set one source on the loaded context. */
+export function writeActive(state: InspectorState, id: string, on: boolean): InspectorState {
+  const area = loadedArea(state);
+  if (!area) return { ...state, world: { ...state.world, [id]: on } };
+  return {
+    ...state,
+    areas: state.areas.map((a) => (a.id === area.id ? { ...a, sources: { ...a.sources, [id]: on } } : a)),
+  };
+}
+
+/** Pure: replace the whole set for the loaded context (presets, variants). */
+export function replaceActive(state: InspectorState, next: SourceSet): InspectorState {
+  const area = loadedArea(state);
+  if (!area) return { ...state, world: { ...next } };
+  return {
+    ...state,
+    areas: state.areas.map((a) => (a.id === area.id ? { ...a, sources: { ...next } } : a)),
+  };
+}
+
+/**
+ * Pure: coerce a persisted payload into a valid state.
+ *
+ * The bbox is RECOMPUTED rather than trusted: it is derived data, and a payload
+ * whose bbox disagrees with its ring would silently mis-filter every source in
+ * that area through withinScope's cheap reject.
+ */
+export function coerceState(saved: unknown): InspectorState {
+  if (!saved || typeof saved !== "object" || Array.isArray(saved)) return { ...EMPTY };
+  const s = saved as Partial<InspectorState>;
+  const areas: InspectorArea[] = [];
+  if (Array.isArray(s.areas)) {
+    for (const raw of s.areas) {
+      if (!raw || typeof raw !== "object") continue;
+      const a = raw as Partial<InspectorArea>;
+      const ring = sanitiseRing(a.polygon as unknown);
+      if (!ring || typeof a.id !== "string" || typeof a.label !== "string") continue;
+      areas.push({
+        id: a.id,
+        label: a.label,
+        polygon: ring,
+        bbox: bboxOfRing(ring),
+        createdAt: typeof a.createdAt === "number" && Number.isFinite(a.createdAt) ? a.createdAt : 0,
+        sources: cleanSet(a.sources),
+      });
+    }
+  }
+  const loaded =
+    typeof s.loaded === "string" && areas.some((a) => a.id === s.loaded) ? s.loaded : null;
+  return { world: cleanSet(s.world), areas: areas.slice(0, AREA_CAP), loaded };
+}
+
+// --- store ------------------------------------------------------------------
+
+let state: InspectorState = { ...EMPTY };
+const listeners = new Set<() => void>();
+
+function commit(next: InspectorState) {
+  state = next;
+  for (const l of listeners) l();
+  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+}
+
+export const inspectorStore = {
+  get: (): InspectorState => state,
+  subscribe(l: () => void): () => void {
+    listeners.add(l);
+    return () => {
+      listeners.delete(l);
+    };
+  },
+
+  /** Pull persisted contexts back in. Called once from ConsoleShell, client-side. */
+  hydrate() {
+    commit(coerceState(loadPersisted<InspectorState>(PERSIST_KEY, PERSIST_VERSION)));
+  },
+
+  /** Save a drawn ring as an area. Returns its id, or null for a ring that is not one. */
+  add(ring: readonly [number, number][], label: string): string | null {
+    const area = newArea(ring, label, Date.now());
+    if (!area) return null;
+    commit({ ...state, areas: addArea(state.areas, area) });
+    return area.id;
+  },
+
+  remove(id: string) {
+    commit({
+      ...state,
+      areas: removeArea(state.areas, id),
+      loaded: state.loaded === id ? null : state.loaded,
+    });
+  },
+
+  rename(id: string, label: string) {
+    commit({ ...state, areas: renameArea(state.areas, id, label) });
+  },
+
+  /** null unloads (back to World). An unknown id is ignored rather than stranding. */
+  load(id: string | null) {
+    if (id !== null && !state.areas.some((a) => a.id === id)) return;
+    if (state.loaded === id) return;
+    commit({ ...state, loaded: id });
+  },
+
+  setSource(id: string, on: boolean) {
+    commit(writeActive(state, id, on));
+  },
+
+  replaceSources(next: SourceSet) {
+    commit(replaceActive(state, next));
+  },
+};
+
+export function useInspector(): InspectorState {
+  return useSyncExternalStore(inspectorStore.subscribe, inspectorStore.get, () => EMPTY);
+}

--- a/lib/shell/inspector.ts
+++ b/lib/shell/inspector.ts
@@ -149,6 +149,31 @@ export function effectiveSet(state: InspectorState): SourceSet {
   return out;
 }
 
+/**
+ * The set the console DRAWS, memoised on the state object.
+ *
+ * effectiveSet() builds a fresh object whenever an area is loaded, because it has to
+ * force ALWAYS_ON_SOURCES in. useSyncExternalStore compares snapshots by identity, so
+ * a store calling effectiveSet() per render hands React a new snapshot every time —
+ * the documented infinite-loop bug. World hid it: with nothing loaded effectiveSet
+ * returns state.world by identity, so the globe was stable and only loading an area
+ * would have hung the console. There are no component tests in this repo to catch
+ * that, so the guard is an identity assertion in tests/unit/inspector-routing.test.ts.
+ *
+ * The state object is replaced on every write and never mutated, so its identity is
+ * the correct cache key.
+ */
+let memoState: InspectorState | null = null;
+let memoSet: SourceSet = {};
+
+export function effectiveSetMemo(state: InspectorState): SourceSet {
+  if (state !== memoState) {
+    memoState = state;
+    memoSet = effectiveSet(state);
+  }
+  return memoSet;
+}
+
 /** Pure: set one source on the loaded context. */
 export function writeActive(state: InspectorState, id: string, on: boolean): InspectorState {
   const area = loadedArea(state);

--- a/lib/shell/inspector.ts
+++ b/lib/shell/inspector.ts
@@ -201,6 +201,37 @@ export function coerceState(saved: unknown): InspectorState {
   return { world: cleanSet(s.world), areas: areas.slice(0, AREA_CAP), loaded };
 }
 
+const EARTH_RADIUS_KM = 6371.0088;
+
+/**
+ * Pure: the spherical area of a closed ring, in km².
+ *
+ * A PLANAR shoelace on lon/lat is wrong by the cosine of the latitude — at 50°N it
+ * overstates by about 55%, and an area label that overstates is worse than no label
+ * on a product whose whole claim is that it does not overstate. This is the spherical
+ * excess form, which is correct at any latitude and costs nothing at these ring sizes.
+ * Returns 0 for anything that is not an area, rather than a plausible fake.
+ */
+export function ringAreaKm2(ring: readonly [number, number][]): number {
+  if (!Array.isArray(ring) || ring.length < 3) return 0;
+  const rad = Math.PI / 180;
+  let total = 0;
+  for (let i = 0; i < ring.length; i++) {
+    const [lon1, lat1] = ring[i];
+    const [lon2, lat2] = ring[(i + 1) % ring.length];
+    total += (lon2 - lon1) * rad * (2 + Math.sin(lat1 * rad) + Math.sin(lat2 * rad));
+  }
+  return Math.abs((total * EARTH_RADIUS_KM * EARTH_RADIUS_KM) / 2);
+}
+
+/** Pure: the one-line summary the index row and the dossier header both print. */
+export function areaSummary(area: InspectorArea): string {
+  const on = Object.values(area.sources).filter(Boolean).length;
+  const km2 = Math.round(ringAreaKm2(area.polygon));
+  const count = on === 0 ? "No sources" : on === 1 ? "1 source" : `${on} sources`;
+  return `${count} · ${km2.toLocaleString("en-GB")} km²`;
+}
+
 // --- store ------------------------------------------------------------------
 
 let state: InspectorState = { ...EMPTY };

--- a/lib/shell/inspector.ts
+++ b/lib/shell/inspector.ts
@@ -262,10 +262,19 @@ export function areaSummary(area: InspectorArea): string {
 let state: InspectorState = { ...EMPTY };
 const listeners = new Set<() => void>();
 
+/** Nothing persists before hydrate() has read what is already saved. See commit(). */
+let hydrated = false;
+
 function commit(next: InspectorState) {
   state = next;
   for (const l of listeners) l();
-  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+  // THE GATE IS LOAD-BEARING. variantStore.bootstrap() runs BEFORE hydrate() by
+  // design, and it writes World through this store (layersStore.applyExact and
+  // signalsStore.applyExact are views onto the loaded context). Persisting that
+  // write would save the pre-hydrate state — areas: [] — over the user's saved
+  // areas, and the hydrate that follows then reads back the file it just
+  // destroyed. Measured on a preview: one reload emptied the Inspector.
+  if (hydrated) savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
 }
 
 export const inspectorStore = {
@@ -296,6 +305,8 @@ export const inspectorStore = {
    */
   hydrate() {
     const saved = coerceState(loadPersisted<InspectorState>(PERSIST_KEY, PERSIST_VERSION));
+    // Read BEFORE the gate opens, write after: from here on every change persists.
+    hydrated = true;
     commit({ ...saved, world: state.world });
   },
 

--- a/lib/signals/store.ts
+++ b/lib/signals/store.ts
@@ -6,8 +6,11 @@
 //
 // Keyed by the registry source id (an arbitrary string), so adding a layer needs
 // no edit here. Like the core layers, a signal that is OFF is never fetched —
-// WorldMap mounts each signal's <SignalFeed> only while its id is on. State is
-// persisted to localStorage so a composed view survives a reload.
+// WorldMap mounts each signal's <SignalFeed> only while its id is on.
+//
+// STATE IS NOT PERSISTED HERE — see the same correction in lib/layers.ts. It
+// survives a reload as a variant override under tn.variant.v1; tn.signals.v1 is a
+// dead key.
 
 import { useSyncExternalStore } from "react";
 

--- a/lib/signals/store.ts
+++ b/lib/signals/store.ts
@@ -10,53 +10,60 @@
 // persisted to localStorage so a composed view survives a reload.
 
 import { useSyncExternalStore } from "react";
-import { loadPersisted, savePersisted } from "@/lib/shell/persist";
 
 /** Map of signal id → on/off. A missing id reads as off (default). */
 export type SignalState = Record<string, boolean>;
 
-const PERSIST_KEY = "tn.signals.v1";
-const PERSIST_VERSION = 1;
+import { DEFAULT_STATE } from "@/lib/layers";
+import { effectiveSetMemo, inspectorStore, type SourceSet } from "@/lib/shell/inspector";
 
-let state: SignalState = {};
-const listeners = new Set<() => void>();
-
-function emit() {
-  for (const l of listeners) l();
-  savePersisted(PERSIST_KEY, PERSIST_VERSION, state);
+// Signals are the sparse half of a context's SourceSet: an id that is not present
+// reads as off, exactly as before. No projection is needed — a SourceSet IS a
+// SignalState — so this returns the context's map directly.
+//
+// It must go through the MEMOISED reader. An earlier cut of this file called
+// effectiveSet() and claimed its identity was "already stable across renders": true
+// for World, which is returned by identity, and false for an area, where the
+// always-on ids are forced into a fresh object on every call. useSignals() would have
+// looped as soon as an area loaded. Pinned by an identity assertion in
+// tests/unit/inspector-routing.test.ts.
+function current(): SignalState {
+  return effectiveSetMemo(inspectorStore.get());
 }
 
 export const signalsStore = {
   isOn(id: string): boolean {
-    return state[id] === true;
+    return current()[id] === true;
   },
   toggle(id: string) {
-    state = { ...state, [id]: !state[id] };
-    emit();
+    inspectorStore.setSource(id, !(current()[id] === true));
   },
   set(id: string, on: boolean) {
-    if ((state[id] === true) === on) return;
-    state = { ...state, [id]: on };
-    emit();
+    if ((current()[id] === true) === on) return;
+    inspectorStore.setSource(id, on);
   },
   applyExact(next: SignalState) {
-    state = { ...next };
-    emit();
+    // MERGE, never replace — the exact mirror of the note in lib/layers.ts. Layers and
+    // signals used to own separate module state, so neither could reach the other; they
+    // now project onto ONE SourceSet per context. A variant writes both (layers first,
+    // then signals, in lib/variants/store.ts), so a whole-set replace here resets every
+    // map layer to its floor a moment after the variant set it. Only the layer half is
+    // carried over; every signal id comes from `next`, so a signal absent from it still
+    // reads off, exactly as before.
+    const set: SourceSet = { ...next };
+    const cur = effectiveSetMemo(inspectorStore.get());
+    for (const k of Object.keys(DEFAULT_STATE)) {
+      if (typeof cur[k] === "boolean") set[k] = cur[k];
+    }
+    inspectorStore.replaceSources(set);
   },
-  get(): SignalState {
-    return state;
-  },
-  /** Pull persisted toggles back in. Call once, client-side, after mount. */
+  get: current,
+  /** Kept for API compatibility. inspectorStore.hydrate() owns rehydration now. */
   hydrate() {
-    const saved = loadPersisted<SignalState>(PERSIST_KEY, PERSIST_VERSION);
-    if (saved) state = { ...saved };
-    emit();
+    /* no-op */
   },
   subscribe(listener: () => void): () => void {
-    listeners.add(listener);
-    return () => {
-      listeners.delete(listener);
-    };
+    return inspectorStore.subscribe(listener);
   },
 };
 

--- a/lib/variants/store.ts
+++ b/lib/variants/store.ts
@@ -6,6 +6,7 @@ import type { OverrideDelta, PanelPlacement, Variant } from "@/lib/variants/type
 import { resolveSignals } from "@/lib/variants/resolveSignals";
 import { diffFromVariant, isEmptyDelta } from "@/lib/variants/diff";
 import { layersStore, DEFAULT_STATE, type LayerState } from "@/lib/layers";
+import { inspectorStore } from "@/lib/shell/inspector";
 import { signalsStore, type SignalState } from "@/lib/signals/store";
 import { uiStore } from "@/lib/shell/ui";
 import { cameraFilterStore } from "@/lib/cameraFilter";
@@ -57,6 +58,13 @@ function emit() { for (const l of listeners) l(); }
 
 function captureOverride() {
   if (applying) return;
+  // Only World's toggles belong to a variant. layersStore/signalsStore now project
+  // whichever source context is loaded, and they are what this is subscribed to, so
+  // without this guard every toggle made INSIDE an area — and the act of loading one
+  // — would be captured as the variant's override. Unloading would then leave the
+  // globe wearing the area's set, which is exactly the leak the contexts model
+  // exists to prevent.
+  if (inspectorStore.get().loaded !== null) return;
   const v = resolveVariant(state.activeId);
   const delta = diffFromVariant(
     { layers: layersStore.get(), signals: signalsStore.get(), theme: uiStore.get().theme },

--- a/lib/webcams/titles.ts
+++ b/lib/webcams/titles.ts
@@ -12,7 +12,9 @@
 // miss returns nothing and callers fall back to the id, which is honest — never a
 // fabricated name.
 
-import { useSyncExternalStore } from "react";
+import { useSyncExternalStore, useMemo } from "react";
+import { filterToScope } from "@/lib/scopeFilter";
+import { useScope } from "@/lib/shell/scope";
 
 export interface WebcamRow {
   id: string;
@@ -87,10 +89,20 @@ const EMPTY: WebcamRow[] = [];
 
 /** Every known webcam row, or an empty list until the first load resolves. */
 export function useWebcamDirectory(): WebcamRow[] {
-  return useSyncExternalStore(
+  const all = useSyncExternalStore(
     subscribe,
     () => rows ?? EMPTY,
     () => EMPTY,
+  );
+  const scope = useScope();
+  return useMemo(
+    () =>
+      filterToScope(all, scope, (w) =>
+        typeof w.lat === "number" && typeof w.lon === "number"
+          ? { lat: w.lat, lon: w.lon }
+          : null,
+      ),
+    [all, scope],
   );
 }
 

--- a/lib/world.ts
+++ b/lib/world.ts
@@ -8,7 +8,7 @@
 
 import type { IconKey } from "@/lib/icons/svg";
 
-export type WorldObjectKind = "camera" | "satellite" | "plane" | "webcam" | "signal" | "country";
+export type WorldObjectKind = "camera" | "satellite" | "plane" | "webcam" | "signal" | "country" | "area";
 
 export interface WorldObject {
   kind: WorldObjectKind;

--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -17,11 +17,28 @@ import { defineConfig } from "@playwright/test";
 // `vercel env run` so the value never appears in a command line either. Do NOT
 // substitute `x-vercel-oidc-token` — different header, different purpose. And
 // do not reach for disabling Deployment Protection: the control is correct.
+//
+// THE HEADER CANNOT BE USED BY A SPEC THAT ASSERTS ON THE MAP. Setting any custom
+// request header makes the browser CORS-preflight cross-origin requests, and
+// tiles.openfreemap.org — the default basemap, lib/basemaps.ts — answers 405 to
+// OPTIONS. The basemap then dies silently, and an unloaded map draws nothing, which
+// is indistinguishable from a correctly filtered one. Measured twice.
+//
+// So there is a second way in: PREVIEW_SHARE_URL, a `_vercel_share` link, which a
+// spec visits once in a beforeEach to set an auth COOKIE and sets no header at all.
+// When it is set, the header is omitted. Runs that already pass VERCEL_OIDC_TOKEN are
+// unaffected.
 const token = process.env.VERCEL_OIDC_TOKEN;
+const share = process.env.PREVIEW_SHARE_URL;
 const baseURL = process.env.PREVIEW_URL;
 
 if (!baseURL) throw new Error("PREVIEW_URL is not set");
-if (!token) throw new Error("VERCEL_OIDC_TOKEN is not set — run under `vercel env run`");
+if (!token && !share) {
+  throw new Error(
+    "no way in: set VERCEL_OIDC_TOKEN (under `vercel env run`), or PREVIEW_SHARE_URL " +
+      "for specs that assert on what the map draws",
+  );
+}
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -31,6 +48,8 @@ export default defineConfig({
   workers: 1,
   use: {
     baseURL,
-    extraHTTPHeaders: { "x-vercel-trusted-oidc-idp-token": token },
+    ...(share
+      ? {}
+      : { extraHTTPHeaders: { "x-vercel-trusted-oidc-idp-token": token as string } }),
   },
 });

--- a/tests/e2e/inspector-areas.spec.ts
+++ b/tests/e2e/inspector-areas.spec.ts
@@ -20,13 +20,19 @@ import { test, expect, type Page } from "@playwright/test";
 // 0 features cropped to 0 features would sail through a naive "fewer after loading"
 // check if the world count were never asserted.
 
-// Kharkiv, as [lon, lat] — the polygon order lib/shell/scope.ts uses.
+// The western Pacific, as [lon, lat] — the polygon order lib/shell/scope.ts uses.
+//
+// A SEISMICALLY ACTIVE box on purpose. Cropping to a quiet area (Kharkiv was the first
+// draft) proves only that the count fell, because "kept the right features" and
+// "dropped everything" both land on 0. With quakes inside it, the post-load count can
+// be checked against the features genuinely within the ring — see the last assertion.
 const RING: [number, number][] = [
-  [36.0, 49.8],
-  [36.5, 49.8],
-  [36.5, 50.2],
-  [36.0, 50.2],
+  [90, -60],
+  [180, -60],
+  [180, 70],
+  [90, 70],
 ];
+const BBOX: [number, number, number, number] = [90, -60, 180, 70];
 
 const SIGNAL = "earthquakes"; // global, keyless, and reliably non-empty
 
@@ -48,7 +54,7 @@ test.beforeEach(async ({ page }) => {
 
 async function boot(page: Page) {
   await page.addInitScript(
-    ({ ring, signal }) => {
+    ({ ring, box, signal }) => {
       // The launch sequence is a position:fixed inset:0 layer; without this stamp a
       // click lands on the plate instead of the control under it. Copied from
       // map-rail.spec.ts for the reason stated there.
@@ -70,9 +76,9 @@ async function boot(page: Page) {
             areas: [
               {
                 id: "area:1",
-                label: "Kharkiv",
+                label: "West Pacific",
                 polygon: ring,
-                bbox: [36.0, 49.8, 36.5, 50.2],
+                bbox: box,
                 createdAt: 1,
                 sources: { [signal]: true },
               },
@@ -81,7 +87,7 @@ async function boot(page: Page) {
         }),
       );
     },
-    { ring: RING, signal: SIGNAL },
+    { ring: RING, box: BBOX, signal: SIGNAL },
   );
 }
 
@@ -140,9 +146,30 @@ test("the Inspector lists a saved area, and loading it crops the map", async ({ 
     .toBeGreaterThan(0);
   const worldCount = await drawnSignals(page);
 
+  // What SHOULD survive: the world features whose position falls in the ring. The ring
+  // is a rectangle, so point-in-polygon and the bbox test are the same predicate here.
+  const insideCount = await page.evaluate(([w, s, e, n]) => {
+    const map = (window as unknown as { __map?: unknown }).__map as {
+      getSource: (id: string) => { serialize?: () => { data?: { features?: unknown[] } } } | undefined;
+    };
+    const features = (map.getSource("signals")?.serialize?.().data?.features ?? []) as {
+      geometry?: { type?: string; coordinates?: [number, number] };
+    }[];
+    let k = 0;
+    for (const f of features) {
+      if (f.geometry?.type !== "Point") continue;
+      const [lon, lat] = f.geometry.coordinates as [number, number];
+      if (lon >= w && lon <= e && lat >= s && lat <= n) k++;
+    }
+    return k;
+  }, BBOX);
+  // PRECONDITION 3 — the area is not empty, or "cropped" and "wiped" look identical.
+  expect(insideCount).toBeGreaterThan(0);
+  expect(insideCount).toBeLessThan(worldCount);
+
   await page.getByRole("tab", { name: "Inspector" }).click();
   await expect(page.locator(".tn-insp-row")).toHaveCount(1);
-  await expect(page.locator(".tn-insp-label")).toHaveText("Kharkiv");
+  await expect(page.locator(".tn-insp-label")).toHaveText("West Pacific");
   // Nothing is loaded yet, so no row carries the pill.
   await expect(page.locator(".tn-insp-pill", { hasText: "LOADED" })).toHaveCount(0);
 
@@ -152,14 +179,16 @@ test("the Inspector lists a saved area, and loading it crops the map", async ({ 
   await page.getByRole("button", { name: "Load this area" }).click();
 
   await expect(page.locator(".tn-insp-pill", { hasText: "LOADED" })).toHaveCount(1);
-  await expect(page.locator(".tn-ctxbar")).toHaveText(/Kharkiv/);
+  await expect(page.locator(".tn-ctxbar")).toHaveText(/West Pacific/);
 
-  // THE CLAIM. Kharkiv holds a small fraction of the world's earthquakes, so the
-  // drawn count must fall. Strictly fewer, not merely different.
+  // THE CLAIM, and it is an equality rather than an inequality: the map must end up
+  // drawing EXACTLY the features inside the ring. "Fewer than before" would also pass
+  // on a build that simply drops everything.
   await expect
     .poll(() => drawnSignals(page), {
-      message: `the map still draws ${worldCount} features after loading an area — it did not crop`,
+      message: `the map draws neither ${worldCount} (uncropped) nor ${insideCount} ` +
+        "(the features inside the ring) after loading the area",
       timeout: 30_000,
     })
-    .toBeLessThan(worldCount);
+    .toBe(insideCount);
 });

--- a/tests/e2e/inspector-areas.spec.ts
+++ b/tests/e2e/inspector-areas.spec.ts
@@ -5,19 +5,20 @@ import { test, expect, type Page } from "@playwright/test";
 //
 // WHY THE PRECONDITIONS ARE HALF THIS FILE. The central claim — "loading an area
 // crops the map" — has a failure mode that looks exactly like a pass. If the basemap
-// never loads, the map draws nothing, and "nothing drawn" is indistinguishable in a
-// screenshot from "perfectly cropped". A run using the repo's
-// playwright.preview.config.ts hits that: its context-level extraHTTPHeaders
-// CORS-preflights tiles.openfreemap.org, which answers 405 to any OPTIONS, and the
-// basemap dies silently. So this file asserts, before it asserts anything else:
+// never loads, the map draws nothing, and "nothing drawn" is indistinguishable from
+// "perfectly cropped". A run using the repo's playwright.preview.config.ts hits that:
+// its context-level extraHTTPHeaders CORS-preflights tiles.openfreemap.org, which
+// answers 405 to any OPTIONS, and the basemap dies silently. Reach a protected
+// preview with a _vercel_share COOKIE instead — see PREVIEW_SHARE_URL below.
+//
+// So this file asserts, before it asserts anything else:
 //
 //   1. at least one 200 from the tile host — the basemap is really up;
 //   2. the world count is greater than zero — there is something to crop.
 //
-// Without (2) the test passes on a build where the signal layer is simply broken,
-// which is the vacuous-assertion trap: 0 < 0 is false, but 0 features cropped to 0
-// features would sail through a naive "fewer after loading" check if the world count
-// were never checked.
+// Without (2) the test passes on a build where the signal layer is simply broken:
+// 0 features cropped to 0 features would sail through a naive "fewer after loading"
+// check if the world count were never asserted.
 
 // Kharkiv, as [lon, lat] — the polygon order lib/shell/scope.ts uses.
 const RING: [number, number][] = [
@@ -29,6 +30,22 @@ const RING: [number, number][] = [
 
 const SIGNAL = "earthquakes"; // global, keyless, and reliably non-empty
 
+// lib/basemaps.ts: DEFAULT_BASEMAP is "streets", whose style is
+// tiles.openfreemap.org/styles/liberty. Measured against a preview: 200s arrive from
+// this host and none from basemaps.cartocdn.com, which only serves the dark variant.
+const TILE_HOST = "tiles.openfreemap.org";
+
+// Reaching a protection-enabled preview WITHOUT setting a request header, because a
+// header is what CORS-preflights the tile host and silently kills the basemap.
+// PREVIEW_SHARE_URL is a _vercel_share link; visiting it once sets the auth cookie
+// for the rest of the run. Unset (a local run, or an unprotected deployment) this is
+// a no-op.
+const SHARE_URL = process.env.PREVIEW_SHARE_URL;
+
+test.beforeEach(async ({ page }) => {
+  if (SHARE_URL) await page.goto(SHARE_URL, { waitUntil: "domcontentloaded" });
+});
+
 async function boot(page: Page) {
   await page.addInitScript(
     ({ ring, signal }) => {
@@ -39,23 +56,10 @@ async function boot(page: Page) {
         "tn.terminal.boot.v1",
         JSON.stringify({ v: 1, d: { seenVersion: 1 } }),
       );
-      // World's source set belongs to the VARIANT spine, not to this store — see
-      // inspectorStore.hydrate. So the signal is switched on the way a user's own
-      // toggle persists: as a captured override under tn.variant.v1. Seeding it in
-      // tn.inspector.v1 would be silently discarded on boot, which is what the
-      // first run of this spec discovered.
-      window.localStorage.setItem(
-        "tn.variant.v1",
-        JSON.stringify({
-          v: 1,
-          d: {
-            activeId: "explore",
-            userVariants: [],
-            overrides: { explore: { signals: { [signal]: true } } },
-            layoutOverrides: {},
-          },
-        }),
-      );
+      // Only the AREAS are seeded. World's set belongs to the variant spine, not to
+      // this store — see inspectorStore.hydrate — and seeding tn.variant.v1 to switch
+      // the signal on was measured NOT to take. The test toggles it through the rail
+      // instead, which is the path a user actually takes.
       window.localStorage.setItem(
         "tn.inspector.v1",
         JSON.stringify({
@@ -95,7 +99,7 @@ function drawnSignals(page: Page): Promise<number> {
 test("the Inspector lists a saved area, and loading it crops the map", async ({ page }) => {
   const tileStatuses: number[] = [];
   page.on("response", (r) => {
-    if (r.url().includes("tiles.openfreemap.org")) tileStatuses.push(r.status());
+    if (r.url().includes(TILE_HOST)) tileStatuses.push(r.status());
   });
 
   await boot(page);
@@ -106,26 +110,35 @@ test("the Inspector lists a saved area, and loading it crops the map", async ({ 
   // mistaken for "cropped".
   await expect
     .poll(() => tileStatuses.filter((s) => s === 200).length, {
-      message: "no 200 from tiles.openfreemap.org — the basemap never loaded, so no " +
-        "claim about what the map draws can be trusted",
-      timeout: 45_000,
+      message: `no 200 from ${TILE_HOST} — the basemap never loaded, so no claim ` +
+        "about what the map draws can be trusted",
+      timeout: 60_000,
     })
     .toBeGreaterThan(0);
-
-  // PRECONDITION 2 — the world context is drawing real features.
-  await expect
-    .poll(() => drawnSignals(page), {
-      message: "the signal source never filled under World — nothing to crop",
-      timeout: 45_000,
-    })
-    .toBeGreaterThan(0);
-  const worldCount = await drawnSignals(page);
 
   await page.keyboard.press("ControlOrMeta+k");
   await expect(page.locator(".tn-rail")).toBeVisible();
 
   // The context bar is rendered in BOTH tabs and names what a toggle would write.
-  await expect(page.locator(".tn-ctxbar")).toBeVisible();
+  await expect(page.locator(".tn-ctxbar")).toHaveText(/World/);
+
+  // Switch the signal on for WORLD, through the rail. The row carries its own id, and
+  // the switch is .tn-src-toggle — .tn-src-label only opens the provenance popover.
+  await page.getByRole("tab", { name: "Sources" }).click();
+  await page.getByLabel("Search sources").fill("earthquake");
+  const row = page.locator(`[data-source-row="${SIGNAL}"]`);
+  await expect(row).toHaveCount(1);
+  if ((await row.getAttribute("data-on")) !== "true") await row.locator(".tn-src-toggle").click();
+  await expect(row).toHaveAttribute("data-on", "true");
+
+  // PRECONDITION 2 — the world context is drawing real features.
+  await expect
+    .poll(() => drawnSignals(page), {
+      message: "the signal source never filled under World — nothing to crop",
+      timeout: 90_000,
+    })
+    .toBeGreaterThan(0);
+  const worldCount = await drawnSignals(page);
 
   await page.getByRole("tab", { name: "Inspector" }).click();
   await expect(page.locator(".tn-insp-row")).toHaveCount(1);
@@ -139,6 +152,7 @@ test("the Inspector lists a saved area, and loading it crops the map", async ({ 
   await page.getByRole("button", { name: "Load this area" }).click();
 
   await expect(page.locator(".tn-insp-pill", { hasText: "LOADED" })).toHaveCount(1);
+  await expect(page.locator(".tn-ctxbar")).toHaveText(/Kharkiv/);
 
   // THE CLAIM. Kharkiv holds a small fraction of the world's earthquakes, so the
   // drawn count must fall. Strictly fewer, not merely different.

--- a/tests/e2e/inspector-areas.spec.ts
+++ b/tests/e2e/inspector-areas.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The Inspector, end to end: the tab renders a saved area, and LOADING one actually
+// crops the map.
+//
+// WHY THE PRECONDITIONS ARE HALF THIS FILE. The central claim — "loading an area
+// crops the map" — has a failure mode that looks exactly like a pass. If the basemap
+// never loads, the map draws nothing, and "nothing drawn" is indistinguishable in a
+// screenshot from "perfectly cropped". A run using the repo's
+// playwright.preview.config.ts hits that: its context-level extraHTTPHeaders
+// CORS-preflights tiles.openfreemap.org, which answers 405 to any OPTIONS, and the
+// basemap dies silently. So this file asserts, before it asserts anything else:
+//
+//   1. at least one 200 from the tile host — the basemap is really up;
+//   2. the world count is greater than zero — there is something to crop.
+//
+// Without (2) the test passes on a build where the signal layer is simply broken,
+// which is the vacuous-assertion trap: 0 < 0 is false, but 0 features cropped to 0
+// features would sail through a naive "fewer after loading" check if the world count
+// were never checked.
+
+// Kharkiv, as [lon, lat] — the polygon order lib/shell/scope.ts uses.
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+const SIGNAL = "earthquakes"; // global, keyless, and reliably non-empty
+
+async function boot(page: Page) {
+  await page.addInitScript(
+    ({ ring, signal }) => {
+      // The launch sequence is a position:fixed inset:0 layer; without this stamp a
+      // click lands on the plate instead of the control under it. Copied from
+      // map-rail.spec.ts for the reason stated there.
+      window.localStorage.setItem(
+        "tn.terminal.boot.v1",
+        JSON.stringify({ v: 1, d: { seenVersion: 1 } }),
+      );
+      window.localStorage.setItem(
+        "tn.inspector.v1",
+        JSON.stringify({
+          v: 1,
+          d: {
+            world: { [signal]: true },
+            loaded: null,
+            areas: [
+              {
+                id: "area:1",
+                label: "Kharkiv",
+                polygon: ring,
+                bbox: [36.0, 49.8, 36.5, 50.2],
+                createdAt: 1,
+                sources: { [signal]: true },
+              },
+            ],
+          },
+        }),
+      );
+    },
+    { ring: RING, signal: SIGNAL },
+  );
+}
+
+/** Features currently in the aggregated signal source — what the map is really drawing. */
+function drawnSignals(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const map = (window as unknown as { __map?: unknown }).__map as
+      | { getSource: (id: string) => { serialize?: () => { data?: { features?: unknown[] } } } | undefined }
+      | undefined;
+    const data = map?.getSource("signals")?.serialize?.().data;
+    return Array.isArray(data?.features) ? data.features.length : -1;
+  });
+}
+
+test("the Inspector lists a saved area, and loading it crops the map", async ({ page }) => {
+  const tileStatuses: number[] = [];
+  page.on("response", (r) => {
+    if (r.url().includes("tiles.openfreemap.org")) tileStatuses.push(r.status());
+  });
+
+  await boot(page);
+  await page.goto("/app");
+  await expect(page.locator(".map-canvas")).toHaveCount(1);
+
+  // PRECONDITION 1 — the basemap is genuinely up, so "nothing drawn" cannot be
+  // mistaken for "cropped".
+  await expect
+    .poll(() => tileStatuses.filter((s) => s === 200).length, {
+      message: "no 200 from tiles.openfreemap.org — the basemap never loaded, so no " +
+        "claim about what the map draws can be trusted",
+      timeout: 45_000,
+    })
+    .toBeGreaterThan(0);
+
+  // PRECONDITION 2 — the world context is drawing real features.
+  await expect
+    .poll(() => drawnSignals(page), {
+      message: "the signal source never filled under World — nothing to crop",
+      timeout: 45_000,
+    })
+    .toBeGreaterThan(0);
+  const worldCount = await drawnSignals(page);
+
+  await page.keyboard.press("ControlOrMeta+k");
+  await expect(page.locator(".tn-rail")).toBeVisible();
+
+  // The context bar is rendered in BOTH tabs and names what a toggle would write.
+  await expect(page.locator(".tn-ctxbar")).toBeVisible();
+
+  await page.getByRole("tab", { name: "Inspector" }).click();
+  await expect(page.locator(".tn-insp-row")).toHaveCount(1);
+  await expect(page.locator(".tn-insp-label")).toHaveText("Kharkiv");
+  // Nothing is loaded yet, so no row carries the pill.
+  await expect(page.locator(".tn-insp-pill", { hasText: "LOADED" })).toHaveCount(0);
+
+  // Open the dossier from the index row, and load from there.
+  await page.locator(".tn-insp-row").click();
+  await expect(page.getByRole("button", { name: "Load this area" })).toBeVisible();
+  await page.getByRole("button", { name: "Load this area" }).click();
+
+  await expect(page.locator(".tn-insp-pill", { hasText: "LOADED" })).toHaveCount(1);
+
+  // THE CLAIM. Kharkiv holds a small fraction of the world's earthquakes, so the
+  // drawn count must fall. Strictly fewer, not merely different.
+  await expect
+    .poll(() => drawnSignals(page), {
+      message: `the map still draws ${worldCount} features after loading an area — it did not crop`,
+      timeout: 30_000,
+    })
+    .toBeLessThan(worldCount);
+});

--- a/tests/e2e/inspector-areas.spec.ts
+++ b/tests/e2e/inspector-areas.spec.ts
@@ -39,12 +39,29 @@ async function boot(page: Page) {
         "tn.terminal.boot.v1",
         JSON.stringify({ v: 1, d: { seenVersion: 1 } }),
       );
+      // World's source set belongs to the VARIANT spine, not to this store — see
+      // inspectorStore.hydrate. So the signal is switched on the way a user's own
+      // toggle persists: as a captured override under tn.variant.v1. Seeding it in
+      // tn.inspector.v1 would be silently discarded on boot, which is what the
+      // first run of this spec discovered.
+      window.localStorage.setItem(
+        "tn.variant.v1",
+        JSON.stringify({
+          v: 1,
+          d: {
+            activeId: "explore",
+            userVariants: [],
+            overrides: { explore: { signals: { [signal]: true } } },
+            layoutOverrides: {},
+          },
+        }),
+      );
       window.localStorage.setItem(
         "tn.inspector.v1",
         JSON.stringify({
           v: 1,
           d: {
-            world: { [signal]: true },
+            world: {},
             loaded: null,
             areas: [
               {

--- a/tests/unit/inspector-boot-order.test.ts
+++ b/tests/unit/inspector-boot-order.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { inspectorStore } from "@/lib/shell/inspector";
+import { signalsStore } from "@/lib/signals/store";
+
+// ConsoleShell's boot order, without React.
+//
+// variantStore.bootstrap() runs BEFORE inspectorStore.hydrate(), and that is
+// deliberate — with an area loaded, bootstrap's writes would otherwise land on the
+// AREA and replace the user's configuration with the variant's layers. But the order
+// has a second edge, and it destroys data in the other direction: bootstrap writes
+// World THROUGH this store, so an unguarded commit persists the pre-hydrate state —
+// areas: [] — over the saved areas, and the hydrate that follows reads back the file
+// it just destroyed. Measured on a preview: one reload emptied the Inspector.
+//
+// This lives in its own file because the gate is module state that hydrate() opens
+// once. Vitest isolates per file, so the store here is genuinely un-hydrated — which
+// is the whole condition under test.
+
+const KEY = "tn.inspector.v1";
+
+const SAVED = {
+  v: 1,
+  d: {
+    world: {},
+    loaded: null,
+    areas: [
+      {
+        id: "area:1",
+        label: "Kharkiv",
+        polygon: [
+          [36.0, 49.8],
+          [36.5, 49.8],
+          [36.5, 50.2],
+          [36.0, 50.2],
+        ],
+        createdAt: 1,
+        sources: { earthquakes: true },
+      },
+    ],
+  },
+};
+
+function fakeWindow(store: Map<string, string>) {
+  return {
+    localStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    },
+  };
+}
+
+describe("inspector boot order", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = new Map([[KEY, JSON.stringify(SAVED)]]);
+    // lib/shell/persist.ts resolves window at CALL time, so installing it here is
+    // enough — no import-order games needed.
+    (globalThis as { window?: unknown }).window = fakeWindow(store);
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it("keeps saved areas when the variant spine writes World before hydrate", () => {
+    // What variantStore.bootstrap() does on every boot, before hydrate() runs.
+    signalsStore.applyExact({ wildfires: true });
+
+    inspectorStore.hydrate();
+
+    const areas = inspectorStore.get().areas;
+    expect(areas).toHaveLength(1);
+    expect(areas[0]?.label).toBe("Kharkiv");
+    expect(areas[0]?.sources).toEqual({ earthquakes: true });
+  });
+
+  it("persists again once hydrate has run", () => {
+    inspectorStore.hydrate();
+    inspectorStore.rename("area:1", "Kharkiv Oblast");
+
+    const written = JSON.parse(store.get(KEY) as string);
+    expect(written.d.areas[0].label).toBe("Kharkiv Oblast");
+  });
+});

--- a/tests/unit/inspector-labels.test.ts
+++ b/tests/unit/inspector-labels.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { areaSummary, ringAreaKm2, type InspectorArea } from "@/lib/shell/inspector";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+const AREA: InspectorArea = {
+  id: "area:1",
+  label: "Kharkiv corridor",
+  polygon: RING,
+  bbox: [36, 49.8, 36.5, 50.2],
+  createdAt: 1,
+  sources: { planes: true, conflict: true },
+};
+
+test("ringAreaKm2 is within 5% of the true spherical area of a known box", () => {
+  // 0.5deg lon x 0.4deg lat at ~50N. Reference computed from the spherical excess
+  // formula: ~35.8km x 44.5km = ~1,593 km2.
+  const km2 = ringAreaKm2(RING);
+  expect(km2).toBeGreaterThan(1_500);
+  expect(km2).toBeLessThan(1_700);
+});
+
+test("ringAreaKm2 refuses a degenerate ring rather than returning a fake number", () => {
+  expect(ringAreaKm2([[0, 0], [1, 1]])).toBe(0);
+});
+
+test("areaSummary counts the sources actually on, not the keys present", () => {
+  expect(areaSummary({ ...AREA, sources: { planes: true, conflict: false } })).toMatch(/^1 source /);
+});
+
+test("areaSummary pluralises and rounds", () => {
+  expect(areaSummary(AREA)).toMatch(/^2 sources · [\d,]+ km²$/);
+});
+
+test("areaSummary states zero honestly rather than hiding it", () => {
+  expect(areaSummary({ ...AREA, sources: {} })).toMatch(/^No sources · /);
+});

--- a/tests/unit/inspector-routing.test.ts
+++ b/tests/unit/inspector-routing.test.ts
@@ -11,8 +11,13 @@ const RING: [number, number][] = [
 ];
 
 beforeEach(() => {
-  // A clean store between tests — hydrate with nothing persisted resets to empty.
+  // A clean store between tests. hydrate() alone is NOT a reset any more: it
+  // deliberately preserves World, because the variant spine owns that half and
+  // re-derives it on every boot. So World is cleared explicitly — with nothing
+  // loaded, replaceSources writes World.
   inspectorStore.hydrate();
+  inspectorStore.load(null);
+  inspectorStore.replaceSources({});
 });
 
 test("with nothing loaded, layersStore reads World and matches today's defaults", () => {
@@ -124,4 +129,40 @@ test("the two stores share one map and must not wipe each other's half", () => {
   layersStore.applyExact({ ...DEFAULT_STATE, planes: false });
   expect(signalsStore.isOn("conflict-coverage")).toBe(true);
   expect(layersStore.get().planes).toBe(false);
+});
+
+// --- the two the BROWSER found, that no unit test could have --------------------
+
+test("hydrate restores areas but leaves World to the variant spine", () => {
+  // variantStore.bootstrap is, in its own words, the ONLY load-time hydration path:
+  // it re-derives World's whole set on every boot. If this store restored World too
+  // there would be two owners for one piece of state, and the loser was the user:
+  // with an area loaded, bootstrap's writes landed on the AREA and one reload
+  // replaced its sources with the variant's layers. Measured on a preview.
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  layersStore.set("planes", false);
+  const worldBefore = { ...inspectorStore.get().world };
+  inspectorStore.hydrate();
+  expect(inspectorStore.get().world).toEqual(worldBefore);
+  // The area is gone because nothing is persisted in this environment — the point
+  // is only that World was NOT reset out from under the variant.
+  expect(inspectorStore.get().areas.some((a) => a.id === id)).toBe(false);
+});
+
+test("a toggle inside an area is not captured as the variant's override", async () => {
+  const { variantStore } = await import("@/lib/variants/store");
+  // bootstrap is what SUBSCRIBES captureOverride. Without this call nothing is
+  // listening and the assertion below passes whatever the guard does — which is
+  // exactly what the first cut of this test did.
+  variantStore.bootstrap(new URLSearchParams(""));
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  const before = JSON.stringify(variantStore.get().overrides);
+  layersStore.set("planes", true);
+  signalsStore.set("earthquakes", true);
+  // layersStore/signalsStore project the LOADED context and are what captureOverride
+  // subscribes to. Without the guard, an area's set is written into the variant's
+  // override and unloading leaves the globe wearing the area's toggles — the exact
+  // leak the contexts model exists to prevent.
+  expect(JSON.stringify(variantStore.get().overrides)).toBe(before);
 });

--- a/tests/unit/inspector-routing.test.ts
+++ b/tests/unit/inspector-routing.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, expect, test } from "vitest";
+import { inspectorStore } from "@/lib/shell/inspector";
+import { DEFAULT_STATE, layersStore } from "@/lib/layers";
+import { signalsStore } from "@/lib/signals/store";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+beforeEach(() => {
+  // A clean store between tests — hydrate with nothing persisted resets to empty.
+  inspectorStore.hydrate();
+});
+
+test("with nothing loaded, layersStore reads World and matches today's defaults", () => {
+  expect(layersStore.get()).toEqual(DEFAULT_STATE);
+});
+
+test("a layer toggle while World is loaded writes World, not an area", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  layersStore.set("planes", false);
+  expect(inspectorStore.get().world.planes).toBe(false);
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.planes).toBeUndefined();
+});
+
+test("a layer toggle while an area is loaded writes the area and leaves World alone", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  layersStore.set("planes", false); // World: planes off
+  inspectorStore.load(id);
+  layersStore.set("planes", true); // area: planes on
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.planes).toBe(true);
+  expect(inspectorStore.get().world.planes).toBe(false);
+});
+
+test("unloading restores World's set exactly", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  layersStore.set("satellites", false);
+  const world = { ...layersStore.get() };
+  inspectorStore.load(id);
+  layersStore.set("satellites", true);
+  inspectorStore.load(null);
+  expect(layersStore.get()).toEqual(world);
+});
+
+test("an area forces cameras and webcams on however its own set reads", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  layersStore.set("cameras", false);
+  layersStore.set("webcams", false);
+  expect(layersStore.get().cameras).toBe(true);
+  expect(layersStore.get().webcams).toBe(true);
+});
+
+test("World keeps webcams opt-in — the always-on rule is areas only", () => {
+  expect(layersStore.get().webcams).toBe(false);
+});
+
+test("signalsStore routes the same way", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  signalsStore.set("earthquakes", true);
+  inspectorStore.load(id);
+  expect(signalsStore.isOn("earthquakes")).toBe(false);
+  signalsStore.set("conflict", true);
+  expect(signalsStore.isOn("conflict")).toBe(true);
+  inspectorStore.load(null);
+  expect(signalsStore.isOn("earthquakes")).toBe(true);
+  expect(signalsStore.isOn("conflict")).toBe(false);
+});
+
+test("applyPreset writes the loaded area, not World", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  layersStore.applyPreset("air-space");
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.planes).toBe(true);
+  expect(inspectorStore.get().world.planes).toBeUndefined();
+});
+
+// --- the two the first cut got wrong ----------------------------------------
+
+test("an empty area reads every layer OFF except the always-on pair", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  // A new area starts with an empty set. DEFAULT_STATE is World's floor, not an
+  // area's — flooring an area with it would silently hand the user a context they
+  // never configured, and would drift again the day a default flips.
+  expect(layersStore.get()).toEqual({
+    cameras: true, // always-on
+    webcams: true, // always-on
+    satellites: false,
+    planes: false,
+    ships: false,
+    weather: false,
+    countries: false,
+  });
+});
+
+test("get() is identity-stable while an area is loaded — a fresh object per call loops React", () => {
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.load(id);
+  // effectiveSet() FORCES the always-on ids in, so it builds a new object every
+  // call. useSyncExternalStore compares snapshots by identity: returning a new one
+  // per render is the documented infinite-loop bug, and there are no component
+  // tests in this repo to catch it. World never showed it — it returns state.world
+  // by identity — so this only bites once an area loads.
+  expect(layersStore.get()).toBe(layersStore.get());
+  expect(signalsStore.get()).toBe(signalsStore.get());
+});
+
+test("the two stores share one map and must not wipe each other's half", () => {
+  // Layers and signals used to own separate module state, so neither applyExact
+  // could reach the other. They now project onto ONE SourceSet per context, which
+  // makes a whole-set replace from either side destructive. A variant writes both
+  // (lib/variants/store.ts applies layers, then signals) so whichever runs second
+  // would silently reset the first — caught by tests/unit/variants-store.test.ts.
+  layersStore.applyExact({ ...DEFAULT_STATE, satellites: false });
+  signalsStore.applyExact({ "conflict-coverage": true });
+  expect(layersStore.get().satellites).toBe(false);
+  expect(signalsStore.isOn("conflict-coverage")).toBe(true);
+
+  // ...and the mirror: a layer preset must not switch every signal layer off.
+  layersStore.applyExact({ ...DEFAULT_STATE, planes: false });
+  expect(signalsStore.isOn("conflict-coverage")).toBe(true);
+  expect(layersStore.get().planes).toBe(false);
+});

--- a/tests/unit/inspector-store.test.ts
+++ b/tests/unit/inspector-store.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "vitest";
+import {
+  AREA_CAP,
+  ALWAYS_ON_SOURCES,
+  activeSet,
+  addArea,
+  coerceState,
+  effectiveSet,
+  newArea,
+  removeArea,
+  renameArea,
+  replaceActive,
+  writeActive,
+  type InspectorArea,
+  type InspectorState,
+} from "@/lib/shell/inspector";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+function area(id: string, createdAt = 1): InspectorArea {
+  return { id, label: id, polygon: RING, bbox: [36, 49.8, 36.5, 50.2], createdAt, sources: {} };
+}
+
+function state(partial: Partial<InspectorState> = {}): InspectorState {
+  return { world: {}, areas: [], loaded: null, ...partial };
+}
+
+test("newArea derives a bbox and keeps the ring open", () => {
+  const a = newArea(RING, "Kharkiv corridor", 1788744123456);
+  expect(a).not.toBeNull();
+  expect(a!.bbox).toEqual([36, 49.8, 36.5, 50.2]);
+  expect(a!.polygon).toHaveLength(4);
+  expect(a!.label).toBe("Kharkiv corridor");
+  expect(a!.sources).toEqual({});
+});
+
+test("newArea refuses a ring that is not an area", () => {
+  expect(newArea([[0, 0], [1, 1]], "line", 1)).toBeNull();
+  expect(newArea([], "empty", 1)).toBeNull();
+});
+
+test("addArea puts the newest first and dedupes by id", () => {
+  const list = addArea(addArea([], area("a")), area("b"));
+  expect(list.map((x) => x.id)).toEqual(["b", "a"]);
+  const again = addArea(list, { ...area("a"), label: "renamed" });
+  expect(again.map((x) => x.id)).toEqual(["a", "b"]);
+  expect(again[0].label).toBe("renamed");
+});
+
+test("addArea caps the list, dropping the oldest", () => {
+  let list: InspectorArea[] = [];
+  for (let i = 0; i < AREA_CAP + 5; i++) list = addArea(list, area(`a${i}`, i));
+  expect(list).toHaveLength(AREA_CAP);
+  expect(list[0].id).toBe(`a${AREA_CAP + 4}`);
+});
+
+test("removeArea and renameArea are pure and by id", () => {
+  const list = addArea(addArea([], area("a")), area("b"));
+  expect(removeArea(list, "a").map((x) => x.id)).toEqual(["b"]);
+  expect(renameArea(list, "b", "Gulf of Aden")[0].label).toBe("Gulf of Aden");
+  expect(list[0].label).toBe("b"); // original untouched
+});
+
+test("activeSet returns World's set when nothing is loaded", () => {
+  const s = state({ world: { cameras: true }, areas: [area("a")], loaded: null });
+  expect(activeSet(s)).toEqual({ cameras: true });
+});
+
+test("activeSet returns the loaded area's own set", () => {
+  const a = { ...area("a"), sources: { planes: true } };
+  expect(activeSet(state({ world: { cameras: true }, areas: [a], loaded: "a" }))).toEqual({ planes: true });
+});
+
+test("a loaded id that no longer exists falls back to World", () => {
+  const s = state({ world: { cameras: true }, areas: [], loaded: "gone" });
+  expect(activeSet(s)).toEqual({ cameras: true });
+});
+
+test("effectiveSet forces the always-on sources on inside an area", () => {
+  const a = { ...area("a"), sources: { planes: true } };
+  const eff = effectiveSet(state({ areas: [a], loaded: "a" }));
+  for (const id of ALWAYS_ON_SOURCES) expect(eff[id]).toBe(true);
+  expect(eff.planes).toBe(true);
+});
+
+test("effectiveSet leaves World alone — webcams stays opt-in on the globe", () => {
+  const eff = effectiveSet(state({ world: { cameras: true } }));
+  expect(eff).toEqual({ cameras: true });
+  expect(eff.webcams).toBeUndefined();
+});
+
+test("writeActive lands on the loaded area and leaves World untouched", () => {
+  const a = area("a");
+  const s = state({ world: { cameras: true }, areas: [a], loaded: "a" });
+  const next = writeActive(s, "planes", true);
+  expect(next.areas[0].sources).toEqual({ planes: true });
+  expect(next.world).toEqual({ cameras: true });
+});
+
+test("writeActive lands on World when nothing is loaded", () => {
+  const next = writeActive(state({ world: {} }), "planes", true);
+  expect(next.world).toEqual({ planes: true });
+});
+
+test("replaceActive swaps the whole set for the loaded context only", () => {
+  const a = { ...area("a"), sources: { planes: true } };
+  const s = state({ world: { cameras: true }, areas: [a], loaded: "a" });
+  const next = replaceActive(s, { ships: true });
+  expect(next.areas[0].sources).toEqual({ ships: true });
+  expect(next.world).toEqual({ cameras: true });
+});
+
+test("coerceState turns junk into a valid empty state", () => {
+  expect(coerceState(null)).toEqual({ world: {}, areas: [], loaded: null });
+  expect(coerceState("nonsense")).toEqual({ world: {}, areas: [], loaded: null });
+  expect(coerceState({ areas: "no" })).toEqual({ world: {}, areas: [], loaded: null });
+});
+
+test("coerceState drops areas whose ring is not an area, and a dangling loaded id", () => {
+  const s = coerceState({
+    world: { cameras: true, junk: "yes" },
+    areas: [
+      { id: "good", label: "Good", polygon: RING, createdAt: 1, sources: { planes: true } },
+      { id: "bad", label: "Bad", polygon: [[0, 0]], createdAt: 2, sources: {} },
+    ],
+    loaded: "bad",
+  });
+  expect(s.areas.map((a) => a.id)).toEqual(["good"]);
+  expect(s.world).toEqual({ cameras: true });
+  expect(s.loaded).toBeNull();
+});
+
+test("coerceState recomputes the bbox rather than trusting the payload", () => {
+  const s = coerceState({
+    world: {},
+    areas: [{ id: "a", label: "A", polygon: RING, bbox: [0, 0, 0, 0], createdAt: 1, sources: {} }],
+    loaded: null,
+  });
+  expect(s.areas[0].bbox).toEqual([36, 49.8, 36.5, 50.2]);
+});

--- a/tests/unit/scope-filter.test.ts
+++ b/tests/unit/scope-filter.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { filterToScope } from "@/lib/scopeFilter";
+import { aoiScope, WORLD_SCOPE } from "@/lib/shell/scope";
+
+const RING: [number, number][] = [
+  [36.0, 49.8],
+  [36.5, 49.8],
+  [36.5, 50.2],
+  [36.0, 50.2],
+];
+
+const AT = (p: { lat: number; lon: number }) => p;
+const INSIDE = { lat: 50.0, lon: 36.2 };
+const OUTSIDE = { lat: 51.5, lon: -0.1 };
+
+test("the world scope filters nothing and returns the SAME array", () => {
+  const items = [INSIDE, OUTSIDE];
+  expect(filterToScope(items, WORLD_SCOPE, AT)).toBe(items);
+});
+
+test("an aoi scope keeps only what is inside the ring", () => {
+  const out = filterToScope([INSIDE, OUTSIDE], aoiScope(RING), AT);
+  expect(out).toEqual([INSIDE]);
+});
+
+test("an item with no position is DROPPED inside an area, not silently kept", () => {
+  const out = filterToScope([INSIDE, { lat: NaN, lon: NaN }], aoiScope(RING), (p) =>
+    Number.isFinite(p.lat) ? p : null,
+  );
+  expect(out).toEqual([INSIDE]);
+});
+
+test("an item with no position is KEPT under the world scope", () => {
+  const items = [{ lat: NaN, lon: NaN }];
+  expect(filterToScope(items, WORLD_SCOPE, () => null)).toBe(items);
+});
+
+test("an empty list stays empty rather than throwing", () => {
+  expect(filterToScope([], aoiScope(RING), AT)).toEqual([]);
+});


### PR DESCRIPTION
Reworks the console's Sources rail into two tabs — **Sources** (as before) and a new
**Inspector** — and gives every saved area its own source profile.

## What it does

- **Draw an area, and it is saved.** The Inspector tab is the index: one row each,
  with its size and how many sources it carries.
- **Load an area and the whole console narrows to it** — the map, the feed, and the
  widgets that show counts. Unload and the globe is exactly as you left it.
- **An area ignores the globe's toggles and carries its own.** No inheritance: two
  areas can watch entirely different things, and neither disturbs World. Cameras and
  webcams stay on everywhere, so an area never loads to a blank map.
- **Sources are configured in one place.** The Sources tab is already pointed at
  whichever context is loaded, and a context bar in both tabs names what a toggle
  would write. The dossier's source list is deliberately read-only.
- **Clicking a country opens its dossier**, in the same right-edge panel a camera or
  a plane opens in. Inspector = index, right rail = detail.
- **Area alerts ship as a labelled, inert "coming soon" block.**

## How the state is arranged

`layersStore` and `signalsStore` become views onto one `SourceSet` per context — World,
or one per area. That is the whole feature, and it is also where the risk was: every
existing **subscriber** of those stores silently began receiving a different context's
state. Two data-destroying bugs came from exactly that, and neither `tsc` nor the unit
suite could see either one.

## Verified in a browser, because nothing else could see it

Both bugs were found by running it, and both are fixed and guarded:

1. **A reload replaced a loaded area's configuration with the variant's layers.**
   `variantStore.bootstrap()` writes World through those stores, so with an area
   loaded it wrote the variant's set into the user's area. Measured: an area seeded
   `{earthquakes, wildfires}` came back holding the variant's layers.
2. **Every reload emptied the Inspector — the mirror of the first.** Fixing the order
   meant bootstrap's write hit a `commit()` that persisted unconditionally, saving the
   pre-hydrate `areas: []` over the saved areas; the hydrate that followed read back
   the file it had just destroyed. Measured on the preview:
   `{"world":{…},"areas":[],"loaded":null}`. Now nothing persists until `hydrate()`
   has read what is already there.

`tests/unit/inspector-boot-order.test.ts` drives the real boot order against an
injected `localStorage` and fails with `expected [] to have a length of 1` when the
gate is removed — I checked it goes red, rather than trusting that it would.

**The central claim, measured:** `tests/e2e/inspector-areas.spec.ts` against the
preview — loading an area cropped the map from **193 drawn features to 11, exactly the
11 inside the ring**, computed at run time. It asserts an equality, not "fewer than
before", because a build that drops everything satisfies the inequality too — the
first ring I picked was seismically quiet and cropped 193 → 0, where "filtered" and
"wiped" look identical. Inverted, it fails `Expected: 192, Received: 11`.

`playwright.preview.config.ts` could not run a map spec at all: it sets the protection
token as a request header, and any custom header CORS-preflights
`tiles.openfreemap.org`, which answers 405 to OPTIONS — the basemap dies silently,
which is a false-positive generator for precisely this claim. It now also accepts
`PREVIEW_SHARE_URL`. Existing runs are unaffected.

## Gate

`npx tsc --noEmit` clean. **324 test files / 3,162 tests** green. The e2e spec passes
against the preview through the repo's own config.

## Deferred, with reasons in the plan

Area alerts (ships inert) and the camera tray split, which `wallpicker` has pre-agreed
and which needs its own red/green because it can strand an armed pick.

Plan and the full record of what running it found:
`docs/superpowers/plans/2026-09-07-inspector-areas.md`.
