### PR TITLE
Hand out access keys that expire, and store nothing to do it

### DIFF
--- a/app/api/gate/route.ts
+++ b/app/api/gate/route.ts
@@ -6,6 +6,7 @@ import {
   withDenied,
   gateCookieHeader,
 } from "@/lib/gate/token";
+import { verifyTempKey } from "@/lib/gate/tempkey";
 
 /**
  * The one door through the maintenance curtain.
@@ -16,6 +17,11 @@ import {
  * It answers 404 when the gate is not armed, matching how `/admin` and `/api/admin`
  * disappear in production rather than announcing themselves. A password endpoint that
  * exists on a site with no password is a target and nothing else.
+ *
+ * TEMPORARY KEYS come through this same door. A key is minted offline by
+ * `scripts/mint-gate-key.mjs`, carries its own expiry and is signed with the master
+ * code, so verifying one needs no storage. Presenting one buys a cookie that lasts
+ * exactly as long as the key has left. See lib/gate/tempkey.ts.
  *
  * There is no rate limiting here, so the access code must be long. Six digits is 10^6,
  * exposed for a month; a script walks that while nobody is watching. If the gate ever
@@ -34,15 +40,34 @@ export async function POST(request: NextRequest) {
   const presented = typeof form.get("password") === "string" ? String(form.get("password")) : "";
   const expected = process.env.MAINTENANCE_PASSWORD ?? "";
 
-  if (expected === "" || !(await constantTimeEqual(presented, expected))) {
+  if (expected === "") {
     return NextResponse.redirect(new URL(withDenied(next), request.url), { status: 303 });
   }
 
-  // 303 so the browser reissues the request as a GET; a 307 would repost the form.
-  const response = NextResponse.redirect(new URL(next, request.url), { status: 303 });
-  response.headers.set(
-    "set-cookie",
-    gateCookieHeader(await gateToken(expected), request.nextUrl.protocol === "https:"),
-  );
-  return response;
+  const secure = request.nextUrl.protocol === "https:";
+
+  // The master code: a full thirty-day session, as before.
+  if (await constantTimeEqual(presented, expected)) {
+    // 303 so the browser reissues the request as a GET; a 307 would repost the form.
+    const response = NextResponse.redirect(new URL(next, request.url), { status: 303 });
+    response.headers.set("set-cookie", gateCookieHeader(await gateToken(expected), secure));
+    return response;
+  }
+
+  // A TEMPORARY KEY. The cookie's lifetime is the key's REMAINING life, not the
+  // permanent one — issuing the thirty-day cookie here would turn a thirty-minute key
+  // into a permanent one, and nothing would look wrong while it happened.
+  //
+  // The cookie's value is the signed key itself rather than a digest of it, so the
+  // expiry is re-checked at the edge on every request. Max-Age asks the browser to drop
+  // it; the signature is what actually stops it.
+  const temp = await verifyTempKey(expected, presented, Math.floor(Date.now() / 1000));
+  if (temp.ok) {
+    const remaining = temp.expiresAt - Math.floor(Date.now() / 1000);
+    const response = NextResponse.redirect(new URL(next, request.url), { status: 303 });
+    response.headers.set("set-cookie", gateCookieHeader(presented, secure, remaining));
+    return response;
+  }
+
+  return NextResponse.redirect(new URL(withDenied(next), request.url), { status: 303 });
 }

--- a/lib/gate/tempkey.ts
+++ b/lib/gate/tempkey.ts
@@ -1,0 +1,173 @@
+/**
+ * Temporary access keys for the maintenance gate: hand one to somebody, it works for
+ * half an hour, then it is dead — and NOTHING is stored anywhere to make that true.
+ *
+ * THE KEY CARRIES ITS OWN EXPIRY, AND AN HMAC OVER THAT EXPIRY, signed with the master
+ * access code. A deployment can therefore verify one with only the environment variable
+ * it already has: no KV, no table, no per-key record, no cleanup job. That is the same
+ * property the permanent cookie was built on, and it is the only thing that keeps this
+ * free — the outage exists because the site got expensive, so a feature that adds a
+ * datastore would be answering the wrong question.
+ *
+ * THE SIGNATURE COVERS THE EXPIRY, which is the whole security argument. The expiry
+ * travels in plain sight and is completely untrusted; editing it does not extend the
+ * key, it invalidates it. Anyone can read when a key dies, nobody can move it.
+ *
+ * FORMAT: `t.<expiry base36>.<hmac hex, truncated>`, e.g. `t.1n8kq7z.9f3c...`. The `t.`
+ * tag makes a temp key distinguishable from the permanent cookie value (a bare SHA-256
+ * hex) without verifying it, so the middleware can pick the right check.
+ *
+ * WHAT THIS IS NOT: authentication. There is no rate limiting on the unlock route, no
+ * per-key identity and no audit trail — a key is a bearer token, so whoever holds it is
+ * through, and forwarding one to a friend works exactly as well as using it. It is a
+ * curtain held open for a named guest for thirty minutes, not a login.
+ *
+ * REVOCATION IS ALL-OR-NOTHING. Because nothing is stored, the only way to kill an
+ * outstanding key early is to change MAINTENANCE_PASSWORD, which kills every key and
+ * every session at once. That is the trade for storing nothing, and it is a fine trade
+ * at a thirty-minute horizon; it would not be at a thirty-day one, which is part of why
+ * the cap below exists.
+ */
+
+/** Distinguishes a temp key from the permanent cookie value. */
+export const TEMP_KEY_TAG = "t";
+
+/**
+ * Domain-separates this HMAC from `gateToken`'s digest, so the two can never be
+ * confused for one another even though both are keyed on the same secret. Bump the
+ * version to invalidate every outstanding key without changing the master code.
+ */
+export const TEMP_KEY_PREFIX = "provenance-temp-v1:";
+
+/** What Sampo asked for, and what the minting script uses when told nothing else. */
+export const TEMP_KEY_DEFAULT_MINUTES = 30;
+
+/**
+ * A day. Not a technical limit — the format would happily carry a year — but a
+ * deliberate one: revocation is all-or-nothing (see above), so a long-lived key is a
+ * thing you cannot take back without logging everyone out. Past a day, the honest
+ * answer is to give somebody the real code.
+ */
+export const TEMP_KEY_MAX_MINUTES = 60 * 24;
+
+/**
+ * 64 bits of signature, hex.
+ *
+ * Enough that guessing one is hopeless, short enough that the whole key is about thirty
+ * characters and survives being pasted into a Discord message. The full 256-bit digest
+ * would make a key nobody could read back over a call, and buys nothing against an
+ * attacker who gets one online guess per request against a route with no rate limiting
+ * — the master code's own length is the binding constraint there, not this.
+ */
+const SIG_CHARS = 16;
+
+const encoder = new TextEncoder();
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Web Crypto only — no node:crypto — so the same function runs in Edge middleware. */
+async function hmacHex(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return toHex(await crypto.subtle.sign("HMAC", key, encoder.encode(message)));
+}
+
+/** Seconds for a duration in minutes, refusing anything outside the allowed band. */
+export function tempKeyTtlSeconds(minutes: number): number {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    throw new Error(`A temporary key must last a positive number of minutes, got ${minutes}`);
+  }
+  if (minutes > TEMP_KEY_MAX_MINUTES) {
+    throw new Error(
+      `A temporary key may last at most ${TEMP_KEY_MAX_MINUTES} minutes (got ${minutes}). ` +
+        "Revoking one early means changing the master code, which logs everyone out.",
+    );
+  }
+  return Math.round(minutes * 60);
+}
+
+/**
+ * True for anything SHAPED like a temp key. Says nothing about whether it is valid —
+ * it exists so the middleware can choose between the two checks without paying for a
+ * signature it was never going to match.
+ */
+export function isTempKey(value: string): boolean {
+  if (typeof value !== "string") return false;
+  const parts = value.split(".");
+  return parts.length === 3 && parts[0] === TEMP_KEY_TAG && parts[1].length > 0 && parts[2].length > 0;
+}
+
+/** Mint a key that stops working at `expiresAtSec` (absolute unix seconds). */
+export async function mintTempKey(secret: string, expiresAtSec: number): Promise<string> {
+  if (!secret) {
+    // Minting against "" would produce a key that a deployment with no code set would
+    // then happily accept, which is the fail-open the whole gate exists to avoid.
+    throw new Error("Cannot mint a temporary key without a master access code");
+  }
+  if (!Number.isFinite(expiresAtSec) || expiresAtSec <= 0) {
+    throw new Error(`Expiry must be a positive unix timestamp, got ${expiresAtSec}`);
+  }
+  const exp = Math.floor(expiresAtSec).toString(36);
+  const sig = (await hmacHex(secret, TEMP_KEY_PREFIX + exp)).slice(0, SIG_CHARS);
+  return `${TEMP_KEY_TAG}.${exp}.${sig}`;
+}
+
+export interface TempKeyVerdict {
+  ok: boolean;
+  /** Absolute unix seconds. 0 when the key could not be read at all. */
+  expiresAt: number;
+  /** Why it was refused; undefined when it was not. */
+  reason?: "malformed" | "signature" | "expired";
+}
+
+/**
+ * Check a key against the master code at a given moment.
+ *
+ * ORDER MATTERS: the signature is checked BEFORE the expiry. Checking expiry first
+ * would answer "that key has expired" for a string that was never a valid key, which
+ * tells an attacker their forgery parsed. The reason is only ever returned to code,
+ * not to a visitor, but the ordering costs nothing and removes the question.
+ */
+export async function verifyTempKey(
+  secret: string,
+  key: string,
+  nowSec: number,
+): Promise<TempKeyVerdict> {
+  if (!secret || !isTempKey(key)) return { ok: false, expiresAt: 0, reason: "malformed" };
+
+  const [, exp, sig] = key.split(".");
+  const expiresAt = Number.parseInt(exp, 36);
+  // `parseInt` is lenient — it stops at the first bad character rather than failing —
+  // so the parse is confirmed by round-tripping it back to the string that was signed.
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0 || expiresAt.toString(36) !== exp) {
+    return { ok: false, expiresAt: 0, reason: "malformed" };
+  }
+
+  const expected = (await hmacHex(secret, TEMP_KEY_PREFIX + exp)).slice(0, SIG_CHARS);
+  if (!constantTimeEqualHex(sig, expected)) {
+    return { ok: false, expiresAt, reason: "signature" };
+  }
+  if (!Number.isFinite(nowSec) || nowSec > expiresAt) {
+    return { ok: false, expiresAt, reason: "expired" };
+  }
+  return { ok: true, expiresAt };
+}
+
+/**
+ * Equality with no early exit. Both sides are already fixed-width hex from the same
+ * truncation, so unlike `constantTimeEqual` in token.ts there is nothing to hash first
+ * — but a length mismatch is still answered in constant time over the expected length,
+ * because returning early on length is itself a leak.
+ */
+function constantTimeEqualHex(a: string, b: string): boolean {
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < b.length; i++) diff |= (a.charCodeAt(i) || 0) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/lib/gate/token.ts
+++ b/lib/gate/token.ts
@@ -80,12 +80,27 @@ export function withDenied(next: string): string {
   return url.pathname + url.search;
 }
 
-/** The Set-Cookie header value for a fresh session. */
-export function gateCookieHeader(token: string, secure: boolean): string {
+/**
+ * The Set-Cookie header value for a fresh session.
+ *
+ * `maxAge` exists for TEMPORARY KEYS, and defaulting it to the permanent lifetime is
+ * the only safe default: a thirty-minute key issued with the thirty-DAY cookie would
+ * work forever, and nothing would look wrong — it would simply never stop working.
+ *
+ * Note that Max-Age is only the FIRST of two stops, and the weaker one: it is a request
+ * to the browser. The second is that a temporary cookie's VALUE is the signed key
+ * itself, so a browser that keeps it anyway, or a cookie copied to another machine, is
+ * still refused at the edge. See lib/gate/tempkey.ts.
+ */
+export function gateCookieHeader(
+  token: string,
+  secure: boolean,
+  maxAge: number = GATE_COOKIE_MAX_AGE,
+): string {
   const parts = [
     `${GATE_COOKIE}=${token}`,
     "Path=/",
-    `Max-Age=${GATE_COOKIE_MAX_AGE}`,
+    `Max-Age=${Math.max(0, Math.floor(maxAge))}`,
     "HttpOnly",
     "SameSite=Lax",
   ];

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { isGatedPath } from "@/lib/gate/paths";
 import { GATE_COOKIE, GATE_QUERY, GATE_DENIED, gateToken } from "@/lib/gate/token";
+import { isTempKey, verifyTempKey } from "@/lib/gate/tempkey";
 import { maintenanceHtml } from "@/lib/gate/page";
 
 /**
@@ -34,9 +35,19 @@ export default async function middleware(request: NextRequest) {
   if (!isGatedPath(pathname)) return NextResponse.next();
 
   const code = process.env.MAINTENANCE_PASSWORD ?? "";
-  if (code) {
-    const presented = request.cookies.get(GATE_COOKIE)?.value;
-    if (presented && presented === (await gateToken(code))) return NextResponse.next();
+  const presented = request.cookies.get(GATE_COOKIE)?.value;
+  if (code && presented) {
+    // A TEMPORARY KEY re-checks its own expiry here, on every request. Max-Age asked
+    // the browser to drop the cookie; this is what actually stops it, so a browser
+    // that ignored the request, or a cookie copied to another machine, still expires
+    // on time. The shape check comes first so the permanent path never pays for an
+    // HMAC it was not going to match, and vice versa.
+    if (isTempKey(presented)) {
+      const verdict = await verifyTempKey(code, presented, Math.floor(Date.now() / 1000));
+      if (verdict.ok) return NextResponse.next();
+    } else if (presented === (await gateToken(code))) {
+      return NextResponse.next();
+    }
   }
 
   return new NextResponse(

--- a/scripts/mint-gate-key.mjs
+++ b/scripts/mint-gate-key.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Mint a temporary access key for the maintenance gate.
+ *
+ *   node scripts/mint-gate-key.mjs            # 30 minutes
+ *   node scripts/mint-gate-key.mjs 90         # 90 minutes
+ *
+ * Runs on Node's built-in TypeScript stripping (Node 22.18+), so it imports the SAME
+ * module the edge runs rather than reimplementing the HMAC. A second implementation
+ * would drift, and the failure mode of drift here is a key that mints cleanly and is
+ * refused in production.
+ *
+ * THERE IS NO --count. A key is a pure function of (master code, expiry second), so
+ * minting twice in the same second returns the identical string - a "batch" would print
+ * the same key N times. That is not a bug to paper over: without storage there is no
+ * per-key identity, so handing a key to five people IS handing out one key five times,
+ * and the tool should not imply otherwise.
+ *
+ * Needs the master code in the environment:
+ *
+ *   MAINTENANCE_PASSWORD=... node scripts/mint-gate-key.mjs
+ *   vercel env pull .env.production.local && node --env-file=.env.production.local scripts/mint-gate-key.mjs
+ *
+ * WHY THIS IS A SCRIPT AND NOT AN ENDPOINT. A `/api/gate/mint` route would be more
+ * convenient — mint a key from a phone, paste it into Discord — but it would put a
+ * second password-checking door on a site that has no rate limiting, during exactly the
+ * month when nobody is watching it. This runs on a machine that already has the code,
+ * so it adds no attack surface at all. If the convenience turns out to matter more than
+ * the surface, the endpoint is a small change and this file already has the logic.
+ *
+ * The key is verified before it is printed. Minting and checking share one
+ * implementation (lib/gate/tempkey.ts) — the same file the edge runs — so a key that
+ * prints here cannot fail in production for a reason this script could have caught.
+ */
+
+import { mintTempKey, verifyTempKey, tempKeyTtlSeconds, TEMP_KEY_DEFAULT_MINUTES }
+  from "../lib/gate/tempkey.ts";
+
+function die(message) {
+  console.error(`\n  ${message}\n`);
+  process.exit(1);
+}
+
+const positional = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+const minutes = positional.length ? Number(positional[0]) : TEMP_KEY_DEFAULT_MINUTES;
+
+const secret = process.env.MAINTENANCE_PASSWORD ?? "";
+if (!secret) {
+  die(
+    "MAINTENANCE_PASSWORD is not set, and a key signed with an empty code would be\n" +
+    "  accepted by a deployment that has no code set at all. Pull it first:\n\n" +
+    "    vercel env pull .env.production.local\n" +
+    "    node --env-file=.env.production.local scripts/mint-gate-key.mjs",
+  );
+}
+let ttl;
+try {
+  ttl = tempKeyTtlSeconds(minutes);
+} catch (err) {
+  die(err.message);
+}
+
+const now = Math.floor(Date.now() / 1000);
+const expiresAt = now + ttl;
+
+const key = await mintTempKey(secret, expiresAt);
+
+// Verified before it is printed, with the same function the edge will use. A key that
+// prints here cannot then fail in production for a reason this script could have caught.
+const check = await verifyTempKey(secret, key, now);
+if (!check.ok) die(`Minted a key that does not verify (${check.reason}). This is a bug.`);
+
+console.log(
+  `\n  Key, valid ${minutes} minute${minutes === 1 ? "" : "s"}, ` +
+  `until ${new Date(expiresAt * 1000).toISOString().replace("T", " ").slice(0, 16)} UTC:\n\n` +
+  `    ${key}\n`,
+);
+
+console.log(
+  "\n  Paste one into the access-code box on the maintenance page.\n" +
+  "  It stops working at the time above, wherever it has been forwarded to.\n" +
+  "  To kill every outstanding key early, change MAINTENANCE_PASSWORD — which also\n" +
+  "  logs out every existing session, because nothing is stored per key.\n",
+);

--- a/tests/unit/gate-tempkey.test.ts
+++ b/tests/unit/gate-tempkey.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  TEMP_KEY_DEFAULT_MINUTES,
+  TEMP_KEY_MAX_MINUTES,
+  isTempKey,
+  mintTempKey,
+  verifyTempKey,
+  tempKeyTtlSeconds,
+} from "@/lib/gate/tempkey";
+import { GATE_COOKIE_MAX_AGE, gateCookieHeader, gateToken } from "@/lib/gate/token";
+
+/**
+ * Temporary access keys: handed to someone for half an hour, then dead, with NOTHING
+ * stored anywhere.
+ *
+ * The key carries its own expiry and an HMAC over it, signed with the master code. So
+ * a deployment can verify one with only the env var it already has — no KV, no table,
+ * no per-key record to clean up — which is the same property the permanent cookie was
+ * built on and the only one that keeps this free.
+ *
+ * THE SIGNATURE COVERS THE EXPIRY. That is the whole security argument: the expiry is
+ * in plain sight and completely untrusted, so editing it invalidates the key rather
+ * than extending it.
+ */
+
+const SECRET = "a-long-master-code-nobody-guesses";
+const NOW = 1_760_000_000; // fixed, so nothing here depends on the wall clock
+
+describe("temporary access keys", () => {
+  it("mints a key that verifies against the same secret", async () => {
+    const key = await mintTempKey(SECRET, NOW + 1800);
+    const v = await verifyTempKey(SECRET, key, NOW);
+    expect(v.ok).toBe(true);
+    expect(v.expiresAt).toBe(NOW + 1800);
+  });
+
+  it("is recognisable as a temp key without verifying it", async () => {
+    expect(isTempKey(await mintTempKey(SECRET, NOW + 60))).toBe(true);
+    // The permanent cookie is a bare sha256 hex, and must not be mistaken for one.
+    expect(isTempKey(await gateToken(SECRET))).toBe(false);
+    expect(isTempKey("")).toBe(false);
+    expect(isTempKey("t.")).toBe(false);
+  });
+
+  it("refuses a key that has expired", async () => {
+    const key = await mintTempKey(SECRET, NOW + 1800);
+    expect((await verifyTempKey(SECRET, key, NOW + 1799)).ok).toBe(true);
+    expect((await verifyTempKey(SECRET, key, NOW + 1801)).ok).toBe(false);
+    expect((await verifyTempKey(SECRET, key, NOW + 1801)).reason).toBe("expired");
+  });
+
+  it("refuses a key signed with a different secret", async () => {
+    const key = await mintTempKey(SECRET, NOW + 1800);
+    const v = await verifyTempKey("some-other-code", key, NOW);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toBe("signature");
+  });
+
+  // The point of signing the expiry rather than trusting it.
+  it("refuses a key whose expiry has been edited to last longer", async () => {
+    const key = await mintTempKey(SECRET, NOW + 60);
+    const [tag, , sig] = key.split(".");
+    const forged = [tag, (NOW + 999_999).toString(36), sig].join(".");
+    const v = await verifyTempKey(SECRET, forged, NOW);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toBe("signature");
+  });
+
+  it("refuses a truncated or re-signed key", async () => {
+    const key = await mintTempKey(SECRET, NOW + 1800);
+    expect((await verifyTempKey(SECRET, key.slice(0, -1), NOW)).ok).toBe(false);
+    expect((await verifyTempKey(SECRET, key + "0", NOW)).ok).toBe(false);
+  });
+
+  it("returns a reason rather than throwing on anything malformed", async () => {
+    for (const junk of ["", "t", "t.", "t..", "t.zz.zz", "....", "not-a-key", "t.-1.abc"]) {
+      const v = await verifyTempKey(SECRET, junk, NOW);
+      expect(v.ok, junk).toBe(false);
+      expect(v.reason, junk).toBeTruthy();
+    }
+  });
+
+  // Rotating the master code is the ONLY revocation there is, because nothing is
+  // stored. Worth a test so the property is not quietly lost.
+  it("invalidates every outstanding key when the master code changes", async () => {
+    const a = await mintTempKey(SECRET, NOW + 1800);
+    const b = await mintTempKey(SECRET, NOW + 3600);
+    for (const key of [a, b]) {
+      expect((await verifyTempKey(SECRET + "!", key, NOW)).ok).toBe(false);
+    }
+  });
+
+  it("refuses to mint against an empty secret", async () => {
+    await expect(mintTempKey("", NOW + 60)).rejects.toThrow();
+  });
+
+  it("defaults to thirty minutes and caps how long one may last", () => {
+    expect(TEMP_KEY_DEFAULT_MINUTES).toBe(30);
+    expect(tempKeyTtlSeconds(TEMP_KEY_DEFAULT_MINUTES)).toBe(1800);
+    expect(() => tempKeyTtlSeconds(0)).toThrow();
+    expect(() => tempKeyTtlSeconds(-5)).toThrow();
+    expect(() => tempKeyTtlSeconds(TEMP_KEY_MAX_MINUTES + 1)).toThrow();
+  });
+});
+
+/**
+ * THE COOKIE MUST NOT OUTLIVE THE KEY, and this is the part that is easy to get wrong.
+ *
+ * The permanent code sets a thirty-DAY cookie. Reusing that for a thirty-MINUTE key
+ * would hand out thirty days of access and the mistake would be invisible: everything
+ * would work, and the key would simply never stop working.
+ *
+ * Two independent stops, because the first one is client-side and therefore advisory:
+ * Max-Age asks the browser to drop it, and the signed expiry inside the cookie value
+ * means a browser that keeps it anyway is refused at the edge.
+ */
+describe("the cookie a temporary key buys", () => {
+  it("can be issued for less than the permanent lifetime", () => {
+    const short = gateCookieHeader("value", true, 1800);
+    expect(short).toContain("Max-Age=1800");
+    expect(short).toContain("HttpOnly");
+    expect(short).toContain("Secure");
+  });
+
+  it("still defaults to the permanent lifetime when no age is given", () => {
+    expect(gateCookieHeader("value", true)).toContain(`Max-Age=${GATE_COOKIE_MAX_AGE}`);
+  });
+
+  it("never issues a cookie that outlives the key inside it", async () => {
+    const key = await mintTempKey(SECRET, NOW + 1800);
+    const v = await verifyTempKey(SECRET, key, NOW);
+    const remaining = v.expiresAt - NOW;
+    expect(gateCookieHeader(key, true, remaining)).toContain(`Max-Age=${remaining}`);
+    expect(remaining).toBeLessThan(GATE_COOKIE_MAX_AGE);
+  });
+
+  // A browser that ignores Max-Age, or a cookie copied to another machine, is still
+  // refused — because the value itself is checked, not merely its presence.
+  it("is refused at the edge once the key inside it has expired, however it got there", async () => {
+    const key = await mintTempKey(SECRET, NOW + 1800);
+    expect((await verifyTempKey(SECRET, key, NOW + 5000)).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Codes are going out to testers. A permanent code given to one person is a permanent code given to everyone they forward it to, and the only way to take it back was to change it for everybody.

```
$ node --env-file=.env.production.local scripts/mint-gate-key.mjs

  Key, valid 30 minutes, until 2026-09-07 05:41 UTC:

    t.tkzbtu.54664eead627b219
```

Paste it into the same access-code box on the curtain. No second flow, no new UI.

## Nothing is stored, and that is the design

The key carries its own expiry and an HMAC over that expiry, signed with the master code. A deployment verifies one with the environment variable it **already has** — no KV, no table, no per-key record, no cleanup job. The outage exists because the site got expensive, so a feature that adds a datastore would be answering the wrong question.

Format is `t.<expiry base36>.<hmac hex>` — 26 characters, survives being pasted into Discord. The `t.` tag lets the edge tell a temp key from the permanent cookie (a bare SHA-256) without paying for an HMAC it was never going to match.

**The signature covers the expiry**, which is the whole security argument. The expiry travels in plain sight and is completely untrusted: editing it invalidates the key rather than extending it. Anyone can read when a key dies; nobody can move it. There is a test that forges exactly that.

## The cookie must not outlive the key

This is the part that was easy to get wrong, and it would have failed silently.

The master code buys a **thirty-day** cookie. Reusing that for a **thirty-minute** key hands out thirty days of access, and nothing looks wrong — the key simply never stops working. So `gateCookieHeader` now takes a max-age, defaulting to the permanent one because that is the only safe default.

**Two stops, not one**, because the first is advisory:

| | what it does | what defeats it |
|---|---|---|
| `Max-Age` | asks the browser to drop the cookie | a browser that ignores it; a cookie copied elsewhere |
| the signed value | re-checked at the edge every request | nothing — it is the key itself |

The temporary cookie's *value* is the signed key, not a digest of it, so expiry is enforced server-side on every request.

## Minting is a script, not an endpoint

A `/api/gate/mint` route would be more convenient — mint from a phone, paste into Discord — and would put a **second password-checking door on a site with no rate limiting, during the month nobody is watching it**. The script runs on a machine that already has the code, so it adds no attack surface at all.

It imports the same module the edge runs (Node 22.18+ type stripping) rather than reimplementing the HMAC, and verifies each key before printing it. The failure mode of a second implementation is a key that mints cleanly and is refused in production.

If the convenience turns out to matter more than the surface, the endpoint is a small change and the logic is already there.

## Two trades, written down because they are trades

**Revocation is all-or-nothing.** Nothing is stored, so killing one outstanding key early means changing `MAINTENANCE_PASSWORD` — which logs out every session too. Fine at a thirty-minute horizon, not at a thirty-day one, which is why a key is capped at **one day**.

**There is no per-key identity.** A key is a pure function of (master code, expiry second), so minting twice in the same second returns the identical string. Handing a key to five people *is* handing out one key five times — which is why there is no `--count` flag printing the same string N times, and why the script says so.

## Gate

`npx tsc --noEmit` clean. **3,223 tests across 327 files pass**, 14 new, each watched fail before the code that satisfies it — including the forged-expiry, wrong-secret, truncated-key and cookie-lifetime cases.

Exercised end to end on the real code path: mint → verify at t+0 (ok) → verify past expiry (refused, `expired`) → verify with a rotated secret (refused, `signature`).

## Note on the live site

Production is now **serving the curtain** (`503`, `Retry-After: 3600`, `Cache-Control: no-store`) — `MAINTENANCE_MODE` is set and the gate is armed. Temp keys only start working once this is merged **and deployed**; until then the live site accepts the master code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPc6asqo4ePhWJF684Ccuz
