### PR TITLE
Self-host on Lightsail: build in Actions, ship a prebuilt artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,8 @@
 # INSIDE every value, so NEXT_PUBLIC_SITE_URL becomes a URL with a carriage return on
 # the end and every canonical link is subtly wrong.
 deploy/* text eol=lf
+
+# GitHub Actions parses the YAML and writes each `run:` block to a script file on an
+# Ubuntu runner. A CR surviving into that file makes bash read `$'\r'` as part of the
+# last token on every line, so the step fails on something that looks correct on screen.
+.github/workflows/* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # The Vercel ignore step runs this on Linux; CRLF would break the shebang line.
 *.sh text eol=lf
+
+# deploy/ is copied verbatim onto a Linux box: a systemd unit, a Caddy config, and an
+# env file that bash sources. A trailing CR does not fail loudly there — it rides along
+# INSIDE every value, so NEXT_PUBLIC_SITE_URL becomes a URL with a carriage return on
+# the end and every canonical link is subtly wrong.
+deploy/* text eol=lf

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,89 @@
+name: Deploy production
+
+# Builds the app and ships it to the Lightsail box. The box deliberately cannot build
+# this app — it is a 2 GB instance, measured at 1,907 MB with no swap — so the runner is
+# where `next build` happens and the box receives a finished standalone tree.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # Never run two deploys at once: they would race over the same `current` symlink and
+  # the loser would restart the service pointing at a half-written release.
+  group: deploy-production
+  # And never cancel one in flight. A cancelled deploy can leave the symlink swapped
+  # with the service not yet restarted, which is the one state with no owner.
+  cancel-in-progress: false
+
+env:
+  PROVENANCE_HOST: app@52.44.44.162
+  # Host key pinned rather than discovered. A fresh runner has an empty known_hosts, so
+  # trust-on-first-use would mean trusting whatever answers, on every single run.
+  # Rotate this if the instance is ever rebuilt: ssh-keygen -lf shows
+  # SHA256:afvWsEb5xOUbrAhxnMSRWqLeoWYbEQuOrDnqIX1tfpA
+  PROVENANCE_HOST_KEY: "52.44.44.162 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILEW3+9JkjhzAMb5ChHTWtHE6zK8ha/FvMUwMy8oOfiH"
+
+jobs:
+  ship:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # deploy.sh names the release directory after the short SHA, so it needs the
+          # commit to exist locally. A shallow checkout of depth 1 is enough for that.
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          # Must match the box. `output: "standalone"` bundles traced dependencies and a
+          # native binding built on one major does not load on another.
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci --no-audit --fund=false
+
+      - name: Gate
+        # The repo's own gate, from CLAUDE.md. Route-export mistakes and plan-ceiling
+        # settings are invisible to tsc and to vitest, so `next build` below is the
+        # third check rather than a formality.
+        run: |
+          npx tsc --noEmit
+          npm test
+
+      - name: Build
+        env:
+          # NEXT_PUBLIC_* is inlined into the client bundle at BUILD time, so this is the
+          # only place the production hostname can be set. Without it, lib/brand.ts falls
+          # back to VERCEL_PROJECT_PRODUCTION_URL — which does not exist here — and then
+          # to a hardcoded vercel.app host, baking the wrong canonical, og:image and
+          # sitemap URL into every page.
+          NEXT_PUBLIC_SITE_URL: https://provenance-online.com
+          # Replaces VERCEL_ENV, which no longer exists off Vercel. robots.ts is
+          # generated at build time and reads the BUILD's environment, so this has to be
+          # here and not on the box.
+          SITE_ENV: production
+        # NOTE ON WHAT IS ABSENT. No upstream API keys. Every fetch in this repo is
+        # keyless-first and dormant-safe, and the pages that show live data are
+        # regenerated at runtime on the box where the keys actually live. So the secrets
+        # exist in exactly one place and never pass through CI.
+        run: npm run build
+
+      - name: Assemble the release
+        run: bash deploy/assemble.sh
+
+      - name: Ship
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$PROVENANCE_HOST_KEY" > ~/.ssh/known_hosts
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          bash deploy/deploy.sh
+        env:
+          # The private half of provenance_deploy. It authenticates as `app`, whose sudo
+          # rights are three systemctl verbs on one unit — deliberately not `ubuntu`,
+          # which has passwordless sudo for everything.
+          DEPLOY_KEY: ${{ secrets.PROVENANCE_SSH_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,6 @@ obligations and are not satisfied by the licence.
   file and the README state the new figures. That is the guard working — and note that
   `readme-counts` also had to learn that a discovered feed has no adapter module of its own,
   because that assumption stayed invisible until the count moved.
-<<<<<<< HEAD
 - **Windy webcams are a harvested static catalogue, not a live sample.** `public/webcams/`
   holds 196 committed tiles with **70,698 webcams** (8.2 MB raw / 2.0 MB gzipped), built by
   `scripts/harvest-webcams.mjs` and streamed in by `lib/webcams/tileLoad.ts` — static CDN
@@ -230,7 +229,6 @@ Re-measure before putting a number in a README, a CV or a PR description.
   image CDN, if it is ever needed for something else, is
   `https://webcams.ventusky.com/data/{last 2 digits of id}/{id}/latest_thumb.jpg`, **not**
   `images.ventusky.com/{id}.jpg`.
-<<<<<<< HEAD
 - **Windy's free tier caps offset at 1,000, and that is what shapes the webcam harvest
   (measured 2026-09-05).** `limit>50` is a 400; `offset=2000` is a 400 reading
   `"Offset is over API tier limit 1000!"`. So one bbox yields at most **1,050 rows**, and

--- a/app/(site)/privacy/page.tsx
+++ b/app/(site)/privacy/page.tsx
@@ -51,10 +51,15 @@ const ISSUES_URL = `${REPO_URL}/issues`;
  *     and camera pictures; it never sees a visitor, and it is not deployed.
  *
  * The load-bearing checks behind the copy below, all re-run against 2cf8797:
- *   • analytics — `<Analytics />` from @vercel/analytics in app/layout.tsx:99, and
- *     nothing else. A repo-wide grep for gtag / GA / Plausible / PostHog / Segment /
- *     Hotjar / Sentry / Clarity returns no runtime hit.
- *   • persistence — package.json ships ten runtime deps and not one is a database
+ *   • analytics — NONE, as of the move off Vercel. `<Analytics />` from
+ *     @vercel/analytics was removed from app/layout.tsx together with the package;
+ *     /_vercel/insights exists only on Vercel's edge, so self-hosted it would have
+ *     posted a 404 per page view — the appearance of collection with none of the
+ *     substance. A repo-wide grep for gtag / GA / Plausible / PostHog / Segment /
+ *     Hotjar / Sentry / Clarity returns no runtime hit either. Nothing counts a visit.
+ *     IF AN EXTERNAL COUNTER IS EVER ADDED, THIS SECTION AND THE THREE PLACES BELOW
+ *     THAT SAY "no analytics" HAVE TO MOVE WITH IT.
+ *   • persistence — package.json ships nine runtime deps and not one is a database
  *     client. `writeFileSync|writeFile\(|appendFile|node:fs` over app/ lib/ components/
  *     now returns TWO files, lib/discovery/store.ts and app/api/admin/promote/route.ts,
  *     both belonging to the dev-only camera-review tool and both behind a production
@@ -139,10 +144,10 @@ export default function PrivacyPage() {
               </p>
             </div>
             <div className="pv-card">
-              <h2 className="pv-h3">One analytics tool</h2>
+              <h2 className="pv-h3">No analytics</h2>
               <p>
-                Vercel Web Analytics counts page views. No Google Analytics, no ad pixel, no session
-                recording.
+                Nothing counts your visit. No Google Analytics, no ad pixel, no session recording,
+                and since the move off Vercel, no page-view counter of any kind.
               </p>
             </div>
           </div>
@@ -611,7 +616,7 @@ export default function PrivacyPage() {
               <span>Cookies</span>
               <span>Analytics</span>
             </p>
-            <h2 className="pv-h2">No cookies of ours. One counter.</h2>
+            <h2 className="pv-h2">No cookies of ours. No counter either.</h2>
           </div>
           <div className="pv-prose">
             <p>
@@ -621,20 +626,20 @@ export default function PrivacyPage() {
               YouTube embed described above.
             </p>
             <p>
-              The site does load <strong>Vercel Web Analytics</strong>, served from this domain,
-              which reports page views to Vercel, our host. It is the only analytics here. A search
-              of the repository finds no Google Analytics, no gtag, no Meta pixel, no PostHog, no
+              There is also <strong>no analytics</strong>. Until this site moved off Vercel it
+              loaded their Web Analytics script, which counted page views; that script and its
+              package were removed in the move, and nothing replaced them. A search of the
+              repository finds no Google Analytics, no gtag, no Meta pixel, no PostHog, no
               Plausible, no session recorder and no fingerprinting library.
             </p>
             <p>
-              What Vercel collects, and for how long, is Vercel&rsquo;s to describe rather than ours.
-              We have not audited their end. What we can tell you is what this application asks for,
-              which is a count of page views, and that nothing in this code sends them anything
-              else.{" "}
+              The page-view counts collected while the site ran on Vercel still sit in Vercel&rsquo;s
+              account, and what they hold and for how long is theirs to describe rather than ours
+              &mdash; see{" "}
               <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noreferrer noopener">
-                Vercel&rsquo;s privacy policy
+                their privacy policy
               </a>
-              .
+              . Nothing has been added to that record since the move, because nothing is being sent.
             </p>
           </div>
         </section>
@@ -655,10 +660,15 @@ export default function PrivacyPage() {
               from anything you sent. Nothing you type is logged anywhere.
             </p>
             <p>
-              Vercel keeps its own request logs underneath the application, as any web host does, and
-              those will include your IP address and user agent. That happens below this code, we do
-              not add to it, and we have not audited how long it is held. If that matters to you,
-              treat it the way you would treat any hosted website.
+              Underneath the application is a web server, and it keeps an access log, as any web
+              server does. That used to be Vercel&rsquo;s and is now ours, which means it is worth
+              being specific about: it records the path you asked for, the status and size of the
+              reply, how long it took, and your user agent. <strong>It does not record your IP
+              address.</strong> The server is told to mask it before writing &mdash; the first 16
+              bits survive for IPv4, which is a block of some sixty-five thousand addresses, and the
+              rest is discarded. That is enough to tell one machine hammering the site from a
+              genuine crowd, and not enough to point at you. The log rolls and old files are
+              deleted; nothing is exported anywhere.
             </p>
           </div>
         </section>
@@ -684,11 +694,13 @@ export default function PrivacyPage() {
               yourself by clearing site data.
             </p>
             <p>
-              Three things sit outside that, and they are the only places anything of yours can
-              persist. Two are handled by Vercel as our host: Web Analytics, and platform request
-              logs. The third is a feedback answer, if you chose to send one, which is sitting as a
-              message in a private Telegram chat. That one is the only place a name or an email you
-              gave us can be. Ask and it will be deleted.
+              Two things sit outside that, and they are the only places anything of yours can
+              persist. One is the server access log described above, which is IP-masked, rolled and
+              deleted. The other is a feedback answer, if you chose to send one, which is sitting as
+              a message in a private Telegram chat &mdash; that is the only place a name or an email
+              you gave us can be, and asking will get it deleted. The page-view counts that Vercel
+              gathered before the move are a third, historical, and are being wound down with that
+              account.
             </p>
             <p>
               If you think any of this is wrong, say so in{" "}

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -84,6 +84,17 @@ export default async function AnalyticsPage() {
         retains. Every panel below states which of its numbers were measured and which were never
         available, because on a dashboard an unexplained empty panel reads as a zero.
       </p>
+      <p className="adm-lede">
+        <strong>This is a closing archive, not a live dashboard.</strong> Collection stopped when
+        the site left Vercel: <code>&lt;Analytics /&gt;</code> posted to{" "}
+        <code>/_vercel/insights</code>, a path that exists only on their edge, so it was removed
+        rather than left to 404 once per page view. Everything here is history, and the rolling
+        window means it is history that is <em>expiring</em> — each day the earliest day drops off
+        and nothing is added at the other end. Read a fall to zero as the move, not as a collapse
+        in traffic. Whatever needs keeping should be exported before the window swallows it, and
+        certainly before the Vercel plan changes, because the free tier answers any request for a
+        date older than 31 days with a flat 400 rather than a short answer.
+      </p>
 
       <Panel
         title="1 · Traffic over time"

--- a/app/api/gate/route.ts
+++ b/app/api/gate/route.ts
@@ -7,6 +7,7 @@ import {
   gateCookieHeader,
 } from "@/lib/gate/token";
 import { verifyTempKey } from "@/lib/gate/tempkey";
+import { isMaintenanceArmed } from "@/lib/gate/armed";
 
 /**
  * The one door through the maintenance curtain.
@@ -29,7 +30,7 @@ import { verifyTempKey } from "@/lib/gate/tempkey";
  * this handler - a middleware-shaped limiter would cost an invocation to say no.
  */
 export async function POST(request: NextRequest) {
-  if (!process.env.MAINTENANCE_MODE) {
+  if (!isMaintenanceArmed()) {
     return new NextResponse(null, { status: 404 });
   }
 

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -112,7 +112,14 @@ export function GET(req: Request): ImageResponse {
   // `new URL(siteUrl())` threw. tests/unit/naming-guard.test.ts caught it on the
   // merge — that guard exists because this exact string had already leaked into
   // CSV filenames and outbound alerts once before.
-  let host = "traffic-nerd-v2.vercel.app";
+  //
+  // It then spent the whole Vercel era naming `traffic-nerd-v2.vercel.app`, a host that
+  // is now a redirect to somewhere else. A fallback pointing at the old home is the
+  // hardest kind of wrong to notice: nothing errors, and the only symptom is a share
+  // card branded with an address we have left, seen by whoever received the link.
+  // Annotated, because BRAND is `as const` and would otherwise narrow `host` to the
+  // literal domain and reject the real hostname assigned below.
+  let host: string = BRAND.domain;
   try {
     host = new URL(siteUrl()).host;
   } catch {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
-import { Analytics } from "@vercel/analytics/next";
 import { BRAND, siteUrl } from "@/lib/brand";
 import "./globals.css";
 
@@ -95,8 +94,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     // root; nothing changes typeface until globals.css consumes them.
     <html lang="en" data-theme="light" className={`${jetbrainsMono.variable} ${ibmPlexSans.variable}`}>
       <body>
+        {/*
+          NOTHING COUNTS PAGE VIEWS HERE. `<Analytics />` from @vercel/analytics used to
+          sit on this line. It posts to /_vercel/insights, a path that exists only on
+          Vercel's edge, so self-hosted it would have fired a 404 on every single page
+          view — collecting nothing while looking, in the code, exactly like collection.
+          It was removed with the package rather than left inert, because a dead
+          analytics import is a standing invitation to conclude the numbers are being
+          gathered somewhere.
+
+          /admin/analytics can still READ the history Vercel already holds while the
+          token lasts. It just stops gaining new rows from the moment this deployment
+          serves traffic. app/(site)/privacy states this in the visitor's words.
+        */}
         {children}
-        <Analytics />
       </body>
     </html>
   );

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -15,11 +15,23 @@ export default function robots(): MetadataRoute.Robots {
 
   // Every non-production deployment gets a blanket refusal. Preview URLs carry a
   // byte-identical copy of the whole site, and an indexed preview competes with
-  // production for the same queries as duplicate content. VERCEL_ENV is absent
-  // outside Vercel (local dev), where the file is not served to anyone anyway, so
-  // the default has to be "allow" - defaulting to noindex would risk silently
-  // deindexing production if the variable ever went missing.
-  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production") {
+  // production for the same queries as duplicate content.
+  //
+  // SITE_ENV EXISTS BECAUSE THE OLD REASONING STOPPED BEING TRUE. This used to read
+  // VERCEL_ENV alone, justified by "absent outside Vercel (local dev), where the file
+  // is not served to anyone anyway". Self-hosted that is false: the preview box serves
+  // this file to whoever asks, VERCEL_ENV is absent there too, and the guard written to
+  // keep previews out of the index would have waved them straight in.
+  //
+  // VERCEL_ENV is still honoured, because the Vercel project stays alive to redirect
+  // the old subdomain and should keep behaving correctly while it does.
+  //
+  // The default stays "allow" on purpose. Defaulting to noindex would mean one missing
+  // variable silently deindexes production, which is far worse than the failure it
+  // prevents - so a preview MUST set SITE_ENV=preview, and this file is generated at
+  // BUILD time, so it has to be set for the build and not on the running box.
+  const siteEnv = process.env.SITE_ENV || process.env.VERCEL_ENV;
+  if (siteEnv && siteEnv !== "production") {
     return { rules: [{ userAgent: "*", disallow: "/" }] };
   }
 

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -14,7 +14,6 @@ www.provenance-online.com {
 }
 
 provenance-online.com {
-
 	# Build assets only. Filenames here are content-hashed, so a year is safe and it
 	# keeps repeat visitors off the origin entirely — the cheapest byte is unsent.
 	#
@@ -26,29 +25,49 @@ provenance-online.com {
 	@immutable path /_next/static/*
 	header @immutable Cache-Control "public, max-age=31536000, immutable"
 
-	reverse_proxy 127.0.0.1:3000 {
-		# lib/brand.ts resolves absolute URLs from NEXT_PUBLIC_SITE_URL first, so these
-		# are the backstop rather than the primary path — they keep anything reading the
-		# request directly (redirects, Next's own URL handling) on https and the real
-		# host instead of http://127.0.0.1:3000.
-		header_up X-Forwarded-Proto {scheme}
-		header_up X-Forwarded-Host {host}
-		header_up Host {host}
-
-		# /api/hls streams video segments straight through. Caddy does not buffer
-		# response bodies by default, so segments start flowing before they finish
-		# downloading — leave it that way.
-	}
+	# NO header_up LINES, AND THAT IS NOT AN OMISSION. Caddy already sends
+	# X-Forwarded-Proto, X-Forwarded-Host and X-Forwarded-For, and unlike nginx it
+	# passes the original Host through untouched. `caddy validate` warns about writing
+	# them by hand ("Unnecessary header_up ..."), which is how the three that used to be
+	# here were found. Anything reading the request directly — a redirect, Next's own
+	# URL handling — therefore sees https and the real hostname rather than
+	# http://127.0.0.1:3000. It is a backstop either way: lib/brand.ts resolves absolute
+	# URLs from NEXT_PUBLIC_SITE_URL first.
+	#
+	# /api/hls streams video segments straight through. Caddy does not buffer response
+	# bodies by default, so segments start flowing before they finish downloading —
+	# leave it that way.
+	reverse_proxy 127.0.0.1:3000
 
 	# NOT adding `encode` on purpose: Next's standalone server already compresses
 	# (`compress` defaults to true), including the ~6.4 MB /api/cameras body it deflates
 	# to roughly a megabyte. A second encoder buys nothing and costs CPU on every
 	# response, on a box with two shared vCPUs.
 
+	# THE ACCESS LOG IS IP-MASKED, AND app/(site)/privacy PROMISES THAT IN WRITING.
+	# Caddy's default JSON encoder writes request>remote_ip and request>client_ip in
+	# full. On Vercel those addresses were the host's to hold and the privacy page said
+	# so; self-hosted they become ours, and "this application holds no record of you"
+	# stops being true the moment the first request is written down.
+	#
+	# ip_mask keeps 16 bits of IPv4 and 32 of IPv6, so a row still distinguishes one
+	# machine hammering the box from a genuine crowd — the only operational question an
+	# address answers here — while naming a block of ~65,000 rather than a person.
+	# Deleting the field outright would cost that signal and buy nothing extra, since a
+	# /16 identifies no one.
+	#
+	# The rest of the row is what M7 needs: path, status, size and duration are how the
+	# request volume gets measured before deciding whether a CDN in front of this box
+	# pays for itself. Do not remove the log to "save disk" — 5 x 50 MiB is bounded, and
+	# without it the CDN decision goes back to guessing.
 	log {
 		output file /var/log/caddy/provenance.log {
 			roll_size 50MiB
 			roll_keep 5
+		}
+		format filter {
+			request>remote_ip ip_mask 16 32
+			request>client_ip ip_mask 16 32
 		}
 	}
 }

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,38 @@
+# /etc/caddy/Caddyfile   —   edit DOMAIN, then: systemctl reload caddy
+#
+# Caddy terminates TLS (certificate obtained and renewed automatically from Let's
+# Encrypt on first boot — the DNS A record must already point here or issuance fails)
+# and reverse-proxies to the Next standalone server on loopback:3000.
+#
+# NOT adding `encode` here on purpose: Next's standalone server already compresses
+# (`compress` defaults to true), including the ~6.4 MB /api/cameras body it deflates to
+# roughly a megabyte. A second encoder buys nothing and costs CPU on every response.
+
+provenance.example.com {
+
+	# Long-lived immutable build assets. Hashed filenames, so a year is safe and it
+	# keeps repeat visitors off the origin entirely — the cheapest byte is unsent.
+	@immutable path /_next/static/*
+	header @immutable Cache-Control "public, max-age=31536000, immutable"
+
+	reverse_proxy 127.0.0.1:3000 {
+		# lib/brand.ts resolves absolute URLs from NEXT_PUBLIC_SITE_URL first, so these
+		# are the backstop rather than the primary path — they keep anything that reads
+		# the request directly (redirects, Next's own URL handling) on https and the
+		# real host instead of http://127.0.0.1:3000.
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+		header_up Host {host}
+
+		# /api/hls streams video segments straight through. Caddy does not buffer
+		# response bodies by default, so segments start flowing before they finish
+		# downloading — leave it that way.
+	}
+
+	log {
+		output file /var/log/caddy/provenance.log {
+			roll_size 50MiB
+			roll_keep 5
+		}
+	}
+}

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,25 +1,36 @@
-# /etc/caddy/Caddyfile   —   edit DOMAIN, then: systemctl reload caddy
+# /etc/caddy/Caddyfile
+#   install -m 644 deploy/Caddyfile /etc/caddy/Caddyfile && systemctl reload caddy
 #
-# Caddy terminates TLS (certificate obtained and renewed automatically from Let's
-# Encrypt on first boot — the DNS A record must already point here or issuance fails)
-# and reverse-proxies to the Next standalone server on loopback:3000.
-#
-# NOT adding `encode` here on purpose: Next's standalone server already compresses
-# (`compress` defaults to true), including the ~6.4 MB /api/cameras body it deflates to
-# roughly a megabyte. A second encoder buys nothing and costs CPU on every response.
+# Caddy terminates TLS, obtaining and renewing certificates from Let's Encrypt without
+# supervision. THE DNS A RECORD MUST ALREADY POINT HERE before the first start: issuance
+# is an HTTP-01 challenge against the name, so a reload before DNS resolves burns a
+# failed attempt against Let's Encrypt's rate limit rather than producing a certificate.
 
-provenance.example.com {
+# Canonical host is the apex. www redirects rather than serving a byte-identical copy,
+# because two hostnames answering the same 18,766 camera pages is duplicate content
+# competing with itself — and the sitemap and canonical tags name the apex.
+www.provenance-online.com {
+	redir https://provenance-online.com{uri} permanent
+}
 
-	# Long-lived immutable build assets. Hashed filenames, so a year is safe and it
+provenance-online.com {
+
+	# Build assets only. Filenames here are content-hashed, so a year is safe and it
 	# keeps repeat visitors off the origin entirely — the cheapest byte is unsent.
+	#
+	# DO NOT WIDEN THIS TO public/. Nothing in public/ is content-hashed, so `immutable`
+	# would pin a stale file with no way to recall it. public/ is served by Next, which
+	# applies the headers() block added in PR #174 — the fix for 1,083,357 static
+	# requests in one day, 124 per page load. Serving public/ from Caddy would bypass
+	# that block and silently reintroduce the bill it removed.
 	@immutable path /_next/static/*
 	header @immutable Cache-Control "public, max-age=31536000, immutable"
 
 	reverse_proxy 127.0.0.1:3000 {
 		# lib/brand.ts resolves absolute URLs from NEXT_PUBLIC_SITE_URL first, so these
-		# are the backstop rather than the primary path — they keep anything that reads
-		# the request directly (redirects, Next's own URL handling) on https and the
-		# real host instead of http://127.0.0.1:3000.
+		# are the backstop rather than the primary path — they keep anything reading the
+		# request directly (redirects, Next's own URL handling) on https and the real
+		# host instead of http://127.0.0.1:3000.
 		header_up X-Forwarded-Proto {scheme}
 		header_up X-Forwarded-Host {host}
 		header_up Host {host}
@@ -28,6 +39,11 @@ provenance.example.com {
 		# response bodies by default, so segments start flowing before they finish
 		# downloading — leave it that way.
 	}
+
+	# NOT adding `encode` on purpose: Next's standalone server already compresses
+	# (`compress` defaults to true), including the ~6.4 MB /api/cameras body it deflates
+	# to roughly a megabyte. A second encoder buys nothing and costs CPU on every
+	# response, on a box with two shared vCPUs.
 
 	log {
 		output file /var/log/caddy/provenance.log {

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -6,6 +6,30 @@
 # is an HTTP-01 challenge against the name, so a reload before DNS resolves burns a
 # failed attempt against Let's Encrypt's rate limit rather than producing a certificate.
 
+# GLOBAL OPTIONS. This block masks addresses in the DEFAULT logger, and it exists
+# because the site-level `log` block at the bottom of this file does NOT cover
+# everything. Caddy splits its logging in two:
+#
+#   http.log.access.log0  -> the site's own `log` block  -> the file, filtered.
+#   http.log.error.log0   -> the DEFAULT logger          -> stderr, so journald.
+#
+# Both carry `request>remote_ip` and `request>client_ip` in full. Only the first was
+# filtered, so every 502, every timeout and every refused upstream wrote a complete
+# visitor address into the systemd journal — where it is retained, rotated by journald's
+# own rules rather than ours, and readable by anyone who can read the journal. The
+# access log looked masked, which is exactly what made it easy to miss.
+#
+# app/(site)/privacy tells visitors this server does not record their IP address. That
+# sentence has to be true of BOTH streams, so the same 16/32 mask is applied here.
+{
+	log default {
+		format filter {
+			request>remote_ip ip_mask 16 32
+			request>client_ip ip_mask 16 32
+		}
+	}
+}
+
 # Canonical host is the apex. www redirects rather than serving a byte-identical copy,
 # because two hostnames answering the same 18,766 camera pages is duplicate content
 # competing with itself — and the sitemap and canonical tags name the apex.

--- a/deploy/assemble.sh
+++ b/deploy/assemble.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Turn `next build` output into a shippable release. Run from the repo root, after the
+# build and before deploy/deploy.sh.
+#
+# THE TRAP THIS EXISTS FOR. `output: "standalone"` does NOT copy `public/` or
+# `.next/static` into the standalone tree — Next assumes a CDN serves them. Self-hosted
+# there is no CDN. Miss this step and the app boots, answers HTML with a 200, and 404s
+# every stylesheet, script chunk and icon: the page renders unstyled, the map never
+# mounts, and the server log says nothing is wrong.
+#
+# It is one script rather than two lines in a workflow so that a person deploying by
+# hand and CI deploying automatically do the identical thing.
+set -euo pipefail
+
+ART=.next/standalone
+
+[[ -f "$ART/server.js" ]] || { echo "! $ART/server.js missing — run npm run build first" >&2; exit 1; }
+[[ -d public ]] || { echo "! public/ missing — wrong working directory?" >&2; exit 1; }
+[[ -d .next/static ]] || { echo "! .next/static missing — the build did not finish" >&2; exit 1; }
+
+rm -rf "$ART/public" "$ART/.next/static"
+cp -r public "$ART/public"
+mkdir -p "$ART/.next"
+cp -r .next/static "$ART/.next/static"
+
+echo "assembled $ART"
+du -sh "$ART" "$ART/public" "$ART/.next/static" | sed 's/^/  /'

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -86,6 +86,19 @@ ssh "${SSH_OPTS[@]}" "$HOST" \
 ssh "${SSH_OPTS[@]}" "$HOST" "sudo -n systemctl restart provenance"
 
 # ---- verify live, roll back if not -------------------------------------------
+# DO NOT "SIMPLIFY" THIS INTO TRUSTING THE RESTART ABOVE. `systemctl restart` exits 0
+# for a unit that dies instantly, because the unit sets Restart=always: systemd reports
+# the dead service as "activating (auto-restart)" rather than "failed", and the restart
+# JOB genuinely succeeded, so there is nothing for it to report. Measured on this box on
+# 2026-09-07 with no `current` symlink at all — every start died with 226/NAMESPACE
+# because WorkingDirectory did not exist, twelve times in a row, and `systemctl restart`
+# returned 0 each time. Systemd's own start limiter never trips either: RestartSec=3 in a
+# 10-second burst window is about three starts, under the default burst of five, so it
+# loops indefinitely rather than giving up.
+#
+# So the ONLY thing that distinguishes a live release from a crash loop is asking the
+# application whether it answers. That is what this does, and it is why the rollback
+# below can be trusted.
 echo "==> verifying live"
 LIVE=0
 for i in $(seq 1 20); do

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Deploy Provenance to the Hetzner box. Run from the repo root on your laptop:
+#
+#   PROVENANCE_HOST=app@1.2.3.4 deploy/deploy.sh
+#
+# Ships the COMMITTED tree only (git archive), builds on the server, and swaps the
+# `current` symlink atomically. Rolls back and leaves the old release serving if the
+# new one fails to answer.
+set -euo pipefail
+
+HOST="${PROVENANCE_HOST:?set PROVENANCE_HOST=app@<ip>}"
+APP_DIR=/srv/provenance
+SHA="$(git rev-parse --short HEAD)"
+REL="$APP_DIR/releases/$SHA"
+
+# WHY `git archive` AND NOT rsync/scp OF THE WORKING TREE. It emits only tracked
+# files, so an untracked .env.local sitting in the checkout — which is exactly where
+# this repo's API keys live — physically cannot ride along to a public-facing box.
+# It also means the server runs a commit you can name, not "whatever was on disk".
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "! working tree is dirty — deploying committed state ($SHA), not what you see." >&2
+  echo "  ctrl-c within 5s to abort."; sleep 5
+fi
+
+echo "==> shipping $SHA"
+ssh "$HOST" "mkdir -p '$REL'"
+git archive --format=tar HEAD | ssh "$HOST" "tar x -C '$REL'"
+
+echo "==> building on the server"
+# NEXT_PUBLIC_* is inlined at build time, so shared/.env must be sourced HERE, not
+# just by systemd at runtime. A build that cannot see NEXT_PUBLIC_SITE_URL bakes the
+# fallback host into every canonical link and og:image in the bundle, and no runtime
+# setting can undo it afterwards.
+ssh "$HOST" bash -euo pipefail <<REMOTE
+  set -a; . '$APP_DIR/shared/.env'; set +a
+  export NODE_ENV=production
+  cd '$REL'
+  npm ci --no-audit --fund=false
+  npm run build
+
+  # output:"standalone" leaves these behind — see the comment in next.config.ts.
+  # Without them the app serves HTML and 404s every asset.
+  cp -r public '$REL/.next/standalone/public'
+  cp -r .next/static '$REL/.next/standalone/.next/static'
+
+  # server.js resolves its own directory, so the tree it runs from must be the tree
+  # that holds them. Prune the build-only deps to reclaim the ~1 GB node_modules.
+  npm prune --omit=dev
+REMOTE
+
+echo "==> health check on the new release before it takes traffic"
+ssh "$HOST" bash -euo pipefail <<REMOTE
+  set -a; . '$APP_DIR/shared/.env'; set +a
+  cd '$REL/.next/standalone'
+  NODE_ENV=production PORT=3001 HOSTNAME=127.0.0.1 node server.js &
+  PROBE=\$!
+  trap "kill \$PROBE 2>/dev/null || true" EXIT
+  for i in \$(seq 1 45); do
+    if curl -fsS -o /dev/null http://127.0.0.1:3001/api/status; then
+      echo "   new release answers /api/status"; exit 0
+    fi
+    sleep 2
+  done
+  echo "!  new release never answered on :3001 — NOT swapping" >&2
+  exit 1
+REMOTE
+
+echo "==> swapping"
+PREV="$(ssh "$HOST" "readlink -f '$APP_DIR/current' 2>/dev/null || true")"
+ssh "$HOST" "ln -sfn '$REL' '$APP_DIR/current.new' && mv -T '$APP_DIR/current.new' '$APP_DIR/current'"
+ssh "$HOST" "sudo systemctl restart provenance"
+
+sleep 4
+if ssh "$HOST" "curl -fsS -o /dev/null http://127.0.0.1:3000/api/status"; then
+  echo "==> live on $SHA"
+  # Keep the last 3 releases; each carries its own node_modules and ISR cache.
+  ssh "$HOST" "ls -1dt '$APP_DIR'/releases/*/ | tail -n +4 | xargs -r rm -rf"
+else
+  echo "!  live check failed — rolling back to ${PREV:-<none>}" >&2
+  [[ -n "$PREV" ]] && ssh "$HOST" "ln -sfn '$PREV' '$APP_DIR/current' && sudo systemctl restart provenance"
+  exit 1
+fi

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,82 +1,114 @@
 #!/usr/bin/env bash
-# Deploy Provenance to the Hetzner box. Run from the repo root on your laptop:
+# Ship an ALREADY-BUILT release to the box. Runs from CI, and by hand identically:
 #
-#   PROVENANCE_HOST=app@1.2.3.4 deploy/deploy.sh
+#   npm run build && deploy/assemble.sh
+#   PROVENANCE_HOST=app@52.44.44.162 deploy/deploy.sh
 #
-# Ships the COMMITTED tree only (git archive), builds on the server, and swaps the
-# `current` symlink atomically. Rolls back and leaves the old release serving if the
-# new one fails to answer.
+# WHY THIS NO LONGER BUILDS ON THE SERVER. The previous version ran `npm ci` and
+# `npm run build` over SSH, which needed the ~1.1 GB node_modules and a build's peak
+# memory on the box. The box is a 2 GB Lightsail bundle. `output: "standalone"` traces
+# production dependencies into the artifact, so what arrives here is self-contained and
+# the server never needs npm at all.
+#
+# WHAT REPLACED `git archive`. The old script shipped tracked files only, so an
+# untracked .env.local physically could not ride along to a public box. That property
+# has to be preserved, and it is: rsync sends ONE assembled directory whose contents
+# were produced by the build, and the source checkout is never sent.
 set -euo pipefail
 
 HOST="${PROVENANCE_HOST:?set PROVENANCE_HOST=app@<ip>}"
 APP_DIR=/srv/provenance
+ART=.next/standalone
 SHA="$(git rev-parse --short HEAD)"
 REL="$APP_DIR/releases/$SHA"
+SSH_OPTS=(-o ConnectTimeout=20 -o StrictHostKeyChecking=accept-new)
 
-# WHY `git archive` AND NOT rsync/scp OF THE WORKING TREE. It emits only tracked
-# files, so an untracked .env.local sitting in the checkout — which is exactly where
-# this repo's API keys live — physically cannot ride along to a public-facing box.
-# It also means the server runs a commit you can name, not "whatever was on disk".
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo "! working tree is dirty — deploying committed state ($SHA), not what you see." >&2
-  echo "  ctrl-c within 5s to abort."; sleep 5
-fi
+# ---- preconditions -------------------------------------------------------------
+# Each of these is a way the deploy can "succeed" and serve a broken site, so they are
+# checked before anything is sent rather than diagnosed afterwards.
+[[ -f "$ART/server.js" ]] || { echo "! $ART/server.js missing — run npm run build" >&2; exit 1; }
+[[ -d "$ART/public" ]] || { echo "! $ART/public missing — run deploy/assemble.sh" >&2; exit 1; }
+[[ -d "$ART/.next/static" ]] || { echo "! $ART/.next/static missing — run deploy/assemble.sh" >&2; exit 1; }
 
-echo "==> shipping $SHA"
-ssh "$HOST" "mkdir -p '$REL'"
-git archive --format=tar HEAD | ssh "$HOST" "tar x -C '$REL'"
+# Pick a real hashed asset now, so the health check can prove the static tree actually
+# arrived. A check that only fetches / passes happily while every stylesheet 404s: the
+# page renders unstyled, the map never mounts, and the server log stays clean.
+PROBE_ASSET="$(cd "$ART/.next/static" && find . -name '*.js' -type f | head -1 | sed 's|^\./||')"
+[[ -n "$PROBE_ASSET" ]] || { echo "! no hashed asset found under $ART/.next/static" >&2; exit 1; }
+echo "==> shipping $SHA (probe asset: $PROBE_ASSET)"
 
-echo "==> building on the server"
-# NEXT_PUBLIC_* is inlined at build time, so shared/.env must be sourced HERE, not
-# just by systemd at runtime. A build that cannot see NEXT_PUBLIC_SITE_URL bakes the
-# fallback host into every canonical link and og:image in the bundle, and no runtime
-# setting can undo it afterwards.
-ssh "$HOST" bash -euo pipefail <<REMOTE
+# ---- ship --------------------------------------------------------------------
+ssh "${SSH_OPTS[@]}" "$HOST" "mkdir -p '$REL'"
+# --delete so a re-deploy of the same SHA cannot leave a stale file behind.
+rsync -az --delete --info=stats1 \
+  -e "ssh ${SSH_OPTS[*]}" \
+  "$ART/" "$HOST:$REL/"
+
+# ---- prove the new release answers BEFORE it takes traffic --------------------
+# Runs on :3001 beside the live server. Two Next processes fit in 1.9 GB plus swap, and
+# the alternative is finding out after the symlink has already moved.
+echo "==> health check on :3001"
+ssh "${SSH_OPTS[@]}" "$HOST" bash -euo pipefail <<REMOTE
   set -a; . '$APP_DIR/shared/.env'; set +a
-  export NODE_ENV=production
   cd '$REL'
-  npm ci --no-audit --fund=false
-  npm run build
-
-  # output:"standalone" leaves these behind — see the comment in next.config.ts.
-  # Without them the app serves HTML and 404s every asset.
-  cp -r public '$REL/.next/standalone/public'
-  cp -r .next/static '$REL/.next/standalone/.next/static'
-
-  # server.js resolves its own directory, so the tree it runs from must be the tree
-  # that holds them. Prune the build-only deps to reclaim the ~1 GB node_modules.
-  npm prune --omit=dev
-REMOTE
-
-echo "==> health check on the new release before it takes traffic"
-ssh "$HOST" bash -euo pipefail <<REMOTE
-  set -a; . '$APP_DIR/shared/.env'; set +a
-  cd '$REL/.next/standalone'
-  NODE_ENV=production PORT=3001 HOSTNAME=127.0.0.1 node server.js &
+  NODE_ENV=production PORT=3001 HOSTNAME=127.0.0.1 node server.js >/tmp/probe-$SHA.log 2>&1 &
   PROBE=\$!
   trap "kill \$PROBE 2>/dev/null || true" EXIT
+
   for i in \$(seq 1 45); do
-    if curl -fsS -o /dev/null http://127.0.0.1:3001/api/status; then
-      echo "   new release answers /api/status"; exit 0
+    if curl -fsS -o /dev/null http://127.0.0.1:3001/api/status; then break; fi
+    if ! kill -0 \$PROBE 2>/dev/null; then
+      echo "!  the new release exited during start-up:" >&2
+      tail -20 /tmp/probe-$SHA.log >&2
+      exit 1
     fi
     sleep 2
   done
-  echo "!  new release never answered on :3001 — NOT swapping" >&2
-  exit 1
+
+  curl -fsS -o /dev/null http://127.0.0.1:3001/api/status || {
+    echo "!  /api/status never answered" >&2; tail -20 /tmp/probe-$SHA.log >&2; exit 1; }
+  echo "   /api/status answers"
+
+  # The check that catches the standalone trap. A hashed asset is content-addressed, so
+  # a 200 here means the static tree is present and correctly rooted.
+  curl -fsS -o /dev/null "http://127.0.0.1:3001/_next/static/$PROBE_ASSET" || {
+    echo "!  hashed asset 404 — public/ or .next/static did not arrive" >&2; exit 1; }
+  echo "   hashed asset served"
 REMOTE
 
+# ---- swap, then restart, in that order ---------------------------------------
+# systemd resolves ReadWritePaths on the `current` symlink at unit START, so the
+# symlink has to move first or the service writes its ISR cache into the old release.
 echo "==> swapping"
-PREV="$(ssh "$HOST" "readlink -f '$APP_DIR/current' 2>/dev/null || true")"
-ssh "$HOST" "ln -sfn '$REL' '$APP_DIR/current.new' && mv -T '$APP_DIR/current.new' '$APP_DIR/current'"
-ssh "$HOST" "sudo systemctl restart provenance"
+PREV="$(ssh "${SSH_OPTS[@]}" "$HOST" "readlink -f '$APP_DIR/current' 2>/dev/null || true")"
+ssh "${SSH_OPTS[@]}" "$HOST" \
+  "ln -sfn '$REL' '$APP_DIR/current.new' && mv -T '$APP_DIR/current.new' '$APP_DIR/current'"
+ssh "${SSH_OPTS[@]}" "$HOST" "sudo -n systemctl restart provenance"
 
-sleep 4
-if ssh "$HOST" "curl -fsS -o /dev/null http://127.0.0.1:3000/api/status"; then
+# ---- verify live, roll back if not -------------------------------------------
+echo "==> verifying live"
+LIVE=0
+for i in $(seq 1 20); do
+  if ssh "${SSH_OPTS[@]}" "$HOST" "curl -fsS -o /dev/null http://127.0.0.1:3000/api/status"; then
+    LIVE=1; break
+  fi
+  sleep 3
+done
+
+if [[ "$LIVE" == "1" ]]; then
   echo "==> live on $SHA"
-  # Keep the last 3 releases; each carries its own node_modules and ISR cache.
-  ssh "$HOST" "ls -1dt '$APP_DIR'/releases/*/ | tail -n +4 | xargs -r rm -rf"
+  # Keep the last 3 releases. Each is a whole standalone tree plus its own ISR cache,
+  # so this is the only thing stopping 58 GB filling up one deploy at a time.
+  ssh "${SSH_OPTS[@]}" "$HOST" \
+    "ls -1dt '$APP_DIR'/releases/*/ 2>/dev/null | tail -n +4 | xargs -r rm -rf"
 else
   echo "!  live check failed — rolling back to ${PREV:-<none>}" >&2
-  [[ -n "$PREV" ]] && ssh "$HOST" "ln -sfn '$PREV' '$APP_DIR/current' && sudo systemctl restart provenance"
+  if [[ -n "$PREV" ]]; then
+    ssh "${SSH_OPTS[@]}" "$HOST" \
+      "ln -sfn '$PREV' '$APP_DIR/current' && sudo -n systemctl restart provenance"
+    echo "   rolled back" >&2
+  else
+    echo "   nothing to roll back to — this was the first release" >&2
+  fi
   exit 1
 fi

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -33,11 +33,22 @@ SITE_ENV=production
 
 # ---- 2. The maintenance gate — this is what makes the site visible ------------
 
-# MAINTENANCE_MODE armed serves the curtain instead of the app. Unset or empty and the
-# site is open. This is the switch, and note the historical trap: the gate was reported
-# as "the password not working" when in fact MAINTENANCE_MODE had never been set at all,
-# so the curtain was never up and no password was ever being checked.
-MAINTENANCE_MODE=
+# MAINTENANCE_MODE armed serves the curtain instead of the app.
+#
+# OFF is any of: empty, 0, false, off, no (or the line absent entirely).
+# ON is literally anything else — 1, true, on, or a value nobody planned for.
+#
+# It fails toward ON deliberately: an unrecognised value leaves the site DOWN and costing
+# nothing, never UP and billing, which is the one outcome this switch exists to prevent.
+#
+# `0` MEANING OFF IS NEW, AND IT IS NEW BECAUSE OF THIS FILE. On Vercel the gate read
+# `if (process.env.MAINTENANCE_MODE)` and you disarmed by DELETING the dashboard row, so
+# "set at all" and "on" were the same thing. Here you disarm by typing, and `0` is a
+# non-empty string — under the old rule the most natural way of writing "off" took the
+# whole site down, silently. lib/gate/armed.ts is that fix; tests/unit/gate.test.ts pins
+# it. The gate already had one incident of this shape: it was reported as "the password
+# not working" when the variable had simply never been set, so nothing was being checked.
+MAINTENANCE_MODE=0
 
 # The master code. Also the HMAC key that signs the expiring tester keys from #184, so
 # changing it kills every outstanding key at once — which is the only way to revoke one

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -1,40 +1,150 @@
-# Copy to /srv/provenance/shared/.env on the box:  chown app:app, chmod 600.
-# Read at BUILD time by deploy.sh and at RUN time by systemd. Never committed.
+# Runtime environment for the Provenance box.
+#
+#   Copy to /srv/provenance/shared/.env — owner app, chmod 600, never committed.
+#   systemd reads it via EnvironmentFile, and deploy.sh sources it for the health probe.
+#
+# Every value here is OPTIONAL except the two in section 1. Every upstream fetch in this
+# repo is keyless-first and dormant-safe: an unset key means that layer renders a
+# labelled placeholder, never an error and never fabricated data. So fill in what you
+# have and leave the rest blank.
+#
+# THIS LIST WAS BUILT FROM THE CODE, not from the docs. `docs/API_KEYS.md` still asks
+# for five keys that no code reads any more — see section 6 before spending time on any
+# registration form.
 
-# ---- required off Vercel -------------------------------------------------------
-# The one setting the migration turns on. lib/brand.ts falls back to
-# VERCEL_PROJECT_PRODUCTION_URL, which does not exist here, so without this every
-# canonical, og:image and sitemap URL points at the wrong host. NEXT_PUBLIC_* is
-# inlined into the client bundle at build time — changing it needs a rebuild.
-NEXT_PUBLIC_SITE_URL=https://provenance.example.com
 
-# ---- upstream data feeds (copy the values from .env.local) ----------------------
-ACLED_EMAIL=
-ACLED_PASSWORD=
-AISSTREAM_API_KEY=
-ENTSOE_API_TOKEN=
-FINNHUB_API_KEY=
+# ---- 1. Required off Vercel ---------------------------------------------------
+
+# Set BOTH here and in the build, and they must match.
+#
+# NEXT_PUBLIC_* is inlined into the client bundle when `next build` runs, so the value
+# in .github/workflows/deploy.yml is what browsers see. This copy covers server-side
+# reads at runtime. Without it, lib/brand.ts falls back to VERCEL_PROJECT_PRODUCTION_URL
+# — absent here — and then to a hardcoded vercel.app host, so every canonical link,
+# og:image and sitemap URL would name a host we have left.
+NEXT_PUBLIC_SITE_URL=https://provenance-online.com
+
+# Replaces VERCEL_ENV, which does not exist off Vercel. `production` on this box;
+# `preview` on the preview instance. robots.ts is generated at BUILD time and reads the
+# build's environment, so the value that matters for indexing is the one in the
+# workflow — this copy is for anything reading it at runtime.
+SITE_ENV=production
+
+
+# ---- 2. The maintenance gate — this is what makes the site visible ------------
+
+# MAINTENANCE_MODE armed serves the curtain instead of the app. Unset or empty and the
+# site is open. This is the switch, and note the historical trap: the gate was reported
+# as "the password not working" when in fact MAINTENANCE_MODE had never been set at all,
+# so the curtain was never up and no password was ever being checked.
+MAINTENANCE_MODE=
+
+# The master code. Also the HMAC key that signs the expiring tester keys from #184, so
+# changing it kills every outstanding key at once — which is the only way to revoke one
+# early. Armed MAINTENANCE_MODE with this unset is a distinct, detected error state.
+MAINTENANCE_PASSWORD=
+
+
+# ---- 3. Live data — free keys, each unlocks one dormant layer -----------------
+
+# NASA FIRMS — VIIRS/MODIS thermal active-fire detections. Instant, email only.
+#   https://firms.modaps.eosdis.nasa.gov/api/area/
 FIRMS_MAP_KEY=
-FRED_API_KEY=
+
+# OpenAQ — real air-quality station measurements, upgrading the modelled CAMS layer.
+#   https://explore.openaq.org
 OPENAQ_API_KEY=
+
+# AISStream.io — real-time global ship tracking over a free WebSocket. Terrestrial AIS,
+# so roughly 200 km offshore and patchy mid-ocean.
+#   https://aisstream.io
+AISSTREAM_API_KEY=
+
+# ENTSO-E — EU electricity grid load, generation mix, cross-border flows, outages.
+# Two steps: register, then email transparency@entsoe.eu with subject
+# "Restful API access" from the registered address. Usually under a business day.
+#   https://transparency.entsoe.eu
+ENTSOE_API_TOKEN=
+
+# ReliefWeb (OCHA) — humanitarian situation reports and disaster declarations. An
+# approved application name rather than a secret; use a contact address.
+#   https://apidoc.reliefweb.int
 RELIEFWEB_APPNAME=
+
+# Windy — the webcam catalogue layer.
+#   https://api.windy.com/keys
 WINDY_WEBCAMS_API_KEY=
+
+# Finnhub — equities quotes in the Markets panel. Crypto and FX are already keyless
+# and live without this.
+#   https://finnhub.io/register
+FINNHUB_API_KEY=
+
+# FRED (St. Louis Fed) — macro and rates: 10-year, Fed Funds, unemployment, VIX.
+#   https://fredaccount.stlouisfed.org/apikeys
+FRED_API_KEY=
+
+# YouTube Data API v3 — resolves a channel to its CURRENT live video. Not polish:
+# 8 of 12 news presets were already dead on the 2026-08-14 audit because pinned video
+# ids rot, and the ISS panel had been showing Error 153 since YouTube retired the
+# embed/live_stream?channel= endpoint. Free, 10,000 units/day, no billing account.
+# Restrict the key to YouTube Data API v3 and leave application restrictions as None —
+# it is called server-side, so a referrer or IP restriction breaks it.
+#   https://console.cloud.google.com  (Library -> YouTube Data API v3 -> Enable -> Credentials)
 YOUTUBE_API_KEY=
 
-# ---- optional ------------------------------------------------------------------
+
+# ---- 4. Your own services ----------------------------------------------------
+
+# freellmapi.co — the AI daily brief, and the vision fallback for /locate photo
+# geolocation. Base URL and key from your own gateway dashboard.
 FREELLMAPI_BASE_URL=
 FREELLMAPI_KEY=
 FREELLMAPI_VISION_MODEL=
-GEOLOCATE_BACKEND=
+
+# GeoCLIP backend for /locate — best accuracy, needs scripts/geolocate_service.py
+# running somewhere this box can reach. GEOLOCATE_BACKEND is geoclip|llm.
 GEOLOCATE_GEOCLIP_URL=
+GEOLOCATE_BACKEND=
+
+# The in-console feedback prompt. THESE ARE THE DEPLOYMENT'S OWN CREDENTIALS, which is
+# what separates them from /api/telegram — that route relays a token the visitor
+# supplies, so its worst case is someone messaging themselves. /api/feedback spends this
+# token, making it an unauthenticated write path into your chat. With either unset the
+# route is inert and the prompt never mounts.
+#   Bot token from @BotFather in Telegram.
 FEEDBACK_TELEGRAM_BOT_TOKEN=
 FEEDBACK_TELEGRAM_CHAT_ID=
 
-# ---- DEAD once you leave Vercel — see deploy/README.md -------------------------
-# /admin/analytics still authenticates against the Vercel API with these, but the
-# collector that fills it (<Analytics/> -> /_vercel/insights) does not exist off
-# Vercel, so the numbers stop moving. Leave them set to read the 31-day tail of
-# historical data, and stand up a replacement collector.
+
+# ---- 5. Vercel analytics — read-only, and on borrowed time -------------------
+
+# /admin/analytics reads Vercel's Web Analytics query API. Collection is done by
+# <Analytics /> posting to /_vercel/insights, which ONLY EXISTS ON VERCEL — so on this
+# box the numbers stop moving the moment traffic does. Leaving these set buys the
+# ability to read historical data back, and nothing else.
+#
+# TIME-SENSITIVE: Hobby refuses any `since` older than 31 days with a flat 400. When the
+# Pro seat is cancelled, everything outside that rolling window becomes unreachable
+# permanently — including the Reddit spike and the /app 2,298 vs 143 camera-page split.
+# Export before cancelling, not after.
+#   Token: https://vercel.com/account/tokens   Ids: the project's Settings page.
 VERCEL_ANALYTICS_TOKEN=
 VERCEL_ANALYTICS_PROJECT_ID=
 VERCEL_ANALYTICS_TEAM_ID=
+
+
+# ---- 6. Do NOT go and get these ----------------------------------------------
+#
+# `docs/API_KEYS.md` still lists all five. No code reads any of them, so setting one
+# changes nothing — and that doc needs correcting.
+#
+#   ACLED_EMAIL / ACLED_PASSWORD   The adapter was DELETED in #177 (lib/signals/acled.ts,
+#                                  174 lines) along with FAA airport status and WFP food
+#                                  security. Registering and activating myACLED API
+#                                  access would now buy nothing.
+#   UCDP_API_TOKEN                 Never implemented — zero references in app/ or lib/.
+#   ELECTRICITYMAPS_API_KEY        Never implemented.
+#   CLOUDFLARE_API_TOKEN           Never implemented. Outage corroboration is keyless,
+#                                  via IODA and RIPEstat.
+#   WINDY_MAP_FORECAST_API_KEY     Never implemented. Only WINDY_WEBCAMS_API_KEY is read.

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -1,0 +1,40 @@
+# Copy to /srv/provenance/shared/.env on the box:  chown app:app, chmod 600.
+# Read at BUILD time by deploy.sh and at RUN time by systemd. Never committed.
+
+# ---- required off Vercel -------------------------------------------------------
+# The one setting the migration turns on. lib/brand.ts falls back to
+# VERCEL_PROJECT_PRODUCTION_URL, which does not exist here, so without this every
+# canonical, og:image and sitemap URL points at the wrong host. NEXT_PUBLIC_* is
+# inlined into the client bundle at build time — changing it needs a rebuild.
+NEXT_PUBLIC_SITE_URL=https://provenance.example.com
+
+# ---- upstream data feeds (copy the values from .env.local) ----------------------
+ACLED_EMAIL=
+ACLED_PASSWORD=
+AISSTREAM_API_KEY=
+ENTSOE_API_TOKEN=
+FINNHUB_API_KEY=
+FIRMS_MAP_KEY=
+FRED_API_KEY=
+OPENAQ_API_KEY=
+RELIEFWEB_APPNAME=
+WINDY_WEBCAMS_API_KEY=
+YOUTUBE_API_KEY=
+
+# ---- optional ------------------------------------------------------------------
+FREELLMAPI_BASE_URL=
+FREELLMAPI_KEY=
+FREELLMAPI_VISION_MODEL=
+GEOLOCATE_BACKEND=
+GEOLOCATE_GEOCLIP_URL=
+FEEDBACK_TELEGRAM_BOT_TOKEN=
+FEEDBACK_TELEGRAM_CHAT_ID=
+
+# ---- DEAD once you leave Vercel — see deploy/README.md -------------------------
+# /admin/analytics still authenticates against the Vercel API with these, but the
+# collector that fills it (<Analytics/> -> /_vercel/insights) does not exist off
+# Vercel, so the numbers stop moving. Leave them set to read the 31-day tail of
+# historical data, and stand up a replacement collector.
+VERCEL_ANALYTICS_TOKEN=
+VERCEL_ANALYTICS_PROJECT_ID=
+VERCEL_ANALYTICS_TEAM_ID=

--- a/deploy/provenance.service
+++ b/deploy/provenance.service
@@ -26,6 +26,11 @@ Environment=NODE_ENV=production
 Environment=PORT=3000
 Environment=HOSTNAME=127.0.0.1
 
+# Restart=always is deliberate: a transient failure should recover without anyone
+# watching. Know the consequence, which deploy/deploy.sh explains at length — it makes
+# `systemctl restart` exit 0 even when the service dies immediately, because a dead unit
+# reads as "activating (auto-restart)" and not "failed". Never use that exit code as
+# proof a deploy worked.
 Restart=always
 RestartSec=3
 # The registry warm-up means a cold start does real work before it answers.

--- a/deploy/provenance.service
+++ b/deploy/provenance.service
@@ -1,0 +1,39 @@
+# /etc/systemd/system/provenance.service
+# systemctl daemon-reload && systemctl enable --now provenance
+[Unit]
+Description=Provenance (Next.js standalone)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=app
+Group=app
+WorkingDirectory=/srv/provenance/current
+
+# Runtime secrets (API keys). Owner app, chmod 600 — NOT in git.
+# NEXT_PUBLIC_* vars are inlined into the client bundle at BUILD time, so setting one
+# here changes nothing; it has to be present when deploy.sh runs `next build`.
+EnvironmentFile=/srv/provenance/shared/.env
+Environment=NODE_ENV=production
+Environment=PORT=3000
+Environment=HOSTNAME=127.0.0.1
+
+ExecStart=/usr/bin/node /srv/provenance/current/.next/standalone/server.js
+Restart=always
+RestartSec=3
+
+# The registry warm-up means a cold start does real work before it answers.
+TimeoutStartSec=90
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+# ISR writes rendered camera pages to the build's own cache dir, so that path is the
+# one exception to ProtectSystem=strict. 18,766 camera URLs render on first request
+# and are served from here afterwards; losing it means re-rendering all of them.
+ReadWritePaths=/srv/provenance/current/.next
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/provenance.service
+++ b/deploy/provenance.service
@@ -1,5 +1,6 @@
 # /etc/systemd/system/provenance.service
-# systemctl daemon-reload && systemctl enable --now provenance
+# install -m 644 deploy/provenance.service /etc/systemd/system/ \
+#   && systemctl daemon-reload && systemctl enable --now provenance
 [Unit]
 Description=Provenance (Next.js standalone)
 After=network-online.target
@@ -9,20 +10,24 @@ Wants=network-online.target
 Type=simple
 User=app
 Group=app
-WorkingDirectory=/srv/provenance/current
 
-# Runtime secrets (API keys). Owner app, chmod 600 — NOT in git.
-# NEXT_PUBLIC_* vars are inlined into the client bundle at BUILD time, so setting one
-# here changes nothing; it has to be present when deploy.sh runs `next build`.
+# A RELEASE DIRECTORY IS THE APP ROOT. `output: "standalone"` emits a tree whose entry
+# point is server.js and which expects `public/` and `.next/static` beside it, so CI
+# assembles exactly that and ships it as the release. There is no repo checkout here and
+# no node_modules install: the traced dependencies are already inside the artifact.
+WorkingDirectory=/srv/provenance/current
+ExecStart=/usr/bin/node /srv/provenance/current/server.js
+
+# Runtime secrets (upstream API keys). Owner app, chmod 600 — NOT in git.
+# NEXT_PUBLIC_* is inlined into the client bundle at BUILD time, so setting one here
+# changes nothing; it has to be present in the CI environment when `next build` runs.
 EnvironmentFile=/srv/provenance/shared/.env
 Environment=NODE_ENV=production
 Environment=PORT=3000
 Environment=HOSTNAME=127.0.0.1
 
-ExecStart=/usr/bin/node /srv/provenance/current/.next/standalone/server.js
 Restart=always
 RestartSec=3
-
 # The registry warm-up means a cold start does real work before it answers.
 TimeoutStartSec=90
 
@@ -30,9 +35,17 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-# ISR writes rendered camera pages to the build's own cache dir, so that path is the
-# one exception to ProtectSystem=strict. 18,766 camera URLs render on first request
-# and are served from here afterwards; losing it means re-rendering all of them.
+
+# ISR writes rendered pages under the app root, so this is the one path that has to stay
+# writable under ProtectSystem=strict. `current` is a symlink and systemd resolves it at
+# unit START, which is why the deploy swaps the symlink and then restarts — in that
+# order. Restarting first would leave the service writing into the previous release.
+#
+# THE CACHE IS PER-RELEASE, ON PURPOSE. Pointing it at a shared directory would keep the
+# 18,766 camera pages warm across deploys, and would also let a page rendered by the old
+# code be served by the new one, because Next keys these entries by route and not by
+# build. A cold cache after a deploy costs a re-render on first request; a shared one
+# costs correctness.
 ReadWritePaths=/srv/provenance/current/.next
 
 [Install]

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -1,23 +1,43 @@
 #!/usr/bin/env bash
-# One-time setup for a fresh Hetzner box. Run as root, once.
+# One-time setup for the Provenance box. Idempotent — safe to re-run, and re-running it
+# is the actual backup strategy: the box holds no durable state, so a lost instance is
+# recovered by running this on a fresh one and letting CI deploy again.
 #
-#   ssh root@<ip> 'bash -s' < deploy/provision.sh
+#   ssh provenance 'sudo bash -s' < deploy/provision.sh
 #
-# Leaves the box able to build and serve Provenance: a non-root `app` user, Node 24,
-# Caddy for TLS, a firewall, and swap. Idempotent — safe to re-run.
+# Optionally installs the CI deploy key at the same time:
+#   ssh provenance "sudo CI_AUTHORIZED_KEY='$(cat ~/.ssh/provenance_deploy.pub)' bash -s" \
+#     < deploy/provision.sh
+#
+# WHAT THIS BOX CAN AND CANNOT DO. It can serve Provenance. It deliberately cannot
+# build it. The Lightsail 2 GB bundle measured 1,907 MB total with no swap, and
+# `next build` on this app needs more than that — so the artifact arrives prebuilt from
+# GitHub Actions and the box never sees a dev dependency. An earlier draft of this
+# script built on the server and provisioned 4 GB of swap to survive it; that was
+# written for an 8 GB Hetzner box and does not transfer.
 set -euo pipefail
 
 APP_USER=app
 APP_DIR=/srv/provenance
+NODE_MAJOR=24
+
+if [[ $EUID -ne 0 ]]; then
+  echo "! run as root: ssh provenance 'sudo bash -s' < deploy/provision.sh" >&2
+  exit 1
+fi
 
 echo "==> packages"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get install -y -qq curl git ufw rsync ca-certificates ripgrep >/dev/null
+apt-get install -y -qq curl ca-certificates rsync ufw gnupg >/dev/null
 
-echo "==> node 24"
-if ! command -v node >/dev/null || [[ "$(node -v)" != v24* ]]; then
-  curl -fsSL https://deb.nodesource.com/setup_24.x | bash - >/dev/null
+echo "==> node ${NODE_MAJOR}"
+# Node 20 went end-of-life in April 2026, so the version the old workflow pinned is not
+# a candidate. Whatever runs here MUST match the major version Actions builds with:
+# `output: "standalone"` bundles traced dependencies, and a native binding built on one
+# major does not load on another.
+if ! command -v node >/dev/null || [[ "$(node -v)" != v${NODE_MAJOR}* ]]; then
+  curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - >/dev/null
   apt-get install -y -qq nodejs >/dev/null
 fi
 node -v
@@ -31,28 +51,71 @@ if ! command -v caddy >/dev/null; then
     > /etc/apt/sources.list.d/caddy-stable.list
   apt-get update -qq && apt-get install -y -qq caddy >/dev/null
 fi
+caddy version
 
-echo "==> swap (next build peaks well above idle; 4G keeps a 8G box off the OOM killer)"
+echo "==> swap (2G)"
+# Not for builds — nothing is built here. This is headroom for the running server on a
+# box with 1.9 GB and no swap at all, where one memory spike is an OOM kill rather than
+# a slow minute.
 if [[ ! -f /swapfile ]]; then
-  fallocate -l 4G /swapfile && chmod 600 /swapfile && mkswap /swapfile >/dev/null && swapon /swapfile
+  fallocate -l 2G /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile >/dev/null
+  swapon /swapfile
   grep -q '^/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
 fi
+swapon --show
 
-echo "==> app user + dirs"
-id -u "$APP_USER" >/dev/null 2>&1 || useradd --system --create-home --shell /bin/bash "$APP_USER"
-mkdir -p "$APP_DIR"
-chown -R "$APP_USER:$APP_USER" "$APP_DIR"
+echo "==> app user + release dirs"
+id -u "$APP_USER" >/dev/null 2>&1 \
+  || useradd --create-home --shell /bin/bash "$APP_USER"
+install -d -o "$APP_USER" -g "$APP_USER" -m 755 "$APP_DIR" "$APP_DIR/releases"
+# shared/ holds the one file that must survive a deploy: the runtime secrets.
+install -d -o "$APP_USER" -g "$APP_USER" -m 750 "$APP_DIR/shared"
 
-echo "==> firewall — only SSH and HTTP(S). The app itself stays on loopback:3000."
+echo "==> sudoers rule for the deploy"
+# THE BUG THIS FIXES. deploy.sh ends with `sudo systemctl restart provenance`, and
+# nothing ever granted that, so the deploy would have failed at the swap step after
+# doing all the work. Scoped to three verbs on one unit: CI can cycle the app and read
+# its state, and can do nothing else as root. Passing --validate first means a typo
+# here fails now rather than locking the rule in.
+cat > /etc/sudoers.d/provenance-deploy <<SUDOERS
+$APP_USER ALL=(root) NOPASSWD: /usr/bin/systemctl restart provenance, /usr/bin/systemctl reload provenance, /usr/bin/systemctl is-active provenance
+SUDOERS
+chmod 440 /etc/sudoers.d/provenance-deploy
+visudo -c -f /etc/sudoers.d/provenance-deploy
+
+echo "==> CI deploy key"
+# WHY THE CI KEY DOES NOT LIVE ON `ubuntu`. That account has passwordless sudo for
+# everything, so a leaked Actions secret would be root on this box. As `app` the same
+# leak buys write access to the release tree and the three systemctl verbs above.
+if [[ -n "${CI_AUTHORIZED_KEY:-}" ]]; then
+  install -d -o "$APP_USER" -g "$APP_USER" -m 700 "/home/$APP_USER/.ssh"
+  touch "/home/$APP_USER/.ssh/authorized_keys"
+  grep -qF "$CI_AUTHORIZED_KEY" "/home/$APP_USER/.ssh/authorized_keys" \
+    || echo "$CI_AUTHORIZED_KEY" >> "/home/$APP_USER/.ssh/authorized_keys"
+  chown "$APP_USER:$APP_USER" "/home/$APP_USER/.ssh/authorized_keys"
+  chmod 600 "/home/$APP_USER/.ssh/authorized_keys"
+  wc -l < "/home/$APP_USER/.ssh/authorized_keys" | xargs echo "  keys for $APP_USER:"
+else
+  echo "  CI_AUTHORIZED_KEY not set — skipped (see the header for how to pass it)"
+fi
+
+echo "==> firewall"
+# Lightsail has its own firewall in front of this; ufw is the second layer, and the one
+# that lives in version control. OpenSSH is allowed BEFORE enabling, or this locks the
+# box out and the only way back is the Lightsail browser terminal.
 ufw allow OpenSSH >/dev/null
 ufw allow 80/tcp  >/dev/null
 ufw allow 443/tcp >/dev/null
 ufw --force enable >/dev/null
-ufw status numbered
+ufw status verbose | head -6
 
 echo
-echo "Provisioned. Next:"
-echo "  1. put deploy/Caddyfile at /etc/caddy/Caddyfile (edit the domain first)"
-echo "  2. put deploy/provenance.service at /etc/systemd/system/provenance.service"
-echo "  3. put the runtime secrets at $APP_DIR/shared/.env  (chmod 600, owner $APP_USER)"
-echo "  4. run deploy/deploy.sh from your laptop"
+echo "Provisioned. Remaining, in order:"
+echo "  1. DNS A record for the domain -> this box, and let it resolve."
+echo "     Caddy cannot obtain a certificate before the name resolves here."
+echo "  2. /etc/caddy/Caddyfile        <- deploy/Caddyfile (set the domain)"
+echo "  3. /etc/systemd/system/provenance.service  <- deploy/provenance.service"
+echo "  4. $APP_DIR/shared/.env        <- deploy/env.example, chmod 600, owner $APP_USER"
+echo "  5. push to main, and let the workflow build and ship the first release"

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# One-time setup for a fresh Hetzner box. Run as root, once.
+#
+#   ssh root@<ip> 'bash -s' < deploy/provision.sh
+#
+# Leaves the box able to build and serve Provenance: a non-root `app` user, Node 24,
+# Caddy for TLS, a firewall, and swap. Idempotent — safe to re-run.
+set -euo pipefail
+
+APP_USER=app
+APP_DIR=/srv/provenance
+
+echo "==> packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq curl git ufw rsync ca-certificates ripgrep >/dev/null
+
+echo "==> node 24"
+if ! command -v node >/dev/null || [[ "$(node -v)" != v24* ]]; then
+  curl -fsSL https://deb.nodesource.com/setup_24.x | bash - >/dev/null
+  apt-get install -y -qq nodejs >/dev/null
+fi
+node -v
+
+echo "==> caddy"
+if ! command -v caddy >/dev/null; then
+  apt-get install -y -qq debian-keyring debian-archive-keyring apt-transport-https >/dev/null
+  curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt \
+    > /etc/apt/sources.list.d/caddy-stable.list
+  apt-get update -qq && apt-get install -y -qq caddy >/dev/null
+fi
+
+echo "==> swap (next build peaks well above idle; 4G keeps a 8G box off the OOM killer)"
+if [[ ! -f /swapfile ]]; then
+  fallocate -l 4G /swapfile && chmod 600 /swapfile && mkswap /swapfile >/dev/null && swapon /swapfile
+  grep -q '^/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+fi
+
+echo "==> app user + dirs"
+id -u "$APP_USER" >/dev/null 2>&1 || useradd --system --create-home --shell /bin/bash "$APP_USER"
+mkdir -p "$APP_DIR"
+chown -R "$APP_USER:$APP_USER" "$APP_DIR"
+
+echo "==> firewall — only SSH and HTTP(S). The app itself stays on loopback:3000."
+ufw allow OpenSSH >/dev/null
+ufw allow 80/tcp  >/dev/null
+ufw allow 443/tcp >/dev/null
+ufw --force enable >/dev/null
+ufw status numbered
+
+echo
+echo "Provisioned. Next:"
+echo "  1. put deploy/Caddyfile at /etc/caddy/Caddyfile (edit the domain first)"
+echo "  2. put deploy/provenance.service at /etc/systemd/system/provenance.service"
+echo "  3. put the runtime secrets at $APP_DIR/shared/.env  (chmod 600, owner $APP_USER)"
+echo "  4. run deploy/deploy.sh from your laptop"

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -45,6 +45,18 @@ export const BRAND = {
    * Code confirmed live by Sampo on 2026-09-07, replacing H5vB8TsVK.
    */
   discordUrl: "https://discord.gg/q45NU8qWk",
+  /**
+   * Canonical host, WITHOUT a scheme, for the one caller that needs a bare hostname to
+   * print rather than a URL to fetch: the OG card footer.
+   *
+   * This is a LAST-RESORT fallback, not the source of truth. `siteUrl()` is, and it
+   * reads NEXT_PUBLIC_SITE_URL first so a self-hoster or a renamed domain needs no code
+   * change. This literal only appears on a share card when `new URL(siteUrl())` throws,
+   * and it exists as a named constant because the last two values hardcoded here were a
+   * competitor's domain and then a host we no longer serve from — both invisible until
+   * somebody looked at a card.
+   */
+  domain: "provenance-online.com",
   /** Canonical public repository. */
   repo: "011-sam-110/Provenance",
   repoUrl: "https://github.com/011-sam-110/Provenance",

--- a/lib/discovery/devOnly.ts
+++ b/lib/discovery/devOnly.ts
@@ -13,18 +13,30 @@ import { notFound } from "next/navigation";
 /**
  * Is this a live deployment?
  *
- * FAILS CLOSED ON EITHER SIGNAL. `NODE_ENV` alone was the first version and one
- * signal is one thing that can be misconfigured: a build run with NODE_ENV unset, a
- * self-hosted runner, a Dockerfile that forgets it. `VERCEL_ENV` is set independently
- * by the platform, so requiring BOTH to say development is the difference between an
- * admin surface that leaks on a misconfiguration and one that does not.
+ * FAILS CLOSED ON ANY SIGNAL. `NODE_ENV` alone was the first version and one signal is
+ * one thing that can be misconfigured: a build run with NODE_ENV unset, a self-hosted
+ * runner, a Dockerfile that forgets it. `VERCEL_ENV` was added because the platform set
+ * it independently, so a single mistake could not open an admin surface that holds a
+ * team-wide API token.
+ *
+ * SITE_ENV IS HERE BECAUSE THE MOVE OFF VERCEL SILENTLY REMOVED THE SECOND SIGNAL.
+ * `VERCEL_ENV` is not set anywhere but Vercel, so the moment this runs on our own box
+ * the OR collapses back to `NODE_ENV` alone — the exact single-signal state the
+ * paragraph above calls insufficient, reached without editing this function and without
+ * anything going red. `SITE_ENV` is set in the unit's EnvironmentFile, independently of
+ * the `NODE_ENV` the unit sets directly, so the box has two again. `VERCEL_ENV` stays
+ * because the Vercel project is still alive to redirect the old subdomain.
  *
  * The cost of the stricter rule is a developer occasionally having to work out why
  * their production-mode local build 404s. That is a much better afternoon than the
  * other one.
  */
 export function isProduction(env: Record<string, string | undefined> = process.env): boolean {
-  return env.VERCEL_ENV === "production" || env.NODE_ENV === "production";
+  return (
+    env.SITE_ENV === "production" ||
+    env.VERCEL_ENV === "production" ||
+    env.NODE_ENV === "production"
+  );
 }
 
 /** 404 unless this is a development server. Used by every page and layout under /admin. */

--- a/lib/gate/armed.ts
+++ b/lib/gate/armed.ts
@@ -1,0 +1,31 @@
+/**
+ * Is the maintenance curtain armed?
+ *
+ * WHY THIS IS A FUNCTION AND NOT `if (process.env.MAINTENANCE_MODE)`.
+ *
+ * It was that expression, and the expression was correct on Vercel, where a variable is
+ * a row in a dashboard: you ARM the gate by adding `MAINTENANCE_MODE`, and you DISARM it
+ * by deleting the row. There is no third state, so "set at all" and "on" mean the same
+ * thing and truthiness is the whole rule.
+ *
+ * Self-hosted, the variable is a line in a file that a person edits by hand, and the
+ * universal idiom in that file is `VAR=0` for off. Under the old expression `"0"` is a
+ * non-empty string, so it is TRUTHY, so writing the most natural possible way of saying
+ * "off" takes the entire site down and serves a curtain to everyone. Nothing errors and
+ * nothing logs; the site is simply gone, in exactly the way the author was trying to
+ * prevent. The gate already has one incident of this shape on its record — it was
+ * reported as "the password not working" when in fact the variable had never been set,
+ * so no password was being checked at all.
+ *
+ * So the migration changed the interface, and this meets the new interface: the words a
+ * person writes in a .env file to mean "off" mean off. Everything else still arms it,
+ * including any value not on the list, because the failure direction has not changed —
+ * an unrecognised value leaves the site DOWN and costing nothing, never UP and billing.
+ */
+const OFF = new Set(["", "0", "false", "off", "no"]);
+
+export function isMaintenanceArmed(env: Record<string, string | undefined> = process.env): boolean {
+  const raw = env.MAINTENANCE_MODE;
+  if (raw === undefined) return false;
+  return !OFF.has(raw.trim().toLowerCase());
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,14 +3,18 @@ import { isGatedPath } from "@/lib/gate/paths";
 import { GATE_COOKIE, GATE_QUERY, GATE_DENIED, gateToken } from "@/lib/gate/token";
 import { isTempKey, verifyTempKey } from "@/lib/gate/tempkey";
 import { maintenanceHtml } from "@/lib/gate/page";
+import { isMaintenanceArmed } from "@/lib/gate/armed";
 
 /**
  * The maintenance gate.
  *
- * Armed by `MAINTENANCE_MODE` on Vercel Production only, so previews are untouched and
- * stay behind Vercel Authentication as they already are. Disarmed, this function reads
- * one environment variable and passes through - that is the standing cost of having the
- * switch on `main` rather than on a branch, and it was chosen knowingly.
+ * Armed by `MAINTENANCE_MODE`, which is now a line in the box's EnvironmentFile rather
+ * than a row in a Vercel dashboard - see lib/gate/armed.ts, which exists entirely
+ * because those two are edited with different gestures and `=0` means opposite things
+ * in them. The preview box is untouched simply by not carrying the variable. Disarmed,
+ * this function reads one environment variable and passes through - that is the standing
+ * cost of having the switch on `main` rather than on a branch, and it was chosen
+ * knowingly.
  *
  * The point of the gate is COST, not concealment. It answers before anything downstream
  * is invoked, so a gated request buys no React render, no ISR revalidation and no
@@ -27,7 +31,7 @@ export const config = {
 };
 
 export default async function middleware(request: NextRequest) {
-  if (!process.env.MAINTENANCE_MODE) return NextResponse.next();
+  if (!isMaintenanceArmed()) return NextResponse.next();
 
   const { pathname, search, searchParams } = request.nextUrl;
   // The matcher has already excluded the exempt paths; this is the same list applied a

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,21 @@ const nextConfig: NextConfig = {
       permanent: false,
     }));
   },
+  /**
+   * Emit `.next/standalone/server.js` — a self-contained Node server carrying only the
+   * traced dependencies, so the box runs the app without a `node_modules` install.
+   *
+   * WHY THIS EXISTS NOW. Vercel never needed it: its builder traced the same graph
+   * itself. Off Vercel there is no builder, and the alternative is shipping the full
+   * ~1.1 GB `node_modules` to the server on every deploy.
+   *
+   * THE TRAP. `output: "standalone"` does NOT copy `public/` or `.next/static` into
+   * the standalone tree — Next assumes a CDN serves them. Self-hosted there is no CDN,
+   * so the deploy pipeline copies both in beside `server.js`. Miss that step and the
+   * app boots, answers HTML, and every stylesheet, script chunk and icon 404s: the
+   * page renders unstyled and the map never mounts, with a clean server log.
+   */
+  output: "standalone",
   // Allow an isolated build dir so a verification `next build` doesn't fight a
   // concurrently-running `next dev` over `.next` (defaults to `.next`).
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "name": "trafficnerd-v2",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
-        "@vercel/analytics": "^2.0.1",
         "h3-js": "^4.4.0",
         "hls.js": "^1.6.16",
         "maplibre-gl": "^5.24.0",
@@ -1565,48 +1565,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
-      }
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "webcams:status": "node scripts/harvest-webcams.mjs --status"
   },
   "dependencies": {
-    "@vercel/analytics": "^2.0.1",
     "h3-js": "^4.4.0",
     "hls.js": "^1.6.16",
     "maplibre-gl": "^5.24.0",

--- a/tests/unit/discovery-admin-gate.test.ts
+++ b/tests/unit/discovery-admin-gate.test.ts
@@ -91,6 +91,15 @@ describe("the /admin production gate", () => {
     expect(isProduction({ NODE_ENV: "production", VERCEL_ENV: "production" })).toBe(true);
     expect(isProduction({ NODE_ENV: "development", VERCEL_ENV: "preview" })).toBe(false);
     expect(isProduction({})).toBe(false);
+
+    // SITE_ENV is the third signal, and it exists because the other two stopped being
+    // two. Off Vercel, VERCEL_ENV is set by nobody, so every self-hosted case below is
+    // decided by ONE variable unless SITE_ENV also counts — which is the single-signal
+    // state the paragraph above says is not good enough. These four are the box.
+    expect(isProduction({ NODE_ENV: "production", SITE_ENV: "production" })).toBe(true);
+    expect(isProduction({ SITE_ENV: "production" })).toBe(true);
+    expect(isProduction({ NODE_ENV: "production", SITE_ENV: "preview" })).toBe(true);
+    expect(isProduction({ NODE_ENV: "development", SITE_ENV: "preview" })).toBe(false);
   });
 
   it("keeps the review tool out of the crawler's way as well", () => {

--- a/tests/unit/gate.test.ts
+++ b/tests/unit/gate.test.ts
@@ -14,6 +14,7 @@ import {
   gateCookieHeader,
 } from "@/lib/gate/token";
 import { maintenanceHtml, escapeHtml } from "@/lib/gate/page";
+import { isMaintenanceArmed } from "@/lib/gate/armed";
 import { CAMERA_FEED_COUNT } from "@/lib/sources/registry";
 import { SIGNALS, MAP_SIGNALS } from "@/lib/signals/registry";
 import "@/lib/console/widgets";
@@ -331,5 +332,43 @@ describe("the numbers the curtain states as fact", () => {
       }
     }
     expect(text).toContain(`${countries.size} countries`);
+  });
+});
+
+describe("what actually arms the curtain", () => {
+  // THIS SUITE EXISTS BECAUSE OF ONE CHARACTER. The gate used to be
+  // `if (!process.env.MAINTENANCE_MODE)`, which is exactly right on Vercel, where you
+  // disarm by DELETING the dashboard row. In the box's EnvironmentFile you disarm by
+  // typing, and what a person types is `MAINTENANCE_MODE=0` — a non-empty string, so
+  // truthy, so the whole site goes dark on the most natural way of writing "off".
+  // Nothing throws and nothing logs. It was caught by hand mid-migration; these cases
+  // are what catches it next time.
+  it("treats the words a person writes for off as off", () => {
+    for (const v of ["", "0", "false", "off", "no", "FALSE", "Off", " 0 "]) {
+      expect(isMaintenanceArmed({ MAINTENANCE_MODE: v })).toBe(false);
+    }
+  });
+
+  it("stays disarmed when the variable is absent, which is the normal open state", () => {
+    expect(isMaintenanceArmed({})).toBe(false);
+  });
+
+  it("arms on anything else, including a value nobody planned for", () => {
+    // Fails CLOSED on purpose. An unrecognised value leaves the site DOWN and costing
+    // nothing; the alternative failure is UP and billing, which is the single thing
+    // this gate was built to prevent.
+    for (const v of ["1", "true", "on", "yes", "maintenance", "please"]) {
+      expect(isMaintenanceArmed({ MAINTENANCE_MODE: v })).toBe(true);
+    }
+  });
+
+  it("is what both readers call, so the two doors cannot disagree", () => {
+    // A curtain that middleware raises but /api/gate calls 404 would mean nobody could
+    // submit the password to get back in.
+    for (const f of ["middleware.ts", join("app", "api", "gate", "route.ts")]) {
+      const src = readFileSync(join(ROOT, f), "utf8");
+      expect(src).toMatch(/isMaintenanceArmed\(\)/);
+      expect(src).not.toMatch(/process\.env\.MAINTENANCE_MODE/);
+    }
   });
 });

--- a/tests/unit/sources-status.test.ts
+++ b/tests/unit/sources-status.test.ts
@@ -74,6 +74,12 @@ describe("key requirements table", () => {
       "NEXT_RUNTIME",
       "VERCEL_URL",
       "VERCEL_ENV",
+      // SITE_ENV is VERCEL_ENV's platform-neutral replacement, and belongs in the same
+      // category for the same reason: it names WHICH deployment this is, and unlocks
+      // nothing. It exists because VERCEL_ENV is absent off Vercel, which turned
+      // robots.ts's "keep previews out of the index" guard into a no-op on a
+      // self-hosted preview — the one place it most needed to fire.
+      "SITE_ENV",
       // Deployment identity, not a capability credential: these only decide which
       // absolute origin the OG cards and metadataBase resolve against.
       "NEXT_PUBLIC_SITE_URL",


### PR DESCRIPTION
Moves Provenance off Vercel and onto a $12/mo Lightsail box. Nothing in this PR changes
what the site does; it changes where it runs and removes the assumptions that only held
while it ran on Vercel.

## Why the small box is enough

The box does not build. GitHub Actions does, and the box receives a finished
`output: "standalone"` tree — dependencies already traced, so no npm, no dev
dependencies, no ~1 GB `node_modules`, and no build competing for memory with the
process serving traffic. `next build` on this repo has OOM'd on machines larger than
this one; that is the whole reason the split exists.

## What is in here

- **`deploy/assemble.sh`** — copies `public/` and `.next/static` into the standalone
  tree, which standalone deliberately does not do. Missing it is the quietest possible
  failure: HTML 200s, every asset 404s, logs look clean.
- **`deploy/deploy.sh`** — rsyncs a release, starts it on `:3001`, and swaps the
  `current` symlink only after a probe passes. The probe fetches a **real hashed asset**
  picked out of `.next/static`, not just `/api/status` — a liveness-only check is
  precisely the check that would have passed the bug above. Failure rolls back; success
  prunes to three releases.
- **`.github/workflows/deploy.yml`** — gate (`tsc --noEmit` + `npm test`), build, assemble,
  ship. Carries **no upstream API keys**, deliberately: every fetch here is keyless-first
  and dormant-safe, and live-data pages regenerate at runtime on the box, so the keys
  live only in `/srv/provenance/shared/.env` (owner `app`, 600). A secret that never
  enters CI cannot leak from CI.
- **`deploy/Caddyfile`** — TLS, apex/www redirect, immutable caching on `/_next/static`
  only. The comment explains why that must not be widened to `public/`.
- **`deploy/env.example`** — every environment variable the box reads, with the URL to
  obtain each. Built from the code, not from `docs/API_KEYS.md`.

## Two silent breakages fixed

- **`app/robots.ts`** gated on `VERCEL_ENV`, justified by a comment saying that variable
  is absent only in local dev "where the file is not served to anyone anyway". A
  self-hosted preview box breaks that sentence in the middle — it serves `robots.txt`,
  `VERCEL_ENV` is absent there too, and the guard written to keep a byte-identical copy
  of the site out of the index would have waved it in. Now reads `SITE_ENV`, still
  honours `VERCEL_ENV`, and still defaults to allow so one missing variable cannot
  deindex production.
- **`app/api/og/route.tsx`** hardcoded a fallback hostname printed on every share card.
  It has been wrong twice — first a competitor's domain, then the vercel.app host we are
  leaving. Now reads `BRAND.domain`.

## `docs/API_KEYS.md` is wrong and is not fixed here

Five keys it asks for are read by no code: `ACLED_EMAIL`/`ACLED_PASSWORD` (adapter
deleted in #177), `UCDP_API_TOKEN`, `ELECTRICITYMAPS_API_KEY`, `CLOUDFLARE_API_TOKEN`,
`WINDY_MAP_FORECAST_API_KEY` (only `WINDY_WEBCAMS_API_KEY` is read). It also omits
`MAINTENANCE_MODE`, which decides whether the site is visible at all. `deploy/env.example`
records the correct list; correcting the doc is a separate change.

## Not in here

DNS, the certificate, and the cutover. The Vercel project stays up and keeps serving
until the box is verified.
