### PR TITLE
Fix the deploy: find | head -1 SIGPIPEs under pipefail

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -33,7 +33,15 @@ SSH_OPTS=(-o ConnectTimeout=20 -o StrictHostKeyChecking=accept-new)
 # Pick a real hashed asset now, so the health check can prove the static tree actually
 # arrived. A check that only fetches / passes happily while every stylesheet 404s: the
 # page renders unstyled, the map never mounts, and the server log stays clean.
-PROBE_ASSET="$(cd "$ART/.next/static" && find . -name '*.js' -type f | head -1 | sed 's|^\./||')"
+# `-print -quit` rather than `| head -1`, and that is the whole bug this line once had.
+# `head` closes the pipe after the first line, `find` then takes SIGPIPE while writing the
+# second, and `set -euo pipefail` at the top of this file promotes that into a failed
+# deploy. It is load-bearing that the tree is BIG: locally, with few files, find often
+# finishes before head closes and the pipeline exits 0, so this passed by hand and failed
+# on the runner against a real build. `-print -quit` stops find after the first match, so
+# there is no second write and nothing to fail. (GNU findutils; the runner is ubuntu and
+# git-bash ships it too, which is the other place this script is run from.)
+PROBE_ASSET="$(cd "$ART/.next/static" && find . -name '*.js' -type f -print -quit | sed 's|^\./||')"
 [[ -n "$PROBE_ASSET" ]] || { echo "! no hashed asset found under $ART/.next/static" >&2; exit 1; }
 echo "==> shipping $SHA (probe asset: $PROBE_ASSET)"
 

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -109,7 +109,11 @@ ufw allow OpenSSH >/dev/null
 ufw allow 80/tcp  >/dev/null
 ufw allow 443/tcp >/dev/null
 ufw --force enable >/dev/null
-ufw status verbose | head -6
+# sed, not `head -6`: this script also runs under `set -euo pipefail`, and head closing
+# the pipe early would SIGPIPE ufw and fail the whole provision on its last step. It has
+# not bitten yet only because ufw's output happens to be short enough that head reads it
+# all. sed reads to EOF, so it cannot.
+ufw status verbose | sed -n '1,6p'
 
 echo
 echo "Provisioned. Remaining, in order:"


### PR DESCRIPTION
The first deploy (run 34146859806) failed at **Ship**. Gate, Build and Assemble all
passed. The entire log was:

```
find: 'standard output': Broken pipe
find: write error
Process completed with exit code 1
```

`deploy.sh` picked the health-check probe asset with `find . -name '*.js' -type f | head -1`.
`head` closes the pipe after one line, `find` is still walking the tree, takes SIGPIPE on
its next write and exits **141**. The script runs `set -euo pipefail`, so that aborts it.

**Why it survived review and a by-hand run.** The failure depends on the tree being large
enough that `find` is still writing when `head` leaves. Reproduced both ways against
`node_modules`:

| form | exit | result |
|---|---|---|
| `find … \| head -1` | **141** | correct asset |
| `find … -print -quit` | **0** | correct asset |

The line always produced the right answer. On a small tree `find` just finishes first and
the pipeline exits 0. `-print -quit` stops after the first match, so there is no second
write and nothing to fail.

**The same bug was in `provision.sh:112`** — `ufw status verbose | head -6`, also under
`pipefail`. It has never fired only because ufw's output is currently short enough that
`head` consumes all of it. That is a fact about ufw's output, not about the code. Replaced
with `sed -n '1,6p'`, which reads to EOF. It matters because re-running `provision.sh` is
this box's backup strategy, and a spurious failure on its last step would make a healthy
re-provision look broken.

**Nothing shipped.** The probe-asset line sits in the preconditions block above the
`rsync`, so the box was never touched — `releases/` empty, no `current` symlink, service
inactive. Verified before changing anything.

Merging re-triggers the deploy.
