### PR TITLE
Warn testers what they are walking into, once

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5772,6 +5772,54 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
 .tn-fb-btn.is-ghost:hover:not(:disabled) { color: var(--tn-text); background: var(--tn-surface-2); }
 @media (prefers-reduced-motion: reduce) { .tn-fb-card { animation: none; } }
 
+/* ── The live-build warning ─────────────────────────────────────────────────
+   z-index 1200: above the feedback modal (1100) and the Discord note (1050). If
+   any two ever coincide, this is the one that has to be readable, and the z-order
+   settles it with no cross-component wiring. */
+.tn-dev { position: fixed; inset: 0; z-index: 1200; display: grid; place-items: center; padding: 16px; }
+.tn-dev-veil { position: fixed; inset: 0; background: rgba(15, 23, 42, .62); }
+.tn-dev-card {
+  position: relative; width: min(540px, 100%); max-height: calc(100vh - 32px); overflow-y: auto;
+  background: var(--tn-surface); border: 1px solid var(--tn-border); border-radius: 14px;
+  box-shadow: 0 24px 64px -28px rgba(15, 23, 42, .55);
+}
+.tn-dev-head { padding: 18px 20px 14px; border-bottom: 1px solid var(--tn-border); }
+.tn-dev-flag {
+  display: inline-block; font-size: var(--tnx-fs-xs); font-weight: 700; letter-spacing: .1em;
+  /* The "lagging" ink/tint pair, not "down": this is a caution, not a failure. Both
+     are contrast-tuned for text on a light surface (see the status INK block). */
+  text-transform: uppercase; color: var(--tn-lagging-ink); background: var(--tn-lagging-bg);
+  border-radius: 999px; padding: 3px 10px; margin-bottom: 9px;
+}
+.tn-dev-title { margin: 0; font-size: var(--tnx-fs-lg); font-weight: 700; color: var(--tn-text); }
+.tn-dev-body { padding: 16px 20px; display: flex; flex-direction: column; gap: 13px; }
+.tn-dev-lead { margin: 0; font-size: var(--tnx-fs-md); line-height: 1.55; color: var(--tn-text); }
+.tn-dev-list { margin: 0; padding-left: 18px; display: flex; flex-direction: column; gap: 9px; }
+.tn-dev-list li { font-size: var(--tnx-fs-md); line-height: 1.5; color: var(--tn-text-muted); }
+.tn-dev-list b { color: var(--tn-text); }
+.tn-dev-legal {
+  margin: 0; font-size: var(--tnx-fs-sm); line-height: 1.55; color: var(--tn-text-muted);
+  border-left: 2px solid var(--tn-border-strong); padding-left: 10px;
+}
+.tn-dev-ask { margin: 0; font-size: var(--tnx-fs-md); line-height: 1.5; color: var(--tn-text-muted); }
+/* STICKY, because the card is the scroll container. On a phone the text is taller
+   than the viewport, so a static action bar leaves "I understand" below the fold and
+   the only way out of a modal is something you have to go looking for. */
+.tn-dev-actions {
+  position: sticky; bottom: 0; background: var(--tn-surface);
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 13px 20px 16px; border-top: 1px solid var(--tn-border);
+}
+.tn-dev-btn {
+  display: inline-flex; align-items: center; gap: 7px; text-decoration: none;
+  font: inherit; font-size: var(--tnx-fs-md); font-weight: 600; padding: 8px 16px; border-radius: 8px;
+  border: 1px solid var(--tn-border-strong); background: var(--tn-surface-2); color: var(--tn-text);
+  cursor: pointer;
+}
+.tn-dev-btn.is-primary { background: var(--tn-accent); border-color: transparent; color: #fff; }
+.tn-dev-btn.is-primary:hover { background: var(--tn-accent-strong); }
+.tn-dev-btn.is-discord:hover { border-color: var(--tn-accent); color: var(--tn-accent-strong); }
+
 /* ── The Discord invitation ─────────────────────────────────────────────────
    A corner note, not a banner and not a modal: no veil, no focus trap, nothing
    behind it goes inert. It takes the console's own card surface, border and

--- a/components/shell/CommunityNote.tsx
+++ b/components/shell/CommunityNote.tsx
@@ -143,8 +143,14 @@ export default function CommunityNote() {
           </div>
           <div className="tn-note-body">
             <p className="tn-note-title">Join our Discord!</p>
+            {/* This used to lead with "say what is broken", which the live-build notice
+                (components/shell/DevNotice.tsx) now asks for directly and at much greater
+                length, on arrival. Two cards competing for the same request trains people
+                to skim both, so this one drops the duplicate and keeps the half the notice
+                does NOT cover: the people. The "new and quiet" line stays — being honest
+                that it is small reads as an invitation rather than a claim to be checked. */}
             <p className="tn-note-text">
-              Ask for a camera or a layer, say what is broken, or watch what gets built. It is
+              Join if you want to chat about the project and meet the people using it. It is
               new and quiet — come and make it less so.
             </p>
             <div className="tn-note-actions">

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -33,6 +33,7 @@ import SkipLink from "@/components/shell/SkipLink";
 import CommandPalette from "@/components/shell/CommandPalette";
 import FeedbackPrompt from "@/components/shell/FeedbackPrompt";
 import CommunityNote from "@/components/shell/CommunityNote";
+import DevNotice from "@/components/shell/DevNotice";
 import { FeedOverlay } from "@/components/FeedOverlay";
 import { CinematicDive } from "@/components/CinematicDive";
 import { scopeStore } from "@/lib/shell/scope";
@@ -336,6 +337,13 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
           Mounted AFTER FeedbackPrompt for readability only — the two are ordered by
           z-index (1050 under 1100), not by DOM position. */}
       <CommunityNote />
+      {/* Gates itself the same way (lib/shell/devnotice.ts). Mounted last and sitting
+          at z-index 1200, above both of the above: while access codes are being handed
+          out, this is the first thing a new tester sees, and it is the only place they
+          are told the data is unverified and the software unwarranted. It holds for the
+          boot plate and nothing else — a warning that waits is a warning that arrives
+          after the bug it was about. */}
+      <DevNotice />
       {/* The toast is now mounted ALWAYS, empty when idle, instead of appearing and
           disappearing with its text. A live region has to already be in the
           accessibility tree when its content changes for the change to be

--- a/components/shell/DevNotice.tsx
+++ b/components/shell/DevNotice.tsx
@@ -1,0 +1,210 @@
+"use client";
+// The live-build warning — the first thing anyone handed an access code sees, shown
+// once and then not again until its text is revised.
+//
+// IT IS A MODAL, WHERE CommunityNote NEXT DOOR IS A CORNER CARD, and the difference is
+// the design rather than an inconsistency. The invitation asks for nothing and may be
+// ignored at no cost, so it takes no veil and never moves focus. This one carries the
+// only statement anybody gets that the data is unverified and the software is
+// unwarranted, and a person who never reads it is the person the warning existed for.
+// So it takes the veil and focus trap FeedbackPrompt uses.
+//
+// Escape still closes it. A dialog with no way out is an accessibility defect, and
+// this is a notice rather than a contract — the licence it points at binds whether or
+// not anyone clicks a button, so trapping people would buy nothing legally and cost
+// real usability. Clicking the veil does NOT close it, because that is the accidental
+// dismissal, and this is the one card worth protecting from one.
+//
+// Every decision about WHETHER to show lives in lib/shell/devnotice.ts as pure
+// functions over an injectable store, unit-tested in the node environment. This file
+// is the thin shell: a hold, a card, two controls.
+//
+// z-index 1200 puts it above FeedbackPrompt's 1100 and CommunityNote's 1050. If any
+// of them ever coincide, the warning is the one that must be readable, and that falls
+// out of the z-order with no cross-component subscription to keep in sync.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BRAND } from "@/lib/brand";
+import { BOOT_FADE_MS, BOOT_MS } from "@/lib/terminal/boot";
+import DiscordMark from "@/components/brand/DiscordMark";
+import {
+  NOTICE_REVISION,
+  type DevNoticeState,
+  loadDevNoticeState,
+  markAcknowledged,
+  saveDevNoticeState,
+  shouldWarn,
+  forcedFromSearch,
+} from "@/lib/shell/devnotice";
+
+/** Long enough for the cold-start plate and its fade to be gone — the same constants
+ *  and the same reasoning as CommunityNote's hold. BOOT_MS is the boot's ceiling, so
+ *  this holds for the worst case and is never early. */
+const INITIAL_HOLD_MS = BOOT_MS + BOOT_FADE_MS + 500;
+
+/**
+ * Captured in the module body, not inside an effect.
+ *
+ * The console rewrites its own query string, stripping every param it does not own.
+ * Read from inside an effect, the override would work or not depending on which
+ * effect ran first. Module bodies evaluate at import time, strictly before React
+ * renders and so strictly before anything can rewrite the URL — this removes the race
+ * rather than winning it. Guarded for SSR, where there is no window at all.
+ */
+const FORCED = typeof window === "undefined" ? false : forcedFromSearch(window.location.search);
+
+export default function DevNotice() {
+  const [open, setOpen] = useState(false);
+  const state = useRef<DevNoticeState | null>(null);
+  const restoreFocus = useRef<HTMLElement | null>(null);
+  const card = useRef<HTMLDivElement>(null);
+  const primary = useRef<HTMLButtonElement>(null);
+
+  /* ── The gate ─────────────────────────────────────────────────────────── */
+
+  useEffect(() => {
+    const s = loadDevNoticeState();
+    state.current = s;
+
+    // No qualifying time, unlike the invitation next door: a warning shown late has
+    // already been overtaken by the bug it was warning about. The only wait is for
+    // the boot plate, so the card is readable when it lands.
+    const t = window.setTimeout(() => {
+      if (FORCED || shouldWarn(s, { bootPlaying: false })) setOpen(true);
+    }, INITIAL_HOLD_MS);
+
+    return () => window.clearTimeout(t);
+  }, []);
+
+  const acknowledge = useCallback(() => {
+    const next = markAcknowledged(state.current ?? { acknowledged: 0 }, NOTICE_REVISION);
+    state.current = next;
+    saveDevNoticeState(next);
+    setOpen(false);
+    restoreFocus.current?.focus?.();
+  }, []);
+
+  /* ── Focus management ─────────────────────────────────────────────────── */
+
+  // Focus the PRIMARY ACTION explicitly, not "the first focusable in the card".
+  // The licence link sits mid-paragraph and is first in DOM order, so a generic
+  // first-focusable query drops the caret into the middle of the legal sentence:
+  // a screen reader starts there, and a sighted keyboard user sees the ring on a
+  // link they did not ask for. The way out of the dialog is the thing to land on.
+  useEffect(() => {
+    if (!open) return;
+    restoreFocus.current = document.activeElement as HTMLElement | null;
+    primary.current?.focus();
+  }, [open]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      acknowledge();
+      return;
+    }
+    if (e.key !== "Tab" || !card.current) return;
+    const focusable = Array.from(
+      card.current.querySelectorAll<HTMLElement>("button, [href]"),
+    ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
+    if (focusable.length === 0) return;
+    const firstEl = focusable[0];
+    const lastEl = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === firstEl) {
+      e.preventDefault();
+      lastEl.focus();
+    } else if (!e.shiftKey && document.activeElement === lastEl) {
+      e.preventDefault();
+      firstEl.focus();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="tn-dev"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tn-dev-title"
+      onKeyDown={onKeyDown}
+    >
+      {/* No onClick: an accidental veil click must not dismiss this one. */}
+      <div className="tn-dev-veil" aria-hidden />
+      <div className="tn-dev-card" ref={card}>
+        <div className="tn-dev-head">
+          <span className="tn-dev-flag">Preview build</span>
+          <h2 className="tn-dev-title" id="tn-dev-title">
+            You are looking at a live build
+          </h2>
+        </div>
+
+        <div className="tn-dev-body">
+          <p className="tn-dev-lead">
+            {BRAND.name} is being actively developed while you use it. Expect half-finished
+            features, visible bugs, layouts that break and the occasional crash. None of that
+            is a surprise to us — it is what an access code buys you.
+          </p>
+
+          <ul className="tn-dev-list">
+            <li>
+              <b>The data is not verified.</b> Everything on the map comes from open sources
+              and is shown as those sources published it. Some of it is wrong, stale, or
+              coded by a machine that misread a news article.
+            </li>
+            <li>
+              <b>Do not rely on it for anything that matters.</b> It is not fit for safety,
+              navigation, operational or emergency decisions, and it is not a substitute for
+              an official source.
+            </li>
+            <li>
+              <b>Nothing here is promised.</b> No uptime, no accuracy, no feature staying
+              where you found it, and no notice before any of that changes.
+            </li>
+          </ul>
+
+          {/* The disclaimer is NOT drafted here. The project ships under AGPL-3.0, whose
+              sections 15 and 16 already disclaim warranty and limit liability; writing a
+              parallel set of terms would risk contradicting the licence the software is
+              actually distributed under. So this states it plainly and points at the real
+              text, which is the binding one. */}
+          <p className="tn-dev-legal">
+            Provided <b>as is</b>, without warranty of any kind, under the{" "}
+            <a href={BRAND.license.url} target="_blank" rel="noopener noreferrer">
+              {BRAND.license.short} licence
+            </a>{" "}
+            — see sections 15 and 16 for the full disclaimer of warranty and limitation of
+            liability. Use it at your own risk.
+          </p>
+
+          {/* THE POINT OF THIS PARAGRAPH IS TO UNDO THE ONE ABOVE IT. Telling someone to
+              expect bugs quietly tells them not to report any — they assume anything they
+              hit is already known, and the tester who would have filed it stays silent.
+              Saying so explicitly is the only thing that recovers those reports. */}
+          <p className="tn-dev-ask">
+            None of that means you cannot find bugs — please look for them.{" "}
+            <b>State the obvious.</b> If something looks wrong, assume nobody has noticed it
+            yet and say so anyway. Opinions count as much as faults: what is missing, what
+            should exist, how the layout ought to work. All of it goes in the Discord, and it
+            is the reason you have a code.
+          </p>
+        </div>
+
+        <div className="tn-dev-actions">
+          <button ref={primary} type="button" className="tn-dev-btn is-primary" onClick={acknowledge}>
+            I understand
+          </button>
+          <a
+            className="tn-dev-btn is-discord"
+            href={BRAND.discordUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <DiscordMark />
+            Report on Discord
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/shell/devnotice.ts
+++ b/lib/shell/devnotice.ts
@@ -1,0 +1,126 @@
+// The live-build warning's gate. PURE: no React, no DOM, no "use client" — the same
+// reason lib/shell/community.ts and lib/shell/feedback.ts are pure, and the same
+// payoff: whether anyone is warned, and what makes it stop, is unit-tested in the
+// node environment with no window.
+//
+// WHAT THIS IS FOR. Access codes are being handed out while the site is behind the
+// maintenance gate, so the people arriving are invited testers rather than passers-by.
+// They are the first to see a half-built console, and they need to know that before
+// they hit it — what looks like a broken product is a product mid-build.
+//
+// HOW IT DIFFERS FROM THE COMMUNITY INVITATION, AND WHY. Both are one-time cards over
+// a persisted envelope, so the shape is deliberately the same. Two rules are not:
+//
+//   (a) NO QUALIFYING TIME. CommunityNote waits 40 seconds of visible time, because an
+//       invitation shown to a bounce is wasted. A warning is the opposite: shown late,
+//       it arrives after the person already hit the bug it was warning about, which is
+//       worse than not showing it. So it appears the moment the boot plate is gone.
+//
+//   (b) ACKNOWLEDGEMENT IS VERSIONED, NOT PERMANENT. Community stores `resolved`
+//       forever. This stores WHICH REVISION of the text was acknowledged, so bumping
+//       NOTICE_REVISION re-shows it to everyone — including people already holding a
+//       code. Once a code is issued there is no other channel to them, and a warning
+//       that cannot be updated is a warning that rots.
+//
+// AND IT IS A MODAL, where CommunityNote is a corner card. The invitation asks for
+// nothing and may be ignored at no cost. This one carries the only statement anybody
+// gets that the data is unverified and the software is unwarranted, so it takes the
+// veil and the focus trap that FeedbackPrompt uses. Escape still closes it, because a
+// dialog nobody can leave is an accessibility defect and this is a notice, not a
+// contract.
+
+import { loadPersisted, savePersisted } from "@/lib/shell/persist";
+
+export const DEV_NOTICE_KEY = "tn.devnotice.v1";
+export const DEV_NOTICE_VERSION = 1;
+
+/**
+ * The revision of the notice's TEXT, not of its storage schema.
+ *
+ * Bump it when the warning itself changes in a way people who already acknowledged
+ * need to see — a new limitation, a changed promise. Bumping re-shows the dialog to
+ * everyone exactly once. Do NOT bump it for a typo: every bump spends the attention
+ * of every existing tester, and a card people learn to click through unread is worth
+ * nothing when it finally says something that matters.
+ */
+export const NOTICE_REVISION = 1;
+
+export interface DevNoticeState {
+  /** The highest NOTICE_REVISION this person has acknowledged. 0 means never. */
+  acknowledged: number;
+}
+
+export const EMPTY_DEV_NOTICE_STATE: DevNoticeState = { acknowledged: 0 };
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * Read the envelope, and FAIL OPEN on anything unexpected.
+ *
+ * A corrupt, hand-edited or half-written value resolves to "never acknowledged", so
+ * the cost of confusion is one extra dialog. The other direction — treating nonsense
+ * as an acknowledgement — silently suppresses the warning, and nothing downstream
+ * would ever reveal that it had.
+ */
+export function loadDevNoticeState(storage?: StorageLike): DevNoticeState {
+  const raw = loadPersisted<DevNoticeState>(DEV_NOTICE_KEY, DEV_NOTICE_VERSION, storage);
+  if (!raw || typeof raw !== "object") return { ...EMPTY_DEV_NOTICE_STATE };
+  const n = raw.acknowledged;
+  // Number.isFinite rejects NaN and both infinities; 1e400 parses to Infinity.
+  if (typeof n !== "number" || !Number.isFinite(n) || n <= 0) return { ...EMPTY_DEV_NOTICE_STATE };
+  return { acknowledged: Math.floor(n) };
+}
+
+export function saveDevNoticeState(state: DevNoticeState, storage?: StorageLike): void {
+  savePersisted<DevNoticeState>(DEV_NOTICE_KEY, DEV_NOTICE_VERSION, state, storage);
+}
+
+/* ── Pure state transitions ─────────────────────────────────────────────── */
+
+export function markAcknowledged(state: DevNoticeState, revision: number): DevNoticeState {
+  if (!Number.isFinite(revision) || revision <= 0) return state;
+  return { ...state, acknowledged: Math.max(state.acknowledged, Math.floor(revision)) };
+}
+
+/* ── The gate ───────────────────────────────────────────────────────────── */
+
+export interface DevNoticeGateContext {
+  /** The cold-start plate is still on screen. */
+  bootPlaying: boolean;
+}
+
+/**
+ * Why the notice is being withheld, or null if nothing is withholding it. A reason
+ * rather than a boolean so a test names the arm it is exercising.
+ *
+ * There is deliberately no `diveActive` arm, unlike the community gate. A cinematic
+ * dive cannot be running before the first paint, and if one somehow were, a warning
+ * still outranks it — that gate protects an immersive moment from an advert, which is
+ * not what this is.
+ */
+export function blockedBy(state: DevNoticeState, ctx: DevNoticeGateContext): string | null {
+  if (ctx.bootPlaying) return "boot";
+  if (state.acknowledged >= NOTICE_REVISION) return "acknowledged";
+  return null;
+}
+
+export function shouldWarn(state: DevNoticeState, ctx: DevNoticeGateContext): boolean {
+  return blockedBy(state, ctx) === null;
+}
+
+/**
+ * `?notice=1` forces it open, the precedent `?discord=1` and `?feedback=1` set.
+ *
+ * IT DIFFERS FROM BOTH ON PURPOSE. Those refuse to bypass a recorded answer, because
+ * re-asking someone who already said no disrespects the no. There is no "no" here —
+ * acknowledging a warning declines nothing — so re-reading it costs nothing, and being
+ * able to send a tester straight back to the terms is worth having. It does not
+ * override the boot arm: that one is about the notice being readable at all.
+ */
+export function forcedFromSearch(search: string): boolean {
+  try {
+    return new URLSearchParams(search).get("notice") === "1";
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/devnotice.test.ts
+++ b/tests/unit/devnotice.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEV_NOTICE_KEY,
+  DEV_NOTICE_VERSION,
+  NOTICE_REVISION,
+  type DevNoticeState,
+  EMPTY_DEV_NOTICE_STATE,
+  loadDevNoticeState,
+  saveDevNoticeState,
+  markAcknowledged,
+  blockedBy,
+  shouldWarn,
+  forcedFromSearch,
+} from "@/lib/shell/devnotice";
+
+/**
+ * The gate for the "this is a live build" warning, which is the FIRST thing anyone
+ * handed an access code sees. Its whole job is to be shown once, before the console
+ * is used, and then never nag again.
+ *
+ * It is deliberately NOT modelled on the community invitation next door, and the
+ * two differences are the interesting part:
+ *
+ *   (a) NO QUALIFYING TIME. CommunityNote waits 40 seconds of visible time because
+ *       an invitation shown to a bounce is wasted. A warning shown late is WORSE
+ *       than not shown at all - the person has already hit the bug it was warning
+ *       about. So it shows the moment the boot plate is gone.
+ *
+ *   (b) ACKNOWLEDGEMENT IS VERSIONED, NOT PERMANENT. Community records "resolved"
+ *       forever. This records WHICH REVISION of the text was acknowledged, so
+ *       bumping NOTICE_REVISION re-shows it to people who are already through the
+ *       gate. That is the only channel to them once they hold a code, and a warning
+ *       nobody can update is a warning that rots.
+ */
+
+function store(seed?: Record<string, string>) {
+  const map = new Map(Object.entries(seed ?? {}));
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    raw: map,
+  };
+}
+
+const AFTER_BOOT = { bootPlaying: false };
+
+describe("the live-build warning gate", () => {
+  it("warns a first-time visitor as soon as the boot plate is gone", () => {
+    expect(shouldWarn(EMPTY_DEV_NOTICE_STATE, AFTER_BOOT)).toBe(true);
+  });
+
+  // The cold-start plate owns the screen. A dialog on top of it is a dialog nobody
+  // reads, and this is the one card that has to actually be read.
+  it("withholds it while the boot plate is still playing", () => {
+    expect(blockedBy(EMPTY_DEV_NOTICE_STATE, { bootPlaying: true })).toBe("boot");
+    expect(shouldWarn(EMPTY_DEV_NOTICE_STATE, { bootPlaying: true })).toBe(false);
+  });
+
+  it("does not warn twice for the same revision", () => {
+    const seen = markAcknowledged(EMPTY_DEV_NOTICE_STATE, NOTICE_REVISION);
+    expect(blockedBy(seen, AFTER_BOOT)).toBe("acknowledged");
+    expect(shouldWarn(seen, AFTER_BOOT)).toBe(false);
+  });
+
+  // The reason the state stores a number and not a boolean.
+  it("warns again when the text is revised past what was acknowledged", () => {
+    const seenOld: DevNoticeState = { acknowledged: NOTICE_REVISION - 1 };
+    expect(shouldWarn(seenOld, AFTER_BOOT)).toBe(true);
+  });
+
+  it("survives a hand-edited or half-written envelope by warning again", () => {
+    const s = store({ [DEV_NOTICE_KEY]: '{"v":1,"d":{"acknowledged":"yes"}}' });
+    expect(loadDevNoticeState(s)).toEqual(EMPTY_DEV_NOTICE_STATE);
+    expect(shouldWarn(loadDevNoticeState(s), AFTER_BOOT)).toBe(true);
+  });
+
+  // Failing OPEN is the correct direction for a warning: an unreadable envelope
+  // costs one extra dialog, where the other direction silently suppresses it.
+  it("warns again rather than staying quiet when the value is nonsense", () => {
+    for (const bad of ["-3", "NaN", "1e400", "null"]) {
+      const s = store({ [DEV_NOTICE_KEY]: `{"v":1,"d":{"acknowledged":${bad}}}` });
+      expect(shouldWarn(loadDevNoticeState(s), AFTER_BOOT), bad).toBe(true);
+    }
+  });
+
+  it("round-trips an acknowledgement through storage", () => {
+    const s = store();
+    saveDevNoticeState(markAcknowledged(EMPTY_DEV_NOTICE_STATE, NOTICE_REVISION), s);
+    expect(loadDevNoticeState(s).acknowledged).toBe(NOTICE_REVISION);
+    expect(shouldWarn(loadDevNoticeState(s), AFTER_BOOT)).toBe(false);
+  });
+
+  it("ignores an envelope written by a different schema version", () => {
+    const s = store({
+      [DEV_NOTICE_KEY]: JSON.stringify({ v: DEV_NOTICE_VERSION + 1, d: { acknowledged: 99 } }),
+    });
+    expect(shouldWarn(loadDevNoticeState(s), AFTER_BOOT)).toBe(true);
+  });
+
+  /**
+   * `?notice=1` forces it open, the precedent `?discord=1` and `?feedback=1` set.
+   *
+   * IT DIFFERS FROM THOSE TWO ON PURPOSE: they refuse to bypass a recorded answer,
+   * because re-asking someone who already said no disrespects the no. There is no
+   * "no" here - acknowledging a warning is not declining anything - so re-reading it
+   * costs nothing and being able to link someone straight to it is worth having.
+   */
+  it("can be forced open for review, even after it has been acknowledged", () => {
+    expect(forcedFromSearch("?notice=1")).toBe(true);
+    expect(forcedFromSearch("?notice=0")).toBe(false);
+    expect(forcedFromSearch("")).toBe(false);
+    expect(forcedFromSearch("not a query string")).toBe(false);
+  });
+
+  it("still withholds a forced notice while the boot plate is playing", () => {
+    // The force overrides the acknowledgement, not the readability problem.
+    expect(blockedBy(EMPTY_DEV_NOTICE_STATE, { bootPlaying: true })).toBe("boot");
+  });
+});


### PR DESCRIPTION
Access codes are going out while the site is behind the maintenance gate, so the people arriving are **invited testers, not passers-by**. They are the first to see a half-built console and nothing told them so.

Shown once, after the boot plate, then not again until the text is revised.

## It is a modal, where the Discord card next door is not

The invitation asks for nothing and may be ignored at no cost, so it takes no veil and never moves focus. This one carries the only statement anybody gets that the data is unverified and the software unwarranted, and **the person who never reads it is the person it existed for** — so it takes the veil and focus trap `FeedbackPrompt` already uses.

- **Escape still closes it.** A dialog with no way out is an accessibility defect, and the licence binds whether or not a button is clicked, so trapping people buys nothing legally and costs real usability.
- **Clicking the veil does not.** That is the accidental dismissal, and this is the one card worth protecting from one.
- **z-index 1200**, above FeedbackPrompt (1100) and CommunityNote (1050). If any two ever coincide this is the one that must be readable, and the z-order settles it with no cross-component wiring.

## The disclaimer is not drafted here, deliberately

The project ships under **AGPL-3.0, whose sections 15 and 16 already disclaim warranty and limit liability**. Writing a parallel set of terms would risk contradicting the licence the software is actually distributed under — so the card states the position in plain English and links the real text, which is the binding one.

What it says in its own words: the data is not verified and comes from open sources as published; do not rely on it for safety, navigation, operational or emergency decisions; no uptime, no accuracy, no feature staying where you found it.

## Two rules differ from the community gate on purpose

| | CommunityNote | DevNotice |
|---|---|---|
| qualifying time | 40s visible — an invitation shown to a bounce is wasted | **none** — a warning shown late has already been overtaken by the bug it was about |
| stopping | `resolved`, permanent | **`acknowledged` is a revision number** — bumping `NOTICE_REVISION` re-shows it |

The second one matters more than it looks: once a code is issued there is no other channel to that person, and a warning that cannot be updated is a warning that rots.

## The last paragraph exists to undo the one above it

Telling someone to expect bugs quietly tells them **not to report any** — they assume anything they hit is already known, and the tester who would have filed it stays silent. So the card says the opposite explicitly: *state the obvious, assume nobody has noticed it yet, opinions count as much as faults.*

For the same reason `CommunityNote` drops "say what is broken", which this now asks for directly and at length. Two cards competing for the same request trains people to skim both. It keeps the half this does not cover — the people — and keeps the honest "it is new and quiet" line.

## Caught in visual review, at 1440x900 and 390x844

- **Focus landed on the licence link**, mid-legal-sentence, because it is first in DOM order. A screen reader would have started there. Now the primary button explicitly.
- **The action bar is sticky.** On a phone the text is taller than the viewport, and the only way out of a modal must not be below the fold.
- Confirmed the console strips `?notice=1` on rewrite, which is exactly why `FORCED` is captured in the module body rather than in an effect.

## Gate

`npx tsc --noEmit` clean. **3,209 tests across 326 files pass**, 10 new, each watched fail before the code that satisfies it.

The gate is pure and lives in `lib/shell/devnotice.ts`, so it is unit-tested in the node environment with no window — the same shape as `community.ts` and `feedback.ts`. It **fails open**: a corrupt or hand-edited envelope costs one extra dialog, where the other direction silently suppresses the warning and nothing would ever reveal it had.

`?notice=1` forces it open, and unlike `?discord=1` it bypasses an acknowledgement — there is no "no" here to disrespect, and being able to send a tester back to the terms is worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPc6asqo4ePhWJF684Ccuz
