### PR TITLE
Redirect the old Vercel host to the new domain, and archive the analytics first

### DIFF
--- a/docs/VERCEL_ANALYTICS_ARCHIVE.md
+++ b/docs/VERCEL_ANALYTICS_ARCHIVE.md
@@ -1,0 +1,95 @@
+# Vercel Web Analytics — the whole record, captured 2026-09-07
+
+Everything below was read out of Vercel's Web Analytics API on 2026-09-07, the day the
+site moved to its own box. **It is written down because it is about to become
+unreachable.** Collection stopped when `<Analytics />` was removed (it posts to
+`/_vercel/insights`, which exists only on Vercel's edge), and the Hobby tier refuses any
+`since` older than 31 days with a flat 400 — so once the Pro seat is cancelled, the
+window below cannot be queried again by anyone, including us.
+
+Period: **2026-06-25 → 2026-09-08** (the project's whole life; created 2026-06-26).
+
+## Totals
+
+| | |
+|---|---|
+| Visitors | **9,570** |
+| Pageviews | **24,456** |
+
+## By week — the shape matters more than the total
+
+| Week beginning | Visitors | Pageviews |
+|---|---:|---:|
+| 2026-07-06 | 70 | 118 |
+| 2026-07-13 | 93 | 128 |
+| 2026-07-20 | 23 | 27 |
+| 2026-07-27 | 18 | 26 |
+| 2026-08-03 | 12 | 16 |
+| 2026-08-10 | 1,081 | 2,712 |
+| 2026-08-17 | 1,192 | 2,868 |
+| 2026-08-24 | 443 | 875 |
+| **2026-08-31** | **4,298** | **11,933** |
+| 2026-09-07 (partial) | 2,340 | 5,753 |
+
+Two things to read here. The site went from ~20 visitors a week in early August to
+**4,298 in the week of 31 August** — a 200x rise in under a month, and the steepest week
+was the last full one. And that is the week the maintenance curtain went up. Whatever the
+curtain cost, it was not charged against a flat line.
+
+## Where people came from
+
+| Referrer | Visitors | Pageviews |
+|---|---:|---:|
+| (direct / none) | 8,889 | 19,853 |
+| google.com | 1,551 | 1,829 |
+| reddit.com | 956 | 1,096 |
+| com.google.android.googlequicksearchbox | 386 | 493 |
+| com.reddit.frontpage | 239 | 341 |
+| github.com | 192 | 238 |
+| duckduckgo.com | 156 | 242 |
+| search.brave.com | 81 | 92 |
+| t.co | 70 | 83 |
+| bing.com | 48 | 68 |
+
+**SEARCH IS THE LARGEST REFERRED CHANNEL, NOT REDDIT.** Folding in the mobile apps,
+Google sent **1,937** and Reddit **1,195**; add DuckDuckGo, Brave, Bing and Ecosia and
+search reaches ~2,180. Earlier notes in this repo said the opposite — they were reading a
+window taken days after a single Reddit post, when Reddit genuinely dominated. Over the
+project's life it does not.
+
+That is the fact that makes `lib/brand.legacy.ts` load-bearing rather than tidy: every one
+of those search results names `provenance-online.vercel.app`.
+
+## What people actually looked at
+
+| Path | Visitors | Pageviews |
+|---|---:|---:|
+| `/` | 8,353 | 10,331 |
+| `/app` | 8,256 | 13,256 |
+| (Others, ~20k camera pages combined) | 330 | 739 |
+| `/privacy` | 19 | 20 |
+| `/camera/cetsp:184` | 8 | 13 |
+| `/camera/tfl:JamCams_00002.00865` | 8 | 8 |
+| `/cameras/ca` | 6 | 13 |
+
+**The console and the landing page are the product; the camera long tail is not.** `/`
+and `/app` took 16,609 of 16,939 measured visitors. Every camera page ever generated —
+roughly twenty thousand routes — accounts for at most a few hundred, and the best
+individual one managed **eight visitors in ten weeks**.
+
+Three standing decisions rest on that ratio, and all three should be re-read against it:
+ISR on camera pages (`provenance_isr_camera_pages` — writes 2.7x more than it reads),
+whether a CDN in front of the box is worth buying, and how much crawl budget the camera
+sitemap deserves.
+
+## How this was captured
+
+Through the authenticated Vercel MCP session, not an API token — `mode: count` for the
+totals and `mode: aggregate` with `by: [week | referrerHostname | requestPath]` for the
+rest. `by: [day]` is capped at 62 days by the API, which is why the series above is
+weekly.
+
+Project `traffic-nerd-v2` = `prj_PEFRuo9AZYtxN9WmY3a1cyiWlGRQ`,
+team `team_6DpNWQt4IZhA94yPzmyoRbOe`. Neither is a secret; both are the values
+`VERCEL_ANALYTICS_PROJECT_ID` and `VERCEL_ANALYTICS_TEAM_ID` want if that route is ever
+wired up again.

--- a/lib/brand.legacy.ts
+++ b/lib/brand.legacy.ts
@@ -1,0 +1,33 @@
+/**
+ * Hosts this site used to be served from, and the one it is served from now.
+ *
+ * A MOVED SITE KEEPS ITS OLD ADDRESS FOREVER. Links posted to Reddit, the OG cards
+ * already unfurled in other people's chat logs, and every search result Google has
+ * indexed all still name the old host. Measured over this project's whole life on
+ * 2026-09-07, search was the LARGEST referred channel — 1,551 visitors from google.com
+ * plus 386 from the Android search app, against 956 + 239 from Reddit — and all of it
+ * points at the Vercel host. Dropping that host loses the traffic; redirecting it moves
+ * the ranking to the new domain instead.
+ *
+ * EXACT MATCH, NOT A SUFFIX. Vercel gives every preview deployment its own
+ * `*.vercel.app` hostname, and previews exist to be reviewed, not redirected away. A
+ * `.endsWith(".vercel.app")` test would bounce every preview to production and make the
+ * review surface useless. Only the production alias belongs here.
+ */
+export const LEGACY_HOSTS: readonly string[] = ["provenance-online.vercel.app"];
+
+/** The host this site is served from now. Redirect target for every entry above. */
+export const CANONICAL_HOST = "provenance-online.com";
+
+/**
+ * The absolute URL a request for a legacy host should be sent to, or null to pass it
+ * through. Pure, so tests/unit/legacy-host-redirect.test.ts can enumerate the cases
+ * without a request object.
+ */
+export function legacyRedirect(host: string | null, pathAndQuery: string): string | null {
+  if (!host) return null;
+  // Strip a port before comparing: a Host header may carry one, the list never does.
+  const bare = host.toLowerCase().split(":")[0];
+  if (!LEGACY_HOSTS.includes(bare)) return null;
+  return `https://${CANONICAL_HOST}${pathAndQuery}`;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,7 @@ import { GATE_COOKIE, GATE_QUERY, GATE_DENIED, gateToken } from "@/lib/gate/toke
 import { isTempKey, verifyTempKey } from "@/lib/gate/tempkey";
 import { maintenanceHtml } from "@/lib/gate/page";
 import { isMaintenanceArmed } from "@/lib/gate/armed";
+import { legacyRedirect } from "@/lib/brand.legacy";
 
 /**
  * The maintenance gate.
@@ -31,6 +32,22 @@ export const config = {
 };
 
 export default async function middleware(request: NextRequest) {
+  // THE LEGACY-HOST REDIRECT RUNS FIRST, AND THAT ORDER IS THE POINT.
+  //
+  // The obvious home for this is `redirects()` in next.config.ts, where it would cost no
+  // function invocation at all. It cannot go there: middleware runs BEFORE the routing
+  // layer applies those rules, so while MAINTENANCE_MODE is armed on the Vercel project
+  // the curtain would answer every request and the redirect would never fire. The old
+  // host would sit on 503 while search engines decided it was dead — losing exactly the
+  // ranking this redirect exists to move.
+  //
+  // Above the gate, it wins regardless of the curtain, and the old host consolidates
+  // into the new one whether or not anyone remembers to unset a variable.
+  const moved = legacyRedirect(request.headers.get("host"), request.nextUrl.pathname + request.nextUrl.search);
+  // 301 and not 308: this is GET traffic from crawlers and shared links, and 301 is the
+  // status every search engine treats as "move the ranking".
+  if (moved) return NextResponse.redirect(moved, 301);
+
   if (!isMaintenanceArmed()) return NextResponse.next();
 
   const { pathname, search, searchParams } = request.nextUrl;

--- a/tests/unit/legacy-host-redirect.test.ts
+++ b/tests/unit/legacy-host-redirect.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { legacyRedirect, LEGACY_HOSTS, CANONICAL_HOST } from "@/lib/brand.legacy";
+
+/**
+ * The redirect that moves the old Vercel host's search ranking onto the new domain.
+ *
+ * Measured on 2026-09-07 over the project's whole life: google.com sent 1,551 visitors
+ * and the Android search app another 386, against Reddit's 956 + 239. Search was the
+ * largest referred channel and every one of those results named the Vercel host. This
+ * file is what keeps those links arriving somewhere.
+ */
+describe("the legacy-host redirect", () => {
+  it("moves the old production host, keeping path and query", () => {
+    expect(legacyRedirect("provenance-online.vercel.app", "/app?v=osint")).toBe(
+      "https://provenance-online.com/app?v=osint",
+    );
+    expect(legacyRedirect("provenance-online.vercel.app", "/")).toBe("https://provenance-online.com/");
+    // Camera deep links are the long tail search actually indexed.
+    expect(legacyRedirect("provenance-online.vercel.app", "/camera/tfl:JamCams_00002.00865")).toBe(
+      "https://provenance-online.com/camera/tfl:JamCams_00002.00865",
+    );
+  });
+
+  it("ignores a port on the Host header", () => {
+    expect(legacyRedirect("provenance-online.vercel.app:443", "/")).toBe("https://provenance-online.com/");
+  });
+
+  it("is case-insensitive, because a Host header need not be lower-case", () => {
+    expect(legacyRedirect("Provenance-Online.Vercel.App", "/")).toBe("https://provenance-online.com/");
+  });
+
+  it("LEAVES PREVIEW DEPLOYMENTS ALONE — the whole reason this is an exact match", () => {
+    // Vercel gives every preview its own *.vercel.app host. A suffix test would bounce
+    // each one to production and destroy the review surface entirely.
+    for (const h of [
+      "traffic-nerd-v2-git-feat-something-011-sam-110s-projects.vercel.app",
+      "traffic-nerd-v2-abc123.vercel.app",
+      "some-other-project.vercel.app",
+      "vercel.app",
+    ]) {
+      expect(legacyRedirect(h, "/")).toBeNull();
+    }
+  });
+
+  it("leaves the canonical host and the box alone, so it cannot loop", () => {
+    // If this ever returned a URL for the canonical host the site would redirect to
+    // itself forever, and the box serves exactly this host.
+    expect(legacyRedirect(CANONICAL_HOST, "/")).toBeNull();
+    expect(legacyRedirect("www.provenance-online.com", "/")).toBeNull();
+    expect(legacyRedirect("127.0.0.1:3000", "/")).toBeNull();
+    expect(legacyRedirect(null, "/")).toBeNull();
+  });
+
+  it("never lists the canonical host as legacy, which would be an instant loop", () => {
+    expect(LEGACY_HOSTS).not.toContain(CANONICAL_HOST);
+  });
+
+  it("runs BEFORE the maintenance gate in middleware, or it never fires", () => {
+    // next.config's redirects() would be cheaper, but middleware runs first: with the
+    // curtain armed on the old project, a routing-layer rule would never be reached and
+    // the old host would sit on 503 until search engines dropped it.
+    const src = readFileSync(join(process.cwd(), "middleware.ts"), "utf8");
+    const redirectAt = src.indexOf("legacyRedirect(");
+    const gateAt = src.indexOf("isMaintenanceArmed()");
+    expect(redirectAt).toBeGreaterThan(-1);
+    expect(gateAt).toBeGreaterThan(-1);
+    expect(redirectAt).toBeLessThan(gateAt);
+  });
+});


### PR DESCRIPTION
Two things with the same deadline attached.

## The redirect

`provenance-online.vercel.app` is the host search engines have indexed, and it is
currently answering **503** behind the maintenance curtain. That is the one state that
*loses* the ranking rather than moving it — a prolonged 503 eventually reads as "gone",
not "moved".

**It is in middleware, not `next.config`'s `redirects()`, and that is deliberate.**
`redirects()` is the obvious home and would cost no function invocation. It cannot work
here: middleware runs *before* the routing layer applies those rules, so with
`MAINTENANCE_MODE` armed on the Vercel project the curtain answers first and the redirect
never fires. Above the gate it wins regardless, and nobody has to remember to unset a
variable for the old host to start consolidating.

**Exact host match, not a suffix.** Vercel gives every preview deployment its own
`*.vercel.app` hostname; `endsWith(".vercel.app")` would bounce all of them to production
and destroy the review surface. The test enumerates four preview-shaped hosts and asserts
each passes through, and asserts the canonical host is never in the legacy list — which
would be an instant loop.

7 tests. Gate green at 329 files / 3,266 tests.

## The archive — this is the part with a clock on it

Collection stopped when `<Analytics />` was removed, and Hobby answers any `since` older
than 31 days with a flat 400. **Once the Pro seat is cancelled this window is unreachable
by anyone, including us.** Captured through the authenticated MCP session rather than an
API token, so no `VERCEL_ANALYTICS_TOKEN` was needed.

**9,570 visitors / 24,456 pageviews** over the project's life. Two findings change
decisions rather than decorate them:

**Search is the largest referred channel, not Reddit.** Google 1,551 + 386 from the
Android search app, against Reddit's 956 + 239 — ~2,180 from search once the other engines
are counted. Notes in this repo say the opposite; they were reading a window taken days
after one Reddit post. That is exactly what makes the redirect above load-bearing.

**The camera long tail is not the product.** `/` and `/app` took **16,609 of 16,939**
measured visitors. Roughly twenty thousand camera routes account for a few hundred
between them, and the best single one managed **eight visitors in ten weeks**. ISR on
camera pages, whether a CDN in front of the box pays for itself, and how much crawl budget
the camera sitemap deserves should all be re-read against that ratio.

Also worth seeing in `docs/VERCEL_ANALYTICS_ARCHIVE.md`: traffic went from ~20 visitors a
week in early August to **4,298 in the week of 31 August**, and that was the week the
curtain went up.

## After merging

The redirect ships to Vercel on merge (that project still builds from `main`). Once it is
live, `MAINTENANCE_MODE` can come off the Vercel project — the redirect makes the curtain
redundant there. Order matters: deploy first, unset second, so there is never a window
where the old host serves the full site as duplicate content.
