### PR TITLE
Point /admin/analytics at our own access log, and say what it cannot answer

### DIFF
--- a/app/(site)/privacy/page.tsx
+++ b/app/(site)/privacy/page.tsx
@@ -86,12 +86,32 @@ const ISSUES_URL = `${REPO_URL}/issues`;
  *     every visitor's full IP address before we do. What reaches our log is masked; what
  *     reaches Cloudflare is not, and no wording on our side changes that.
  *   • persistence — package.json ships ten runtime deps and not one is a database
- *     client. `writeFileSync|writeFile\(|appendFile|node:fs` over app/ lib/ components/
- *     now returns TWO files, lib/discovery/store.ts and app/api/admin/promote/route.ts,
- *     both belonging to the dev-only camera-review tool and both behind a production
- *     404. tests/unit/discovery-admin-gate.test.ts asserts that list is exactly those
- *     two and that every route under app/admin and app/api/admin carries the guard —
- *     proven by injection in both directions before it was committed, not by reading.
+ *     client. The guard in tests/unit/discovery-admin-gate.test.ts is now TWO checks and
+ *     the difference matters to the copy below.
+ *
+ *     WRITING: a grep for writeFileSync|appendFileSync|writeFile\(|createWriteStream|
+ *     renameSync|mkdirSync|rmSync|unlinkSync|truncateSync|copyFileSync over app/ lib/
+ *     components/ returns exactly TWO files, lib/discovery/store.ts and
+ *     app/api/admin/promote/route.ts, both belonging to the dev-only camera-review tool
+ *     and both behind a production 404. So "nothing this site serves writes a file"
+ *     stays true.
+ *
+ *     READING: `node:fs` returns a THIRD, lib/analytics/rollupRead.ts, which reads the
+ *     access-log rollups for /admin/analytics and is held to reading by the write check
+ *     above. A further check fails if anything under app/, lib/ or components/ imports
+ *     from scripts/, which is where the code that WRITES the rollups lives — outside
+ *     what Next bundles, so a route cannot reach it even by accident.
+ *
+ *     ROLLUPS, added 2026-09-08: scripts/rollup-access-log.mts folds the access log into
+ *     one aggregate per day under /srv/provenance/shared/analytics, and those aggregates
+ *     are KEPT INDEFINITELY while the log itself rotates away in about three and a half
+ *     days. That is a real change to what persists and the logs section says so. They
+ *     hold counts only — paths, referrer hostnames, country codes, device classes,
+ *     statuses, byte totals — and no addresses at any resolution. The one per-visitor
+ *     structure is a set of salted truncated hashes of (masked address, user agent) used
+ *     to size a day's visitor count, and it is DELETED when the day is finalised.
+ *     ANY CHANGE THAT KEEPS THOSE HASHES, OR ADDS A FIELD DERIVED FROM AN ADDRESS,
+ *     MAKES THE LOGS SECTION FALSE.
  *   • identity — `next/headers|cookies\(\)|x-forwarded-for|x-real-ip|req(uest)?\.ip`
  *     over app/ lib/ components/ returns exactly ONE hit, app/api/feedback/route.ts:63,
  *     and the page names it rather than rounding it down to "we read nothing". That
@@ -766,6 +786,31 @@ export default function PrivacyPage() {
               The log rolls and old files are deleted; nothing is exported anywhere.
             </p>
             <p>
+              <strong>
+                Counts taken from that log are kept, and they outlive the log.
+              </strong>{" "}
+              Every five minutes a job on the same machine folds the new lines into one
+              summary per day: how many requests, how many of them were pages, which paths,
+              which referring hostnames, which country codes, which device classes, which
+              status codes, how many bytes and how long things took. Those summaries are
+              kept indefinitely, while the log they came from is gone in about three and a
+              half days. This is what the traffic figures behind the scenes are read from,
+              and it exists because the alternative was a third party&rsquo;s dashboard.
+            </p>
+            <p>
+              What those summaries do <em>not</em> contain is any address, at any resolution
+              &mdash; not even the masked form, which is discarded along with the log line
+              it came from. A summary is a set of totals and nothing that points at a
+              request. The single exception is how the daily visitor number is arrived at:
+              for the day in progress the job keeps a set of short salted hashes, each one
+              made from a masked address and a user agent, purely so that the same browser
+              is not counted twice in a day. That set is <strong>deleted</strong> when the
+              day is closed off, leaving only the count. It is also why that number is
+              described as approximate wherever it appears: two people on one network using
+              the same browser are one of them, and one person on a phone and a laptop is
+              two.
+            </p>
+            <p>
               <strong>Something sits in front of that server now, and it does see your address.</strong>{" "}
               This site is served through{" "}
               <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noreferrer noopener">
@@ -804,15 +849,16 @@ export default function PrivacyPage() {
               yourself by clearing site data.
             </p>
             <p>
-              Three things sit outside that, and they are the only places anything of yours can
+              Four things sit outside that, and they are the only places anything of yours can
               persist. One is the server access log described above, which is IP-masked, rolled and
-              deleted. One is the page-view counter described above, which holds no cookie and
-              nothing that survives your tab, and which will not have counted you at all if your
-              browser sends Do Not Track. The third is a feedback answer, if you chose to send one,
-              which is sitting as a message in a private Telegram chat &mdash; that is the only place a name or an email
-              you gave us can be, and asking will get it deleted. The page-view counts that Vercel
-              gathered before the move are a third, historical, and are being wound down with that
-              account.
+              deleted &mdash; together with the daily counts taken from it, which are kept but hold
+              no address at any resolution. One is the page-view counter described above, which
+              holds no cookie and nothing that survives your tab, and which will not have counted
+              you at all if your browser sends Do Not Track. The third is a feedback answer, if you
+              chose to send one, which is sitting as a message in a private Telegram chat &mdash;
+              that is the only place a name or an email you gave us can be, and asking will get it
+              deleted. The fourth is historical: the page-view counts a previous host gathered
+              before the move, which are being wound down with that account and cannot be added to.
             </p>
             <p>
               If you think any of this is wrong, say so in{" "}

--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -4,22 +4,46 @@
 // GATE. `assertDevOnly()` 404s this route in production, and it is called here as well
 // as in the admin layout rather than trusted from the layout alone — a layout is a file
 // someone else can restructure, and the failure mode of getting this wrong is a public
-// admin page over a team-wide API token. The helper fails closed on either VERCEL_ENV or
-// NODE_ENV, and `tests/unit/discovery-admin-gate.test.ts` enumerates this directory, so
-// this page is picked up by that guard automatically.
+// admin page. The helper fails closed on either VERCEL_ENV or NODE_ENV, and
+// `tests/unit/discovery-admin-gate.test.ts` enumerates this directory, so this page is
+// picked up by that guard automatically.
 //
-// The token is read in lib/analytics/vercelApi.ts, on the server, and only aggregate
-// numbers are passed down as props. Nothing credential-shaped crosses into the client.
+// THE SOURCE CHANGED, AND THAT IS THE POINT OF THIS FILE'S REWRITE. It used to read
+// Vercel's Web Analytics API. Collection there stopped the day the site left Vercel —
+// <Analytics /> posted to /_vercel/insights, a path that exists only on their edge — so
+// those numbers have been a closing archive since, on a rolling 31-day window that
+// deletes the oldest day every day. The live source is now our own Caddy access log,
+// folded into daily aggregates by scripts/rollup-access-log.mts. The Vercel archive is
+// still readable and still worth reading; it is the last section rather than the first.
+//
+// EVERY PANEL SAYS WHAT ITS NUMBERS ARE NOT. A dashboard's failure mode is not being
+// wrong, it is being confidently approximate: "visitors" here is a count of salted
+// hashes over /16-masked addresses, "pageviews" excludes anything that declared itself
+// a robot, and neither of those is qualified anywhere but on this screen. Panels state
+// it inline rather than in a footnote, because a figure read on its own is exactly how
+// a wrong number escapes into a decision.
 
 import type { Metadata } from "next";
 import { Panel, FailureNotice, EmptyNotice } from "@/components/admin/analytics/Panel";
-import { TrafficOverTime } from "@/components/admin/analytics/TrafficOverTime";
+import { CountTable } from "@/components/admin/analytics/CountTable";
+import { DailySeries } from "@/components/admin/analytics/DailySeries";
 import { DimensionTable } from "@/components/admin/analytics/DimensionTable";
 import { Limitations } from "@/components/admin/analytics/Limitations";
+import { VercelPlanNotes } from "@/components/admin/analytics/VercelPlanNotes";
 import { dailySeries, loadDashboard, PANEL_LIMITS } from "@/lib/analytics/dashboard";
+import { MAP_CAP } from "@/lib/analytics/rollup";
+import { readRollups, stalenessSeconds } from "@/lib/analytics/rollupRead";
+import {
+  apiByteShare,
+  buildWindow,
+  bytes,
+  directShare,
+  durationBuckets,
+  lastDays,
+  rows,
+} from "@/lib/analytics/rollupView";
 import { assertDevOnly } from "@/lib/discovery/devOnly";
 import { totals as sumDaily } from "@/lib/analytics/window";
-import type { AggregateRow, AnalyticsResult } from "@/lib/analytics/vercelApi";
 
 export const dynamic = "force-dynamic";
 
@@ -28,204 +52,325 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-function Grouped({
-  result,
-  dimension,
-  valueHeading,
-  emptyLabel,
-  limit,
-  what,
-  since,
-  until,
-}: {
-  result: AnalyticsResult<AggregateRow[]>;
-  dimension: string;
-  valueHeading: string;
-  emptyLabel?: string;
-  limit: number;
-  what: string;
-  since: string;
-  until: string;
-}) {
-  if (!result.ok) return <FailureNotice failure={result.failure} />;
-  if (result.data.length === 0) return <EmptyNotice what={what} since={since} until={until} />;
+/** How many days of rollups the panels aggregate over. */
+const WINDOW_DAYS = 30;
+
+function Stat({ n, k, note }: { n: string; k: string; note?: string }) {
   return (
-    <DimensionTable
-      rows={result.data}
-      dimension={dimension}
-      valueHeading={valueHeading}
-      emptyLabel={emptyLabel}
-      limit={limit}
-    />
+    <div className="adm-stat">
+      <span className="adm-stat-n">{n}</span>
+      <span className="adm-stat-k">{k}</span>
+      {note && <p className="adm-stat-note">{note}</p>}
+    </div>
   );
+}
+
+function freshness(seconds: number | null): { text: string; stale: boolean } {
+  if (seconds == null) {
+    return { text: "The rollup job has never recorded a run.", stale: true };
+  }
+  const mins = Math.round(seconds / 60);
+  // The timer fires every five minutes, so anything past fifteen is two missed runs and
+  // not a slow one. A frozen dashboard looks exactly like a quiet night, which is why
+  // this is stated rather than left to be noticed.
+  if (seconds > 900) {
+    return {
+      text: `Last run ${mins.toLocaleString("en-GB")} minutes ago, which is at least two missed runs — check systemctl status provenance-rollup.service.`,
+      stale: true,
+    };
+  }
+  return { text: `Last run ${mins <= 1 ? "under a minute" : `${mins} minutes`} ago.`, stale: false };
 }
 
 export default async function AnalyticsPage() {
   assertDevOnly();
 
   const now = new Date();
-  const d = await loadDashboard(now);
-  const sinceLabel = d.since.toISOString().slice(0, 10);
-  const untilLabel = d.until.toISOString().slice(0, 10);
+  const todayUtc = now.toISOString().slice(0, 10);
+  const source = readRollups();
+  const view = buildWindow(lastDays(source.days, WINDOW_DAYS));
+  const fresh = freshness(stalenessSeconds(source, now.getTime()));
 
-  const series = d.daily.ok ? dailySeries(d.daily.data, d.since, d.until) : [];
-  const seriesTotals = sumDaily(series);
-  const uniqueVisitors = d.totals.ok ? d.totals.data.visitors : null;
-  const cameraPageCount = d.cameraPaths.ok
-    ? d.cameraPaths.data.filter((r) => r.requestPath !== "Others").length
-    : null;
+  // Still issued, so the archive section shows what Vercel says today rather than what
+  // it said when this file was last edited.
+  const vercel = await loadDashboard(now);
+  const vercelSeries = vercel.daily.ok ? dailySeries(vercel.daily.data, vercel.since, vercel.until) : [];
+  const vercelTotals = sumDaily(vercelSeries);
 
   return (
     <>
       <h1 className="adm-h1">Traffic</h1>
-      <p className="adm-lede">
-        What the site actually received, read back from Vercel Web Analytics: {sinceLabel} to{" "}
-        {untilLabel}, a rolling {d.windowDays}-day window that is the whole of what this plan
-        retains. Every panel below states which of its numbers were measured and which were never
-        available, because on a dashboard an unexplained empty panel reads as a zero.
-      </p>
-      <p className="adm-lede">
-        <strong>This is a closing archive, not a live dashboard.</strong> Collection stopped when
-        the site left Vercel: <code>&lt;Analytics /&gt;</code> posted to{" "}
-        <code>/_vercel/insights</code>, a path that exists only on their edge, so it was removed
-        rather than left to 404 once per page view. Everything here is history, and the rolling
-        window means it is history that is <em>expiring</em> — each day the earliest day drops off
-        and nothing is added at the other end. Read a fall to zero as the move, not as a collapse
-        in traffic. Whatever needs keeping should be exported before the window swallows it, and
-        certainly before the Vercel plan changes, because the free tier answers any request for a
-        date older than 31 days with a flat 400 rather than a short answer.
-      </p>
+
+      {!view ? (
+        <>
+          <p className="adm-lede">
+            There are no rollups to show. This is the expected state anywhere but the production
+            box.
+          </p>
+          <div className="adm-note">
+            <p style={{ margin: 0 }}>{source.reason}</p>
+            <p style={{ margin: "6px 0 0" }}>
+              Looked in <code>{source.dir}</code>. Override with{" "}
+              <code>ANALYTICS_ROLLUP_DIR</code>.
+            </p>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="adm-lede">
+            Read from this server&rsquo;s own Caddy access log, folded into one aggregate per UTC
+            day: {view.from} to {view.to}, {view.dayCount}{" "}
+            {view.dayCount === 1 ? "day" : "days"}. <strong>These aggregates do not expire.</strong>{" "}
+            The log itself holds about three and a half days before it rotates, so the rollups are
+            the only durable record — and the reason they exist is that the previous source, a
+            hosting provider&rsquo;s dashboard, stopped being ours to read.
+          </p>
+          <div className={fresh.stale ? "adm-note" : undefined}>
+            <p style={{ margin: 0, fontSize: 12.5, color: "var(--adm-ink-dim)" }}>{fresh.text}</p>
+          </div>
+
+          <Panel
+            title="1 · The window"
+            subtitle="Totals across every day above. Read the qualifiers on each figure — they are not decoration."
+          >
+            <div className="adm-stats">
+              <Stat
+                n={view.totals.pageviews.toLocaleString("en-GB")}
+                k="Pageviews"
+                note="Documents delivered to something that did not declare itself a robot. Excludes API responses, static files and probes."
+              />
+              <Stat
+                n={`≈ ${view.visitorsMean.toLocaleString("en-GB")}`}
+                k="Visitors per day"
+                note={`Mean of the daily figures; the busiest day was ≈ ${view.visitorsPeak.toLocaleString("en-GB")}. There is deliberately no window total — see section 6.`}
+              />
+              <Stat
+                n={view.totals.requests.toLocaleString("en-GB")}
+                k="Requests"
+                note="Everything, including assets, API calls, robots and probes."
+              />
+              <Stat
+                n={bytes(view.totals.bytes)}
+                k="Sent"
+                note={`${(apiByteShare(view.totals) * 100).toFixed(0)}% of it API responses, not pages.`}
+              />
+              <Stat
+                n={view.meanDurationMs == null ? "—" : `${view.meanDurationMs} ms`}
+                k="Mean page response"
+                note="Time the origin took, measured at Caddy. Not what a visitor waited for."
+              />
+              <Stat
+                n={view.totals.byPath["(other)"] ? `${MAP_CAP.toLocaleString("en-GB")}+` : Object.keys(view.totals.byPath).length.toLocaleString("en-GB")}
+                k="Distinct pages seen"
+                note="Paths with at least one pageview in the window."
+              />
+            </div>
+          </Panel>
+
+          <Panel title="2 · By day" subtitle="Pageviews per UTC day, with the approximate visitor count beside it">
+            <DailySeries points={view.points} todayUtc={todayUtc} />
+          </Panel>
+
+          <Panel
+            title="3 · Where they land"
+            subtitle="Top pages by pageview. Query strings are stripped, so every /app visit is one row rather than one row per map position."
+          >
+            <CountTable rows={rows(view.totals.byPath, 25)} heading="Page" valueHeading="Pageviews" cap={MAP_CAP} />
+          </Panel>
+
+          <Panel
+            title="4 · Where they came from"
+            subtitle="Referring hostname as the browser reported it. This is the panel that corrected “search beats Reddit” to the opposite, so it is worth reading before believing anything about a channel."
+          >
+            <CountTable
+              rows={rows(view.totals.byReferrer, 20)}
+              heading="Referrer"
+              valueHeading="Pageviews"
+              cap={MAP_CAP}
+            />
+          </Panel>
+
+          <Panel title="5 · Who" subtitle="Country from Cloudflare's header; device class from the user-agent string">
+            <div style={{ display: "grid", gap: 18 }}>
+              <div>
+                <h3 className="adm-stat-k" style={{ display: "block", marginBottom: 4 }}>
+                  Country
+                </h3>
+                <CountTable rows={rows(view.totals.byCountry, 15)} heading="Country" valueHeading="Pageviews" />
+              </div>
+              <div>
+                <h3 className="adm-stat-k" style={{ display: "block", marginBottom: 4 }}>
+                  Device
+                </h3>
+                <CountTable rows={rows(view.totals.byDevice, 6)} heading="Device" valueHeading="Pageviews" />
+                <p className="adm-stat-note">
+                  Three classes and no more. A user-agent string cannot give a model or a screen
+                  size without a lookup table that goes stale, and the question this answers is
+                  whether the console is being opened on a phone.
+                </p>
+              </div>
+            </div>
+          </Panel>
+
+          <Panel
+            title="6 · What “visitors” means here, exactly"
+            subtitle="Because it is the figure most likely to be quoted and the one with the most caveats"
+          >
+            <div className="adm-note">
+              <p style={{ margin: 0 }}>
+                A visitor is one distinct salted hash of{" "}
+                <strong>a /16-masked address plus a user-agent string</strong>. The address arrives
+                already masked — Caddy writes <code>86.20.0.0</code>, never the full address — so a
+                /16 names a block of about 65,000 machines. Two people on the same network using
+                the same browser build are therefore <strong>one</strong> visitor, and one person on
+                a phone and a laptop is <strong>two</strong>.
+              </p>
+              <p style={{ margin: "8px 0 0" }}>
+                There is no window total, and that absence is deliberate. The per-day hash sets are
+                deleted when a day is finalised, because keeping them would be keeping a
+                per-visitor record — the thing this whole design exists to avoid. So the unique
+                count across several days is not merely unknown to us, it is{" "}
+                <strong>unknowable from this data</strong>. Summing the days would answer a
+                different question while looking like an answer to this one: someone who visits
+                every day would appear seven times in a week.
+              </p>
+            </div>
+          </Panel>
+
+          <Panel
+            title="7 · What it costs to serve"
+            subtitle="The bandwidth question, which pages do not answer"
+          >
+            <div className="adm-stats" style={{ marginBottom: 14 }}>
+              <Stat n={bytes(view.totals.apiBytes)} k="API bytes" note={`${(apiByteShare(view.totals) * 100).toFixed(0)}% of everything sent`} />
+              <Stat n={view.totals.apiRequests.toLocaleString("en-GB")} k="API requests" />
+              <Stat
+                n={view.totals.assetRequests.toLocaleString("en-GB")}
+                k="Static requests"
+                note="Reaching the ORIGIN. Cloudflare serves /_next/static from its edge, so this is what got past the cache, not what browsers asked for."
+              />
+            </div>
+            <CountTable
+              rows={rows(view.totals.byApiBytes, 15)}
+              heading="API path"
+              valueHeading="Sent"
+              cap={MAP_CAP}
+              format={bytes}
+            />
+            <p className="adm-stat-note">
+              Ranked by bytes rather than by call count, because those give different answers and
+              only one of them is the bill. A single <code>/api/planes</code> response was measured
+              at 1.3 MB.
+            </p>
+          </Panel>
+
+          <Panel title="8 · What is broken" subtitle="Every 4xx and 5xx, by status and path">
+            <CountTable
+              rows={rows(view.totals.errors, 20)}
+              heading="Status and path"
+              valueHeading="Responses"
+              cap={MAP_CAP}
+              empty="No 4xx or 5xx responses in this window."
+            />
+            <p className="adm-stat-note">
+              A 502 here is the origin being unreachable from Caddy, which in practice means a
+              deploy restart caught a request mid-flight. A 404 on a path nobody links to is a
+              probe; one on a path the site does link to is a bug.
+            </p>
+          </Panel>
+
+          <Panel
+            title="9 · Robots, probes, and who is bypassing the edge"
+            subtitle="Three counts that are not traffic and should never be added to it"
+          >
+            <div className="adm-stats" style={{ marginBottom: 14 }}>
+              <Stat
+                n={view.totals.botRequests.toLocaleString("en-GB")}
+                k="Declared robots"
+                note="A floor, never a ceiling. This counts clients that said so; anything pretending to be a browser is in the pageview figure instead."
+              />
+              <Stat
+                n={view.totals.scannerRequests.toLocaleString("en-GB")}
+                k="Probes"
+                note="Requests for /wp-login.php, /.env, /server-status and the like — software this site has never run."
+              />
+              <Stat
+                n={`${(directShare(view.totals) * 100).toFixed(1)}%`}
+                k="Bypassed Cloudflare"
+                note="Requests with no country header, so they reached the origin directly. Above roughly zero means some resolver still hands out the origin address."
+              />
+            </div>
+            <div className="adm-note">
+              <p style={{ margin: 0 }}>
+                That last figure is the one deploy/cloudflare-firewall.sh refuses to run against.
+                Closing the origin while it is non-zero does not move those visitors to the edge,
+                it times them out — which happened, on the day a ten-minute traffic sample read
+                zero and the firewall was closed anyway.
+              </p>
+            </div>
+          </Panel>
+
+          <Panel title="10 · How fast" subtitle="Page response time at the origin, bucketed">
+            <CountTable
+              rows={durationBuckets(view.totals).map((b) => ({ key: b.label, count: b.count, share: b.share }))}
+              heading="Response time"
+              valueHeading="Pageviews"
+            />
+            <p className="adm-stat-note">
+              Measured by Caddy, from receiving the request to finishing the response. It does not
+              include the visitor&rsquo;s network, Cloudflare&rsquo;s leg, or any time the browser
+              spent rendering — so a fast column here is consistent with a page that feels slow.
+            </p>
+          </Panel>
+        </>
+      )}
+
+      <Panel title="11 · What this cannot tell you">
+        <Limitations windowDays={WINDOW_DAYS} />
+      </Panel>
 
       <Panel
-        title="1 · Traffic over time"
-        subtitle="Visitors and pageviews per day, with the retention edge drawn rather than described"
+        title="12 · Vercel archive, closing"
+        subtitle="Read live on every load, so what appears here is what Vercel says today"
       >
-        {d.daily.ok ? (
-          series.length === 0 ? (
-            <EmptyNotice what="pageviews" since={sinceLabel} until={untilLabel} />
-          ) : (
-            <TrafficOverTime
-              points={series}
-              windowDays={d.windowDays}
-              uniqueVisitors={uniqueVisitors}
-              totalPageviews={seriesTotals.pageviews}
+        <p style={{ fontSize: 13, marginTop: 0 }}>
+          Collection stopped when the site left Vercel, and the window is rolling: each day the
+          earliest day drops off and nothing is added at the other end.{" "}
+          <strong>Read a fall to zero as the move, not as a collapse in traffic.</strong> The free
+          tier answers any request for a date older than 31 days with a flat 400, so whatever needs
+          keeping should be exported before the plan changes rather than after.
+        </p>
+        {vercel.daily.ok ? (
+          vercelSeries.length === 0 ? (
+            <EmptyNotice
+              what="pageviews"
+              since={vercel.since.toISOString().slice(0, 10)}
+              until={vercel.until.toISOString().slice(0, 10)}
             />
+          ) : (
+            <>
+              <div className="adm-stats" style={{ marginBottom: 14 }}>
+                <Stat n={vercelTotals.pageviews.toLocaleString("en-GB")} k="Archived pageviews" />
+                <Stat
+                  n={vercel.totals.ok ? vercel.totals.data.visitors.toLocaleString("en-GB") : "—"}
+                  k="Archived visitors"
+                  note="Vercel's own de-duplication, not ours — not comparable with the figure above."
+                />
+              </div>
+              {vercel.routes.ok && (
+                <DimensionTable
+                  rows={vercel.routes.data}
+                  dimension="route"
+                  valueHeading="Route"
+                  limit={PANEL_LIMITS.routes}
+                />
+              )}
+            </>
           )
         ) : (
-          <FailureNotice failure={d.daily.failure} />
+          <FailureNotice failure={vercel.daily.failure} />
         )}
-      </Panel>
-
-      <Panel title="2 · Where they land" subtitle="Top routes by pageviews">
-        <Grouped
-          result={d.routes}
-          dimension="route"
-          valueHeading="Route"
-          limit={PANEL_LIMITS.routes}
-          what="routes"
-          since={sinceLabel}
-          until={untilLabel}
-        />
-      </Panel>
-
-      <Panel
-        title="2b · Did the generated camera pages get visited?"
-        subtitle="Individual paths under the /camera/[id] route"
-      >
-        {cameraPageCount != null && (
-          <p style={{ fontSize: 13, marginTop: 0 }}>
-            <strong>{cameraPageCount.toLocaleString("en-GB")}</strong> distinct camera pages
-            recorded at least one visit in this window.{" "}
-            <span style={{ color: "var(--adm-ink-faint)" }}>
-              This is a floor: the query asks for the top {PANEL_LIMITS.cameraPaths} distinct paths
-              and Vercel buckets the rest, so the true number can only be higher. It is not
-              comparable to the total number of camera pages the site generates, which is a
-              different measurement and is not made here.
-            </span>
-          </p>
-        )}
-        <Grouped
-          result={d.cameraPaths}
-          dimension="requestPath"
-          valueHeading="Path"
-          limit={PANEL_LIMITS.cameraPaths}
-          what="camera-page visits"
-          since={sinceLabel}
-          until={untilLabel}
-        />
-      </Panel>
-
-      <Panel title="3 · Where they came from" subtitle="Referring hostname, as reported by the browser">
-        <Grouped
-          result={d.referrers}
-          dimension="referrerHostname"
-          valueHeading="Referrer"
-          emptyLabel="(direct — typed, bookmarked, or an app that sends no referrer)"
-          limit={PANEL_LIMITS.referrers}
-          what="referrers"
-          since={sinceLabel}
-          until={untilLabel}
-        />
-      </Panel>
-
-      <Panel
-        title="3b · Campaign attribution (UTM)"
-        subtitle="Requested live on every load, so the answer below is the current one rather than a remembered one"
-      >
-        <Grouped
-          result={d.utm}
-          dimension="utmSource"
-          valueHeading="utm_source"
-          limit={PANEL_LIMITS.referrers}
-          what="tagged campaign visits"
-          since={sinceLabel}
-          until={untilLabel}
-        />
-      </Panel>
-
-      <Panel title="4 · Who" subtitle="Country, device and browser">
-        <div style={{ display: "grid", gap: 18 }}>
-          <div>
-            <h3 style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", margin: "0 0 4px", fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.06em" }}>Country</h3>
-            <Grouped
-              result={d.countries}
-              dimension="country"
-              valueHeading="Country"
-              limit={PANEL_LIMITS.countries}
-              what="countries"
-              since={sinceLabel}
-              until={untilLabel}
-            />
-          </div>
-          <div>
-            <h3 style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", margin: "0 0 4px", fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.06em" }}>Device</h3>
-            <Grouped
-              result={d.devices}
-              dimension="deviceType"
-              valueHeading="Device"
-              limit={PANEL_LIMITS.devices}
-              what="device types"
-              since={sinceLabel}
-              until={untilLabel}
-            />
-          </div>
-          <div>
-            <h3 style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", margin: "0 0 4px", fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.06em" }}>Browser</h3>
-            <Grouped
-              result={d.browsers}
-              dimension="browserName"
-              valueHeading="Browser"
-              limit={PANEL_LIMITS.browsers}
-              what="browsers"
-              since={sinceLabel}
-              until={untilLabel}
-            />
-          </div>
-        </div>
-      </Panel>
-
-      <Panel title="5 · What this cannot tell you">
-        <Limitations windowDays={d.windowDays} />
+        <VercelPlanNotes />
       </Panel>
     </>
   );

--- a/components/admin/analytics/CountTable.tsx
+++ b/components/admin/analytics/CountTable.tsx
@@ -1,0 +1,106 @@
+// components/admin/analytics/CountTable.tsx
+// A ranked table of counted things: pages, referrers, countries, API paths, errors.
+//
+// This is NOT DimensionTable. That one renders Vercel's rows, which carry a visitor
+// count per row; the access log has no such thing, because a visitor is a per-day set
+// and not an attribute of a path. Handing rollup rows to a table with a Visitors column
+// would leave a column that is either empty or invented, so there are two tables.
+//
+// EVERY SHARE IS AGAINST THE WHOLE MAP, INCLUDING THE ROWS NOT SHOWN. lib/analytics/
+// rollupView.ts computes it that way on purpose: a share taken against the visible rows
+// adds up to 100% however much was cut off, which is exactly how a truncated table
+// implies it is complete.
+
+import type { Row } from "@/lib/analytics/rollupView";
+
+/**
+ * "(other)" is the rollup's own overflow bucket, written by capMap when a map outgrows
+ * its cardinality cap. It is not a page called "(other)", and the same is true of
+ * "(direct)", "(self)" and "(unknown)" — each is a category the counting rules created,
+ * so each is explained where it is rendered rather than in a caption somewhere else.
+ */
+const SYNTHETIC: Record<string, string> = {
+  "(other)": "everything past the cap this map keeps, added together",
+  "(direct)": "no referrer at all — typed, bookmarked, or an app that sends none",
+  "(self)": "a page on this site — internal navigation, not a traffic source",
+  "(unknown)": "no country header, which means the request did not come through Cloudflare",
+  "(unparseable)": "a referrer the browser sent that is not a URL",
+};
+
+export function CountTable({
+  rows,
+  heading,
+  valueHeading = "Requests",
+  cap,
+  empty = "Nothing recorded in this window.",
+  format = (n) => n.toLocaleString("en-GB"),
+}: {
+  rows: Row[];
+  heading: string;
+  valueHeading?: string;
+  /** The map's cardinality cap, so the table can say when it may be truncated. */
+  cap?: number;
+  empty?: string;
+  /**
+   * How to render the value. Defaults to a grouped integer, which is right for a count
+   * of things and wrong for a count of bytes: the API table is ranked by bytes, and
+   * "573,209,816" beside a tile reading "1.5 GB" makes the reader do the arithmetic to
+   * find out whether the two agree.
+   */
+  format?: (n: number) => string;
+}) {
+  if (rows.length === 0) return <p className="adm-empty">{empty}</p>;
+  const top = rows[0]?.count || 1;
+
+  return (
+    <div>
+      <table className="adm-table">
+        <thead>
+          <tr>
+            <th>{heading}</th>
+            <th style={{ width: "34%" }} />
+            <th style={{ textAlign: "right", width: 110 }}>{valueHeading}</th>
+            <th style={{ textAlign: "right", width: 72 }}>Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.key}>
+              <td style={{ wordBreak: "break-word" }}>
+                <span style={{ fontFamily: "var(--tn-font-mono, ui-monospace, monospace)", fontSize: 12.5 }}>
+                  {r.key}
+                </span>
+                {SYNTHETIC[r.key] && (
+                  <span style={{ color: "var(--adm-ink-faint)", fontSize: 11.5, display: "block" }}>
+                    {SYNTHETIC[r.key]}
+                  </span>
+                )}
+              </td>
+              <td>
+                {/* Width is against the largest row, so the bars compare rows to each
+                    other. The Share column is the one that compares to the total. */}
+                <span className="adm-funnel-track" aria-hidden="true">
+                  <span className="adm-funnel-fill" style={{ width: `${Math.max(2, (r.count / top) * 100)}%` }} />
+                </span>
+              </td>
+              <td style={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                {format(r.count)}
+              </td>
+              <td
+                style={{ textAlign: "right", fontVariantNumeric: "tabular-nums", color: "var(--adm-ink-dim)" }}
+              >
+                {(r.share * 100).toFixed(r.share < 0.01 ? 2 : 1)}%
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {cap != null && rows.some((r) => r.key === "(other)") && (
+        <p className="adm-stat-note">
+          This map reached its {cap.toLocaleString("en-GB")}-key cap, so the tail is added together
+          rather than listed. The totals are unaffected — nothing is discarded, only the names.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/admin/analytics/DailySeries.tsx
+++ b/components/admin/analytics/DailySeries.tsx
@@ -1,0 +1,137 @@
+// components/admin/analytics/DailySeries.tsx
+// Pageviews and approximate visitors per day, drawn from the access-log rollups.
+//
+// NOT TrafficOverTime. That component draws Vercel's rolling retention edge — the line
+// past which their plan simply stops answering — which is a fact about a plan we have
+// left. These rollups do not expire, so there is no edge to draw, and drawing one would
+// be describing a limit that no longer applies.
+//
+// A BAR PER DAY AND NO SMOOTHING. A line chart interpolates between days and invents
+// values at every point in between; with a handful of days that interpolation is most
+// of the ink on the page. Bars also make a partial day obvious, which matters because
+// today is always partial and a line sloping down to it reads as a collapse in traffic.
+
+import type { DayPoint } from "@/lib/analytics/rollupView";
+
+const W = 720;
+const H = 200;
+const PAD = { top: 14, right: 12, bottom: 34, left: 52 };
+
+export function DailySeries({ points, todayUtc }: { points: DayPoint[]; todayUtc: string }) {
+  if (points.length === 0) return <p className="adm-empty">No days recorded yet.</p>;
+
+  const plotW = W - PAD.left - PAD.right;
+  const plotH = H - PAD.top - PAD.bottom;
+  const max = Math.max(1, ...points.map((p) => p.pageviews));
+  const slot = plotW / points.length;
+  const barW = Math.max(3, Math.min(46, slot * 0.62));
+
+  // Ticks at 0, half and max. Every label names a value the chart actually reaches,
+  // rather than a round number the axis was stretched to meet.
+  const ticks = [0, Math.round(max / 2), max];
+
+  return (
+    <div>
+      <div style={{ overflowX: "auto" }}>
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          width="100%"
+          role="img"
+          aria-label={`Pageviews per day from ${points[0]!.date} to ${points[points.length - 1]!.date}`}
+          style={{ display: "block", minWidth: 420 }}
+        >
+          {ticks.map((t) => {
+            const y = PAD.top + plotH - (t / max) * plotH;
+            return (
+              <g key={t}>
+                <line x1={PAD.left} x2={W - PAD.right} y1={y} y2={y} stroke="var(--adm-line)" strokeWidth={1} />
+                <text
+                  x={PAD.left - 8}
+                  y={y + 4}
+                  textAnchor="end"
+                  fill="var(--adm-ink-faint)"
+                  fontSize={11}
+                  style={{ fontVariantNumeric: "tabular-nums" }}
+                >
+                  {t.toLocaleString("en-GB")}
+                </text>
+              </g>
+            );
+          })}
+
+          {points.map((p, i) => {
+            const h = (p.pageviews / max) * plotH;
+            const x = PAD.left + i * slot + (slot - barW) / 2;
+            const partial = p.date === todayUtc;
+            return (
+              <g key={p.date}>
+                <rect
+                  x={x}
+                  y={PAD.top + plotH - h}
+                  width={barW}
+                  height={Math.max(1, h)}
+                  rx={2}
+                  fill={partial ? "var(--adm-ink-faint)" : "var(--adm-accent)"}
+                />
+                {/* Only the ends and every other label, or they collide at 30 days. */}
+                {(i === 0 || i === points.length - 1 || points.length <= 14) && (
+                  <text
+                    x={x + barW / 2}
+                    y={H - 14}
+                    textAnchor="middle"
+                    fill="var(--adm-ink-faint)"
+                    fontSize={10.5}
+                  >
+                    {p.date.slice(5)}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <p className="adm-stat-note">
+        Bars are pageviews. The grey bar is today, which is <strong>partial by definition</strong> —
+        it holds only the hours that have happened, so reading it as a fall in traffic is the one
+        mistake this chart invites.
+      </p>
+      <table className="adm-table" style={{ marginTop: 10 }}>
+        <thead>
+          <tr>
+            <th>Day (UTC)</th>
+            <th style={{ textAlign: "right" }}>Pageviews</th>
+            <th style={{ textAlign: "right" }}>Visitors ≈</th>
+            <th style={{ textAlign: "right" }}>Requests</th>
+          </tr>
+        </thead>
+        <tbody>
+          {[...points].reverse().map((p) => (
+            <tr key={p.date}>
+              <td style={{ fontFamily: "var(--tn-font-mono, ui-monospace, monospace)", fontSize: 12.5 }}>
+                {p.date}
+                {p.date === todayUtc && (
+                  <span style={{ color: "var(--adm-ink-faint)" }}> · partial</span>
+                )}
+              </td>
+              <td style={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                {p.pageviews.toLocaleString("en-GB")}
+              </td>
+              <td style={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                {p.visitors.toLocaleString("en-GB")}
+              </td>
+              <td
+                style={{
+                  textAlign: "right",
+                  fontVariantNumeric: "tabular-nums",
+                  color: "var(--adm-ink-dim)",
+                }}
+              >
+                {p.requests.toLocaleString("en-GB")}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/admin/analytics/Limitations.tsx
+++ b/components/admin/analytics/Limitations.tsx
@@ -1,87 +1,127 @@
 // components/admin/analytics/Limitations.tsx
-// Section 5: what this dashboard cannot tell you, and what it would cost to change.
+// What the access log cannot answer, and which of the three sources can.
 //
-// Everything here is either a refusal we received verbatim or a line transcribed from
-// Vercel's published pricing table. No inference, no recommendation: the reader is
-// the one paying, and the only useful thing this panel can do is put the boundary and
-// the price in the same place and then stop talking.
+// THIS PANEL USED TO BE ABOUT VERCEL'S PRICING TABLE — what a paid plan would unlock —
+// because the dashboard read Vercel's API and the boundary was commercial. The boundary
+// is now physical, and that is a better problem to have but a worse one to be vague
+// about: no amount of money buys a server log a record of something that never reached
+// the server. The plan table moved to the archive section, where it still applies.
+//
+// The one job of this panel is to stop a figure being used for a question it cannot
+// answer. Someone reading "1,015 pageviews" will want a bounce rate next, and the
+// honest answer is not "we have not built it" — it is that a bounce leaves no trace on
+// this side of the wire at all.
 
-import { MEASURED_REFUSALS, PLAN_TABLE, PRO_PRICE_NOTE, SHARED_ALLOWANCE_NOTE } from "@/lib/analytics/limits";
+const SPLIT: { source: string; answers: string; cannot: string }[] = [
+  {
+    source: "This access log",
+    answers:
+      "Every request that reached the server: which page, how often, how large, how fast, from which country, referred by whom, and what errored.",
+    cannot:
+      "Anything a visitor did without making another request — how long they stayed, how far they scrolled, what they clicked that was not a link, whether they left immediately.",
+  },
+  {
+    source: "The beacon (PostHog)",
+    answers:
+      "Engagement: bounce rate, time on page, scroll depth, rage clicks and dead clicks. Cookieless, session-scoped, no replay.",
+    cannot:
+      "Being complete. This audience blocks trackers heavily, so it undercounts by an unknown and probably large margin, and it stops existing entirely for anyone with an ad blocker. It is a sample of behaviour, never a census of traffic.",
+  },
+  {
+    source: "Google Search Console",
+    answers:
+      "Impressions, queries, average position and click-through — the entire SEO picture.",
+    cannot:
+      "Being reconstructed later. It has no backfill: whatever it did not record while verified is gone. It also only ever describes Google.",
+  },
+];
 
 export function Limitations({ windowDays }: { windowDays: number }) {
   return (
     <div style={{ fontSize: 13.5, lineHeight: 1.6 }}>
       <p style={{ marginTop: 0, maxWidth: "78ch", color: "var(--adm-ink-dim)" }}>
-        This page shows pageviews, routes, referrers, countries, devices and browsers, over a
-        rolling {windowDays}-day window. That is the whole of it. It cannot tell you what anyone
-        <em> did</em> once they arrived — not a layer toggled, a camera opened, a board switched or
-        a tour abandoned — because none of that is collected. Custom events are the mechanism for
-        it, and this plan does not include them.
+        The panels above cover up to {windowDays} days of requests. That is a complete record of
+        what was <em>asked for</em> and no record at all of what was <em>done</em>. A visitor who
+        opens a page, reads it for four minutes, toggles six layers and leaves is, in this data,
+        identical to one who opens the same page and closes it at once: both are exactly one
+        request. The gap is not a missing feature, it is the shape of the medium — those actions
+        never travel to a server, so no server log at any price contains them.
       </p>
 
-      <h3 style={{ fontSize: 12.5, margin: "18px 0 4px", textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--adm-ink-faint)" }}>
-        What we asked for and were refused
+      <h3
+        style={{
+          fontSize: 12.5,
+          margin: "18px 0 8px",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          color: "var(--adm-ink-faint)",
+        }}
+      >
+        Three sources, and the question each one owns
       </h3>
-      <p style={{ fontSize: 12, color: "var(--adm-ink-faint)", margin: "0 0 8px" }}>
-        Measured against the live API, quoted exactly as it answered.
-      </p>
       <table className="adm-table">
         <thead>
           <tr>
-            <th style={{ width: "32%" }}>Asked for</th>
-            <th style={{ width: 60 }}>Status</th>
-            <th>Vercel&apos;s answer</th>
+            <th style={{ width: "22%" }}>Source</th>
+            <th>Answers</th>
+            <th>Cannot</th>
           </tr>
         </thead>
         <tbody>
-          {MEASURED_REFUSALS.map((r) => (
-            <tr key={r.asked}>
-              <td>{r.asked}</td>
-              <td className="adm-num">{r.status}</td>
+          {SPLIT.map((s) => (
+            <tr key={s.source}>
               <td>
-                <span style={{ fontStyle: "italic", color: "var(--adm-ink-dim)" }}>
-                  &ldquo;{r.message}&rdquo;
-                </span>
-                <span style={{ color: "var(--adm-ink-faint)", fontSize: 12 }}> — measured {r.measuredOn}</span>
+                <strong>{s.source}</strong>
               </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      <h3 style={{ fontSize: 12.5, margin: "24px 0 4px", textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--adm-ink-faint)" }}>
-        What a paid plan would add
-      </h3>
-      <table className="adm-table">
-        <thead>
-          <tr>
-            <th>Feature</th>
-            <th>Hobby (current)</th>
-            <th>Pro</th>
-            <th>Pro + Analytics Plus</th>
-          </tr>
-        </thead>
-        <tbody>
-          {PLAN_TABLE.map((row) => (
-            <tr key={row.feature}>
-              <td>{row.feature}</td>
-              <td style={{ color: "var(--adm-ink-faint)" }}>{row.hobby}</td>
-              <td>{row.pro}</td>
-              <td>{row.proPlus}</td>
+              <td style={{ color: "var(--adm-ink-dim)" }}>{s.answers}</td>
+              <td style={{ color: "var(--adm-ink-faint)" }}>{s.cannot}</td>
             </tr>
           ))}
         </tbody>
       </table>
 
       <div className="adm-note" style={{ marginTop: 14 }}>
-        {PRO_PRICE_NOTE}
-        <div style={{ marginTop: 6 }}>{SHARED_ALLOWANCE_NOTE}</div>
+        <p style={{ margin: 0 }}>
+          <strong>The three do not reconcile, and should not be made to.</strong> The log counts
+          requests that arrived; the beacon counts sessions that ran its script; Search Console
+          counts what Google showed. A visitor who blocks trackers is in the first and not the
+          second. A crawler is in the first and neither of the others. Averaging them, or picking
+          whichever is highest, produces a number that describes none of them.
+        </p>
       </div>
 
-      <p style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", marginTop: 10, marginBottom: 0 }}>
-        Plan table transcribed from vercel.com/docs/analytics/limits-and-pricing, read 2026-08-19.
-        Prices are list prices on that date and are worth re-reading before anyone spends money.
-      </p>
+      <h3
+        style={{
+          fontSize: 12.5,
+          margin: "24px 0 4px",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          color: "var(--adm-ink-faint)",
+        }}
+      >
+        And what the log is not
+      </h3>
+      <ul style={{ color: "var(--adm-ink-dim)", maxWidth: "78ch", paddingLeft: 20 }}>
+        <li>
+          <strong>Not a person count.</strong> Addresses arrive masked to a /16 before anything
+          reads them, so &ldquo;visitors&rdquo; is a lower bound on households and an upper bound
+          on nothing.
+        </li>
+        <li>
+          <strong>Not a robot filter.</strong> The bot count is of clients that <em>said</em> they
+          were bots. Anything sending a browser&rsquo;s user-agent string is counted as a person,
+          and the well-behaved crawlers are the ones being excluded.
+        </li>
+        <li>
+          <strong>Not everything the browser asked for.</strong> Cloudflare answers cached static
+          files from its own edge, so those requests never reach this log. The static figure is
+          what got <em>past</em> the cache.
+        </li>
+        <li>
+          <strong>Not retroactive.</strong> The rollups begin the day the job was installed. The
+          log holds about three and a half days, so nothing before that window exists anywhere.
+        </li>
+      </ul>
     </div>
   );
 }

--- a/components/admin/analytics/VercelPlanNotes.tsx
+++ b/components/admin/analytics/VercelPlanNotes.tsx
@@ -1,0 +1,104 @@
+// components/admin/analytics/VercelPlanNotes.tsx
+// The refusals Vercel's API gave us, and what a paid plan would have unlocked.
+//
+// THIS IS HISTORY NOW, AND IT IS KEPT BECAUSE IT IS EVIDENCE. It used to be section 5,
+// the answer to "what can this dashboard not tell you", back when the dashboard read
+// Vercel's API and the boundary was commercial. The boundary moved: the live source is
+// this server's own access log, and no plan is involved. But the refusals below were
+// measured against the live API and quoted verbatim, and the plan table was transcribed
+// from the published pricing — that is the record of what leaving actually cost in
+// capability, and deleting it would leave only the assertion that leaving was right.
+//
+// It also still applies to the archive above it: the 31-day window and the flat 400 on
+// anything older are the reason that data has to be exported rather than left in place.
+
+import { MEASURED_REFUSALS, PLAN_TABLE, PRO_PRICE_NOTE, SHARED_ALLOWANCE_NOTE } from "@/lib/analytics/limits";
+
+export function VercelPlanNotes() {
+  return (
+    <div style={{ fontSize: 13.5, lineHeight: 1.6, marginTop: 22 }}>
+      <h3
+        style={{
+          fontSize: 12.5,
+          margin: "0 0 4px",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          color: "var(--adm-ink-faint)",
+        }}
+      >
+        What we asked Vercel for and were refused
+      </h3>
+      <p style={{ fontSize: 12, color: "var(--adm-ink-faint)", margin: "0 0 8px" }}>
+        Measured against the live API, quoted exactly as it answered.
+      </p>
+      <table className="adm-table">
+        <thead>
+          <tr>
+            <th style={{ width: "32%" }}>Asked for</th>
+            <th style={{ width: 60 }}>Status</th>
+            <th>Vercel&apos;s answer</th>
+          </tr>
+        </thead>
+        <tbody>
+          {MEASURED_REFUSALS.map((r) => (
+            <tr key={r.asked}>
+              <td>{r.asked}</td>
+              <td className="adm-num">{r.status}</td>
+              <td>
+                <span style={{ fontStyle: "italic", color: "var(--adm-ink-dim)" }}>
+                  &ldquo;{r.message}&rdquo;
+                </span>
+                <span style={{ color: "var(--adm-ink-faint)", fontSize: 12 }}>
+                  {" "}
+                  — measured {r.measuredOn}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3
+        style={{
+          fontSize: 12.5,
+          margin: "24px 0 4px",
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          color: "var(--adm-ink-faint)",
+        }}
+      >
+        What a paid plan would have added
+      </h3>
+      <table className="adm-table">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Hobby</th>
+            <th>Pro</th>
+            <th>Pro + Analytics Plus</th>
+          </tr>
+        </thead>
+        <tbody>
+          {PLAN_TABLE.map((row) => (
+            <tr key={row.feature}>
+              <td>{row.feature}</td>
+              <td style={{ color: "var(--adm-ink-faint)" }}>{row.hobby}</td>
+              <td>{row.pro}</td>
+              <td>{row.proPlus}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="adm-note" style={{ marginTop: 14 }}>
+        {PRO_PRICE_NOTE}
+        <div style={{ marginTop: 6 }}>{SHARED_ALLOWANCE_NOTE}</div>
+      </div>
+
+      <p style={{ fontSize: 11.5, color: "var(--adm-ink-faint)", marginTop: 10, marginBottom: 0 }}>
+        Plan table transcribed from vercel.com/docs/analytics/limits-and-pricing, read 2026-08-19.
+        Prices are list prices on that date and are worth re-reading before anyone spends money.
+      </p>
+    </div>
+  );
+}

--- a/deploy/install-rollup.sh
+++ b/deploy/install-rollup.sh
@@ -59,3 +59,16 @@ echo
 systemctl --no-pager --lines=20 status provenance-rollup.service || true
 echo
 systemctl list-timers --no-pager provenance-rollup.timer
+
+# Where to look at the result, said here because it is the one question the operator
+# has next and the answer is not guessable: /admin returns 404 whenever NODE_ENV is
+# production, so the dashboard cannot be opened on this box at all.
+cat <<'NOTE'
+
+The rollups are written to /srv/provenance/shared/analytics. To read them:
+
+  scripts/pull-rollups.sh        # from a checkout, copies them down and prints the rest
+
+/admin/analytics 404s in production by design (lib/discovery/devOnly.ts), so it is only
+reachable from `npx next dev` on a laptop pointed at a copy of these files.
+NOTE

--- a/lib/analytics/rollupRead.ts
+++ b/lib/analytics/rollupRead.ts
@@ -1,0 +1,122 @@
+// lib/analytics/rollupRead.ts
+//
+// Reading the daily rollups that scripts/rollup-access-log.mts writes. READ ONLY, and
+// that is a contract rather than a description: app/(site)/privacy tells readers that
+// nothing this site serves writes a file, and tests/unit/discovery-admin-gate.test.ts
+// fails the build if any file under app/, lib/ or components/ so much as mentions a way
+// to write one. This module is on that test's node:fs allowlist and on none of its
+// writer lists. Adding a write here is not a small change; it makes a published
+// sentence false.
+//
+// EVERYTHING HERE FAILS SOFT. The rollup directory does not exist in local development,
+// did not exist on Vercel, and will not exist on a box where the timer was never
+// installed. None of those is an error worth a 500 on an internal page — they are just
+// "no data yet", and they are reported as that, with the path that was looked at, so
+// the answer to "why is this empty" is on the screen rather than in a log.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { type DayRollup } from "@/lib/analytics/rollup";
+
+/** Matches deploy/provenance-rollup.service. Overridable for local inspection. */
+export const ROLLUP_DIR = "/srv/provenance/shared/analytics";
+
+export interface RollupSource {
+  dir: string;
+  /** Days present, oldest first. */
+  days: DayRollup[];
+  /** Unix seconds of the job's last successful run, or null if it has never run. */
+  lastRun: number | null;
+  /** Why there is nothing to show, when there is nothing to show. */
+  reason: string | null;
+}
+
+function readJson<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function isDay(value: unknown): value is DayRollup {
+  const d = value as DayRollup | null;
+  return !!d && typeof d.date === "string" && typeof d.requests === "number" && Array.isArray(d.byHour);
+}
+
+/**
+ * Load the rollups, newest `limitDays` of them.
+ *
+ * Open days live inside state.json and finished ones in days/, which is an
+ * implementation detail of how the job stays crash-safe. Nothing above this line should
+ * have to know about it, so both are read and merged into one list here.
+ */
+export function readRollups(
+  env: Record<string, string | undefined> = process.env,
+  limitDays = 60,
+): RollupSource {
+  const dir = env.ANALYTICS_ROLLUP_DIR?.trim() || ROLLUP_DIR;
+  const empty = (reason: string): RollupSource => ({ dir, days: [], lastRun: null, reason });
+
+  if (!existsSync(dir)) {
+    return empty(
+      "The rollup directory does not exist here. It is created on the production box by " +
+        "deploy/install-rollup.sh; in local development there is no Caddy access log to fold.",
+    );
+  }
+
+  const byDate = new Map<string, DayRollup>();
+
+  const daysDir = join(dir, "days");
+  if (existsSync(daysDir)) {
+    for (const name of readdirSync(daysDir)) {
+      if (!/^\d{4}-\d{2}-\d{2}\.json$/.test(name)) continue;
+      const day = readJson<DayRollup>(join(daysDir, name));
+      if (isDay(day)) byDate.set(day.date, day);
+    }
+  }
+
+  // The state file's open days are the newest data there is, so they win over anything
+  // of the same date already read from days/ — that combination only occurs mid-write.
+  const state = readJson<{ days?: Record<string, DayRollup>; lastRun?: number }>(join(dir, "state.json"));
+  for (const day of Object.values(state?.days ?? {})) {
+    if (isDay(day)) byDate.set(day.date, day);
+  }
+
+  const days = [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date)).slice(-limitDays);
+  const lastRun = typeof state?.lastRun === "number" ? state.lastRun : null;
+
+  if (days.length === 0) {
+    return {
+      dir,
+      days: [],
+      lastRun,
+      reason:
+        "The rollup directory exists but holds no days yet. The job runs every five " +
+        "minutes; if this persists, check `systemctl status provenance-rollup.service`.",
+    };
+  }
+
+  return { dir, days, lastRun, reason: null };
+}
+
+/**
+ * How stale the newest data is, in seconds, or null if the job has never run.
+ *
+ * Worth showing rather than assuming. A timer that has silently stopped leaves a
+ * dashboard that looks fine and is quietly frozen, and the only visible symptom is that
+ * the last day stops growing — which is indistinguishable from a quiet night.
+ */
+export function stalenessSeconds(source: RollupSource, now = Date.now()): number | null {
+  if (source.lastRun == null) return null;
+  return Math.max(0, Math.floor(now / 1000) - source.lastRun);
+}
+
+/** Age of the rollup files on disk, as a cheap cross-check on lastRun. */
+export function directoryMtime(dir: string): number | null {
+  try {
+    return Math.floor(statSync(join(dir, "state.json")).mtimeMs / 1000);
+  } catch {
+    return null;
+  }
+}

--- a/lib/analytics/rollupView.ts
+++ b/lib/analytics/rollupView.ts
@@ -1,0 +1,143 @@
+// lib/analytics/rollupView.ts
+//
+// Shaping the daily rollups into what a panel renders. Pure — no fs, no dates from the
+// clock unless they are passed in — so every rule below is testable against fixtures.
+//
+// THE ONE THING THIS FILE REFUSES TO DO IS ADD UP VISITORS ACROSS DAYS. Each day's
+// figure is the size of that day's set of salted (masked-address, user-agent) hashes,
+// and those sets are deleted when the day is finalised, because keeping them for ever
+// would be keeping a per-visitor record — which is the thing the whole design avoids.
+// So the window's unique-visitor count is not merely unknown, it is unknowable from
+// this data, and summing the days would answer a different question while looking like
+// an answer to that one. Someone who visits every day would be counted seven times in a
+// week. What is shown instead is the per-day figure, its mean and its peak, each of
+// which is exactly true.
+
+import { mergeDay, topN, type DayRollup, DURATION_EDGES_MS } from "@/lib/analytics/rollup";
+
+export interface Row {
+  key: string;
+  count: number;
+  /** Share of the total this row's map covers, 0-1. */
+  share: number;
+}
+
+export interface DayPoint {
+  date: string;
+  pageviews: number;
+  requests: number;
+  visitors: number;
+  bytes: number;
+}
+
+export interface WindowView {
+  from: string;
+  to: string;
+  dayCount: number;
+  totals: DayRollup;
+  points: DayPoint[];
+  /** Mean and peak of the per-day visitor figures. NEVER their sum. */
+  visitorsMean: number;
+  visitorsPeak: number;
+  /** Mean page response time in milliseconds, or null when nothing was timed. */
+  meanDurationMs: number | null;
+}
+
+/** Newest `count` days, oldest first. */
+export function lastDays(days: DayRollup[], count: number): DayRollup[] {
+  return days.slice(-Math.max(1, count));
+}
+
+export function buildWindow(days: DayRollup[]): WindowView | null {
+  if (days.length === 0) return null;
+  const ordered = [...days].sort((a, b) => a.date.localeCompare(b.date));
+  const totals = ordered.reduce((acc, d) => mergeDay(acc, d));
+  const points: DayPoint[] = ordered.map((d) => ({
+    date: d.date,
+    pageviews: d.pageviews,
+    requests: d.requests,
+    visitors: d.visitors,
+    bytes: d.bytes,
+  }));
+  const visitorNumbers = points.map((p) => p.visitors);
+  return {
+    from: ordered[0]!.date,
+    to: ordered[ordered.length - 1]!.date,
+    dayCount: ordered.length,
+    totals,
+    points,
+    visitorsMean: Math.round(visitorNumbers.reduce((a, b) => a + b, 0) / visitorNumbers.length),
+    visitorsPeak: Math.max(...visitorNumbers),
+    meanDurationMs: totals.durationCount ? Math.round(totals.durationMsSum / totals.durationCount) : null,
+  };
+}
+
+/**
+ * Top rows with their share of the map's own total.
+ *
+ * The denominator is the sum of the WHOLE map, including the rows past `n` and
+ * including "(other)". A share computed against the visible rows alone would add up to
+ * 100% no matter how much was cut off, which is the specific way a truncated table
+ * lies.
+ */
+export function rows(map: Record<string, number>, n: number): Row[] {
+  const total = Object.values(map).reduce((a, b) => a + b, 0);
+  return topN(map, n).map(({ key, count }) => ({ key, count, share: total ? count / total : 0 }));
+}
+
+/** Bytes as a human figure. Decimal units, because that is what bandwidth is billed in. */
+export function bytes(n: number): string {
+  if (n < 1000) return `${n} B`;
+  const units = ["kB", "MB", "GB", "TB"];
+  let v = n / 1000;
+  let i = 0;
+  while (v >= 1000 && i < units.length - 1) {
+    v /= 1000;
+    i += 1;
+  }
+  return `${v >= 100 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+}
+
+export interface Bucket {
+  label: string;
+  count: number;
+  share: number;
+}
+
+/** Response-time histogram, labelled from the edges rather than from a repeated list. */
+export function durationBuckets(day: DayRollup): Bucket[] {
+  const total = day.durationBuckets.reduce((a, b) => a + b, 0);
+  return day.durationBuckets.map((count, i) => {
+    const lower = i === 0 ? 0 : DURATION_EDGES_MS[i - 1]!;
+    const upper = DURATION_EDGES_MS[i];
+    return {
+      label: upper === undefined ? `over ${lower} ms` : i === 0 ? `under ${upper} ms` : `${lower}–${upper} ms`,
+      count,
+      share: total ? count / total : 0,
+    };
+  });
+}
+
+/**
+ * The proportion of requests that reached the origin without passing through Cloudflare.
+ *
+ * Not a vanity metric. Anything above roughly zero means some resolver is still handing
+ * out the origin address, which is the exact condition that makes closing the origin
+ * firewall an outage — see deploy/cloudflare-firewall.sh, which refuses to run while it
+ * is true, and the day it was ignored.
+ */
+export function directShare(day: DayRollup): number {
+  const total = day.viaCloudflare + day.direct;
+  return total ? day.direct / total : 0;
+}
+
+/**
+ * What share of the bytes leaving this box are API responses rather than pages.
+ *
+ * Measured at 93% on the first day. It is the number that decides whether a bandwidth
+ * bill is caused by readers or by the console's own polling, and those have completely
+ * different fixes.
+ */
+export function apiByteShare(day: DayRollup): number {
+  return day.bytes ? day.apiBytes / day.bytes : 0;
+}

--- a/scripts/pull-rollups.sh
+++ b/scripts/pull-rollups.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# scripts/pull-rollups.sh
+#
+# Copy the production access-log rollups down, so /admin/analytics can be read on a
+# laptop.
+#
+# WHY THIS IS A SCRIPT AND NOT A NOTE. Two facts combine into something nobody
+# remembers a week later. `/admin` returns 404 whenever NODE_ENV is production
+# (`lib/discovery/devOnly.ts`), so the dashboard cannot be opened on the box that holds
+# its data; and `/srv/provenance/shared` is mode 750 `app:app`, so an ordinary ssh login
+# cannot read the rollups even though the `app` user can. Getting either half wrong
+# produces a page reading "the rollup directory exists but holds no days yet" — which is
+# indistinguishable from the rollup timer having silently stopped. That false alarm is
+# the whole reason this exists.
+#
+# It copies. It never writes to the box, and it never deletes anything there.
+
+set -euo pipefail
+
+HOST="${ROLLUP_HOST:-provenance}"
+REMOTE_PARENT="/srv/provenance/shared"
+DEST="${1:-${ROLLUP_DEST:-$HOME/provenance-rollups}}"
+
+# Extract beside the destination and swap at the end. A pull that dies halfway would
+# otherwise leave a truncated state.json in place, and the page would report that as
+# "no days yet" — the same misleading empty state this script exists to avoid.
+INCOMING="$DEST.incoming.$$"
+trap 'rm -rf "$INCOMING"' EXIT
+
+echo "pull-rollups: $HOST:$REMOTE_PARENT/analytics -> $DEST"
+mkdir -p "$INCOMING"
+
+# sudo, because the parent directory does not admit the login user. tar over a pipe
+# rather than scp -r, because the tree is small and this needs exactly one sudo.
+ssh "$HOST" "sudo tar -C $REMOTE_PARENT -cf - analytics" | tar -C "$INCOMING" -xf -
+
+state="$INCOMING/analytics/state.json"
+if [[ ! -f "$state" ]]; then
+  echo "pull-rollups: FAILED — no state.json arrived. Has the timer ever run?" >&2
+  echo "  check: ssh $HOST 'systemctl status provenance-rollup.service'" >&2
+  exit 1
+fi
+
+# Parse it here rather than letting the page fail soft. readRollups() treats unparseable
+# JSON as absent, on purpose, so a truncated copy reaches the screen as an empty
+# dashboard and not as an error.
+if command -v node >/dev/null 2>&1; then
+  node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "$state" ||
+    { echo "pull-rollups: FAILED — state.json did not parse, so the copy is truncated." >&2; exit 1; }
+fi
+
+rm -rf "$DEST"
+mkdir -p "$(dirname "$DEST")"
+mv "$INCOMING" "$DEST"
+trap - EXIT
+
+finalised="$(find "$DEST/analytics/days" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+echo "pull-rollups: ok — $finalised finalised day(s) plus whatever is open in state.json"
+echo "              (days/ stays empty for the first 36 h; FINALISE_LAG_MS in scripts/lib/rollup-store.mts)"
+echo
+
+# Node on Windows cannot resolve a Git Bash path like /c/Users/..., and the failure is
+# silent: existsSync returns false and the page reports the directory as missing. Print
+# the form the runtime actually accepts.
+abs="$DEST/analytics"
+if command -v cygpath >/dev/null 2>&1; then
+  abs="$(cygpath -m "$DEST/analytics")"
+fi
+
+echo "Now run the dev server against them — /admin only exists outside production:"
+echo
+echo "  ANALYTICS_ROLLUP_DIR=\"$abs\" npx next dev -p 3007"
+echo
+echo "then open http://127.0.0.1:3007/admin/analytics"

--- a/tests/unit/discovery-admin-gate.test.ts
+++ b/tests/unit/discovery-admin-gate.test.ts
@@ -117,10 +117,11 @@ describe("the curation data files", () => {
     expect(src.toLowerCase()).toMatch(/generated|ledger/);
   });
 
-  it("keeps node:fs out of everything except the curation tooling", () => {
-    // The /privacy page tells readers the deployed application writes no files, and
-    // that sentence is only checkable if the exception is exactly one directory. This
-    // is the check the page's claim points at.
+  // Two separate checks, because reading a file and writing one are different promises
+  // and the /privacy page only makes the second. Collapsing them into one grep — which
+  // is what this used to be — means the first module that legitimately needs to READ
+  // gets added to the allowlist, and takes the write ban with it.
+  const walkServed = (test: (src: string) => boolean): string[] => {
     const offenders: string[] = [];
     const walk = (dir: string) => {
       const abs = join(ROOT, dir);
@@ -135,28 +136,50 @@ describe("the curation data files", () => {
         // Comments are stripped first. Without that the /privacy page reports itself,
         // because it documents the very grep this test performs — and a guard that
         // fires on prose is a guard people learn to route around.
-        const src = stripComments(readFileSync(join(ROOT, rel), "utf8"));
-        // Broader than "writeFileSync". The point of the sentence on /privacy is that
-        // the served application puts nothing on disk, and a rename or an mkdir is as
-        // much a write as an append — createWriteStream especially, which is how a file
-        // gets written without any of the obvious names appearing at all.
-        if (
-          /from "node:fs"|require\("node:fs"\)|writeFileSync|appendFileSync|writeFile\(|createWriteStream|renameSync|mkdirSync|rmSync|unlinkSync|truncateSync|copyFileSync/.test(
-            src,
-          )
-        ) {
-          offenders.push(rel);
-        }
+        if (test(stripComments(readFileSync(join(ROOT, rel), "utf8")))) offenders.push(rel);
       }
     };
     walk("app");
     walk("lib");
     walk("components");
+    return offenders;
+  };
+
+  it("keeps every way of WRITING a file out of the served tree", () => {
+    // This is the check app/(site)/privacy points at when it says nothing this site
+    // serves writes a file. Broader than "writeFileSync" on purpose: a rename or an
+    // mkdir is as much a write as an append, and createWriteStream is how a file gets
+    // written without any of the obvious names appearing at all.
+    const writes =
+      /writeFileSync|appendFileSync|writeFile\(|createWriteStream|renameSync|mkdirSync|rmSync|unlinkSync|truncateSync|copyFileSync/;
     const allowed = new Set(["lib/discovery/store.ts", "app/api/admin/promote/route.ts"]);
-    const unexpected = offenders.filter((f) => !allowed.has(f));
+    const unexpected = walkServed((src) => writes.test(src)).filter((f) => !allowed.has(f));
     expect(
       unexpected,
       "these files write to disk outside the dev-only curation tooling, which makes the /privacy page's 'writes no files' sentence false: " +
+        unexpected.join(", "),
+    ).toEqual([]);
+  });
+
+  it("keeps node:fs itself to the few modules that have a stated reason", () => {
+    // Reading is allowed where it is named here and nowhere else, so a new fs import
+    // has to be argued for rather than slipped in. The allowlist is short and each
+    // entry has a reason:
+    //   lib/discovery/store.ts        the camera-review ledger, dev-only, writes too
+    //   app/api/admin/promote/route.ts  the same tool's write endpoint
+    //   lib/analytics/rollupRead.ts   reads the access-log rollups, and only reads —
+    //                                 the check above is what holds it to that
+    const allowed = new Set([
+      "lib/discovery/store.ts",
+      "app/api/admin/promote/route.ts",
+      "lib/analytics/rollupRead.ts",
+    ]);
+    const unexpected = walkServed((src) => /from "node:fs"|require\("node:fs"\)/.test(src)).filter(
+      (f) => !allowed.has(f),
+    );
+    expect(
+      unexpected,
+      "these files reach the filesystem from the served tree without being on the list that explains why: " +
         unexpected.join(", "),
     ).toEqual([]);
   });

--- a/tests/unit/rollup-view.test.ts
+++ b/tests/unit/rollup-view.test.ts
@@ -1,0 +1,229 @@
+// Reading and shaping the rollups for /admin/analytics.
+//
+// THE CENTRAL ASSERTION IN THIS FILE IS A NEGATIVE ONE: buildWindow must never sum the
+// per-day visitor figures. Each day's number is the size of that day's set of salted
+// hashes, and those sets are deleted when a day is finalised, so the union across days
+// is not merely unknown — it is unrecoverable. A sum would answer a different question
+// while looking like an answer to this one, and it would do it in the direction that
+// flatters: someone who visits every day is counted seven times in a week.
+//
+// It is the easiest change in the codebase to make by accident, because summing is what
+// every other field in mergeDay does, and it would never look wrong on screen.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { emptyDay, type DayRollup } from "@/lib/analytics/rollup";
+import { readRollups, stalenessSeconds } from "@/lib/analytics/rollupRead";
+import {
+  apiByteShare,
+  buildWindow,
+  bytes,
+  directShare,
+  durationBuckets,
+  lastDays,
+  rows,
+} from "@/lib/analytics/rollupView";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "rollup-read-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function day(date: string, over: Partial<DayRollup> = {}): DayRollup {
+  return { ...emptyDay(date), ...over };
+}
+
+function writeDayFile(d: DayRollup) {
+  mkdirSync(join(dir, "days"), { recursive: true });
+  writeFileSync(join(dir, "days", `${d.date}.json`), JSON.stringify(d));
+}
+
+function writeStateFile(days: DayRollup[], lastRun = 1_788_800_000) {
+  writeFileSync(
+    join(dir, "state.json"),
+    JSON.stringify({ version: 1, salt: "x", cursors: {}, visitorKeys: {}, lastRun, days: Object.fromEntries(days.map((d) => [d.date, d])) }),
+  );
+}
+
+describe("readRollups", () => {
+  it("says why it is empty rather than throwing, when the directory does not exist", () => {
+    // The normal state in local development and the state on any box where the timer
+    // was never installed. A 500 on an internal page helps nobody.
+    const r = readRollups({ ANALYTICS_ROLLUP_DIR: join(dir, "nope") });
+    expect(r.days).toEqual([]);
+    expect(r.reason).toContain("does not exist");
+    expect(r.dir).toContain("nope");
+  });
+
+  it("says why it is empty when the directory is there but holds nothing", () => {
+    const r = readRollups({ ANALYTICS_ROLLUP_DIR: dir });
+    expect(r.days).toEqual([]);
+    expect(r.reason).toContain("no days yet");
+  });
+
+  it("reads finished days and open days as one list, oldest first", () => {
+    writeDayFile(day("2026-09-05", { requests: 5 }));
+    writeDayFile(day("2026-09-06", { requests: 6 }));
+    writeStateFile([day("2026-09-07", { requests: 7 })]);
+    const r = readRollups({ ANALYTICS_ROLLUP_DIR: dir });
+    expect(r.days.map((d) => d.date)).toEqual(["2026-09-05", "2026-09-06", "2026-09-07"]);
+    expect(r.reason).toBeNull();
+  });
+
+  it("prefers the open copy of a day over the finished one", () => {
+    // Only happens mid-write, and the state file is the newer of the two by definition.
+    writeDayFile(day("2026-09-07", { requests: 1 }));
+    writeStateFile([day("2026-09-07", { requests: 99 })]);
+    expect(readRollups({ ANALYTICS_ROLLUP_DIR: dir }).days[0]?.requests).toBe(99);
+  });
+
+  it("skips a corrupt file instead of losing every other day with it", () => {
+    writeDayFile(day("2026-09-05", { requests: 5 }));
+    mkdirSync(join(dir, "days"), { recursive: true });
+    writeFileSync(join(dir, "days", "2026-09-06.json"), "{ truncated");
+    writeFileSync(join(dir, "days", "not-a-day.json"), "{}");
+    const r = readRollups({ ANALYTICS_ROLLUP_DIR: dir });
+    expect(r.days.map((d) => d.date)).toEqual(["2026-09-05"]);
+  });
+
+  it("keeps only the newest N days", () => {
+    for (let i = 1; i <= 9; i++) writeDayFile(day(`2026-09-0${i}`));
+    expect(readRollups({ ANALYTICS_ROLLUP_DIR: dir }, 3).days.map((d) => d.date)).toEqual([
+      "2026-09-07",
+      "2026-09-08",
+      "2026-09-09",
+    ]);
+  });
+});
+
+describe("stalenessSeconds", () => {
+  it("reports null when the job has never run, and seconds when it has", () => {
+    // A timer that has silently stopped leaves a dashboard that looks fine and is
+    // frozen, and the only symptom is the last day not growing — which is exactly what
+    // a quiet night looks like.
+    expect(stalenessSeconds({ dir, days: [], lastRun: null, reason: null })).toBeNull();
+    expect(stalenessSeconds({ dir, days: [], lastRun: 1000, reason: null }, 1_300_000)).toBe(300);
+  });
+});
+
+describe("buildWindow", () => {
+  const days = [
+    day("2026-09-05", { pageviews: 10, requests: 100, visitors: 7, bytes: 1000 }),
+    day("2026-09-06", { pageviews: 20, requests: 200, visitors: 4, bytes: 2000 }),
+    day("2026-09-07", { pageviews: 30, requests: 300, visitors: 10, bytes: 3000 }),
+  ];
+
+  it("NEVER sums visitors across days — it reports the mean and the peak", () => {
+    const w = buildWindow(days)!;
+    expect(w.visitorsPeak).toBe(10);
+    expect(w.visitorsMean).toBe(7); // (7 + 4 + 10) / 3
+    // 21 is the sum, and it is the wrong answer. If this ever equals 21 someone has
+    // "fixed" mergeDay to add visitors and the dashboard is now inflating by up to the
+    // number of days in the window.
+    expect(w.totals.visitors).not.toBe(21);
+    expect(w.totals.visitors).toBe(10);
+  });
+
+  it("sums everything that IS additive", () => {
+    const w = buildWindow(days)!;
+    expect(w.totals.pageviews).toBe(60);
+    expect(w.totals.requests).toBe(600);
+    expect(w.totals.bytes).toBe(6000);
+  });
+
+  it("orders by date regardless of the order it was handed", () => {
+    const w = buildWindow([days[2]!, days[0]!, days[1]!])!;
+    expect(w.from).toBe("2026-09-05");
+    expect(w.to).toBe("2026-09-07");
+    expect(w.points.map((p) => p.date)).toEqual(["2026-09-05", "2026-09-06", "2026-09-07"]);
+  });
+
+  it("returns null rather than an empty shell when there are no days", () => {
+    expect(buildWindow([])).toBeNull();
+  });
+
+  it("reports no mean response time rather than dividing by zero", () => {
+    expect(buildWindow([day("2026-09-05")])!.meanDurationMs).toBeNull();
+    expect(buildWindow([day("2026-09-05", { durationMsSum: 500, durationCount: 4 })])!.meanDurationMs).toBe(125);
+  });
+});
+
+describe("rows", () => {
+  it("computes each share against the WHOLE map, including rows it does not return", () => {
+    // A share taken against the visible rows adds to 100% however much was cut off,
+    // which is precisely how a truncated table implies it is complete.
+    const map = { a: 50, b: 30, c: 20 };
+    const r = rows(map, 1);
+    expect(r).toHaveLength(1);
+    expect(r[0]!.share).toBeCloseTo(0.5);
+  });
+
+  it("counts the (other) bucket in the denominator", () => {
+    const r = rows({ a: 10, "(other)": 90 }, 1);
+    expect(r[0]!.key).toBe("(other)");
+    expect(r[0]!.share).toBeCloseTo(0.9);
+  });
+
+  it("does not divide by zero on an empty map", () => {
+    expect(rows({}, 5)).toEqual([]);
+  });
+});
+
+describe("bytes", () => {
+  it("uses decimal units, because that is what bandwidth is billed in", () => {
+    expect(bytes(999)).toBe("999 B");
+    expect(bytes(1500)).toBe("1.5 kB");
+    expect(bytes(1_455_900_000)).toBe("1.5 GB");
+    expect(bytes(250_000_000)).toBe("250 MB");
+  });
+});
+
+describe("durationBuckets", () => {
+  it("labels every bucket from the edges, and the last one as an overflow", () => {
+    const d = day("2026-09-07", { durationBuckets: [4, 3, 2, 1, 5] });
+    const b = durationBuckets(d);
+    expect(b.map((x) => x.label)).toEqual([
+      "under 100 ms",
+      "100–300 ms",
+      "300–1000 ms",
+      "1000–3000 ms",
+      "over 3000 ms",
+    ]);
+    expect(b[4]!.count).toBe(5);
+    expect(b.reduce((a, x) => a + x.share, 0)).toBeCloseTo(1);
+  });
+
+  it("returns zero shares rather than NaN when nothing was timed", () => {
+    expect(durationBuckets(day("2026-09-07")).every((b) => b.share === 0)).toBe(true);
+  });
+});
+
+describe("directShare and apiByteShare", () => {
+  it("measures the proportion that bypassed Cloudflare", () => {
+    // Above roughly zero means some resolver still hands out the origin address, which
+    // is the condition that makes closing the origin firewall an outage.
+    expect(directShare(day("d", { viaCloudflare: 5821, direct: 5693 }))).toBeCloseTo(0.4944, 3);
+    expect(directShare(day("d"))).toBe(0);
+  });
+
+  it("measures how much of the egress is API rather than pages", () => {
+    expect(apiByteShare(day("d", { bytes: 1000, apiBytes: 930 }))).toBeCloseTo(0.93);
+    expect(apiByteShare(day("d"))).toBe(0);
+  });
+});
+
+describe("lastDays", () => {
+  it("takes from the end and never returns an empty slice for a positive request", () => {
+    const ds = ["a", "b", "c"].map((x) => day(x));
+    expect(lastDays(ds, 2).map((d) => d.date)).toEqual(["b", "c"]);
+    expect(lastDays(ds, 0)).toHaveLength(1);
+    expect(lastDays(ds, 99)).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
`/admin/analytics` has read Vercel's Web Analytics API since it was built. We have left
Vercel, so that API now describes a project no traffic reaches, and it was going to keep
returning plausible-looking numbers about it indefinitely. This points the page at the
rollups #195 writes.

### What it looks like

Twelve sections, in the order a reader actually asks the questions: how much, over time,
landing where, referred from where, who, what a "visitor" is, what it costs to serve,
what is broken, what is not human, how fast, what this cannot answer, and last the frozen
Vercel archive.

Rendered against a copy of the box's real rollups (one partial day, 12,771 requests):

| | |
|---|---|
| Pageviews | 1,046 |
| Visitors per day | ≈ 114 |
| Sent | 1.6 GB, **92% of it API responses** |
| Mean page response | 126 ms |
| Distinct pages seen | 663 |

### Three decisions worth reading before the diff

**There is no window total for visitors, and that absence is the design.** A day's figure
is the size of that day's set of salted hashes, and those sets are deleted at
finalisation, so the union across days is not merely unknown to us — it is unrecoverable
from this data. `buildWindow` reports the **mean** and the **peak** instead.
`tests/unit/rollup-view.test.ts` asserts the total is *not* the sum, because summing is
what every other field in `mergeDay` does, it is the easiest wrong change in the codebase
to make by accident, and it would never look wrong on screen — someone who visits every
day would appear seven times in a week.

**Every share is against the whole map, including the rows the table cut off** and
including the `(other)` overflow bucket. A share taken against the visible rows adds to
100% however much was truncated, which is precisely how a partial table implies it is
complete.

**Section 11 replaces the old "what a paid plan would unlock" panel.** That boundary was
commercial. This one is physical: no amount of money buys a server log a record of
something that never reached the server. The panel is now a three-way split — access log,
beacon, Search Console — naming what each one owns and what it cannot be asked, so a
figure cannot be borrowed for a question it cannot answer. The plan table moves to the
archive section, where it still applies to the frozen figures beside it.

### The read-only contract

`lib/analytics/rollupRead.ts` reads and never writes, and that is enforced rather than
documented. `/privacy` tells readers that nothing this site serves writes a file, so
`tests/unit/discovery-admin-gate.test.ts` now runs **two** checks over `app/`, `lib/` and
`components/`: one for write calls, one for `node:fs` imports. This module is on the
import allowlist and on neither writer list, so it may read and still cannot write. Both
checks were proven to go red on an injected write and green on revert.

`/privacy` is updated in the same commit because the page's claims moved: counts derived
from the log are now kept **indefinitely**, and the per-day hash sets are deleted at
finalisation. Publishing one without the other would be a half-truth in the direction
that flatters.

### One thing the data surfaced

Ranked by bytes rather than calls, because only one of those is the bill: `/api/planes`
573 MB and `/api/cameras` 447 MB out of 1.5 GB, against 1,046 pageviews. Also visible and
not fixed here — 11 × `404 /favicon.ico`, which is a real if small bug, and a cluster of
`.env*` probes that the section copy already labels as probes rather than breakage.

### How to actually look at it

`/admin` returns 404 whenever `NODE_ENV` is production, so this page cannot be opened on
the box that holds its data — and `/srv/provenance/shared` is mode 750 `app:app`, so an
ordinary ssh login cannot read the rollups either, though the `app` user can. Both halves
have the same wrong answer when you get them wrong: the page says "holds no days yet",
which is indistinguishable from the timer having stopped.

So `scripts/pull-rollups.sh` does it:

```
scripts/pull-rollups.sh                 # copies them down, then prints the dev command
```

It extracts beside the destination and swaps at the end, so a half-finished pull cannot
replace a good copy with a truncated one, and it parses `state.json` before the swap
rather than letting `readRollups()` fail soft into an empty screen. It prints the path
through `cygpath -m`, because Node on Windows cannot resolve `/c/Users/...` and says only
that the directory is missing. `deploy/install-rollup.sh` now ends by naming it.

Verified against the live box: a real pull succeeded; a pull against an unresolvable host
left the previous copy byte-identical, left no `.incoming` directory, and exited non-zero.

### Gate

`npx tsc --noEmit` clean · **333 files / 3,360 tests passed** · `npm run build` succeeded ·
page rendered and screenshotted at 1440 wide against the real rollups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2He37pDHX8hpMh3QqcJ7F

