### PR TITLE
Fix the firewall script leaving the origin world-open while reporting success

### DIFF
--- a/deploy/cloudflare-firewall.sh
+++ b/deploy/cloudflare-firewall.sh
@@ -141,6 +141,17 @@ else
   exit 1
 fi
 
+# READ THE RANGES WITH 'awk NF', NEVER 'cat'. Cloudflare serves ips-v4 and ips-v6 with
+# NO TRAILING NEWLINE, so 'cat v4 v6' glues the last v4 range onto the first v6 one and
+# emits a single malformed token: "131.0.72.0/222400:cb00::/32". awk treats each file's
+# final partial line as a record, so it separates them correctly.
+#
+# THIS ALREADY HAPPENED, and the failure was worse than a crash. ufw rejected the glued
+# token, set -e aborted mid-loop, and the box was left half-configured: 14 of 15 IPv4
+# ranges allowed, NO IPv6 ranges at all, and the world-open rules still in place -- so
+# the firewall looked tightened while the origin stayed reachable by anyone. The
+# per-file CIDR validation above did not catch it either, because grep reads each file
+# separately and both files are individually well-formed.
 count=0
 while read -r cidr; do
   [[ -n "$cidr" ]] || continue
@@ -148,20 +159,42 @@ while read -r cidr; do
   # so re-running this after a range is added upstream only adds the new one.
   ufw allow proto tcp from "$cidr" to any port 80,443 comment 'cloudflare edge' >/dev/null
   count=$((count + 1))
-done < <(cat "$tmp/v4" "$tmp/v6" | tr -d '\r')
+done < <(awk 'NF' "$tmp/v4" "$tmp/v6" | tr -d '\r')
 
 echo "cloudflare-firewall: allowed $count Cloudflare ranges on 80,443"
 
-# Now drop the world-open rules. `ufw delete` returns non-zero when the rule is already
-# gone, which is the normal case on a second run, so these are tolerated individually
-# rather than being allowed to kill the script under `set -e`.
+# Now drop the world-open rules.
+# ufw delete exits non-zero when the rule is already gone, which is the normal case on
+# a second run, so each is tolerated individually rather than allowed to kill the script
+# under set -e. Do NOT gate these on "ufw --dry-run delete": it does not reliably report
+# whether a rule exists, and the version that did left BOTH world-open rules in place
+# while reporting success.
 for rule in "allow 80/tcp" "allow 443/tcp"; do
-  if ufw --dry-run delete $rule >/dev/null 2>&1; then
-    ufw delete $rule >/dev/null && echo "cloudflare-firewall: removed world-open '$rule'"
+  if ufw delete $rule >/dev/null 2>&1; then
+    echo "cloudflare-firewall: removed world-open '$rule'"
   else
     echo "cloudflare-firewall: '$rule' already absent"
   fi
 done
+
+# REFUSE TO FINISH QUIETLY IF THE WORLD IS STILL ALLOWED IN. The entire point of this
+# script is that 80/443 stop being open, and a half-applied firewall that reports
+# success is the exact failure this file already had once. Note the pattern matches
+# "ALLOW" and not "ALLOW IN": plain `ufw status` prints the former and only the verbose
+# form prints the latter, and a check written against the verbose wording silently
+# passed while both rules were still there.
+if ufw status | grep -qE '^(80|443)/tcp( \(v6\))?[[:space:]]+ALLOW'; then
+  echo "cloudflare-firewall: FAILED -- 80/443 are still open to Anywhere" >&2
+  ufw status >&2
+  exit 1
+fi
+
+allowed="$(ufw status | grep -c 'cloudflare edge' || true)"
+if [[ "$allowed" -lt "$count" ]]; then
+  echo "cloudflare-firewall: FAILED -- only $allowed of $count Cloudflare ranges allowed" >&2
+  exit 1
+fi
+echo "cloudflare-firewall: verified $allowed/$count ranges allowed, 80/443 closed to all else"
 
 echo
 ufw status verbose

--- a/deploy/refresh-cloudflare-ips.sh
+++ b/deploy/refresh-cloudflare-ips.sh
@@ -48,7 +48,18 @@ if grep -vqE '^[0-9a-fA-F:.]+/[0-9]{1,3}$' "$tmp/v4" "$tmp/v6"; then
   exit 1
 fi
 
-new="$(cat "$tmp/v4" "$tmp/v6" | tr -d '\r' | paste -sd' ' -)"
+# READ THE RANGES WITH 'awk NF', NEVER 'cat'. Cloudflare serves ips-v4 and ips-v6 with
+# NO TRAILING NEWLINE, so 'cat v4 v6' glues the last v4 range onto the first v6 one and
+# emits a single malformed token: "131.0.72.0/222400:cb00::/32". awk treats each file's
+# final partial line as a record, so it separates them correctly.
+#
+# THIS ALREADY HAPPENED, and the failure was worse than a crash. ufw rejected the glued
+# token, set -e aborted mid-loop, and the box was left half-configured: 14 of 15 IPv4
+# ranges allowed, NO IPv6 ranges at all, and the world-open rules still in place -- so
+# the firewall looked tightened while the origin stayed reachable by anyone. The
+# per-file CIDR validation above did not catch it either, because grep reads each file
+# separately and both files are individually well-formed.
+new="$(awk 'NF' "$tmp/v4" "$tmp/v6" | tr -d '\r' | paste -sd' ' -)"
 old="$(sed -n 's/^[[:space:]]*trusted_proxies static //p' "$CADDYFILE")"
 
 if [[ "$old" == "$new" ]]; then


### PR DESCRIPTION
The origin firewall was applied on 2026-09-07 and reported success. It had in
fact left the box reachable by anyone on 80 and 443.

## What happened

Cloudflare serves `https://www.cloudflare.com/ips-v4` and `/ips-v6` **with no
trailing newline**. `cat "$tmp/v4" "$tmp/v6"` therefore glues the last IPv4
range onto the first IPv6 one and emits a single malformed token:

```
131.0.72.0/222400:cb00::/32
```

`ufw` rejected it, `set -e` aborted the loop, and the box was left with:

- 14 of 15 IPv4 ranges allowed (`131.0.72.0/22` missing)
- **zero** IPv6 ranges
- **both world-open `80/tcp` and `443/tcp` rules still in place**

The per-file CIDR validation immediately above could not have caught it: `grep`
reads each file separately and both files are individually well-formed.

Two smaller faults sat behind the same incident:

- The world-open deletions were gated on `ufw --dry-run delete`, which does not
  reliably report whether a rule exists. Both were skipped and the script
  printed nothing wrong. `ufw delete` is now called directly, with its non-zero
  "already gone" exit tolerated individually so it cannot kill the script under
  `set -e`.
- There was **no post-apply check at all**, so nothing contradicted the success
  message.

`refresh-cloudflare-ips.sh` had the identical `cat` bug. There it would have
written the glued token straight into the Caddyfile's `trusted_proxies` list.

## The fix

`awk 'NF'` reads each file's final partial line as a record, so the ranges stay
separate — 22 rather than a broken 21.

The script now refuses to finish while 80/443 are still open to Anywhere, or
while fewer ranges are allowed than it just added. Note the check matches
`ALLOW` and not `ALLOW IN`: plain `ufw status` prints the former and only the
verbose form prints the latter, which is exactly why the first hand-written
check read as passing while both rules were still there.

## Verified on the box

```
cloudflare-firewall: last 10 min - 522 via Cloudflare, 0 direct (excluding crawlers and our own tooling)
cloudflare-firewall: gate passed - no real direct traffic in the window
cloudflare-firewall: allowed 22 Cloudflare ranges on 80,443
cloudflare-firewall: removed world-open 'allow 80/tcp'
cloudflare-firewall: removed world-open 'allow 443/tcp'
cloudflare-firewall: verified 22/22 ranges allowed, 80/443 closed to all else
```

`ufw status verbose` then shows 22 `# cloudflare edge` rules (15 v4 + 7 v6),
`22/tcp (OpenSSH)`, and nothing else.

From outside:

| request | result |
|---|---|
| `https://provenance-online.com/` via edge `104.21.33.12` | `200`, `Server: cloudflare`, `CF-RAY: …-LHR` |
| `/app`, `/sitemap.xml` via edge `172.67.139.162` | `200` |
| direct `https://…` → `52.44.44.162` | `curl: (28)` timeout |
| direct `http://52.44.44.162/` | `curl: (28)` timeout |

Public resolvers (1.1.1.1, 8.8.8.8, 9.9.9.9, OpenDNS) all return the proxied
`104.21.33.12` / `172.67.139.162`. One stale ISP resolver still hands out the
origin address from the pre-cutover delegation; that is the cached `.com`
delegation ageing out, and it is why the propagation gate exists and why it was
run again immediately before applying this.
