### PR TITLE
Make the access log the analytics source, and keep it honest behind Cloudflare

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -5,27 +5,69 @@
 # supervision. THE DNS A RECORD MUST ALREADY POINT HERE before the first start: issuance
 # is an HTTP-01 challenge against the name, so a reload before DNS resolves burns a
 # failed attempt against Let's Encrypt's rate limit rather than producing a certificate.
-
-# GLOBAL OPTIONS. This block masks addresses in the DEFAULT logger, and it exists
-# because the site-level `log` block at the bottom of this file does NOT cover
-# everything. Caddy splits its logging in two:
-#
-#   http.log.access.log0  -> the site's own `log` block  -> the file, filtered.
-#   http.log.error.log0   -> the DEFAULT logger          -> stderr, so journald.
-#
-# Both carry `request>remote_ip` and `request>client_ip` in full. Only the first was
-# filtered, so every 502, every timeout and every refused upstream wrote a complete
-# visitor address into the systemd journal — where it is retained, rotated by journald's
-# own rules rather than ours, and readable by anyone who can read the journal. The
-# access log looked masked, which is exactly what made it easy to miss.
-#
-# app/(site)/privacy tells visitors this server does not record their IP address. That
-# sentence has to be true of BOTH streams, so the same 16/32 mask is applied here.
 {
+	# TRUSTED PROXIES, AND THIS IS WHAT MAKES THE ACCESS LOG MEAN ANYTHING AGAIN.
+	#
+	# Cloudflare terminates the visitor's TLS and opens its own connection to this box,
+	# so from Caddy's point of view every request in the world now arrives from one of
+	# the ~22 networks listed below. Without this block `client_ip` IS a Cloudflare edge
+	# node: the log still fills up, nothing errors, and every aggregate built on it
+	# measures Cloudflare's topology instead of our visitors.
+	#
+	# `client_ip_headers` tells Caddy where the real address is. Cloudflare sets
+	# CF-Connecting-IP itself and strips any copy the client sent, so it cannot be forged
+	# THROUGH Cloudflare — but it is trivially forged by anyone connecting to this box
+	# directly, which is why Caddy only honours it for source addresses in this list, and
+	# why the firewall is closed to everything else (deploy/cloudflare-firewall.sh).
+	# Both halves are load bearing: the list without the firewall still trusts a header
+	# from a direct connection, and the firewall without the list logs every visitor as
+	# an edge node.
+	#
+	# THE LIST GOES STALE. Fetched 2026-09-07 from https://www.cloudflare.com/ips-v4 and
+	# /ips-v6. Cloudflare adds ranges occasionally; a missing one does not fail, it just
+	# silently logs those visitors as their edge node. Refresh with
+	# deploy/refresh-cloudflare-ips.sh, which diffs before it writes.
+	servers {
+		trusted_proxies static 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13 104.24.0.0/14 172.64.0.0/13 131.0.72.0/22 2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32 2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
+		client_ip_headers Cf-Connecting-Ip
+	}
+
+	# This block masks addresses in the DEFAULT logger, and it exists because the
+	# site-level `log` block at the bottom of this file does NOT cover everything. Caddy
+	# splits its logging in two:
+	#
+	#   http.log.access.log0  -> the site's own `log` block  -> the file, filtered.
+	#   http.log.error.log0   -> the DEFAULT logger          -> stderr, so journald.
+	#
+	# Both carry `request>remote_ip` and `request>client_ip` in full. Only the first was
+	# filtered, so every 502, every timeout and every refused upstream wrote a complete
+	# visitor address into the systemd journal — where it is retained, rotated by
+	# journald's own rules rather than ours, and readable by anyone who can read the
+	# journal. The access log looked masked, which is exactly what made it easy to miss.
+	#
+	# THE SAME TRAP REOPENED THE DAY CLOUDFLARE WENT IN FRONT. Caddy logs every request
+	# header, and Cloudflare adds CF-Connecting-IP — the visitor's full, unmasked address
+	# — to every single request. Masking `client_ip` while logging that header verbatim
+	# would have written the exact thing the mask exists to prevent, into both streams,
+	# from the first proxied request. So the deletions below are duplicated into the site
+	# log block; the two lists must stay in step.
+	#
+	# Cf-Ipcountry is deliberately NOT deleted. It is a two-letter country code, which is
+	# the one geographic signal the rollups want and the only one this box could not
+	# derive for itself without shipping a GeoIP database.
+	#
+	# app/(site)/privacy tells visitors this server does not record their IP address.
+	# That sentence has to be true of BOTH streams.
 	log default {
 		format filter {
 			request>remote_ip ip_mask 16 32
 			request>client_ip ip_mask 16 32
+			request>headers>Cf-Connecting-Ip delete
+			request>headers>X-Forwarded-For delete
+			request>headers>True-Client-Ip delete
+			request>headers>Cf-Visitor delete
+			request>headers>Cf-Ray delete
+			request>headers>Cdn-Loop delete
 		}
 	}
 }
@@ -110,6 +152,12 @@ provenance-online.com {
 			request>remote_ip ip_mask 16 32
 			request>client_ip ip_mask 16 32
 			request>headers>Cookie delete
+			request>headers>Cf-Connecting-Ip delete
+			request>headers>X-Forwarded-For delete
+			request>headers>True-Client-Ip delete
+			request>headers>Cf-Visitor delete
+			request>headers>Cf-Ray delete
+			request>headers>Cdn-Loop delete
 			request>headers>Authorization delete
 			request>headers>Accept delete
 			request>headers>Accept-Encoding delete

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -89,9 +89,44 @@ provenance-online.com {
 			roll_size 50MiB
 			roll_keep 5
 		}
+		# WHAT IS KEPT, AND WHY THE REST IS DELETED.
+		#
+		# This log is the analytics source now — /admin/analytics is built on rollups of it,
+		# not on a third party's dashboard — so these fields are chosen rather than
+		# inherited. Measured an hour after go-live on 2026-09-07: 3,672 rows at ~1,445 bytes
+		# each, which against roll_size 50MiB x roll_keep 5 is about 1.7 DAYS of history.
+		# Almost all of that weight is resp_headers plus a dozen Sec-* request headers that no
+		# aggregate will ever read.
+		#
+		# Deleting them is not only a disk saving. The rollup job parses every row, and the
+		# fields it never reads are the ones it spends its time skipping.
+		#
+		# Referer and User-Agent STAY. Referrer is the channel breakdown — the one measurement
+		# that corrected "Reddit beats search" to the opposite. User-Agent is the only way to
+		# separate the scanners that arrived within minutes of the certificate hitting the CT
+		# log from actual visitors, and an aggregate that counts them as people is worse than
+		# no aggregate.
 		format filter {
 			request>remote_ip ip_mask 16 32
 			request>client_ip ip_mask 16 32
+			request>headers>Cookie delete
+			request>headers>Authorization delete
+			request>headers>Accept delete
+			request>headers>Accept-Encoding delete
+			request>headers>Accept-Language delete
+			request>headers>Priority delete
+			request>headers>Sec-Ch-Ua delete
+			request>headers>Sec-Ch-Ua-Mobile delete
+			request>headers>Sec-Ch-Ua-Platform delete
+			request>headers>Sec-Fetch-Dest delete
+			request>headers>Sec-Fetch-Mode delete
+			request>headers>Sec-Fetch-Site delete
+			request>headers>Sec-Fetch-User delete
+			request>headers>Sec-Gpc delete
+			request>headers>Upgrade-Insecure-Requests delete
+			resp_headers delete
+			request>tls delete
+			request>remote_port delete
 		}
 	}
 }

--- a/deploy/cloudflare-firewall.sh
+++ b/deploy/cloudflare-firewall.sh
@@ -50,6 +50,97 @@ if ! ufw status | grep -qE '^22/tcp|OpenSSH'; then
   exit 1
 fi
 
+# THE PROPAGATION GATE, AND IT IS THE WHOLE REASON THIS SCRIPT IS NOT JUST TWO ufw
+# COMMANDS.
+#
+# Moving the nameservers does NOT move every visitor at once. The old registrar's
+# nameservers keep answering authoritatively for the zone, and resolvers cache the
+# .com delegation for up to 48 hours — measured 86400s on the authoritative RRset the
+# day of the cutover. So for up to two days, some real visitors still resolve straight
+# to the origin IP. Closing 80/443 while that is true does not gently push them to the
+# edge; it hard-fails them with a connection timeout, which is a worse outage than the
+# problem this script exists to fix.
+#
+# Measured on 2026-09-07, from the cutover: 89.8% of an hour's requests still direct,
+# 31.9% over fifteen minutes, 2.1% over five. It drains fast, but not instantly, and
+# the tail is real browsers rather than scanners.
+#
+# So the gate is a MEASUREMENT, not a clock. Requests that came through Cloudflare
+# carry a Cf-Ipcountry header; requests that reached the origin directly never do.
+# That is an exact discriminator, already sitting in the access log. Known crawlers and
+# our own tooling are excluded because neither is a person who loses the site.
+WINDOW_MIN="${CF_FW_WINDOW_MIN:-10}"
+LOG=/var/log/caddy/provenance.log
+
+if [[ "${1:-}" == "--force" ]]; then
+  echo "cloudflare-firewall: --force, skipping the propagation gate"
+elif [[ -r "$LOG" ]]; then
+  gate_out="$(python3 - "$LOG" "$WINDOW_MIN" <<'PY'
+import json, sys, time, collections
+path, window = sys.argv[1], float(sys.argv[2]) * 60
+now = time.time()
+# Excluded from "a person who loses the site": declared crawlers, and the shells this
+# repo drives the box with. A scanner timing out is the intended outcome, not a cost.
+SKIP = ('l9scan', 'discordbot', 'bot/', 'bot;', 'spider', 'crawl', 'curl/', 'wget',
+        'powershell', 'python-requests', 'go-http-client', 'headlesschrome')
+direct = collections.Counter()
+via = 0
+for line in open(path, errors='replace'):
+    line = line.strip()
+    if not line.startswith('{'):
+        continue
+    try:
+        r = json.loads(line)
+    except Exception:
+        continue
+    if now - r.get('ts', 0) > window:
+        continue
+    req = r.get('request') or {}
+    h = req.get('headers') or {}
+    if 'Cf-Ipcountry' in h:
+        via += 1
+        continue
+    ua = (h.get('User-Agent') or ['-'])[0]
+    low = ua.lower()
+    if any(s in low for s in SKIP):
+        continue
+    direct[ua[:70]] += 1
+print('VIA=%d' % via)
+print('DIRECT=%d' % sum(direct.values()))
+for ua, c in direct.most_common(6):
+    print('UA=%d	%s' % (c, ua))
+PY
+)"
+  echo "$gate_out" | sed -n 's/^UA=/    still direct: /p'
+  via_n="$(sed -n 's/^VIA=//p' <<<"$gate_out")"
+  direct_n="$(sed -n 's/^DIRECT=//p' <<<"$gate_out")"
+  echo "cloudflare-firewall: last ${WINDOW_MIN} min - ${via_n:-0} via Cloudflare, ${direct_n:-0} direct (excluding crawlers and our own tooling)"
+  if [[ "${direct_n:-0}" -gt 0 ]]; then
+    cat >&2 <<MSG
+
+cloudflare-firewall: REFUSING TO RUN.
+
+${direct_n} request(s) in the last ${WINDOW_MIN} minutes reached this origin directly from
+what looks like a real browser. Those visitors are on a resolver that still has the
+old delegation cached, and closing 80/443 now would time them out rather than route
+them through the edge.
+
+Re-run when that reaches zero. It falls away on its own as the cached delegation
+expires — up to 48 hours from the nameserver change, though in practice most of it
+goes within the hour. Nothing is at risk while you wait: the origin being reachable
+is the state it has been in all along.
+
+  ./cloudflare-firewall.sh --force     apply anyway, accepting the timeouts
+  CF_FW_WINDOW_MIN=30 ./cloudflare-firewall.sh    use a stricter window
+MSG
+    exit 1
+  fi
+  echo "cloudflare-firewall: gate passed - no real direct traffic in the window"
+else
+  echo "cloudflare-firewall: $LOG unreadable, cannot check propagation; use --force if that is deliberate" >&2
+  exit 1
+fi
+
 count=0
 while read -r cidr; do
   [[ -n "$cidr" ]] || continue

--- a/deploy/cloudflare-firewall.sh
+++ b/deploy/cloudflare-firewall.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Close ports 80 and 443 to everything except Cloudflare. Run ON THE BOX as a sudoer:
+#
+#   scp deploy/cloudflare-firewall.sh ubuntu@<box>:/tmp/ && ssh ubuntu@<box> 'sudo bash /tmp/cloudflare-firewall.sh'
+#
+# WHY. With the A records proxied, every real visitor arrives from a Cloudflare
+# address. Leaving 80/443 open to the world therefore protects nobody and costs two
+# things:
+#
+#   1. Anyone who learns the origin IP — and it is not a secret, it sat in public DNS
+#      for a day and lives in certificate transparency logs forever — can skip
+#      Cloudflare entirely. Every edge protection becomes optional for the one category
+#      of visitor you would most like it to be mandatory for.
+#   2. deploy/Caddyfile trusts CF-Connecting-IP for connections from Cloudflare ranges.
+#      A direct connection that FORGES a Cloudflare source address could otherwise put
+#      any value it liked into the access log. The trust list and this firewall are one
+#      mechanism in two halves; neither is sufficient alone.
+#
+# Port 22 IS DELIBERATELY UNTOUCHED. Locking SSH to Cloudflare would be locking it to
+# nobody — Cloudflare does not proxy SSH on this plan — and would end the session that
+# is running this script with no way back in short of the Lightsail serial console.
+#
+# ORDER MATTERS AND IS NOT COSMETIC: the Cloudflare allows are added BEFORE the broad
+# rules are removed, so there is never an instant where the site is unreachable. A
+# script that deleted first would take the site down for however long the loop takes.
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "cloudflare-firewall: must run as root (sudo bash $0)" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+for v in 4 6; do
+  curl -fsS --max-time 20 "https://www.cloudflare.com/ips-v${v}" -o "$tmp/v${v}"
+  [[ -s "$tmp/v${v}" ]] || { echo "cloudflare-firewall: ips-v${v} empty; aborting" >&2; exit 1; }
+done
+
+if grep -vqE '^[0-9a-fA-F:.]+/[0-9]{1,3}$' "$tmp/v4" "$tmp/v6"; then
+  echo "cloudflare-firewall: fetched list is not all CIDRs; aborting" >&2
+  exit 1
+fi
+
+# Refuse to run if SSH is not currently permitted. If something has already removed the
+# OpenSSH rule, adding a default-deny web policy is how a box becomes unreachable.
+if ! ufw status | grep -qE '^22/tcp|OpenSSH'; then
+  echo "cloudflare-firewall: no SSH allow rule found; refusing to touch the firewall" >&2
+  exit 1
+fi
+
+count=0
+while read -r cidr; do
+  [[ -n "$cidr" ]] || continue
+  # `ufw allow` is idempotent — it reports "Skipping adding existing rule" and exits 0 —
+  # so re-running this after a range is added upstream only adds the new one.
+  ufw allow proto tcp from "$cidr" to any port 80,443 comment 'cloudflare edge' >/dev/null
+  count=$((count + 1))
+done < <(cat "$tmp/v4" "$tmp/v6" | tr -d '\r')
+
+echo "cloudflare-firewall: allowed $count Cloudflare ranges on 80,443"
+
+# Now drop the world-open rules. `ufw delete` returns non-zero when the rule is already
+# gone, which is the normal case on a second run, so these are tolerated individually
+# rather than being allowed to kill the script under `set -e`.
+for rule in "allow 80/tcp" "allow 443/tcp"; do
+  if ufw --dry-run delete $rule >/dev/null 2>&1; then
+    ufw delete $rule >/dev/null && echo "cloudflare-firewall: removed world-open '$rule'"
+  else
+    echo "cloudflare-firewall: '$rule' already absent"
+  fi
+done
+
+echo
+ufw status verbose

--- a/deploy/refresh-cloudflare-ips.sh
+++ b/deploy/refresh-cloudflare-ips.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Refresh the Cloudflare source ranges baked into deploy/Caddyfile.
+#
+# WHY THIS EXISTS RATHER THAN A NOTE TELLING YOU TO DO IT BY HAND. Two things in this
+# repo hardcode Cloudflare's published networks: `trusted_proxies static` in the
+# Caddyfile, and the firewall in deploy/cloudflare-firewall.sh. Cloudflare adds ranges
+# occasionally, and NEITHER failure is loud:
+#
+#   * A range missing from trusted_proxies means Caddy stops believing CF-Connecting-IP
+#     for those visitors and logs them as their edge node. The log keeps filling, every
+#     request still returns 200, and the only symptom is that some fraction of the
+#     analytics quietly describes Cloudflare's topology instead of an audience.
+#   * A range missing from the firewall means those visitors are dropped before Caddy
+#     ever sees them. That one IS visible, but only to the people it is happening to.
+#
+# So this diffs and reports rather than silently rewriting: run it, read what changed,
+# commit it deliberately. Called with --check it only reports, and exits 1 on drift,
+# which is the form a scheduled job or CI should use.
+#
+#   ./deploy/refresh-cloudflare-ips.sh          # rewrite the Caddyfile line if changed
+#   ./deploy/refresh-cloudflare-ips.sh --check  # report only; exit 1 if stale
+set -euo pipefail
+
+CADDYFILE="$(dirname "$0")/Caddyfile"
+CHECK_ONLY=0
+[[ "${1:-}" == "--check" ]] && CHECK_ONLY=1
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# `curl -f` so an HTML error page never gets parsed as a range list. Both files are
+# required: fetching v4 and silently accepting an empty v6 would strip IPv6 visitors
+# from trusted_proxies, and that is exactly the quiet failure described above.
+for v in 4 6; do
+  curl -fsS --max-time 20 "https://www.cloudflare.com/ips-v${v}" -o "$tmp/v${v}"
+  if ! [[ -s "$tmp/v${v}" ]]; then
+    echo "refresh-cloudflare-ips: ips-v${v} came back empty; refusing to write" >&2
+    exit 1
+  fi
+done
+
+# Sanity-check the shape before trusting it. Anything that is not a CIDR means we were
+# served something other than the list — a captive portal, a redirect page, an outage
+# banner — and a malformed token in trusted_proxies makes Caddy refuse to start.
+if grep -vqE '^[0-9a-fA-F:.]+/[0-9]{1,3}$' "$tmp/v4" "$tmp/v6"; then
+  echo "refresh-cloudflare-ips: non-CIDR content in the fetched lists; refusing to write" >&2
+  grep -nvE '^[0-9a-fA-F:.]+/[0-9]{1,3}$' "$tmp/v4" "$tmp/v6" >&2 || true
+  exit 1
+fi
+
+new="$(cat "$tmp/v4" "$tmp/v6" | tr -d '\r' | paste -sd' ' -)"
+old="$(sed -n 's/^[[:space:]]*trusted_proxies static //p' "$CADDYFILE")"
+
+if [[ "$old" == "$new" ]]; then
+  echo "refresh-cloudflare-ips: up to date ($(wc -w <<<"$new") ranges)"
+  exit 0
+fi
+
+echo "refresh-cloudflare-ips: DRIFT"
+# Word-per-line so the diff names the ranges rather than showing one changed long line.
+diff <(tr ' ' '\n' <<<"$old" | sort) <(tr ' ' '\n' <<<"$new" | sort) || true
+
+if (( CHECK_ONLY )); then
+  echo "refresh-cloudflare-ips: --check, not writing" >&2
+  exit 1
+fi
+
+# Replace the whole line. The ranges live on ONE line on purpose: the Caddyfile has no
+# line-continuation syntax, so a multi-line list would not parse.
+python3 - "$CADDYFILE" "$new" <<'PY'
+import io, sys, re
+path, new = sys.argv[1], sys.argv[2]
+s = io.open(path, encoding='utf-8').read()
+s2, n = re.subn(r'(?m)^(\s*trusted_proxies static ).*$', lambda m: m.group(1) + new, s)
+if n != 1:
+    sys.exit('expected exactly one trusted_proxies line, found %d' % n)
+io.open(path, 'w', encoding='utf-8', newline='\n').write(s2)
+PY
+
+echo "refresh-cloudflare-ips: wrote $CADDYFILE"
+echo "Now: caddy validate --config $CADDYFILE, commit, and re-run deploy/cloudflare-firewall.sh on the box."


### PR DESCRIPTION
Cloudflare now sits in front of the origin (zone active, Full (strict), apex and www proxied). This branch is the origin-side half of that: the access log is the analytics source now, so it has to be both small enough to keep and truthful about what it does and does not record.

## Three things a proxy broke silently

**1. The log was about to stop measuring visitors.** Every request now arrives from a Cloudflare address, so `client_ip` was becoming an edge node for the entire internet. Nothing would have errored — the log keeps filling, every response stays 200 — and the only symptom would have been aggregates describing Cloudflares topology instead of an audience. `trusted_proxies` + `client_ip_headers Cf-Connecting-Ip` gives the real address back.

Measured after the reload: `client_ip 86.20.0.0` (a real visitor, masked) alongside `remote_ip 172.70.0.0` (the edge, also masked).

**2. It was about to start recording full IP addresses.** Cloudflare adds `CF-Connecting-IP` — the visitors complete, unmasked address — to every request, and Caddy logs every request header. Masking `client_ip` while writing that header verbatim would have recorded the exact thing the mask exists to prevent, in **both** log streams, from the first proxied request. `app/(site)/privacy` promises in writing that this server does not record your IP address.

The deletions are duplicated into the default logger too, because that one goes to journald and error entries carry the request object as well — the same split that caught us once already.

`Cf-Ipcountry` is deliberately **kept**: a two-letter country code is the one geographic signal the rollups want, and the only one this box could not derive for itself without shipping a GeoIP database.

**3. Row size.** The log was ~1,445 bytes/row against `roll_size 50MiB × roll_keep 5` — about **1.7 days** of history. Almost all the weight was `resp_headers` and a dozen `Sec-*` headers no aggregate will ever read, and the rollup job would have spent its time skipping exactly those fields. `Referer` and `User-Agent` stay: referrer is the channel breakdown that corrected "Reddit beats search" to the opposite, and User-Agent is the only way to separate the scanners that arrived within minutes of the certificate hitting the CT log from actual people.

## Two scripts, because the comments referenced them

- **`refresh-cloudflare-ips.sh`** — the trust list is hardcoded (the Caddyfile has no line-continuation syntax) and goes stale **silently**: a range Cloudflare adds later does not error, it just logs those visitors as their edge node. Diffs before it writes; `--check` exits non-zero on drift for a scheduled job.
- **`cloudflare-firewall.sh`** — closes 80/443 to everything but Cloudflare. The trust list and the firewall are one mechanism in two halves: the list without the firewall trusts a forgeable header from a direct connection, and the firewall without the list logs every visitor as an edge node. Adds the allows *before* removing the world-open rules so there is no unreachable instant, refuses to run if no SSH rule exists, and leaves port 22 alone deliberately.

## The firewall is gated on a measurement, not a clock

Moving the nameservers does not move every visitor at once. Namecheaps nameservers **keep answering authoritatively** for the zone after the switch, and resolvers cache the `.com` delegation for up to 48 hours (86400s on the authoritative RRset, measured on the day). Dropping those visitors packets does not push them to the edge — it times them out.

Measured from the cutover: **89.8%** of the hour still direct, **31.9%** over fifteen minutes, **2.1%** over five, and the tail is real browsers rather than scanners.

So the script counts recent direct requests — requests through Cloudflare carry `Cf-Ipcountry`, direct ones never do, which is an exact discriminator already in the log — excludes declared crawlers and our own tooling, and refuses while any remain, naming the user-agents so you can see who would have lost the site. Verified refusing on the box: 645 via Cloudflare, 22 direct, exit 1, ufw unchanged.

**The firewall has NOT been applied yet.** It is waiting on that gate.

## What I expected to need and did not

I said HTTP-01 renewal would break behind the proxy and that we would have to move to a Cloudflare Origin CA certificate. I measured it instead, with a throwaway proxied hostname:

- `tls-alpn-01` **does** fail — `Cannot negotiate ALPN protocol "acme-tls/1"`, because Cloudflare terminates TLS. That part was right.
- Caddy falls back to `http-01` **on its own** and it succeeds: five `served key authentication` entries, every one arriving from a Cloudflare address, then `certificate obtained successfully`.

Renewal survives the proxy, so no Origin CA certificate and no `xcaddy` DNS-01 build. And because the validations arrive *through* Cloudflare, the firewall above does not break renewal either. The probe hostname, its certificate and its DNS record were all removed.

## Verification

`caddy validate` adapts cleanly on 2.11.4, `caddy fmt` is clean, reload exit 0, unit active. Nine live checks through the Cloudflare edge — apex, `/app`, `/privacy`, `/api/status`, `/robots.txt`, `/sitemap.xml`, `/manifest.webmanifest`, `/admin` still 404 in production, www 301 to apex — **9 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2He37pDHX8hpMh3QqcJ7F