### PR TITLE
Stop every deploy handing 502s to whoever is mid-request

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -103,7 +103,32 @@ provenance-online.com {
 	# /api/hls streams video segments straight through. Caddy does not buffer response
 	# bodies by default, so segments start flowing before they finish downloading —
 	# leave it that way.
-	reverse_proxy 127.0.0.1:3000
+	reverse_proxy 127.0.0.1:3000 {
+		# RETRY THE DIAL INSTEAD OF RETURNING 502, WHICH IS WHAT A DEPLOY LOOKS LIKE
+		# FROM OUT HERE.
+		#
+		# Restarting the app closes port 3000 for as long as it takes Next to drain and
+		# come back. With Caddy's default of no retries, every request arriving in that
+		# window gets a 502 — 89 of them on `/` alone in the first day, plus 11 on
+		# /robots.txt, which is Google being served an error page.
+		#
+		# 12 seconds is sized against the other half of the fix: provenance.service caps
+		# its stop at 5 s and Next answers 1.3 s after start, so the real window is under
+		# 7 s and this has room to spare. Measured before and after with 60 requests at
+		# 100 ms across a restart: 40 x 502 before, 0 after.
+		#
+		# THE COST IS PAID DURING A GENUINE OUTAGE, and it is worth naming. If Next is
+		# crash-looping, requests now hold for 12 s before failing rather than failing at
+		# once. That is the wrong trade if it ever becomes the common case — but a crash
+		# loop is already a total outage, and deploy/deploy.sh rolls one back within a
+		# minute, whereas a deploy happens on every merge.
+		#
+		# Caddy only retries a request whose body it can still replay, so this covers
+		# every GET and nothing that matters is left out: there is no POST on this site
+		# except /api/feedback.
+		lb_try_duration 12s
+		lb_try_interval 200ms
+	}
 
 	# NOT adding `encode` on purpose: Next's standalone server already compresses
 	# (`compress` defaults to true), including the ~6.4 MB /api/cameras body it deflates

--- a/deploy/provenance.service
+++ b/deploy/provenance.service
@@ -36,6 +36,27 @@ RestartSec=3
 # The registry warm-up means a cold start does real work before it answers.
 TimeoutStartSec=90
 
+# CAP THE STOP, BECAUSE THE DEFAULT 90s IS A 90s OUTAGE ON EVERY DEPLOY.
+#
+# Next stops accepting on SIGTERM and then drains in-flight and keep-alive connections,
+# so the port is CLOSED for the whole drain. Measured on this box on 2026-09-07: a stop
+# with no established connections took 0.03s; a stop while a client was making requests
+# on a keep-alive connection took 26.7 SECONDS. /api/hls streams video segments and a
+# player holds that connection open indefinitely, so in production the drain is bounded
+# by the slowest client rather than by the slowest request.
+#
+# That is where the 89 `502 /` responses in the first day came from. Every deploy calls
+# `systemctl restart`, and everything arriving during the drain got a connection refused
+# from Caddy.
+#
+# Five seconds is chosen against the measurement, not picked round: page responses
+# average 127 ms and the slowest upstream fetch in the app times out at 8 s, so an
+# ordinary request finishes comfortably inside it and only a long-lived stream is cut —
+# and a stream is being cut either way. SIGKILL rather than a longer wait is the right
+# trade because deploy/deploy.sh has already proved the incoming release answers on
+# :3001 before the symlink moves; the old process has nothing left to contribute.
+TimeoutStopSec=5
+
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict


### PR DESCRIPTION
The first day of access logs held **149** responses with status 502 — 88 on `/`
and **11 on `/robots.txt`**, which is Google being served an error page. They
cluster on the minute of each deploy.

## The cause is the stop, not the start

Next stops accepting on SIGTERM and then drains in-flight and keep-alive
connections, so port 3000 is **closed for the whole drain** — and
`TimeoutStopSec` was the systemd default of 90 seconds.

Measured on the box:

| condition | stop duration |
|---|---|
| no established connections | **0.03 s** |
| one client making requests over a keep-alive connection | **26.7 s** |

`/api/hls` streams video segments and a player holds that connection open
indefinitely, so in production the drain is bounded by the slowest *client*, not
the slowest request. The journal hides this: it logs `Started` and `✓ Ready in
151ms` but nothing about how long the stop took, which is why my first estimate
of the window was ~150 ms and wrong by two orders of magnitude.

## Two changes

**`TimeoutStopSec=5`** (from 90). Page responses average 127 ms and the slowest
upstream fetch in the app times out at 8 s, so an ordinary request finishes
comfortably inside 5 s and only a long-lived stream is cut — and a stream is being
cut either way. SIGKILL rather than a longer wait is right because `deploy.sh` has
already proved the incoming release answers on `:3001` before the symlink moves;
the old process has nothing left to contribute.

**`lb_try_duration 12s`** on `reverse_proxy`. A request arriving during the window
now waits for the upstream instead of getting a connection refused. With the stop
capped at 5 s and Next answering 1.3 s after start, the real window is under 7 s.

## The cost, named

A crash-looping app now holds requests for 12 s before failing rather than failing
at once. That is the wrong trade if it ever becomes the common case — but a crash
loop is already a total outage and `deploy.sh` rolls one back within a minute,
whereas a deploy happens on every merge. Caddy only retries a request whose body
it can still replay, so this covers every GET; the only POST on the site is
`/api/feedback`.

## Before and after

60 requests at 100 ms spanning a `systemctl restart`:

```
before   40 x 502, 20 x 200
after    60 x 200
```

Both files are installed on the box, `caddy fmt` is clean, and the running Caddy
config carries `try_duration: 12000000000`.
