### PR TITLE
Rotate the adsb.lol sweep's cell order so coverage stops being permanently zero outside the top 10

### DIFF
--- a/lib/sources/adsb.ts
+++ b/lib/sources/adsb.ts
@@ -122,6 +122,71 @@ export const SWEEP_CELLS: readonly SweepCell[] = [
   { lat: 64.1, lon: -21.9, label: "Reykjavik" },
 ];
 
+// ---------------------------------------------------------------------------
+// Fair rotation across cache windows
+// ---------------------------------------------------------------------------
+
+/**
+ * How many of the highest-yield cells stay first, every window, unrotated.
+ * These are the ones {@link fetchAdsbSweep}'s budget reliably reaches (see the
+ * rate-limit block below), so pinning them means the density this sweep is
+ * known to deliver over North America/Europe never regresses because of
+ * rotation — only the cells AFTER them move.
+ */
+export const ANCHOR_SIZE = 4;
+
+/** How many pool cells the rotation advances by per window. Chosen to divide
+ * `SWEEP_CELLS.length - ANCHOR_SIZE` evenly (36 / 6 = 6 windows), so one full
+ * rotation reaches every non-anchor cell with no gaps and no repeats. */
+export const ROTATE_STEP = 6;
+
+/** Fallback cadence for direct/test calls. Production passes the REAL
+ * revalidate window from `lib/sources/opensky.ts` explicitly instead of
+ * relying on this — see the call site there for why. */
+export const ROTATION_WINDOW_MS = 240_000;
+
+/**
+ * Without this, `fetchAdsbSweep(SWEEP_CELLS)` swept the SAME fixed prefix on
+ * every single call, forever: the rate-limit budget below only reaches
+ * roughly the first 9-11 cells, and nothing about that prefix ever changed
+ * between calls. Measured against the deployed 240 s revalidation cadence
+ * (`lib/sources/opensky.ts`): SWEEP_CELLS[11..39] — Tokyo, Delhi, Mumbai,
+ * Sydney, Johannesburg, Sao Paulo and 24 others — were not "thin", they were
+ * unreached, literally, for the deployment's entire lifetime. That is a code
+ * ordering bug, distinct from the honesty boundary above (which is about
+ * receivers genuinely not existing in a region) — this one is fixable in code.
+ *
+ * The fix keeps the {@link ANCHOR_SIZE} highest-yield cells first every
+ * window and rotates everything after them by wall-clock time, so a
+ * DIFFERENT slice of the remaining cells leads each window. Purely a function
+ * of `now`: nothing persists between calls, which matters the same way the
+ * module-state warning in this file's header matters for opensky.ts — there
+ * is no state here a cold serverless invocation could reset or lose, because
+ * there is no state at all.
+ *
+ * Trade-off, stated plainly rather than buried: in a window whose rotated
+ * slice starts deep in the long tail, the modest post-anchor budget is spent
+ * on genuinely low-yield cells instead of the moderate-yield ones that used
+ * to always run next. That is the intended trade — it is what turns "zero,
+ * forever" into "sometimes, on a real cycle" for Asia/Africa/South America/
+ * Oceania — but it is a real one, not a free win, and worth knowing if it
+ * ever needs tuning back the other way.
+ */
+export function rotatingSweepCells(
+  cells: readonly SweepCell[] = SWEEP_CELLS,
+  now: number = Date.now(),
+  windowMs: number = ROTATION_WINDOW_MS,
+  anchorSize: number = ANCHOR_SIZE,
+  rotateStep: number = ROTATE_STEP,
+): SweepCell[] {
+  const anchor = cells.slice(0, anchorSize);
+  const pool = cells.slice(anchorSize);
+  if (pool.length === 0) return anchor;
+  const step = Math.floor(now / windowMs) * rotateStep;
+  const offset = ((step % pool.length) + pool.length) % pool.length;
+  return [...anchor, ...pool.slice(offset), ...pool.slice(0, offset)];
+}
+
 const RADIUS_NM = 250; // the endpoint's documented maximum
 const UA = "TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)";
 const CELL_TIMEOUT_MS = 8_000;

--- a/lib/sources/opensky.ts
+++ b/lib/sources/opensky.ts
@@ -48,7 +48,7 @@ import {
   withCoverage,
   type SignalCoverage,
 } from "@/lib/signals/coverage";
-import { fetchAdsbSweep, sweepToObjects } from "@/lib/sources/adsb";
+import { fetchAdsbSweep, rotatingSweepCells, sweepToObjects, SWEEP_CELLS } from "@/lib/sources/adsb";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -331,9 +331,18 @@ const REVALIDATE_S = 240;
  * good cached one and empty the layer for the rest of the revalidate window. Throwing
  * leaves the previous Data Cache entry in place for the staleness gate to judge —
  * see `decideStaleness`.
+ *
+ * CELL ORDER ROTATES BY WALL CLOCK, not by memory of the last sweep. Passing
+ * `SWEEP_CELLS` unrotated here — as this used to — meant every 240 s window swept the
+ * identical fixed prefix forever, so `SWEEP_CELLS[11..]` (most of Asia, Africa, South
+ * America, Oceania) was never reached, not "rarely" — literally never, for the
+ * deployment's lifetime. `rotatingSweepCells` fixes that without adding any state a
+ * cold serverless invocation could lose: it derives which cells lead purely from
+ * `Date.now()` and `REVALIDATE_S`, so it needs nothing carried over from the previous
+ * call. See its docblock in `lib/sources/adsb.ts` for the trade-off this makes.
  */
 async function fetchAircraftOnce(): Promise<AircraftSnapshot> {
-  const sweep = await fetchAdsbSweep();
+  const sweep = await fetchAdsbSweep(rotatingSweepCells(SWEEP_CELLS, Date.now(), REVALIDATE_S * 1000));
   if (!sweep.objects.length) throw new Error("adsb.lol sweep returned zero positioned aircraft");
   const objects = sweepToObjects(sweep, MAX_PLANES);
   return { ...toAircraftSnapshot(objects), fetchedAt: Date.now(), source: "adsb.lol" };

--- a/tests/unit/planes.adsb.test.ts
+++ b/tests/unit/planes.adsb.test.ts
@@ -20,6 +20,9 @@ import {
   sweepToObjects,
   SWEEP_CELLS,
   cellUrl,
+  rotatingSweepCells,
+  ANCHOR_SIZE,
+  ROTATE_STEP,
   type AdsbRow,
   type SweepResult,
 } from "@/lib/sources/adsb";
@@ -358,4 +361,63 @@ describe("SWEEP_CELLS", () => {
       "https://api.adsb.lol/v2/lat/51.5/lon/-0.1/dist/250",
     );
   });
+});
+
+// --- rotation: the coverage-fairness fix -------------------------------------
+
+describe("rotatingSweepCells", () => {
+  const WINDOW_MS = 240_000; // matches opensky.ts's REVALIDATE_S in production
+
+  it("keeps the anchor cells first, in order, no matter what time it is", () => {
+    const anchorLabels = SWEEP_CELLS.slice(0, ANCHOR_SIZE).map((c) => c.label);
+    for (const now of [0, WINDOW_MS, WINDOW_MS * 5, WINDOW_MS * 37]) {
+      const order = rotatingSweepCells(SWEEP_CELLS, now, WINDOW_MS).map((c) => c.label);
+      expect(order.slice(0, ANCHOR_SIZE)).toEqual(anchorLabels);
+    }
+  });
+
+  it("returns every cell exactly once — a reordering, never a drop or a duplicate", () => {
+    const order = rotatingSweepCells(SWEEP_CELLS, 1_234_567, WINDOW_MS);
+    expect(order).toHaveLength(SWEEP_CELLS.length);
+    const keys = order.map((c) => `${c.lat},${c.lon}`);
+    expect(new Set(keys).size).toBe(SWEEP_CELLS.length);
+  });
+
+  it("rotates the pool after the anchor once the window advances", () => {
+    const first = rotatingSweepCells(SWEEP_CELLS, 0, WINDOW_MS).map((c) => c.label);
+    const next = rotatingSweepCells(SWEEP_CELLS, WINDOW_MS, WINDOW_MS).map((c) => c.label);
+    expect(first.slice(ANCHOR_SIZE)).not.toEqual(next.slice(ANCHOR_SIZE));
+  });
+
+  it("is a pure function of time — the same window number always reorders the same way", () => {
+    const a = rotatingSweepCells(SWEEP_CELLS, WINDOW_MS * 9, WINDOW_MS);
+    const b = rotatingSweepCells(SWEEP_CELLS, WINDOW_MS * 9 + 1000, WINDOW_MS);
+    expect(a.map((c) => c.label)).toEqual(b.map((c) => c.label));
+  });
+
+  it(
+    "brings every long-tail cell to the front within one rotation cycle — " +
+      "this is the actual bug: before this function existed, fetchAdsbSweep(SWEEP_CELLS) " +
+      "swept the identical fixed prefix on every single call, forever, so cells like " +
+      "Tokyo, Sydney and Mumbai were not merely thin, they were unreachable for the " +
+      "deployment's entire lifetime, regardless of how many times the sweep ran",
+    () => {
+      // The rate limit reliably reaches ~9-11 cells (see adsb.ts's own measurement).
+      // ANCHOR_SIZE (4) + one rotated window's worth (ROTATE_STEP=6) = 10, matching
+      // that reality with no slack invented for the test.
+      const attemptableSlice = ANCHOR_SIZE + ROTATE_STEP;
+      const pool = SWEEP_CELLS.slice(ANCHOR_SIZE);
+      const cyclesInOneFullRotation = Math.ceil(pool.length / ROTATE_STEP);
+
+      const reached = new Set<string>();
+      for (let i = 0; i < cyclesInOneFullRotation; i++) {
+        const order = rotatingSweepCells(SWEEP_CELLS, i * WINDOW_MS, WINDOW_MS);
+        for (const c of order.slice(0, attemptableSlice)) reached.add(c.label);
+      }
+
+      for (const cell of pool) {
+        expect(reached.has(cell.label)).toBe(true);
+      }
+    },
+  );
 });


### PR DESCRIPTION
Pensábamos: la cobertura de planes era mala porque nos faltaba una API key o
más rate-limit budget de adsb.lol.

Medimos: `fetchAircraftOnce()` (`lib/sources/opensky.ts`) llamaba
`fetchAdsbSweep(SWEEP_CELLS)` sin rotar el orden, y el rate limit de adsb.lol
solo deja completar ~9-11 celdas dentro del budget de 14s
(`lib/sources/adsb.ts`, medido). Con el orden fijo, cada ventana de 240s
barría exactamente las mismas ~10 celdas (New York, London, Chicago...).
También verificado en vivo: `adsb.lol` solo entrega una key a quien corre su
propio receptor físico, y `airplanes.live` responde con "email us with your
project details" en vez de signup — ninguna de las dos redes ofrece un
endpoint global de todas formas (todas son punto+radio).

Resultó: `SWEEP_CELLS[11..39]` — Tokyo, Delhi, Mumbai, Sydney, Johannesburgo,
Sao Paulo y 24 más — nunca se habían llegado a pedir, no "poco", literalmente
nunca, desde que existe el sweep. No era un límite del proveedor: era el
código siempre preguntando por las mismas celdas.

Cambiamos: `rotatingSweepCells()` en `lib/sources/adsb.ts` — mantiene fijas
las 4 celdas de mayor rendimiento en cada ventana (la densidad conocida sobre
Norteamérica/Europa no regresiona) y rota el resto por `Date.now()`, sin
ningún estado compartido entre invocaciones. Una rotación completa toca cada
celda en 6 ventanas (~24 min). `opensky.ts` ahora pasa
`rotatingSweepCells(SWEEP_CELLS, Date.now(), REVALIDATE_S * 1000)` en vez del
orden sin rotar.

Todavía no sabemos: cuánto sube el conteo real de aviones fuera de
Norteamérica/Europa en producción — eso solo se puede medir después de que
esto corra un rato en vivo, no en local. Tampoco tocamos el rate limit ni el
budget de 14s (medidos aparte, no se tocan sin re-medir).

Trade-off explícito: en una ventana que rota hacia celdas de la cola larga, el
presupuesto sobrante después del núcleo se gasta en celdas de bajo
rendimiento en vez de las de rendimiento medio que antes siempre corrían.
Es la intención — es lo que convierte "cero, para siempre" en "a veces, en un
ciclo real" para Asia/África/Sudamérica/Oceanía — pero es un costo real, no
gratis.

Gate: `npx tsc --noEmit` limpio; `npm test` 307 archivos / 2898 tests pasaron.