### PR TITLE
Console: make drawn areas visible, and stop the globe writing into them

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5068,14 +5068,24 @@ body:has(.tn-terminal) { background: #d6dde6; color: #10161d; }
    the same corner — invisible while the container was bigger than the button and
    an off-register double the moment the two became the same size. */
 .tn-terminal .maplibregl-ctrl-attrib.maplibregl-compact:after { content: none !important; }
-/* Expanded, it is a credit LINE. It needs its padding back, room for the button on
-   the left (MapLibre pins the button to the left edge in a bottom-left control),
-   and a width cap so a four-source credit does not run the width of the map. */
+/* Expanded, it is a credit LINE: padding back, a width cap so a four-source credit
+   does not run the width of the map, and room reserved for the button.
+
+   THE RESERVED SIDE FOLLOWS THE CORNER, and getting that wrong is visible rather
+   than subtle — the first cut reserved the left and the mark landed on top of
+   "OpenStreetMap". maplibre-gl.css pins the button `right: 0` by default and moves
+   it to `left: 0` only inside a `-left` container, so these mirror that structure
+   rather than assuming a corner. The control is bottom-right today; it has moved
+   corners before in this file's history and both cases now hold. */
 .tn-terminal .maplibregl-ctrl-attrib.maplibregl-compact-show {
   box-sizing: border-box !important;
   max-width: min(420px, calc(100vw - 24px));
-  padding: 5px 10px 5px 34px !important;
+  padding: 5px 34px 5px 10px !important;
   line-height: 1.45;
+}
+.tn-terminal .maplibregl-ctrl-bottom-left > .maplibregl-ctrl-attrib.maplibregl-compact-show,
+.tn-terminal .maplibregl-ctrl-top-left > .maplibregl-ctrl-attrib.maplibregl-compact-show {
+  padding: 5px 10px 5px 34px !important;
 }
 .tn-terminal .maplibregl-ctrl-attrib .maplibregl-ctrl-attrib-button,
 .tn-terminal .maplibregl-ctrl.maplibregl-ctrl-attrib .maplibregl-ctrl-attrib-button {
@@ -7000,14 +7010,33 @@ border:1px solid var(--tn-border);background:var(--tn-accent-soft)}
   color: var(--tn-text-faint);
 }
 
-.tn-rail-tabs { display: flex; gap: 4px; padding: 7px 0 2px; }
+/* A SEGMENTED CONTROL, not two loose buttons.
+   It used to be a transparent-bordered pair where only the selected one drew a
+   1px outline. Seen in the browser at the top of the rail that reads as an empty
+   input box beside a floating word: the selected half looks like a text field, the
+   unselected half has no affordance at all and does not look clickable. That was
+   survivable while the strip sat below the context line and above one tab's worth
+   of content; it is now the first control in the rail and the thing that says the
+   presets are still here at all, so it needs to look like a control.
+   One track, two halves, the selected half filled. */
+.tn-rail-tabs {
+  display: flex; gap: 2px; margin: 7px 0 8px; padding: 2px;
+  border-radius: 9px; background: var(--tn-surface-2, rgba(0,0,0,.05));
+  border: 1px solid var(--tn-border);
+}
 .tn-rail-tab {
   flex: 1; padding: 5px 0 6px; font: inherit; font-size: var(--tnx-fs-sm); font-weight: 500;
   border-radius: 7px; border: 1px solid transparent; background: none;
   color: var(--tn-text-faint); cursor: pointer;
 }
+.tn-rail-tab:hover { color: var(--tn-text); }
+.tn-rail-tab:focus-visible { outline: 2px solid var(--tn-accent); outline-offset: -1px; }
+/* The fill carries the selection, not the border. --tn-accent is a pale olive here
+   and an outline in it is nearly invisible against the rail's own surface — which
+   is how the old rule managed to leave the selected tab looking unselected. */
 .tn-rail-tab[aria-selected="true"] {
-  border-color: var(--tn-accent); color: var(--tn-accent); font-weight: 600;
+  background: var(--tn-surface); border-color: var(--tn-border);
+  color: var(--tn-text); font-weight: 600; box-shadow: var(--tn-shadow);
 }
 
 .tn-insp-count { color: var(--tn-text-faint); font-weight: 400; }

--- a/components/shell/CommandPalette.tsx
+++ b/components/shell/CommandPalette.tsx
@@ -6,7 +6,7 @@
 // basemap, or fly to a covered region. Open/close is owned by ConsoleShell.
 
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
-import { layersStore, ACTIVE_LAYERS, useLayers, type LayerKey } from "@/lib/layers";
+import { layersStore, ACTIVE_LAYERS, useEditingLayers, type LayerKey } from "@/lib/layers";
 import { mapViewStore, useMapView } from "@/lib/mapView";
 import { BASEMAPS, type BasemapKey } from "@/lib/basemaps";
 import { CAMERA_REGIONS } from "@/lib/icons/svg";
@@ -241,7 +241,13 @@ export default function CommandPalette({ open, onClose }: { open: boolean; onClo
   const activePreset = useActivePreset();
   const variant = useVariant();
   const layout = useShellLayout();
-  const layerState = useLayers();
+  // THE EDITING PROJECTION, not the union. This snapshot stamps the ON/OFF badge on
+  // each layer command, and the command itself calls layersStore.toggle, which writes
+  // to whichever context the Sources rail is pointed at. Read from the union and the
+  // pair disagree: with the rail on an area and Aircraft on in World, the badge says
+  // ON, the toggle writes false to the AREA, and the badge does not move. The palette
+  // would be a dead control. See lib/layers.ts.
+  const layerState = useEditingLayers();
   const snapshot = useMemo<PaletteSnapshot>(() => ({
     basemap: mapView.basemap,
     stage: layout.stage,

--- a/components/shell/ConsoleShell.tsx
+++ b/components/shell/ConsoleShell.tsx
@@ -88,12 +88,16 @@ export default function ConsoleShell({ feeds }: { feeds: number }) {
   // then re-asserts the variant's theme. Order matters.
   useEffect(() => {
     uiStore.hydrate();
-    // BEFORE inspectorStore.hydrate(), and that order is load-bearing. bootstrap
-    // applies the variant through layersStore/signalsStore, which write whichever
-    // source context is LOADED — so restoring a loaded area first made every reload
-    // overwrite that area's sources with the variant's layers. Nothing is loaded
-    // yet at this point, so the writes land on World, which is what a variant
-    // configures. Then the Inspector restores the areas and which one was loaded.
+    // BEFORE inspectorStore.hydrate(), and this used to be the ONLY thing stopping a
+    // reload from overwriting the edited area with the variant's layers: bootstrap
+    // applies a variant through layersStore/signalsStore, and those wrote whichever
+    // source context the rail was pointed at. Ordering alone was never enough —
+    // `applyPreset(DEFAULT_PRESET_ID)` below runs AFTER hydrate and fires on every
+    // boot while the landing board carries no widgets, so the area absorbed the
+    // board's set instead. Both paths now go through layersStore.applyWorld /
+    // signalsStore.applyWorld, which write World by construction. The order is kept
+    // because a variant should be on the map before the areas layer over it, not
+    // because it is holding a bug shut.
     variantStore.bootstrap(new URLSearchParams(window.location.search));
     inspectorStore.hydrate();
     watchlistStore.hydrate();

--- a/components/shell/DrawBanner.tsx
+++ b/components/shell/DrawBanner.tsx
@@ -32,11 +32,21 @@ export default function DrawBanner() {
   if (!draw.active) return null;
 
   const radius = draw.tool === "radius";
+  // `circle` is an EXTERNAL tool (see setExternalDraw in lib/map/aoi.ts) — a
+  // press-centre-and-drag gesture owned by another surface. It reports the same
+  // centre and radiusKm this component already reads, so it narrates through the
+  // radius branch; only the verb differs, because "click again to set the edge" would
+  // be describing the wrong gesture.
+  const circle = draw.tool === "circle";
   // TWO LINES WITH DIFFERENT JOBS. The lead says what is happening — it does not
   // change, so it is the thing the eye can lock onto. The hint says what to do next
   // and changes as the gesture progresses, which is the part worth re-reading.
-  const lead = radius ? "Drawing a radius" : "Drawing an area";
-  const hint = radius
+  const lead = circle ? "Drawing a circle" : radius ? "Drawing a radius" : "Drawing an area";
+  const hint = circle
+    ? draw.center == null
+      ? "Press on the map and drag out from the centre"
+      : `${formatRadius(draw.radiusKm ?? 0)} — release to set it`
+    : radius
     ? draw.center == null
       ? "Click the centre on the map"
       : `${formatRadius(draw.radiusKm ?? 0)} — click again to set the edge`

--- a/components/shell/SourceCatalog.tsx
+++ b/components/shell/SourceCatalog.tsx
@@ -34,7 +34,7 @@ import { useRef, useState } from "react";
 // wrong answer for a tick beside a toggle. With the rail pointed at an area, a row
 // ticked from the union would claim the area has a source that World has and the
 // area does not, and clicking it would appear to do nothing. See lib/layers.ts.
-import { useEditingLayers, layersStore, type LayerKey } from "@/lib/layers";
+import { useEditingLayers, useLayers, layersStore, type LayerKey } from "@/lib/layers";
 import { signalsStore, useEditingSignals } from "@/lib/signals/store";
 import { useCameraFilter, cameraFilterStore } from "@/lib/cameraFilter";
 import { coverageStore } from "@/lib/shell/coverage";
@@ -166,6 +166,9 @@ export default function SourceCatalog() {
   // The LIVE console layout — the one ConsoleWorkspace draws. Subscribing here is
   // what makes a ＋ light up the instant its widget lands, and go out when the
   // widget is closed from its own ⋯ menu.
+  // The UNION, for the handful of things below that are about what the MAP is
+  // drawing rather than about what a toggle would write.
+  const mapLayers = useLayers();
   const consoleLayout = useShellLayout();
   const openTypes = new Set(consoleLayout.widgets.map((w) => w.type));
 
@@ -321,7 +324,13 @@ export default function SourceCatalog() {
               rail exists to give you. They are a refinement of one source rather
               than a source, so they read better as a trailing panel. Shown only
               while the layer they filter is actually on. */}
-          {layers.cameras ? (
+          {/* THE UNION, not the edited context. cameraFilterStore is GLOBAL — one feed
+              and region filter for the whole console, not a per-context setting — so
+              these belong on screen whenever camera pins are being drawn anywhere.
+              Gated on the edited context they would vanish while you configured an
+              area, taking a global control off the page as a side effect of a choice
+              that has nothing to do with it. */}
+          {mapLayers.cameras ? (
             <>
               <div className="tn-rail-divider" />
               <CameraFilters />

--- a/lib/console/presets.ts
+++ b/lib/console/presets.ts
@@ -414,8 +414,8 @@ export function applyPreset(presetId: string, opts: { reset?: boolean } = {}): v
   // signal layers are lit, so switching persona actually re-skins the map (not just
   // the side rail). See lib/console/presetLayers.ts.
   const { core, signals } = layersForLayout(layout, built?.mapSignals ?? [], built?.mapCore ?? []);
-  layersStore.applyExact(core);
-  signalsStore.applyExact(signals);
+  layersStore.applyWorld(core);
+  signalsStore.applyWorld(signals);
 }
 
 /**

--- a/lib/layers.ts
+++ b/lib/layers.ts
@@ -191,6 +191,25 @@ export const layersStore = {
     for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) set[k] = active[k];
     inspectorStore.replaceSources(set);
   },
+  /**
+   * The same whole-set write, aimed at WORLD however the rail is pointed.
+   *
+   * WHY BOTH EXIST. applyExact is reached from the rail's own layer-preset chips,
+   * where "give this area the Transit set" is a real thing to ask for. This is
+   * reached from the variant spine and from applyPreset, which say in their own
+   * comments that they are driving THE GLOBE. Sending those down the contextual path
+   * quietly poured a board's layers into whatever area was being edited — see the
+   * note on replaceWorld in lib/shell/inspector.ts for how that surfaced.
+   *
+   * The merge base is World's own set rather than the edited one, for the same
+   * reason: reading the area's set here would copy the area's signals onto World.
+   */
+  applyWorld(next: LayerState) {
+    const active = { ...DEFAULT_STATE, ...next };
+    const set: SourceSet = { ...inspectorStore.get().world };
+    for (const k of Object.keys(DEFAULT_STATE) as LayerKey[]) set[k] = active[k];
+    inspectorStore.replaceWorldSources(set);
+  },
   get: current,
   /** The context being edited. For the rail's ticks and for anything that writes. */
   editing: editingProjection,

--- a/lib/map/aoi.ts
+++ b/lib/map/aoi.ts
@@ -10,7 +10,7 @@
 //
 // WHY THIS OWNS ITS OWN LAYERS. WorldMap re-adds every app layer on `style.load`
 // because a basemap switch throws the style away. Rather than thread AOI state
-// through that 2,000-line component, this module re-asserts its own two layers
+// through that 2,000-line component, this module re-asserts its own layers
 // on `styledata` — same guarantee, no edit to the map. The layers sit above
 // everything else and are non-interactive, so nothing about clicking the map
 // changes when an AOI is showing.
@@ -19,10 +19,15 @@ import type { Map as MapLibreMap, GeoJSONSource } from "maplibre-gl";
 import { useSyncExternalStore } from "react";
 import { haversineKm } from "@/lib/geo/haversine";
 import { aoiScope, scopeStore, WORLD_SCOPE, type Scope } from "@/lib/shell/scope";
+import { inspectorStore, type InspectorArea } from "@/lib/shell/inspector";
 
 const AOI_SRC = "aoi-scope";
 const AOI_FILL = "aoi-scope-fill";
 const AOI_LINE = "aoi-scope-line";
+const AREAS_SRC = "aoi-areas";
+const AREAS_FILL = "aoi-areas-fill";
+const AREAS_LINE = "aoi-areas-line";
+const AREAS_LINE_EDIT = "aoi-areas-line-editing";
 const DRAFT_SRC = "aoi-draft";
 const DRAFT_LINE = "aoi-draft-line";
 const DRAFT_DOTS = "aoi-draft-dots";
@@ -43,7 +48,7 @@ export const MIN_VERTICES = 3;
  * and changes nothing downstream. The circle is what the user drew; the ring is
  * how it is stored, drawn and filtered.
  */
-export type DrawTool = "polygon" | "radius";
+export type DrawTool = "polygon" | "radius" | "circle";
 
 export interface DrawState {
   /** True while the user is placing vertices, or placing a centre and an edge. */
@@ -73,6 +78,33 @@ export const aoiDrawStore = {
 
 export function useAoiDraw(): DrawState {
   return useSyncExternalStore(aoiDrawStore.subscribe, aoiDrawStore.get, () => IDLE);
+}
+
+/**
+ * Publish a draw gesture that this module does not own. `null` returns to idle.
+ *
+ * WHY THIS EXISTS. The Streets board draws a circle with a press-centre-and-drag
+ * gesture, which is a different interaction from the two here (both are click-to-
+ * commit) and does not belong bolted onto `startDraw`. But "a draw is running" has to
+ * stay ONE truth: `isDrawing()` guards against two gestures arming at once, and
+ * components/shell/DrawBanner.tsx is the only always-mounted sign that the map is
+ * swallowing clicks. A second gesture with its own private flag would be invisible to
+ * both — the banner would not appear, and the polygon tool would happily arm on top
+ * of it.
+ *
+ * So an external tool reports itself here rather than forking the store, and gets the
+ * banner and the guard for free. `circle` is in DrawTool for the same reason: the
+ * banner switches on the tool, and an unlisted value would fall through to the
+ * polygon copy and narrate the wrong gesture.
+ *
+ * IT DOES NOT PAINT. The draft layers belong to this module's own gestures; an
+ * external tool owns its own geometry on the map and this only publishes the STATE.
+ * It also does not touch `cancelActive`, so `cancelDraw()` reaches the tool that
+ * armed it — an external caller must wire its own Cancel to its own teardown and then
+ * call this with `null`.
+ */
+export function setExternalDraw(next: DrawState | null): void {
+  setDraw(next ?? IDLE);
 }
 
 function setDraw(next: DrawState) {
@@ -273,6 +305,36 @@ export function radiusDraft(
   return { type: "FeatureCollection", features };
 }
 
+/**
+ * Every drawn area as one collection, flagged with which one is being edited.
+ *
+ * SEPARATE FROM THE SCOPE RING, and they are not the same thing. The scope is the
+ * map rail's "restrict results to an area" — one ring at a time, a filter over the
+ * whole console. These are the Inspector's areas: all of them live at once, each
+ * carrying its own sources. Painting them through the scope source would mean only
+ * one could show, which is what the scope source is for.
+ *
+ * WHY IT EXISTS AT ALL. Editing an area used to set the scope as a side effect, so
+ * the ring appeared because the FILTER appeared. Areas stopped narrowing the console
+ * when they became additive, and the rings went with it: you could draw an area,
+ * watch it vanish, and find it only in a list in the rail. "See areas you have
+ * drawn" was half the feature.
+ */
+export function areasCollection(
+  areas: readonly InspectorArea[],
+  editingId: string | null,
+): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: areas
+      .filter((a) => a.polygon.length >= MIN_VERTICES)
+      .map((a) => {
+        const f = ringToFeature(a.polygon);
+        return { ...f, properties: { id: a.id, editing: a.id === editingId } };
+      }),
+  };
+}
+
 const EMPTY: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: [] };
 
 // --- map plumbing -----------------------------------------------------------
@@ -299,14 +361,19 @@ const EMPTY: GeoJSON.FeatureCollection = { type: "FeatureCollection", features: 
 function ensureLayers(map: MapLibreMap): boolean {
   const haveAll =
     map.getSource(AOI_SRC) &&
+    map.getSource(AREAS_SRC) &&
     map.getSource(DRAFT_SRC) &&
     map.getLayer(AOI_FILL) &&
     map.getLayer(AOI_LINE) &&
+    map.getLayer(AREAS_FILL) &&
+    map.getLayer(AREAS_LINE) &&
+    map.getLayer(AREAS_LINE_EDIT) &&
     map.getLayer(DRAFT_LINE) &&
     map.getLayer(DRAFT_DOTS);
   if (haveAll) return true;
   if (!map.isStyleLoaded()) return false;
   if (!map.getSource(AOI_SRC)) map.addSource(AOI_SRC, { type: "geojson", data: EMPTY });
+  if (!map.getSource(AREAS_SRC)) map.addSource(AREAS_SRC, { type: "geojson", data: EMPTY });
   if (!map.getSource(DRAFT_SRC)) map.addSource(DRAFT_SRC, { type: "geojson", data: EMPTY });
 
   if (!map.getLayer(AOI_FILL)) {
@@ -325,6 +392,44 @@ function ensureLayers(map: MapLibreMap): boolean {
       type: "line",
       source: AOI_SRC,
       paint: { "line-color": "#0ea5e9", "line-width": 1.5, "line-opacity": 0.9 },
+    });
+  }
+  // THREE LAYERS FOR TWO STATES, because line-dasharray is not data-driven in
+  // MapLibre — a `case` expression on it is dropped silently, along with the layer.
+  // So the dash is carried by which layer a feature lands in, and the filter picks.
+  if (!map.getLayer(AREAS_FILL)) {
+    map.addLayer({
+      id: AREAS_FILL,
+      type: "fill",
+      source: AREAS_SRC,
+      // Only the edited one is filled. With every area live at once, filling them all
+      // stacks washes over the basemap and says "these are more important than the
+      // map" — they are a reference, not the subject.
+      filter: ["==", ["get", "editing"], true],
+      paint: { "fill-color": "#0ea5e9", "fill-opacity": 0.06 },
+    });
+  }
+  if (!map.getLayer(AREAS_LINE)) {
+    map.addLayer({
+      id: AREAS_LINE,
+      type: "line",
+      source: AREAS_SRC,
+      filter: ["!=", ["get", "editing"], true],
+      paint: {
+        "line-color": "#0ea5e9",
+        "line-width": 1.25,
+        "line-opacity": 0.5,
+        "line-dasharray": [3, 2],
+      },
+    });
+  }
+  if (!map.getLayer(AREAS_LINE_EDIT)) {
+    map.addLayer({
+      id: AREAS_LINE_EDIT,
+      type: "line",
+      source: AREAS_SRC,
+      filter: ["==", ["get", "editing"], true],
+      paint: { "line-color": "#0ea5e9", "line-width": 2, "line-opacity": 0.95 },
     });
   }
   if (!map.getLayer(DRAFT_LINE)) {
@@ -380,6 +485,14 @@ export function paintScope(map: MapLibreMap, scope: Scope): boolean {
   return true;
 }
 
+/** Paint the Inspector's areas. Same contract as paintScope. */
+export function paintAreas(map: MapLibreMap): boolean {
+  if (!ensureLayers(map)) return false;
+  const state = inspectorStore.get();
+  setData(map, AREAS_SRC, areasCollection(state.areas, state.editing));
+  return true;
+}
+
 /**
  * Attach the AOI painter to a map. Returns a teardown.
  *
@@ -393,18 +506,27 @@ export function attachAoi(map: MapLibreMap): () => void {
   // exactly how the polygon went missing while the filter worked.
   let painted = false;
   const repaint = () => {
-    painted = paintScope(map, scopeStore.get());
+    // Both, and `&&` would be wrong: it short-circuits, so a scope repaint that
+    // could not act would skip the areas and the retry flag would then be the only
+    // thing left holding them.
+    const scope = paintScope(map, scopeStore.get());
+    const areas = paintAreas(map);
+    painted = scope && areas;
   };
   const onStyle = () => {
-    if (!painted || !map.getLayer(AOI_FILL)) repaint();
+    if (!painted || !map.getLayer(AOI_FILL) || !map.getLayer(AREAS_FILL)) repaint();
   };
   repaint(); // no-op if the style is not up yet — onStyle picks it up
   const unsub = scopeStore.subscribe(repaint);
+  // A third subscription: drawing an area, deleting one, or switching which one is
+  // edited all change what should be on the map, and none of them touch the scope.
+  const unsubAreas = inspectorStore.subscribe(repaint);
   map.on("styledata", onStyle);
   map.on("load", repaint);
   map.on("idle", onStyle); // last-resort retry once the map has settled
   return () => {
     unsub();
+    unsubAreas();
     map.off("styledata", onStyle);
     map.off("load", repaint);
     map.off("idle", onStyle);
@@ -544,7 +666,21 @@ function beginGesture(map: MapLibreMap, g: Gesture): boolean {
 
   const onKey = (e: KeyboardEvent) => {
     if (e.key === "Escape") abandon();
-    if (e.key === "Enter") finish();
+    if (e.key === "Enter") {
+      // preventDefault, or Enter finishes the area and IMMEDIATELY starts another.
+      // Seen in the browser: press the rail button to arm the tool, place three
+      // vertices, press Enter — the area commits, and the banner comes straight back
+      // reading "Click the map to place your first point". The button that armed the
+      // tool still holds focus, and a focused <button> turns Enter into a click as its
+      // DEFAULT ACTION, which runs after this listener has already torn the gesture
+      // down. So the finish and the re-arm are the same keystroke.
+      //
+      // This listener is on document during the gesture only, so suppressing Enter
+      // costs nothing outside a live draw — and inside one, finishing the area is the
+      // only thing Enter should be doing.
+      e.preventDefault();
+      finish();
+    }
   };
 
   function teardown() {

--- a/lib/shell/inspector.ts
+++ b/lib/shell/inspector.ts
@@ -261,6 +261,31 @@ export function replaceActive(state: InspectorState, next: SourceSet): Inspector
 }
 
 /**
+ * Pure: replace WORLD's set, whatever context is being edited.
+ *
+ * The counterpart to replaceActive, and the split is a bug rather than a preference.
+ * The variant spine and the board presets configure THE GLOBE — "drive the globe to
+ * match the board", in lib/console/presets.ts's own words. Routing those through
+ * replaceActive sent them to whichever context the rail happened to be pointed at,
+ * so an area being edited absorbed them.
+ *
+ * Seen in the browser rather than reasoned about: draw an area, reload, and an area
+ * created with `sources: {}` comes back holding a copy of World's whole set. The
+ * path is ConsoleShell's first-run seed, `applyPreset(DEFAULT_PRESET_ID)`, which
+ * fires on EVERY boot while the landing board carries no widgets, and which runs
+ * AFTER inspectorStore.hydrate() has restored which area was being edited.
+ *
+ * Only whole-set writes move. A per-key write (writeActive, and so every toggle,
+ * and applyMonitor, which drives layersStore.set key by key) still lands on the
+ * edited context — pointing the rail at an area and giving it a monitor's layers is
+ * a thing a user can reasonably want. Handing an area the globe's configuration
+ * behind their back is not.
+ */
+export function replaceWorld(state: InspectorState, next: SourceSet): InspectorState {
+  return { ...state, world: { ...next } };
+}
+
+/**
  * Pure: coerce a persisted payload into a valid state.
  *
  * The bbox is RECOMPUTED rather than trusted: it is derived data, and a payload
@@ -364,15 +389,17 @@ export const inspectorStore = {
    * Pull persisted AREAS back in. Called once from ConsoleShell, client-side,
    * AFTER variantStore.bootstrap().
    *
-   * WORLD IS DELIBERATELY NOT RESTORED, and the ordering is not incidental. The
-   * variant spine is, in its own words, "the ONLY load-time hydration path": every
-   * boot runs applyVariant, which calls layersStore.applyExact and
-   * signalsStore.applyExact and so re-derives World's whole set. Persisting a
-   * second copy of it here would be two owners for one piece of state — the exact
-   * bug the Sources/Inspector split exists to avoid — and it was destructive, not
-   * merely redundant: with an area loaded, bootstrap's writes land on the AREA, so
-   * one reload replaced a user's area configuration with the variant's layers.
-   * Measured on a preview before this ordering was fixed.
+   * WORLD IS DELIBERATELY NOT RESTORED. The variant spine is, in its own words,
+   * "the ONLY load-time hydration path": every boot runs applyVariant, which calls
+   * layersStore.applyWorld and signalsStore.applyWorld and so re-derives World's
+   * whole set. Persisting a second copy of it here would be two owners for one
+   * piece of state — the exact bug the Sources/Inspector split exists to avoid.
+   *
+   * Those two writes used to be applyExact, i.e. aimed at whatever context the rail
+   * was pointed at, and this note used to say the fix was to run bootstrap BEFORE
+   * hydrate so nothing was pointed at an area yet. That was true and insufficient:
+   * ConsoleShell also seeds a board after hydrate. The write itself now names its
+   * target, so neither ordering can send it into an area.
    *
    * So World's toggles persist where they already did for 71 days, as a delta in
    * tn.variant.v1; this store persists the areas and which one is being edited, which nothing else
@@ -426,6 +453,11 @@ export const inspectorStore = {
 
   replaceSources(next: SourceSet) {
     commit(replaceActive(state, next));
+  },
+
+  /** Whole-set write from the variant spine / board presets. Always World. */
+  replaceWorldSources(next: SourceSet) {
+    commit(replaceWorld(state, next));
   },
 };
 

--- a/lib/signals/store.ts
+++ b/lib/signals/store.ts
@@ -71,6 +71,15 @@ export const signalsStore = {
     }
     inspectorStore.replaceSources(set);
   },
+  /** The mirror of layersStore.applyWorld — see the note there. */
+  applyWorld(next: SignalState) {
+    const set: SourceSet = { ...next };
+    const cur = inspectorStore.get().world;
+    for (const k of Object.keys(DEFAULT_STATE)) {
+      if (typeof cur[k] === "boolean") set[k] = cur[k];
+    }
+    inspectorStore.replaceWorldSources(set);
+  },
   get: current,
   /** The context being edited. For the rail's ticks and for anything that writes. */
   editing,

--- a/lib/variants/store.ts
+++ b/lib/variants/store.ts
@@ -37,12 +37,15 @@ function applyVariant(v: Variant, override?: OverrideDelta, sigFromUrl?: string[
   applying = true;
   try {
     const layers = { ...DEFAULT_STATE, ...v.layers, ...override?.layers } as LayerState;
-    layersStore.applyExact(layers);
+    // applyWorld, not applyExact: a variant is a configuration OF THE GLOBE, and
+    // captureOverride below reads World back. Aiming it at the edited context would
+    // write an area on the way in and read World on the way out.
+    layersStore.applyWorld(layers);
 
     let signals: SignalState = { ...resolveSignals(v.signals), ...override?.signals };
     // URL sig= is the authoritative on-set for a shared view — replace rather than merge with any local override.
     if (sigFromUrl) { signals = {}; for (const id of sigFromUrl) signals[id] = true; }
-    signalsStore.applyExact(signals);
+    signalsStore.applyWorld(signals);
 
     uiStore.setTheme(override?.theme ?? v.theme);
     cameraFilterStore.setLiveOnly(v.cameraFilter?.liveOnly ?? false);

--- a/tests/unit/aoi.test.ts
+++ b/tests/unit/aoi.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import {
+  areasCollection,
   MIN_VERTICES,
   RADIUS_RING_STEPS,
   aoiLabel,
@@ -183,4 +184,42 @@ test("the draft is centre-only until the pointer has moved", () => {
   const line = (sized.features[1].geometry as GeoJSON.LineString).coordinates;
   expect(line).toHaveLength(RADIUS_RING_STEPS + 1);
   expect(line[line.length - 1]).toEqual(line[0]);
+});
+
+
+// --- the drawn areas on the map ------------------------------------------------
+
+function area(id: string, ring: [number, number][] = RING) {
+  return { id, label: id, polygon: ring, bbox: [0, 0, 0, 0] as [number, number, number, number], createdAt: 0, sources: {} };
+}
+
+test("every area is painted, not only the one being edited", () => {
+  // The additive model in one assertion: an area does not have to be selected to be
+  // live, so it does not have to be selected to be visible either. Editing used to
+  // set the console scope as a side effect, and painting the scope was the only
+  // reason a ring appeared at all — so when areas stopped narrowing the console the
+  // rings silently stopped being drawn.
+  const c = areasCollection([area("a"), area("b")], "a");
+  expect(c.features).toHaveLength(2);
+  expect(c.features.map((f) => f.properties!.editing)).toEqual([true, false]);
+});
+
+test("the edited flag is false for every area when the rail is on World", () => {
+  const c = areasCollection([area("a"), area("b")], null);
+  expect(c.features.every((f) => f.properties!.editing === false)).toBe(true);
+});
+
+test("a ring that is not an area is not painted", () => {
+  // Nothing should ever store one, but a hand-edited localStorage payload can hold
+  // it, and MapLibre drops an invalid polygon layer SILENTLY — taking the valid
+  // areas beside it off the map with no error anywhere.
+  const c = areasCollection([area("thin", [[0, 0], [1, 1]])], null);
+  expect(c.features).toHaveLength(0);
+});
+
+test("a painted area is a CLOSED ring, like every other polygon here", () => {
+  const c = areasCollection([area("a")], null);
+  const outer = (c.features[0].geometry as GeoJSON.Polygon).coordinates[0];
+  expect(outer).toHaveLength(RING.length + 1);
+  expect(outer[outer.length - 1]).toEqual(outer[0]);
 });

--- a/tests/unit/inspector-routing.test.ts
+++ b/tests/unit/inspector-routing.test.ts
@@ -185,9 +185,9 @@ test("the two stores share one map and must not wipe each other's half", () => {
 test("hydrate restores areas but leaves World to the variant spine", () => {
   // variantStore.bootstrap is, in its own words, the ONLY load-time hydration path:
   // it re-derives World's whole set on every boot. If this store restored World too
-  // there would be two owners for one piece of state, and the loser was the user:
-  // with an area being edited, bootstrap's writes landed on the AREA and one reload
-  // replaced its sources with the variant's layers. Measured on a preview.
+  // there would be two owners for one piece of state. (Bootstrap landing on an AREA
+  // was the other half of that bug; it is fixed at the write now — see the applyWorld
+  // tests below — rather than by running bootstrap before this.)
   const id = inspectorStore.add(RING, "Kharkiv")!;
   layersStore.set("planes", false);
   const worldBefore = { ...inspectorStore.get().world };
@@ -213,6 +213,48 @@ test("a toggle inside an area is not captured as the variant's override", async 
   // area's set is written into the variant's override and the next boot replays it
   // onto the globe — the exact leak the contexts model exists to prevent.
   expect(JSON.stringify(variantStore.get().overrides)).toBe(before);
+});
+
+// --- the globe's own writes: what the BROWSER found a second time ---------------
+
+test("a whole-set write from the spine lands on World even while an area is edited", () => {
+  // Seen in the browser: draw an area, reload, and an area created with no sources
+  // of its own comes back holding a copy of World's whole set. layersStore.applyExact
+  // wrote the EDITED context, and ConsoleShell seeds a board on every boot (the
+  // landing board carries no widgets, so the first-run branch always fires) AFTER
+  // hydrate has restored which area was being edited. applyWorld names its target.
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.edit(id);
+  layersStore.applyWorld({ ...DEFAULT_STATE, planes: false });
+  signalsStore.applyWorld({ fires: true });
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources).toEqual({});
+  expect(inspectorStore.get().world.planes).toBe(false);
+  expect(inspectorStore.get().world.fires).toBe(true);
+});
+
+test("applying a variant while editing an area configures the globe, not the area", async () => {
+  // The same bug through the path a user actually takes. A variant is a description
+  // of the globe; pouring its ~30 layers into a ring the user drew is not a reading
+  // of "switch profile" that anyone would ask for.
+  const { variantStore } = await import("@/lib/variants/store");
+  variantStore.bootstrap(new URLSearchParams(""));
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.edit(id);
+  variantStore.setActive("aviation");
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources).toEqual({});
+  expect(layersStore.get().planes).toBe(true); // ...and the globe did change
+});
+
+test("a per-key write still follows the rail — the split is deliberate", () => {
+  // applyMonitor drives layersStore.set key by key rather than a whole-set write,
+  // and that is the difference: giving an area a monitor's layers is a thing a user
+  // can point the rail at and ask for. Handing it the globe's configuration behind
+  // their back is not.
+  const id = inspectorStore.add(RING, "Kharkiv")!;
+  inspectorStore.edit(id);
+  layersStore.set("ships", true);
+  expect(inspectorStore.get().areas.find((a) => a.id === id)!.sources.ships).toBe(true);
+  expect(inspectorStore.get().world.ships).toBeUndefined();
 });
 
 test("a source on ONLY inside an area is never captured as a World override", () => {


### PR DESCRIPTION
Follow-on to #186, which merged while this was still being checked in a browser. Three commits, and two of the three are bugs #186 introduced or left behind — both found by using the console, neither findable by the suite.

## Drawn areas were invisible

Editing an area used to set the console's AOI scope as a side effect, and painting that scope was the only reason a ring ever appeared on the map. #186 made areas additive, so they stopped setting the scope — and the rings stopped being drawn with it. You could draw an area, watch it vanish the moment it completed, and find it again only as a row in the rail. "See the areas you have drawn" was half the feature.

They are painted from the Inspector's own state now, all of them at once, because all of them are live at once. The edited one is solid with a 6% fill; the rest are dashed and lighter. Three layers rather than one data-driven paint, because `line-dasharray` is not data-driven in MapLibre — a `case` on it is dropped silently, and takes its layer with it.

## Enter finished an area and immediately started another

Arm the tool from the rail, place three vertices, press Enter: the area commits, and the banner comes straight back reading "Click the map to place your first point". The button that armed the tool still holds focus, and a focused `<button>` turns Enter into a click as its **default action** — which runs after the keydown listener has already torn the gesture down. One keystroke, both effects.

## An area silently absorbed the globe's whole source set

Draw an area, reload, and an area created with nothing of its own comes back holding seven layers it never asked for. `layersStore.applyExact` wrote whichever context the rail pointed at, and ConsoleShell seeds a board on boot — not a first-run branch in practice, since the landing board carries no widgets, so it fires on **every** boot, after `hydrate()` has restored which area was being edited.

The ordering note in ConsoleShell claimed this was already handled by running `variantStore.bootstrap()` before `hydrate()`. True of bootstrap, and only of bootstrap. Whole-set writes from the spine now go through `applyWorld`, which names its target; per-key writes still follow the rail, so a monitor applied while pointing at an area still lands on that area, which is a thing a user can reasonably ask for.

## Plus three things that only showed up in a browser

- The Sources/Presets tab strip read as an empty input box beside a floating word — the selection was a 1px outline in a pale olive that is nearly invisible against the rail. Rebuilt as a segmented control.
- The expanded map credit put the ⓘ on top of "OpenStreetMap": #186 reserved padding on the left, and MapLibre pins that button `right: 0` unless it is in a `-left` container. The rules mirror MapLibre's own structure now, so both corners hold.
- Two more dead controls of the class #186 already fixed elsewhere — the ⌘K palette's layer badges and the rail's camera-filter gate were reading the union while writing the edited context.

## Also: `setExternalDraw`

`lib/map/aoi.ts` gains `setExternalDraw(state | null)` so a draw gesture owned by another surface (the Streets circle tool) reports itself to the one draw store. `isDrawing()` and the always-mounted DrawBanner are both blind to a gesture with a private flag. It publishes state only — it paints nothing and does not touch `cancelActive`.

## Checks

`npx tsc --noEmit` clean. `npx vitest run`: **328 files, 3,259 tests, all passing** (count checked against the baseline, since an OOM-killed worker drops a file and still prints green). 7 new tests; the variant-routing one was watched go red against the old code before being kept.

Verified live at `http://localhost:3000/app` — the Vercel preview is protection-gated. Screenshots of the rings, the rubber band and the expanded credit are in the session.
