### PR TITLE
Promise two weeks, and let a test hold us to it

### DIFF
--- a/docs/superpowers/specs/2026-09-07-maintenance-gate-design.md
+++ b/docs/superpowers/specs/2026-09-07-maintenance-gate-design.md
@@ -7,7 +7,8 @@
 ## Why
 
 Visitor volume pushed Provenance's running cost past what the project carries. The site
-comes down for about a month while a new release is built.
+comes down while the cost is fixed. The stated window on the curtain is **within two
+weeks** (revised down from "about a month" on 2026-09-07, before the gate was armed).
 
 The goal is **cost, not concealment**. A gate that hides the UI but still renders pages,
 revalidates ISR and fetches upstreams would have solved nothing. Success is measured as:
@@ -111,8 +112,10 @@ content of every one of them, and it begins dropping them. A `503` with `Retry-A
 says the absence is temporary.
 
 **It is the best signal available, not a guarantee.** Google treats 503 as "come back
-later" and slows crawling, which is correct for days. Across about a month some erosion
-is likely regardless — 503 minimises it, it does not prevent it. The cheap hedge, if the
+later" and slows crawling, which is correct for days. Across two weeks some erosion is
+likely regardless — 503 minimises it, it does not prevent it. The shorter the outage the
+smaller that risk, so the window shrinking from a month to two weeks strengthens this
+argument rather than changing it; a slip back towards a month is the case to re-read. The cheap hedge, if the
 index turns out to matter more than the saving, is to let `/` alone through as a static
 page: it costs nothing to serve and keeps one live URL for crawlers. Not built; a
 one-line change to the exempt list.

--- a/lib/gate/page.ts
+++ b/lib/gate/page.ts
@@ -231,7 +231,7 @@ export function maintenanceHtml(opts: {
     <div class="lede">
       <h1>${name} is offline</h1>
       <p>A surge in visitors pushed the running cost past what this project can carry, so the site is down for now.</p>
-      <p>A lot of feedback came in with those visitors. A new release is planned in about a month, and development updates go to the Discord.</p>
+      <p>We are working to fix this, and expect the site to be up and ready for normal use again within two weeks. Development updates go to the Discord.</p>
       <p class="pulse" id="pulse" hidden><span class="dot"></span>Still in active development &mdash; last commit <a id="pulse-link" href="${BRAND.repoUrl}/commits" rel="noopener"><span id="pulse-when"></span></a>.</p>
       <div class="ctas">
         <a class="discord" href="${BRAND.discordUrl}" rel="noopener">${DISCORD_MARK}Updates on Discord</a>

--- a/tests/unit/gate.test.ts
+++ b/tests/unit/gate.test.ts
@@ -246,9 +246,13 @@ describe("the curtain", () => {
     expect(noJs).not.toMatch(/last commit[^<]*\d/);
   });
 
-  it("says why the site is down, not just that it is", () => {
+  // Two things a visitor needs and cannot infer: WHY it is down, and WHEN it returns.
+  // The window is stated as a commitment ("within two weeks"), which is the point -
+  // if it slips, this test is the thing that makes changing the page a deliberate act
+  // rather than something everyone forgets is still on the only page the site serves.
+  it("says why the site is down and when it comes back, not just that it is down", () => {
     expect(html).toContain("running cost");
-    expect(html).toContain("about a month");
+    expect(html).toContain("two weeks");
   });
 
   it("shows a refusal only when the code was refused", () => {


### PR DESCRIPTION
Follow-on to #181. The curtain said a release was planned in **about a month**. It now says:

> A surge in visitors pushed the running cost past what this project can carry, so the site is down for now.
>
> **We are working to fix this, and expect the site to be up and ready for normal use again within two weeks.** Development updates go to the Discord.

## The window is pinned, and that is the point

The old test asserted only `"running cost"` — why it is down. This one also asserts `"two weeks"` — when it comes back.

That is not symmetry for its own sake. The window is a **commitment made to every visitor**, on the only page the site serves, and it is the kind of sentence that quietly stops being true. Pinning it means that if the date slips, changing the page is a deliberate act by whoever is looking at this test, rather than something everybody forgets is still standing there in week three.

## The design doc carried the figure twice

Once in the summary, and once inside the SEO argument — `docs/superpowers/specs/2026-09-07-maintenance-gate-design.md`. The second one is load bearing rather than decorative: the case for `503` over `200` rests on how much index erosion is tolerable across the outage.

**A shorter outage strengthens that argument rather than changing it.** Google treats 503 as "come back later" and slows crawling, which is correct for days; across two weeks some erosion is still likely, and 503 minimises it without preventing it. The note now says which direction a slip would move it, so the case gets re-read if two weeks turns back into a month.

## Gate

`npx tsc --noEmit` clean. **3,199 tests across 325 files pass.**

## Unchanged and still outstanding

**`MAINTENANCE_MODE` is set in no Vercel environment**, which is why the password appeared not to work — middleware returns `next()` on its first line without it. Arming the gate is `MAINTENANCE_MODE=1` on Production plus a redeploy.

**The Discord invite expires 2026-10-07 02:37 UTC.** Two weeks from today lands well before that, so it is less sharp than it was — but it is still the main link on this page, and Expire After: Never is a setting on Discord's side no test here can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPc6asqo4ePhWJF684Ccuz
