### PR TITLE
Stage B: 2,468 live cameras, and the census that overturned Stage A

### DIFF
--- a/app/admin/admin.css
+++ b/app/admin/admin.css
@@ -492,10 +492,20 @@
   background: var(--adm-panel-2);
   overflow: hidden;
 }
+/*
+ * Scaled, not resized, and the reason is specific to this page rather than general
+ * performance advice: the meter ticks continuously while a stream decodes, and this
+ * deck exists so a person can judge whether that video is stuttering. A meter that
+ * animates `width` lays out the page on every tick, next to a running video element —
+ * so our own chrome would be a source of the jank the reviewer is being asked to
+ * attribute to the camera. `transform` composites and cannot do that.
+ */
 .lv-meter-fill {
   height: 100%;
+  width: 100%;
+  transform-origin: left center;
   background: var(--adm-accent-bright);
-  transition: width 120ms linear;
+  transition: transform 120ms linear;
 }
 .lv-meter-label {
   color: var(--adm-ink-dim);
@@ -503,12 +513,18 @@
   font-size: 12px;
   white-space: nowrap;
 }
+/*
+ * Bordered in the warn colour on all four sides, matching `.adm-env` above, which is the
+ * only other "this needs your attention" element on the admin surface. It previously had
+ * a 3px left rule and square left corners; that was the single border-left in the file,
+ * so it was a one-off rather than a house pattern worth keeping.
+ */
 .lv-warn {
-  border-left: 3px solid var(--adm-warn);
+  border: 1px solid var(--adm-warn);
   background: var(--adm-panel);
   color: var(--adm-ink-dim);
   padding: 8px 12px;
-  border-radius: 0 8px 8px 0;
+  border-radius: 8px;
   margin: 8px 0 0;
   font-size: 13px;
 }

--- a/components/admin/LiveDeck.tsx
+++ b/components/admin/LiveDeck.tsx
@@ -245,7 +245,7 @@ export function LiveDeck({ queue }: { queue: QueueCamera[] }) {
           <div className="lv-meter-track">
             <div
               className="lv-meter-fill"
-              style={{ width: `${Math.min(100, (producingMs / MIN_PRODUCING_MS) * 100)}%` }}
+              style={{ transform: `scaleX(${Math.min(1, producingMs / MIN_PRODUCING_MS)})` }}
             />
           </div>
           <span className="lv-meter-label">

--- a/data/liveness/castlerock-hosts.json
+++ b/data/liveness/castlerock-hosts.json
@@ -1,0 +1,4885 @@
+{
+  "version": 1,
+  "ranAt": "2026-09-08T00:49:14.797Z",
+  "systems": [
+    {
+      "site": "fl511.com",
+      "total": 4953,
+      "pulled": 4953,
+      "withVideo": 4382
+    },
+    {
+      "site": "511ga.org",
+      "total": 0,
+      "pulled": 0,
+      "withVideo": 0,
+      "error": "511ga.org @0: 500"
+    },
+    {
+      "site": "511ny.org",
+      "total": 1873,
+      "pulled": 1873,
+      "withVideo": 1568
+    },
+    {
+      "site": "511.idaho.gov",
+      "total": 457,
+      "pulled": 457,
+      "withVideo": 0
+    },
+    {
+      "site": "newengland511.org",
+      "total": 406,
+      "pulled": 406,
+      "withVideo": 0
+    },
+    {
+      "site": "511la.org",
+      "total": 336,
+      "pulled": 336,
+      "withVideo": 335
+    },
+    {
+      "site": "511on.ca",
+      "total": 944,
+      "pulled": 944,
+      "withVideo": 0
+    },
+    {
+      "site": "511.alberta.ca",
+      "total": 354,
+      "pulled": 354,
+      "withVideo": 0
+    },
+    {
+      "site": "511.novascotia.ca",
+      "total": 57,
+      "pulled": 57,
+      "withVideo": 0
+    },
+    {
+      "site": "511.gnb.ca",
+      "total": 57,
+      "pulled": 57,
+      "withVideo": 0
+    },
+    {
+      "site": "www.nvroads.com",
+      "total": 640,
+      "pulled": 640,
+      "withVideo": 625
+    },
+    {
+      "site": "www.drivenc.gov",
+      "total": 1139,
+      "pulled": 1139,
+      "withVideo": 1084
+    },
+    {
+      "site": "511pa.com",
+      "total": 1542,
+      "pulled": 1542,
+      "withVideo": 1275
+    },
+    {
+      "site": "az511.com",
+      "total": 644,
+      "pulled": 644,
+      "withVideo": 0
+    },
+    {
+      "site": "ctroads.org",
+      "total": 347,
+      "pulled": 347,
+      "withVideo": 0
+    },
+    {
+      "site": "511.alaska.gov",
+      "total": 129,
+      "pulled": 129,
+      "withVideo": 0
+    }
+  ],
+  "hosts": [
+    {
+      "host": "dis-se18.divas.cloud:8200",
+      "sampleUrl": "https://dis-se18.divas.cloud:8200/chan-1_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 236,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 236,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se16.divas.cloud:8200",
+      "sampleUrl": "https://dis-se16.divas.cloud:8200/chan-3_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 241,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 241,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se13.divas.cloud:8200",
+      "sampleUrl": "https://dis-se13.divas.cloud:8200/chan-6_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 226,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 226,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se12.divas.cloud:8200",
+      "sampleUrl": "https://dis-se12.divas.cloud:8200/chan-8_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 229,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 229,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se11.divas.cloud:8200",
+      "sampleUrl": "https://dis-se11.divas.cloud:8200/chan-9_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 231,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 231,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se10.divas.cloud:8200",
+      "sampleUrl": "https://dis-se10.divas.cloud:8200/chan-10_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 237,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 237,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se9.divas.cloud:8200",
+      "sampleUrl": "https://dis-se9.divas.cloud:8200/chan-20_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 220,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 220,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se6.divas.cloud:8200",
+      "sampleUrl": "https://dis-se6.divas.cloud:8200/chan-30_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 214,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 214,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se5.divas.cloud:8200",
+      "sampleUrl": "https://dis-se5.divas.cloud:8200/chan-32_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 216,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 216,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se4.divas.cloud:8200",
+      "sampleUrl": "https://dis-se4.divas.cloud:8200/chan-34_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 216,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 216,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se2.divas.cloud:8200",
+      "sampleUrl": "https://dis-se2.divas.cloud:8200/chan-38_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 218,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 218,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se17.divas.cloud:8200",
+      "sampleUrl": "https://dis-se17.divas.cloud:8200/chan-43_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 222,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 222,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se15.divas.cloud:8200",
+      "sampleUrl": "https://dis-se15.divas.cloud:8200/chan-47_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 234,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 234,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se14.divas.cloud:8200",
+      "sampleUrl": "https://dis-se14.divas.cloud:8200/chan-49_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 246,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [
+        {
+          "nativeId": "5908",
+          "name": "I-10",
+          "lat": 30.746704,
+          "lon": -85.517224,
+          "url": "https://dis-se14.divas.cloud:8200/chan-12530_h/index.m3u8",
+          "system": {
+            "system": "fl",
+            "site": "fl511.com",
+            "country": "US",
+            "region": "Florida",
+            "agency": "Florida DOT (FL511)"
+          }
+        }
+      ],
+      "authRequired": 245,
+      "open": 1,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se8.divas.cloud:8200",
+      "sampleUrl": "https://dis-se8.divas.cloud:8200/chan-57_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 217,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 217,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se7.divas.cloud:8200",
+      "sampleUrl": "https://dis-se7.divas.cloud:8200/chan-58_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 205,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 205,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se3.divas.cloud:8200",
+      "sampleUrl": "https://dis-se3.divas.cloud:8200/chan-63_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 208,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 208,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se1.divas.cloud:8200",
+      "sampleUrl": "https://dis-se1.divas.cloud:8200/chan-65_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 228,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 228,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se26.divas.cloud:8200",
+      "sampleUrl": "https://dis-se26.divas.cloud:8200/chan-8487_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 57,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 57,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se22.divas.cloud:8200",
+      "sampleUrl": "https://dis-se22.divas.cloud:8200/chan-8122_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 18,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 18,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se19.divas.cloud:8200",
+      "sampleUrl": "https://dis-se19.divas.cloud:8200/chan-11536_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 160,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 160,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se20.divas.cloud:8200",
+      "sampleUrl": "https://dis-se20.divas.cloud:8200/chan-11708_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 24,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 24,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se24.divas.cloud:8200",
+      "sampleUrl": "https://dis-se24.divas.cloud:8200/chan-11737_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 21,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 21,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se21.divas.cloud:8200",
+      "sampleUrl": "https://dis-se21.divas.cloud:8200/chan-11767_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 22,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 22,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se23.divas.cloud:8200",
+      "sampleUrl": "https://dis-se23.divas.cloud:8200/chan-11920_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 15,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 15,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "dis-se25.divas.cloud:8200",
+      "sampleUrl": "https://dis-se25.divas.cloud:8200/chan-12049_h/index.m3u8",
+      "referer": "https://fl511.com/",
+      "count": 21,
+      "system": {
+        "system": "fl",
+        "site": "fl511.com",
+        "country": "US",
+        "region": "Florida",
+        "agency": "Florida DOT (FL511)"
+      },
+      "examples": [],
+      "authRequired": 21,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "s52.nysdot.skyvdn.com",
+      "sampleUrl": "https://s52.nysdot.skyvdn.com/rtplive/R5_013/playlist.m3u8",
+      "referer": "https://511ny.org/",
+      "count": 344,
+      "system": {
+        "system": "ny",
+        "site": "511ny.org",
+        "country": "US",
+        "region": "New York",
+        "agency": "NYSDOT (511NY)"
+      },
+      "examples": [
+        {
+          "nativeId": "16",
+          "name": "NY 33",
+          "lat": 42.9223627,
+          "lon": -78.8435134,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/R5_013/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "21",
+          "name": "NY 33",
+          "lat": 42.9074247,
+          "lon": -78.8436404,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/R5_011/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "22",
+          "name": "NY 33",
+          "lat": 42.9223673,
+          "lon": -78.8438361,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/R5_012/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "679",
+          "name": "Winton RD at Merchants st / Elm",
+          "lat": 43.15951391,
+          "lon": -77.54698428,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/R4_213/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "680",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.01503,
+          "lon": -73.72309,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_011/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "681",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.01429,
+          "lon": -73.7092,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_012/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "682",
+          "name": "Garden State Parkway Connector",
+          "lat": 41.0929,
+          "lon": -74.03941,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_013/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "683",
+          "name": "I-87 - NYS Thruway",
+          "lat": 40.90645,
+          "lon": -73.87841,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_014/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "684",
+          "name": "I-87 - NYS Thruway",
+          "lat": 40.9167,
+          "lon": -73.87181,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_015/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "685",
+          "name": "I-87 - NYS Thruway",
+          "lat": 40.92465,
+          "lon": -73.8586,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_016/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "686",
+          "name": "I-87 - NYS Thruway",
+          "lat": 40.93813,
+          "lon": -73.85536,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_017/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "687",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.11618,
+          "lon": -74.11361,
+          "url": "https://s52.nysdot.skyvdn.com/rtplive/TA_018/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 344,
+      "disabled": 0
+    },
+    {
+      "host": "s51.nysdot.skyvdn.com",
+      "sampleUrl": "https://s51.nysdot.skyvdn.com/rtplive/R1_033/playlist.m3u8",
+      "referer": "https://511ny.org/",
+      "count": 323,
+      "system": {
+        "system": "ny",
+        "site": "511ny.org",
+        "country": "US",
+        "region": "New York",
+        "agency": "NYSDOT (511NY)"
+      },
+      "examples": [
+        {
+          "nativeId": "19",
+          "name": "US 9",
+          "lat": 43.237344,
+          "lon": -73.690416,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/R1_033/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "312",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.05757,
+          "lon": -73.83243,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_001/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "313",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.05911,
+          "lon": -73.82328,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_002/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "314",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.05563,
+          "lon": -73.81012,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_003/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "315",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.04707,
+          "lon": -73.80424,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_004/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "316",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.04579,
+          "lon": -73.79263,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_005/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "317",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.04242,
+          "lon": -73.78608,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_006/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "318",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.04503,
+          "lon": -73.77176,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_007/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "319",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.0448,
+          "lon": -73.76441,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_008/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "320",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.04093,
+          "lon": -73.76253,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_009/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "321",
+          "name": "I-287 - Cross Westchester Expwy",
+          "lat": 41.03282,
+          "lon": -73.75333,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_010/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "322",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.07144,
+          "lon": -73.91165,
+          "url": "https://s51.nysdot.skyvdn.com/rtplive/TA_031/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 323,
+      "disabled": 2
+    },
+    {
+      "host": "s53.nysdot.skyvdn.com",
+      "sampleUrl": "https://s53.nysdot.skyvdn.com/rtplive/R2_029/playlist.m3u8",
+      "referer": "https://511ny.org/",
+      "count": 330,
+      "system": {
+        "system": "ny",
+        "site": "511ny.org",
+        "country": "US",
+        "region": "New York",
+        "agency": "NYSDOT (511NY)"
+      },
+      "examples": [
+        {
+          "nativeId": "20",
+          "name": "NY 5A",
+          "lat": 43.106347,
+          "lon": -75.239611,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/R2_029/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "49",
+          "name": "I-290",
+          "lat": 42.99067,
+          "lon": -78.79924,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/R5_029/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "50",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.00857,
+          "lon": -73.85127,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_021/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "51",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.04137,
+          "lon": -73.83591,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_022/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "52",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.05692,
+          "lon": -73.83504,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_023/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "53",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.06074,
+          "lon": -73.84306,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_024/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "54",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.0605,
+          "lon": -73.85643,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_025/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "55",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.07144,
+          "lon": -73.89642,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_028/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "56",
+          "name": "I-87 - NYS Thruway",
+          "lat": 41.07126,
+          "lon": -73.90788,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_030/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "57",
+          "name": "I-95 - New England Thruway",
+          "lat": 40.88688,
+          "lon": -73.81127,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_051/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "58",
+          "name": "I-95 - New England Thruway",
+          "lat": 40.89966,
+          "lon": -73.79586,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_052/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "59",
+          "name": "I-95 - New England Thruway",
+          "lat": 40.91765,
+          "lon": -73.7809,
+          "url": "https://s53.nysdot.skyvdn.com/rtplive/TA_053/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 330,
+      "disabled": 0
+    },
+    {
+      "host": "s7.nysdot.skyvdn.com",
+      "sampleUrl": "https://s7.nysdot.skyvdn.com/rtplive/R6_005/playlist.m3u8",
+      "referer": "https://511ny.org/",
+      "count": 293,
+      "system": {
+        "system": "ny",
+        "site": "511ny.org",
+        "country": "US",
+        "region": "New York",
+        "agency": "NYSDOT (511NY)"
+      },
+      "examples": [
+        {
+          "nativeId": "374",
+          "name": "NY 414",
+          "lat": 42.154819,
+          "lon": -77.052832,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R6_005/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "375",
+          "name": "I-84",
+          "lat": 41.529714,
+          "lon": -73.813121,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R8_002/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "377",
+          "name": "I-84",
+          "lat": 41.538471,
+          "lon": -73.774562,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R8_004/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "380",
+          "name": "I-84",
+          "lat": 41.452589,
+          "lon": -73.639344,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R8_008/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "381",
+          "name": "I-84",
+          "lat": 41.374777,
+          "lon": -74.60945,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R8_009/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "382",
+          "name": "Saw Mill River Parkway",
+          "lat": 41.081263,
+          "lon": -73.829514,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R8_031/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "384",
+          "name": "Hutchinson River Parkway [Westchester]",
+          "lat": 41.027828,
+          "lon": -73.684031,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R8_037/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "386",
+          "name": "Harlem River Drive",
+          "lat": 40.80397,
+          "lon": -73.93116,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R11_153/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "387",
+          "name": "Long Island Expressway (I-495)",
+          "lat": 40.74907,
+          "lon": -73.75828,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R11_154/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "388",
+          "name": "Long Island Expressway (I-495)",
+          "lat": 40.76378,
+          "lon": -73.72657,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R11_155/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "389",
+          "name": "Van Wyck Expressway (I-678)",
+          "lat": 40.66655,
+          "lon": -73.8027,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R11_157/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "390",
+          "name": "Van Wyck Expressway (I-678)",
+          "lat": 40.666,
+          "lon": -73.80151,
+          "url": "https://s7.nysdot.skyvdn.com/rtplive/R11_158/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 293,
+      "disabled": 0
+    },
+    {
+      "host": "s9.nysdot.skyvdn.com",
+      "sampleUrl": "https://s9.nysdot.skyvdn.com/rtplive/R2_041/playlist.m3u8",
+      "referer": "https://511ny.org/",
+      "count": 278,
+      "system": {
+        "system": "ny",
+        "site": "511ny.org",
+        "country": "US",
+        "region": "New York",
+        "agency": "NYSDOT (511NY)"
+      },
+      "examples": [
+        {
+          "nativeId": "749",
+          "name": "NY 920P",
+          "lat": 42.949608,
+          "lon": -74.369051,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R2_041/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "750",
+          "name": "NY 14",
+          "lat": 42.090502,
+          "lon": -76.805569,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R6_031/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "752",
+          "name": "NY 30",
+          "lat": 43.109147,
+          "lon": -74.268057,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R2_042/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "753",
+          "name": "NY 14",
+          "lat": 42.058224,
+          "lon": -76.806253,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R6_033/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "754",
+          "name": "Westchester",
+          "lat": 41.023311,
+          "lon": -73.695022,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R8_CAMHRP4081/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "755",
+          "name": "North Genesee St",
+          "lat": 43.112024,
+          "lon": -75.216271,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R2_043/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "757",
+          "name": "NY 400 at Transit Road",
+          "lat": 42.83431,
+          "lon": -78.6974,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R5_048/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "758",
+          "name": "I-84",
+          "lat": 41.513894,
+          "lon": -74.158258,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R8_011/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "760",
+          "name": "Sprain Brook Parkway",
+          "lat": 41.006966,
+          "lon": -73.829253,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R8_014/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "765",
+          "name": "Hutchinson River Parkway [Westchester]",
+          "lat": 40.977136,
+          "lon": -73.757885,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R8_041/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "766",
+          "name": "Grand Central Parkway (907M)",
+          "lat": 40.76784,
+          "lon": -73.88369,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R11_223/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        },
+        {
+          "nativeId": "767",
+          "name": "Long Island Expressway (I-495)",
+          "lat": 40.73122,
+          "lon": -73.91717,
+          "url": "https://s9.nysdot.skyvdn.com/rtplive/R11_230/playlist.m3u8",
+          "system": {
+            "system": "ny",
+            "site": "511ny.org",
+            "country": "US",
+            "region": "New York",
+            "agency": "NYSDOT (511NY)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 278,
+      "disabled": 1
+    },
+    {
+      "host": "itsstreamingbr2.dotd.la.gov",
+      "sampleUrl": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-030.streams/playlist.m3u8",
+      "referer": "https://511la.org/",
+      "count": 188,
+      "system": {
+        "system": "la",
+        "site": "511la.org",
+        "country": "US",
+        "region": "Louisiana",
+        "agency": "Louisiana DOTD (511LA)"
+      },
+      "examples": [
+        {
+          "nativeId": "1",
+          "name": "I-20",
+          "lat": 32.538889,
+          "lon": -93.630833,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-030.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "2",
+          "name": "I-20",
+          "lat": 32.4609,
+          "lon": -93.83,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-002.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "3",
+          "name": "I-20",
+          "lat": 32.4844,
+          "lon": -93.774,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-005.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "4",
+          "name": "I-20",
+          "lat": 32.4904,
+          "lon": -93.772,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-006.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "5",
+          "name": "I-20",
+          "lat": 32.4955,
+          "lon": -93.763,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-007.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "6",
+          "name": "I-20",
+          "lat": 32.497017684654,
+          "lon": -93.7586513133894,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-008.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "7",
+          "name": "I-20",
+          "lat": 32.5017,
+          "lon": -93.749,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-009.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "8",
+          "name": "I-20",
+          "lat": 32.5053,
+          "lon": -93.746,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-010.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "9",
+          "name": "I-20",
+          "lat": 32.5102,
+          "lon": -93.743,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-011.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "10",
+          "name": "I-20",
+          "lat": 32.513553068,
+          "lon": -93.736,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-012.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "11",
+          "name": "I-20",
+          "lat": 32.5137,
+          "lon": -93.715,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-014.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "12",
+          "name": "I-20",
+          "lat": 32.51821345231,
+          "lon": -93.709,
+          "url": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-015.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 188,
+      "disabled": 0
+    },
+    {
+      "host": "itsstreamingno.dotd.la.gov",
+      "sampleUrl": "https://ITSStreamingNO.dotd.la.gov/public/hou-cam-002.streams/playlist.m3u8",
+      "referer": "https://511la.org/",
+      "count": 145,
+      "system": {
+        "system": "la",
+        "site": "511la.org",
+        "country": "US",
+        "region": "Louisiana",
+        "agency": "Louisiana DOTD (511LA)"
+      },
+      "examples": [
+        {
+          "nativeId": "19",
+          "name": "LA 24",
+          "lat": 29.60677,
+          "lon": -90.74324,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/hou-cam-002.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "21",
+          "name": "I-55",
+          "lat": 30.15134574,
+          "lon": -90.44853,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-036.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "21",
+          "name": "I-55",
+          "lat": 30.15134574,
+          "lon": -90.44853,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-037.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "22",
+          "name": "I-55",
+          "lat": 30.25419097,
+          "lon": -90.40279,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-030.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "22",
+          "name": "I-55",
+          "lat": 30.25419097,
+          "lon": -90.40279,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-031.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "23",
+          "name": "I-55",
+          "lat": 30.34837687,
+          "lon": -90.41557,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-033.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "23",
+          "name": "I-55",
+          "lat": 30.34837687,
+          "lon": -90.41557,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-034.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "24",
+          "name": "I-55",
+          "lat": 30.4385,
+          "lon": -90.46016667,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-022.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "25",
+          "name": "I-55",
+          "lat": 30.49133333,
+          "lon": -90.49783333,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-023.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "26",
+          "name": "I-55",
+          "lat": 30.504,
+          "lon": -90.50366667,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-021.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "27",
+          "name": "I-59",
+          "lat": 30.322,
+          "lon": -89.7375,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-026.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "28",
+          "name": "I-59",
+          "lat": 30.34266667,
+          "lon": -89.73833333,
+          "url": "https://ITSStreamingNO.dotd.la.gov/public/ns-cam-016.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 145,
+      "disabled": 1
+    },
+    {
+      "host": "itsstreamingbr.dotd.la.gov",
+      "sampleUrl": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-168.streams/playlist.m3u8",
+      "referer": "https://511la.org/",
+      "count": 156,
+      "system": {
+        "system": "la",
+        "site": "511la.org",
+        "country": "US",
+        "region": "Louisiana",
+        "agency": "Louisiana DOTD (511LA)"
+      },
+      "examples": [
+        {
+          "nativeId": "29",
+          "name": "US 61",
+          "lat": 30.4530442717707,
+          "lon": -91.09590149,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-168.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "29",
+          "name": "US 61",
+          "lat": 30.4530442717707,
+          "lon": -91.09590149,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-169.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "30",
+          "name": "US 61",
+          "lat": 30.5085549311101,
+          "lon": -91.171515,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-188.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "31",
+          "name": "US 61",
+          "lat": 30.5093188180344,
+          "lon": -91.149351,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-184.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "32",
+          "name": "US 61",
+          "lat": 30.3593106905663,
+          "lon": -91.0089143646209,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-172.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "33",
+          "name": "US 61",
+          "lat": 30.4883038902307,
+          "lon": -91.1210899090909,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-185.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "34",
+          "name": "US 61",
+          "lat": 30.4712770865729,
+          "lon": -91.1088807149758,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-186.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "35",
+          "name": "US 61",
+          "lat": 30.5023290860851,
+          "lon": -91.13113,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-171.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "36",
+          "name": "US 61",
+          "lat": 30.4432018578934,
+          "lon": -91.08879,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-025.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "37",
+          "name": "US 61",
+          "lat": 30.4043683798029,
+          "lon": -91.0590200013652,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-189.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "38",
+          "name": "US 61",
+          "lat": 30.399070058138,
+          "lon": -91.0541948519492,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-190.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        },
+        {
+          "nativeId": "38",
+          "name": "US 61",
+          "lat": 30.399070058138,
+          "lon": -91.0541948519492,
+          "url": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-191.streams/playlist.m3u8",
+          "system": {
+            "system": "la",
+            "site": "511la.org",
+            "country": "US",
+            "region": "Louisiana",
+            "agency": "Louisiana DOTD (511LA)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 156,
+      "disabled": 0
+    },
+    {
+      "host": "d2wse2.its.nv.gov",
+      "sampleUrl": "https://d2wse2.its.nv.gov:443/renoxcd02/fb89196b-15dc-48fb-992e-030b7a325d34_hspflirxcd02_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 113,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "2",
+          "name": "McCarran & Caughlin/cashill",
+          "lat": 39.484798,
+          "lon": -119.852401,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd02/fb89196b-15dc-48fb-992e-030b7a325d34_hspflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6705",
+          "name": "West 4th St @ Woodland Roundabout",
+          "lat": 39.50925,
+          "lon": -119.89655,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd03/f32c784f-2ea1-4302-a9e4-fde90a7a0c0a_hspflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6733",
+          "name": "US395 Red Rock Virginia Park n Ride",
+          "lat": 39.62526,
+          "lon": -119.91576,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd03/499cd9ed-721f-4663-8ee8-a0af2cdcaf29_hspflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6734",
+          "name": "SR431 Mt Rose Summit",
+          "lat": 39.31161,
+          "lon": -119.89967,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd02/ec6b8c8f-7e43-4af3-a420-e7d91c1014ef_hspflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6735",
+          "name": "SR431 Diamond Peak",
+          "lat": 39.2831,
+          "lon": -119.93504,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd03/9c9baad9-db84-471d-aa62-19bb75a45441_hspflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6736",
+          "name": "SR431 Country Club Dr",
+          "lat": 39.27421,
+          "lon": -119.94688,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd03/8680813f-95d1-47c0-bf28-e7d265e1fced_hspflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6737",
+          "name": "US95 Trinity Rest Area",
+          "lat": 39.94036,
+          "lon": -118.7492,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd03/cf0f29f4-ff62-4343-8bfc-d3ee2e7556fe_hspflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6741",
+          "name": "US-50 Austin LA MM11",
+          "lat": 39.4783,
+          "lon": -117.298,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd03/9199b63d-df30-4195-887a-136e6dd2f8f3_hspflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7076",
+          "name": "Galletti @ Kietzke",
+          "lat": 39.5335,
+          "lon": -119.778,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd02/f945b59b-3ea4-4b1d-af41-e20a9f89bdae_hspflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7078",
+          "name": "I580 @ I80 N E",
+          "lat": 39.537,
+          "lon": -119.7876,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd02/726e8019-76d4-4066-afcd-d254acc465e3_hspflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7080",
+          "name": "I580 @ Kietzke Lane",
+          "lat": 39.5319,
+          "lon": -119.786,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd02/47a314f6-23f7-420d-a48e-55e7b3e857ff_hspflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7083",
+          "name": "I580 @ Mill St",
+          "lat": 39.5197,
+          "lon": -119.7828,
+          "url": "https://d2wse2.its.nv.gov:443/renoxcd02/87b560ad-b350-46a3-b16a-a277140d96d4_hspflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 113,
+      "disabled": 0
+    },
+    {
+      "host": "d2wse1.its.nv.gov",
+      "sampleUrl": "https://d2wse1.its.nv.gov:443/renoxcd03/cfba9931-de51-4d48-95b7-c703a137c7ae_hspflirxcd03_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 69,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "80",
+          "name": "West 4th St @ Woodland Roundabout",
+          "lat": 39.5091388096057,
+          "lon": -119.896934154755,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd03/cfba9931-de51-4d48-95b7-c703a137c7ae_hspflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "623",
+          "name": "McCarran & Lakeside",
+          "lat": 39.476799,
+          "lon": -119.807403,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/468fec45-7a0a-46be-b3d2-380ce76d2e3f_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7077",
+          "name": "I80 @ Lovelock",
+          "lat": 40.177,
+          "lon": -118.4715,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/420e7f80-319e-4ec2-ac89-b339a9b2ceaf_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7079",
+          "name": "I580 @ I80 S W",
+          "lat": 39.537,
+          "lon": -119.7876,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/f619ee21-977d-471a-88e7-eebcfdb55531_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7081",
+          "name": "I-80 @ Lockwood",
+          "lat": 39.51174,
+          "lon": -119.65384,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/8cc12dea-a3ad-47d7-9554-0dec384fbfda_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7087",
+          "name": "Rock Blvd @ I80 WB Onramp",
+          "lat": 39.5342,
+          "lon": -119.7657,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/85f6a09e-a0c7-4712-80ba-1dab2463d0e0_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7088",
+          "name": "Pyramid Way @ I80 EB Onramp",
+          "lat": 39.5337,
+          "lon": -119.7527,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/7fcf89c4-aa87-45e3-8f73-890d49633272_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7089",
+          "name": "E. McCarran Blvd @ I80 EB Offramp",
+          "lat": 39.533,
+          "lon": -119.7392,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/57dbef53-96c9-43fe-8ee9-4ed59d5e0578_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7095",
+          "name": "I80 @ Nugget",
+          "lat": 39.5337,
+          "lon": -119.7579,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/a35bb217-cc01-4140-b435-0f84d981155b_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7097",
+          "name": "I80 @ Trinity",
+          "lat": 39.9518,
+          "lon": -118.7256,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/7cc2547c-b67e-4d22-abd0-7e2864fa164c_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7106",
+          "name": "I80 @ Mustang",
+          "lat": 39.52519,
+          "lon": -119.62217,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/7e0d4063-fae5-4c14-a826-41d3dbcd74ce_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7108",
+          "name": "I80 @ Patrick",
+          "lat": 39.55669,
+          "lon": -119.55914,
+          "url": "https://d2wse1.its.nv.gov:443/renoxcd01/8c585bb3-16de-4c0f-b97e-4471ad4901c5_hspflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 69,
+      "disabled": 0
+    },
+    {
+      "host": "d1wse2.its.nv.gov",
+      "sampleUrl": "https://d1wse2.its.nv.gov:443/vegasxcd02/607991cc-f93b-4b4c-8cbc-17fa2b69a6cd_lvflirxcd03_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 72,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "6642",
+          "name": "Sahara Ave & Boulder Hwy - Fremont",
+          "lat": 36.14541,
+          "lon": -115.10151,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/607991cc-f93b-4b4c-8cbc-17fa2b69a6cd_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6643",
+          "name": "Boulder Hwy & US 95 NB Ramp",
+          "lat": 36.13487,
+          "lon": -115.08962,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/4ffce686-6a62-4d00-b2a1-4cc9da2b334a_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6645",
+          "name": "Boulder Hwy & Tropicana Ave",
+          "lat": 36.10081,
+          "lon": -115.0508,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/02ae4536-d425-4ab3-b8ff-c7edeff3eeaf_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6647",
+          "name": "Charleston Blvd & Fremont St",
+          "lat": 36.15899,
+          "lon": -115.11711,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/4af1c23c-788a-46f2-b70b-31b713ba6281_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6650",
+          "name": "Boulder Hwy & Warm Springs Rd",
+          "lat": 36.05079,
+          "lon": -114.99423,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/9f99fc10-376c-4f2b-b317-308371e2f484_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6654",
+          "name": "Rainbow Blvd & Desert Inn Rd",
+          "lat": 36.12936,
+          "lon": -115.24272,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/c21d478f-14cf-4949-a36b-4b7b9943dd11_lvflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6655",
+          "name": "Boulder Hwy & Horizon Dr-RacetrackRd",
+          "lat": 36.01427,
+          "lon": -114.95354,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/9111ebaf-88b9-4af6-b234-184a2494944d_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6660",
+          "name": "Sahara Ave & Las Vegas Blvd - Festival",
+          "lat": 36.14384,
+          "lon": -115.1571,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/a2a31b07-28af-43f5-a303-5c352b234062_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6662",
+          "name": "Rainbow Blvd & Flamingo Rd",
+          "lat": 36.11481,
+          "lon": -115.24273,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/7e5ae16d-8bed-4bd3-a1ae-0ab3717ed5ff_lvflirxcd02_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6663",
+          "name": "Flamingo Rd & Decatur Blvd",
+          "lat": 36.11573,
+          "lon": -115.20782,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/c979a02e-eec9-46a3-b329-d579aa5cb53d_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6669",
+          "name": "Boulder Hwy & Lake Mead Pkwy",
+          "lat": 36.03965,
+          "lon": -114.98167,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/7f73a121-c6d0-469e-a29c-4f8a689366fd_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6670",
+          "name": "Boulder Hwy & Flamingo Blvd",
+          "lat": 36.11483,
+          "lon": -115.06663,
+          "url": "https://d1wse2.its.nv.gov:443/vegasxcd02/c4dd5d40-7b8d-46c6-af22-a21522a6b7a2_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 72,
+      "disabled": 0
+    },
+    {
+      "host": "d1wse1.its.nv.gov",
+      "sampleUrl": "https://d1wse1.its.nv.gov:443/vegasxcd01/ce41b7e4-bf27-4095-9a8c-e931ef8a282b_lvflirxcd01_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 70,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "6646",
+          "name": "Sahara  Ave & Eastern Ave",
+          "lat": 36.14412,
+          "lon": -115.11902,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/ce41b7e4-bf27-4095-9a8c-e931ef8a282b_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6656",
+          "name": "Decatur Blvd & Sunset Rd",
+          "lat": 36.07194,
+          "lon": -115.20764,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/c0e5bdc6-682e-4736-8d8c-26b61eac1940_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6657",
+          "name": "Sahara Ave & Decatur Blvd",
+          "lat": 36.14476,
+          "lon": -115.20846,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/c87478a0-0f9c-453d-a8dd-756dd24422a9_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6667",
+          "name": "Rainbow Blvd & Oakey Blvd",
+          "lat": 36.15151,
+          "lon": -115.24356,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/a2b901f5-69c4-494d-9bc0-8167af719c4f_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6671",
+          "name": "Durango Dr & North CC 215 WB Ramp",
+          "lat": 36.28085,
+          "lon": -115.28783,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/fbb10712-4f0b-4efb-919d-168c1506e1d0_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6673",
+          "name": "Grand Central Pkwy & Premium Outlet Mall",
+          "lat": 36.16165,
+          "lon": -115.15772,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/f76b81d9-0c3d-4fdc-bd8a-b179d63052a9_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6674",
+          "name": "Grand Central Pkwy & Bonneville-Alta",
+          "lat": 36.16648,
+          "lon": -115.15552,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/9f1d74de-6b11-4ea0-b605-997bce6f294d_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6675",
+          "name": "I-15 SB Lake Mead N",
+          "lat": 36.19612,
+          "lon": -115.13946,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/c1077f9d-8b69-4683-94cc-eb6e452df502_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6677",
+          "name": "Buffalo Dr & South CC 215 WB Ramp",
+          "lat": 36.06717,
+          "lon": -115.26064,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/66ad7e88-005e-4388-82b0-bd2a014d32d1_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6678",
+          "name": "Flamingo Rd & CC 215 NB Ramp",
+          "lat": 36.11514,
+          "lon": -115.30127,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/c7612d6d-5369-4150-abda-38a3086c9b93_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6681",
+          "name": "Durango Dr & South CC215 WB Ramp",
+          "lat": 36.06737,
+          "lon": -115.27939,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/270ff33a-d570-450b-9a37-d8bf77250154_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6684",
+          "name": "Elkhorn Rd & Grand Montecito Pkwy",
+          "lat": 36.29199,
+          "lon": -115.28417,
+          "url": "https://d1wse1.its.nv.gov:443/vegasxcd01/0dfe44ba-f4ff-47c1-b1bc-0bee12006615_lvflirxcd01_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 70,
+      "disabled": 0
+    },
+    {
+      "host": "d3wse1.its.nv.gov",
+      "sampleUrl": "https://d3wse1.its.nv.gov:443/elkoxcd01/76bcd803-4d2f-4aee-af2b-708557b21e8d_hspflirxcd04_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 88,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "6649",
+          "name": "SR-225 Adobe EL MM12",
+          "lat": 40.95032,
+          "lon": -115.87576,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/76bcd803-4d2f-4aee-af2b-708557b21e8d_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7003",
+          "name": "IR-80 MM 200 Golconda Summit HU33",
+          "lat": 40.9212,
+          "lon": -117.3938,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/4b01896c-c7a3-45ba-ada5-c410bb8965a0_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7004",
+          "name": "IR-80 MM 321Halleck EL43",
+          "lat": 40.957,
+          "lon": -115.4786,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/e821e793-276e-4dc6-9d22-819bc6f8fdd3_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7005",
+          "name": "IR-80 MM375 Pequop Summit EL95",
+          "lat": 41.0783,
+          "lon": -114.5696,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/19dc17b3-79c8-4df4-a69d-90445479980d_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7006",
+          "name": "IR-80 MM 298 West Elko EL22",
+          "lat": 40.8014,
+          "lon": -115.8352,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/eef89ab2-bf8e-4010-a23c-e68c61cb725b_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7007",
+          "name": "IR-80 MM 303 East Elko EL18",
+          "lat": 40.8656,
+          "lon": -115.734,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/2b222ee0-1f22-4539-9f4b-7f0d7ce8e1fa_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7008",
+          "name": "IR-80 MM 285 Carlin Tunnel West EL 7.5",
+          "lat": 40.7233,
+          "lon": -116.017,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/a3924004-7af8-4bf6-a6c2-ff8838c92ada_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7009",
+          "name": "IR-80 MM 286 Carlin Tunnel East EL08",
+          "lat": 40.7198,
+          "lon": -116.0104,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/21479ba7-e2d7-420f-a88d-45b2245d7f85_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7010",
+          "name": "IR-80 MM 269 Emigrant Summit EU 18",
+          "lat": 40.6547,
+          "lon": -116.2766,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/349e8907-d301-4c17-99aa-12324de911f6_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7011",
+          "name": "I-80 & Golconda East Bound MM196 Chain Up HU32",
+          "lat": 40.9268,
+          "lon": -117.434,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/3056a9a8-4d89-4d67-94f0-5e1651875d27_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7012",
+          "name": "IR-80 MM 398 Pilot Valley EL100",
+          "lat": 40.8447,
+          "lon": -114.2107,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/8b566376-996b-43f7-8bc4-6b4b3125c459_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "7013",
+          "name": "SR229 EL MM 27 Ruby Valley RWIS",
+          "lat": 40.6795,
+          "lon": -115.2558,
+          "url": "https://d3wse1.its.nv.gov:443/elkoxcd01/2f8d5185-f812-4202-962e-3db34ab4a598_hspflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 88,
+      "disabled": 0
+    },
+    {
+      "host": "d1wse4.its.nv.gov",
+      "sampleUrl": "https://d1wse4.its.nv.gov:443/vegasxcd04/f0e42ab9-1282-4d78-b193-9ebf01b072b7_lvflirxcd06_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 69,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "6652",
+          "name": "Charleston Blvd & Rancho Dr",
+          "lat": 36.15877,
+          "lon": -115.17263,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/f0e42ab9-1282-4d78-b193-9ebf01b072b7_lvflirxcd06_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6653",
+          "name": "Las Vegas Blvd & Lake Mead Blvd",
+          "lat": 36.1957,
+          "lon": -115.12938,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/a1d2d9d2-5a35-469c-ac39-e300d545441e_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6661",
+          "name": "Decatur Blvd & CC 215 EB Ramp",
+          "lat": 36.0669,
+          "lon": -115.20784,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/9493a157-b40a-4787-8041-0a62a788d081_lvflirxcd06_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6672",
+          "name": "Charleston Blvd & CC 215 NB Ramp",
+          "lat": 36.15879,
+          "lon": -115.33663,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/3a9e0ed9-0123-4a64-9a5b-602cb7a946f8_lvflirxcd06_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6699",
+          "name": "Sahara Ave & Paradise Rd - Festival",
+          "lat": 36.14388,
+          "lon": -115.15459,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/141f140b-a5ee-47c5-aac7-ab489b9d025e_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6702",
+          "name": "I-15 SB S of Russell",
+          "lat": 36.08244,
+          "lon": -115.18132,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/ecbb056b-87e4-48e5-9e26-68b64c76dfde_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6703",
+          "name": "I-15 NB Tropicana - Arena",
+          "lat": 36.10124,
+          "lon": -115.1804,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/7c90e838-898a-4f57-9245-91be194ddad1_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6709",
+          "name": "I-15 SB Oakey",
+          "lat": 36.15136,
+          "lon": -115.16545,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/020cb289-3c89-48f4-9d9c-d04c0a863555_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6718",
+          "name": "Charleston Blvd & Town Center Dr",
+          "lat": 36.15914,
+          "lon": -115.32291,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/daa7c41a-3591-4952-ba68-1559e8144dd9_lvflirxcd06_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6722",
+          "name": "Craig Rd & Decatur Blvd",
+          "lat": 36.23903,
+          "lon": -115.20789,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/ac4a59bb-08b3-4dcf-8c5e-93a9e0a6b3da_lvflirxcd06_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6725",
+          "name": "Craig Rd & Losee Rd - Speed",
+          "lat": 36.24008,
+          "lon": -115.11707,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/95487a78-62fb-4f99-80a6-e1be2e8f3a5d_lvflirxcd06_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6726",
+          "name": "Blue Diamond Rd & Buffalo Dr",
+          "lat": 36.01995,
+          "lon": -115.26145,
+          "url": "https://d1wse4.its.nv.gov:443/vegasxcd04/967403f6-cd1f-488d-aad2-e68dcbc798f2_lvflirxcd06_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 69,
+      "disabled": 0
+    },
+    {
+      "host": "d1wse5.its.nv.gov",
+      "sampleUrl": "https://d1wse5.its.nv.gov:443/vegasxcd05/51c88575-37ff-4aed-b137-204b6c47db00_lvflirxcd07_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 72,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "6658",
+          "name": "Durango Dr & North CC 215 EB Ramp",
+          "lat": 36.27898,
+          "lon": -115.2878,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/51c88575-37ff-4aed-b137-204b6c47db00_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6700",
+          "name": "I-215 EB I-15 SB ramp",
+          "lat": 36.0651,
+          "lon": -115.1863,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/aed7089c-c1ff-4de3-8535-2c1792c7cc8f_lvflirxcd05_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6721",
+          "name": "I-215 WB I-15",
+          "lat": 36.06615,
+          "lon": -115.18214,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/b2bec0dc-f008-4f34-8a57-7a8476298a30_lvflirxcd05_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6724",
+          "name": "Desert Inn Rd WB TUNNEL EXIT",
+          "lat": 36.13146,
+          "lon": -115.16647,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/d18d42e6-e9c8-41f3-9488-ead2b15d1c73_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6731",
+          "name": "Sandhill Blvd & I-15",
+          "lat": 36.81208,
+          "lon": -114.06374,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/2786ff79-3d66-4ef0-87ea-a3392c48c96c_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6812",
+          "name": "Lake Mead Blvd & CC-215 NB",
+          "lat": 36.20543,
+          "lon": -115.3407,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/cb07c808-1d23-4e07-ad95-a00257fb6cb5_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6813",
+          "name": "Rainbow Blvd & south CC 215 EB Ramp",
+          "lat": 36.06538,
+          "lon": -115.24244,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/e664c903-c043-4c71-8e79-0e642f42819b_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6823",
+          "name": "Las Vegas Blvd & I-215 WB",
+          "lat": 36.06467,
+          "lon": -115.17271,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/bea9280d-145c-4a34-88d0-492bf6cee834_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6824",
+          "name": "Las Vegas Blvd & I-215 EB",
+          "lat": 36.06269,
+          "lon": -115.17211,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/5a159a4a-84db-4c1d-af0c-f9026ad9d777_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6839",
+          "name": "Lake Mead Blvd & Buffalo Dr",
+          "lat": 36.19633,
+          "lon": -115.26057,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/6ed4308e-7756-4f12-add6-504e3e0123e7_lvflirxcd05_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6855",
+          "name": "Valle Verde Dr & I-215 WB Beltway",
+          "lat": 36.02751,
+          "lon": -115.06254,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/b9f374d4-513b-463e-9114-14da5c7e13f4_lvflirxcd05_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6866",
+          "name": "Jones Blvd & South CC 215 EB Ramp",
+          "lat": 36.06578,
+          "lon": -115.22457,
+          "url": "https://d1wse5.its.nv.gov:443/vegasxcd05/8f5205e3-5fe8-4171-83ca-97d3b1f986f7_lvflirxcd07_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 72,
+      "disabled": 0
+    },
+    {
+      "host": "d1wse3.its.nv.gov",
+      "sampleUrl": "https://d1wse3.its.nv.gov:443/vegasxcd03/4c0bab02-65b4-4b1e-bd8a-ee77a2b0d02c_lvflirxcd04_public.stream/playlist.m3u8",
+      "referer": "https://nvroads.com/",
+      "count": 72,
+      "system": {
+        "system": "nv",
+        "site": "www.nvroads.com",
+        "country": "US",
+        "region": "Nevada",
+        "agency": "Nevada DOT (NVRoads)"
+      },
+      "examples": [
+        {
+          "nativeId": "6659",
+          "name": "Decatur Blvd & CC 215 WB Ramp",
+          "lat": 36.06907,
+          "lon": -115.20784,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/4c0bab02-65b4-4b1e-bd8a-ee77a2b0d02c_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6664",
+          "name": "Flamingo Rd & Las Vegas Blvd F1",
+          "lat": 36.11454,
+          "lon": -115.17308,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/c250fce9-1e47-479e-99eb-a28ba37fe962_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6665",
+          "name": "Tropicana Ave & Las Vegas Blvd Arena",
+          "lat": 36.10106,
+          "lon": -115.17323,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/198fc527-1255-4c29-a318-7e111677d239_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6666",
+          "name": "Decatur Blvd & Russell Rd",
+          "lat": 36.08654,
+          "lon": -115.20768,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/84dcbb2d-c220-4504-b6da-97f6fe8b3d1d_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6679",
+          "name": "Sunset Rd & CC 215 NB Ramp",
+          "lat": 36.07033,
+          "lon": -115.28778,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/1c9f1ce5-170e-424a-90ac-4fa1b31174d2_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6697",
+          "name": "Casino Center Blvd & Ogden Ave",
+          "lat": 36.17195,
+          "lon": -115.14314,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/d84c424f-d6bb-44df-9c77-5fb45dcb5caf_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6698",
+          "name": "Casino Center Blvd & Bonneville Ave",
+          "lat": 36.16489,
+          "lon": -115.14809,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/fbd6fb13-e955-4ea2-9eb1-194e1b613c8a_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6719",
+          "name": "I-515 SB I-15 (Turtles)",
+          "lat": 36.17385,
+          "lon": -115.15308,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/f81c7971-2ab0-4f48-bde9-355fd5255c89_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6723",
+          "name": "Craig Rd & Martin Luther King Blvd",
+          "lat": 36.23926,
+          "lon": -115.16167,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/52d23062-e5cb-4e71-a3d0-f9b79414b813_lvflirxcd04_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6745",
+          "name": "Eastern Ave & Horizon Ridge Pkwy",
+          "lat": 35.99923,
+          "lon": -115.10441,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/aebed15f-3e64-40a6-bb35-5932cb73a548_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6750",
+          "name": "Tropicana Ave & Paradise Rd T&M",
+          "lat": 36.10125,
+          "lon": -115.15003,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/11559fef-80fa-4730-99a6-691383b7b530_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        },
+        {
+          "nativeId": "6752",
+          "name": "Eastern Ave & CC 215 EB Ramp",
+          "lat": 36.02265,
+          "lon": -115.11822,
+          "url": "https://d1wse3.its.nv.gov:443/vegasxcd03/dcc1b63f-709d-43b9-9c85-852b3c1d1b39_lvflirxcd03_public.stream/playlist.m3u8",
+          "system": {
+            "system": "nv",
+            "site": "www.nvroads.com",
+            "country": "US",
+            "region": "Nevada",
+            "agency": "Nevada DOT (NVRoads)"
+          }
+        }
+      ],
+      "authRequired": 0,
+      "open": 72,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse01.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse01.services.ncdot.gov:8887/chan-5135_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 14,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 14,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse02.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse02.services.ncdot.gov:8887/chan-5136_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 19,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 19,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse03.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse03.services.ncdot.gov:8887/chan-5137_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 16,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 16,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse04.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse04.services.ncdot.gov:8887/chan-5138_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 17,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 17,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse05.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse05.services.ncdot.gov:8887/chan-5139_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 21,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [
+        {
+          "nativeId": "6142",
+          "name": "I-85",
+          "lat": 35.25398,
+          "lon": -80.98252,
+          "url": "https://cfmse05.services.ncdot.gov:8887/chan-6642_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        }
+      ],
+      "authRequired": 20,
+      "open": 1,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse06.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse06.services.ncdot.gov:8887/chan-5140_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 24,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [
+        {
+          "nativeId": "6143",
+          "name": "Gilead",
+          "lat": 35.40448,
+          "lon": -80.86954,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6643_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6144",
+          "name": "Gilead",
+          "lat": 35.40702,
+          "lon": -80.86276,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6645_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6145",
+          "name": "Gilead",
+          "lat": 35.40899,
+          "lon": -80.85882,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6646_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6146",
+          "name": "Gilead",
+          "lat": 35.40917,
+          "lon": -80.85669,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6647_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6147",
+          "name": "Gilead",
+          "lat": 35.41011,
+          "lon": -80.85532,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6648_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6148",
+          "name": "Gilead",
+          "lat": 35.41058,
+          "lon": -80.85179,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6649_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6149",
+          "name": "US-21",
+          "lat": 35.41384,
+          "lon": -80.85635,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6650_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6150",
+          "name": "US-21",
+          "lat": 35.41218,
+          "lon": -80.85583,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6651_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6151",
+          "name": "US-21",
+          "lat": 35.40764,
+          "lon": -80.85443,
+          "url": "https://cfmse06.services.ncdot.gov:8887/chan-6652_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        }
+      ],
+      "authRequired": 15,
+      "open": 9,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse07.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse07.services.ncdot.gov:8887/chan-5141_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 19,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [
+        {
+          "nativeId": "6152",
+          "name": "I-485",
+          "lat": 35.10939,
+          "lon": -80.68982,
+          "url": "https://cfmse07.services.ncdot.gov:8887/chan-6653_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6153",
+          "name": "I-485",
+          "lat": 35.11126,
+          "lon": -80.68704,
+          "url": "https://cfmse07.services.ncdot.gov:8887/chan-6654_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6154",
+          "name": "I-485",
+          "lat": 35.10255,
+          "lon": -80.70958,
+          "url": "https://cfmse07.services.ncdot.gov:8887/chan-6655_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6155",
+          "name": "I-485",
+          "lat": 35.119343,
+          "lon": -80.904828,
+          "url": "https://cfmse07.services.ncdot.gov:8887/chan-6656_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        }
+      ],
+      "authRequired": 15,
+      "open": 4,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse08.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse08.services.ncdot.gov:8887/chan-5142_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 15,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 15,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse09.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse09.services.ncdot.gov:8887/chan-5143_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 17,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 17,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse10.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse10.services.ncdot.gov:8887/chan-5144_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 18,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 18,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse12.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse12.services.ncdot.gov:8887/chan-5146_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 14,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 14,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfmse11.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfmse11.services.ncdot.gov:8887/chan-5157_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 18,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 18,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfese02.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfese02.services.ncdot.gov:8887/chan-5221_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 33,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 33,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfase03.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfase03.services.ncdot.gov:8887/chan-5368_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 15,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 15,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfase04.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfase04.services.ncdot.gov:8887/chan-5369_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 10,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 10,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfase02.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfase02.services.ncdot.gov:8887/chan-5373_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 13,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 13,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfase01.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfase01.services.ncdot.gov:8887/chan-5390_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 8,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 8,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfase06.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfase06.services.ncdot.gov:8887/chan-5401_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 9,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 9,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfase05.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfase05.services.ncdot.gov:8887/chan-5412_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 7,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 7,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse01.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse01.services.ncdot.gov:8887/chan-5102_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 21,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 21,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse02.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse02.services.ncdot.gov:8887/chan-5104_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 23,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 23,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse03.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse03.services.ncdot.gov:8887/chan-5106_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 25,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 25,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse04.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse04.services.ncdot.gov:8887/chan-5108_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 23,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 23,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse05.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse05.services.ncdot.gov:8887/chan-5110_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 38,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 38,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse06.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse06.services.ncdot.gov:8887/chan-5112_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 30,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 30,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse07.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse07.services.ncdot.gov:8887/chan-5114_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 27,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 27,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse08.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse08.services.ncdot.gov:8887/chan-5116_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 37,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [
+        {
+          "nativeId": "6134",
+          "name": "US-421",
+          "lat": 34.25328,
+          "lon": -77.95736,
+          "url": "https://cfsse08.services.ncdot.gov:8887/chan-6639_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6136",
+          "name": "US-17B",
+          "lat": 34.22596,
+          "lon": -77.94505,
+          "url": "https://cfsse08.services.ncdot.gov:8887/chan-6633_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6137",
+          "name": "17th",
+          "lat": 34.18183,
+          "lon": -77.91637,
+          "url": "https://cfsse08.services.ncdot.gov:8887/chan-6631_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6138",
+          "name": "US-17",
+          "lat": 34.26496,
+          "lon": -77.82678,
+          "url": "https://cfsse08.services.ncdot.gov:8887/chan-6634_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6139",
+          "name": "NC-417",
+          "lat": 34.27605,
+          "lon": -77.83335,
+          "url": "https://cfsse08.services.ncdot.gov:8887/chan-6635_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6140",
+          "name": "NC-417",
+          "lat": 34.28879,
+          "lon": -77.8228,
+          "url": "https://cfsse08.services.ncdot.gov:8887/chan-6636_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        },
+        {
+          "nativeId": "6141",
+          "name": "US-17",
+          "lat": 34.30164,
+          "lon": -77.78769,
+          "url": "https://cfsse08.services.ncdot.gov:8887/chan-6637_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        }
+      ],
+      "authRequired": 30,
+      "open": 7,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse09.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse09.services.ncdot.gov:8887/chan-5118_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 30,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 30,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse10.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse10.services.ncdot.gov:8887/chan-5120_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 28,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 28,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse11.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse11.services.ncdot.gov:8887/chan-5122_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 25,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 25,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse12.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse12.services.ncdot.gov:8887/chan-5124_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 23,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 23,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfsse13.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfsse13.services.ncdot.gov:8887/chan-5126_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 22,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 22,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse03.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse03.services.ncdot.gov:8887/chan-6338_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 17,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 17,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfese01.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfese01.services.ncdot.gov:8887/chan-5312_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 35,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [
+        {
+          "nativeId": "6135",
+          "name": "US-74",
+          "lat": 34.25016,
+          "lon": -77.94774,
+          "url": "https://cfese01.services.ncdot.gov:8887/chan-6641_l/index.m3u8",
+          "system": {
+            "system": "nc",
+            "site": "www.drivenc.gov",
+            "country": "US",
+            "region": "North Carolina",
+            "agency": "NCDOT (DriveNC)"
+          }
+        }
+      ],
+      "authRequired": 34,
+      "open": 1,
+      "disabled": 0
+    },
+    {
+      "host": "cfese03.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfese03.services.ncdot.gov:8887/chan-5315_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 38,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 38,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfese04.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfese04.services.ncdot.gov:8887/chan-5317_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 50,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 50,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfese05.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfese05.services.ncdot.gov:8887/chan-5319_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 44,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 44,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cfese06.services.ncdot.gov:8887",
+      "sampleUrl": "https://cfese06.services.ncdot.gov:8887/chan-5321_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 41,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 41,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse02.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse02.services.ncdot.gov:8887/chan-5805_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 19,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 19,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse04.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse04.services.ncdot.gov:8887/chan-5807_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 17,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 17,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse05.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse05.services.ncdot.gov:8887/chan-5808_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 18,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 18,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse06.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse06.services.ncdot.gov:8887/chan-5809_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 18,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 18,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse07.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse07.services.ncdot.gov:8887/chan-5810_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 20,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 20,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse08.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse08.services.ncdot.gov:8887/chan-5811_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 17,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 17,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse09.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse09.services.ncdot.gov:8887/chan-5812_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 21,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 21,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse11.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse11.services.ncdot.gov:8887/chan-5813_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 18,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 18,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse10.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse10.services.ncdot.gov:8887/chan-5814_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 18,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 18,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse01.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse01.services.ncdot.gov:8887/chan-5816_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 17,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 17,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "cftse12.services.ncdot.gov:8887",
+      "sampleUrl": "https://cftse12.services.ncdot.gov:8887/chan-5828_l/index.m3u8",
+      "referer": "https://drivenc.gov/",
+      "count": 17,
+      "system": {
+        "system": "nc",
+        "site": "www.drivenc.gov",
+        "country": "US",
+        "region": "North Carolina",
+        "agency": "NCDOT (DriveNC)"
+      },
+      "examples": [],
+      "authRequired": 17,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "pa-se1.arcadis-ivds.com:8200",
+      "sampleUrl": "https://pa-se1.arcadis-ivds.com:8200/chan-2273/index.m3u8",
+      "referer": "https://511pa.com/",
+      "count": 322,
+      "system": {
+        "system": "pa",
+        "site": "511pa.com",
+        "country": "US",
+        "region": "Pennsylvania",
+        "agency": "PennDOT (511PA)"
+      },
+      "examples": [
+        {
+          "nativeId": "4402",
+          "name": "I-78",
+          "lat": 40.60721,
+          "lon": -75.29935,
+          "url": "https://pa-se1.arcadis-ivds.com:8200/chan-29758/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        },
+        {
+          "nativeId": "4412",
+          "name": "US 30",
+          "lat": 40.087629,
+          "lon": -78.905969,
+          "url": "https://pa-se1.arcadis-ivds.com:8200/chan-29768/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        }
+      ],
+      "authRequired": 320,
+      "open": 2,
+      "disabled": 1
+    },
+    {
+      "host": "pa-se2.arcadis-ivds.com:8200",
+      "sampleUrl": "https://pa-se2.arcadis-ivds.com:8200/chan-2276/index.m3u8",
+      "referer": "https://511pa.com/",
+      "count": 308,
+      "system": {
+        "system": "pa",
+        "site": "511pa.com",
+        "country": "US",
+        "region": "Pennsylvania",
+        "agency": "PennDOT (511PA)"
+      },
+      "examples": [
+        {
+          "nativeId": "4401",
+          "name": "I-78",
+          "lat": 40.62163,
+          "lon": -75.28508,
+          "url": "https://pa-se2.arcadis-ivds.com:8200/chan-29757/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        },
+        {
+          "nativeId": "4411",
+          "name": "US 30",
+          "lat": 40.096814,
+          "lon": -78.934919,
+          "url": "https://pa-se2.arcadis-ivds.com:8200/chan-29767/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        }
+      ],
+      "authRequired": 306,
+      "open": 2,
+      "disabled": 1
+    },
+    {
+      "host": "pa-se3.arcadis-ivds.com:8200",
+      "sampleUrl": "https://pa-se3.arcadis-ivds.com:8200/chan-2279/index.m3u8",
+      "referer": "https://511pa.com/",
+      "count": 320,
+      "system": {
+        "system": "pa",
+        "site": "511pa.com",
+        "country": "US",
+        "region": "Pennsylvania",
+        "agency": "PennDOT (511PA)"
+      },
+      "examples": [
+        {
+          "nativeId": "4410",
+          "name": "US 30",
+          "lat": 40.137852,
+          "lon": -79.009764,
+          "url": "https://pa-se3.arcadis-ivds.com:8200/chan-29766/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        },
+        {
+          "nativeId": "4414",
+          "name": "US 30",
+          "lat": 40.058911,
+          "lon": -78.829479,
+          "url": "https://pa-se3.arcadis-ivds.com:8200/chan-29770/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        }
+      ],
+      "authRequired": 318,
+      "open": 2,
+      "disabled": 1
+    },
+    {
+      "host": "d2g22ywzrs8q02.cloudfront.net",
+      "sampleUrl": "https://d2g22ywzrs8q02.cloudfront.net/main_320x240_200k.m3u8",
+      "referer": "https://511pa.com/",
+      "count": 1,
+      "system": {
+        "system": "pa",
+        "site": "511pa.com",
+        "country": "US",
+        "region": "Pennsylvania",
+        "agency": "PennDOT (511PA)"
+      },
+      "examples": [],
+      "authRequired": 1,
+      "open": 0,
+      "disabled": 0
+    },
+    {
+      "host": "pa-se4.arcadis-ivds.com:8200",
+      "sampleUrl": "https://pa-se4.arcadis-ivds.com:8200/chan-2381/index.m3u8",
+      "referer": "https://511pa.com/",
+      "count": 324,
+      "system": {
+        "system": "pa",
+        "site": "511pa.com",
+        "country": "US",
+        "region": "Pennsylvania",
+        "agency": "PennDOT (511PA)"
+      },
+      "examples": [
+        {
+          "nativeId": "4409",
+          "name": "TURNPIKE EXIT ACCESS",
+          "lat": 40.016061,
+          "lon": -79.079069,
+          "url": "https://pa-se4.arcadis-ivds.com:8200/chan-29765/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        },
+        {
+          "nativeId": "4413",
+          "name": "US 30",
+          "lat": 40.076921,
+          "lon": -78.875745,
+          "url": "https://pa-se4.arcadis-ivds.com:8200/chan-29769/index.m3u8",
+          "system": {
+            "system": "pa",
+            "site": "511pa.com",
+            "country": "US",
+            "region": "Pennsylvania",
+            "agency": "PennDOT (511PA)"
+          }
+        }
+      ],
+      "authRequired": 322,
+      "open": 2,
+      "disabled": 2
+    }
+  ]
+}

--- a/data/liveness/castlerock-verdicts.json
+++ b/data/liveness/castlerock-verdicts.json
@@ -1,0 +1,581 @@
+{
+  "version": 1,
+  "verdicts": {
+    "dis-se18.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 236 streams (not probed)",
+      "at": "2026-09-08T00:49:33.768Z",
+      "cams": 236
+    },
+    "dis-se16.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 241 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 241
+    },
+    "dis-se13.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 226 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 226
+    },
+    "dis-se12.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 229 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 229
+    },
+    "dis-se11.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 231 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 231
+    },
+    "dis-se10.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 237 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 237
+    },
+    "dis-se9.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 220 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 220
+    },
+    "dis-se6.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 214 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 214
+    },
+    "dis-se5.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 216 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 216
+    },
+    "dis-se4.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 216 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 216
+    },
+    "dis-se2.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 218 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 218
+    },
+    "dis-se17.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 222 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 222
+    },
+    "dis-se15.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 234 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 234
+    },
+    "dis-se8.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 217 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 217
+    },
+    "dis-se7.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 205 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 205
+    },
+    "dis-se3.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 208 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 208
+    },
+    "dis-se1.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 228 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 228
+    },
+    "dis-se26.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 57 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 57
+    },
+    "dis-se22.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 18 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 18
+    },
+    "dis-se19.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 160 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 160
+    },
+    "dis-se20.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 24 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 24
+    },
+    "dis-se24.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 21 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 21
+    },
+    "dis-se21.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 22 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 22
+    },
+    "dis-se23.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 15 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 15
+    },
+    "dis-se25.divas.cloud:8200": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 21 streams (not probed)",
+      "at": "2026-09-08T00:49:33.770Z",
+      "cams": 21
+    },
+    "cfmse01.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 14 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 14
+    },
+    "cfmse02.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 19 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 19
+    },
+    "cfmse03.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 16 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 16
+    },
+    "cfmse04.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 17 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 17
+    },
+    "cfmse08.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 15 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 15
+    },
+    "cfmse09.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 17 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 17
+    },
+    "cfmse10.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 18 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 18
+    },
+    "cfmse12.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 14 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 14
+    },
+    "cfmse11.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 18 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 18
+    },
+    "cfese02.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 33 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 33
+    },
+    "cfase03.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 15 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 15
+    },
+    "cfase04.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 10 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 10
+    },
+    "cfase02.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 13 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 13
+    },
+    "cfase01.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 8 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 8
+    },
+    "cfase06.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 9 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 9
+    },
+    "cfase05.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 7 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 7
+    },
+    "cfsse01.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 21 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 21
+    },
+    "cfsse02.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 23 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 23
+    },
+    "cfsse03.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 25 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 25
+    },
+    "cfsse04.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 23 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 23
+    },
+    "cfsse05.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 38 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 38
+    },
+    "cfsse06.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 30 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 30
+    },
+    "cfsse07.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 27 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 27
+    },
+    "cfsse09.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 30 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 30
+    },
+    "cfsse10.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 28 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 28
+    },
+    "cfsse11.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 25 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 25
+    },
+    "cfsse12.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 23 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 23
+    },
+    "cfsse13.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 22 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 22
+    },
+    "cftse03.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 17 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 17
+    },
+    "cfese03.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 38 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 38
+    },
+    "cfese04.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 50 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 50
+    },
+    "cfese05.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 44 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 44
+    },
+    "cfese06.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 41 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 41
+    },
+    "cftse02.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 19 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 19
+    },
+    "cftse04.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 17 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 17
+    },
+    "cftse05.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 18 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 18
+    },
+    "cftse06.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 18 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 18
+    },
+    "cftse07.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 20 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 20
+    },
+    "cftse08.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 17 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 17
+    },
+    "cftse09.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 21 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 21
+    },
+    "cftse11.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 18 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 18
+    },
+    "cftse10.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 18 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 18
+    },
+    "cftse01.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 17 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 17
+    },
+    "cftse12.services.ncdot.gov:8887": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 17 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 17
+    },
+    "d2g22ywzrs8q02.cloudfront.net": {
+      "status": "refused",
+      "note": "operator declares isVideoAuthRequired on all 1 streams (not probed)",
+      "at": "2026-09-08T00:49:33.771Z",
+      "cams": 1
+    },
+    "dis-se14.divas.cloud:8200": {
+      "status": "refused",
+      "note": "http 401 Basic realm=\"XEngine\"",
+      "at": "2026-09-08T00:49:34.288Z",
+      "cams": 246
+    },
+    "s52.nysdot.skyvdn.com": {
+      "status": "live",
+      "note": "advanced over 8s",
+      "at": "2026-09-08T00:49:43.144Z",
+      "cams": 344
+    },
+    "s51.nysdot.skyvdn.com": {
+      "status": "live",
+      "note": "advanced over 14s",
+      "at": "2026-09-08T00:49:58.037Z",
+      "cams": 323
+    },
+    "s53.nysdot.skyvdn.com": {
+      "status": "live",
+      "note": "advanced over 8s",
+      "at": "2026-09-08T00:50:06.969Z",
+      "cams": 330
+    },
+    "s7.nysdot.skyvdn.com": {
+      "status": "live",
+      "note": "advanced over 12s",
+      "at": "2026-09-08T00:50:19.843Z",
+      "cams": 293
+    },
+    "s9.nysdot.skyvdn.com": {
+      "status": "live",
+      "note": "advanced over 10s",
+      "at": "2026-09-08T00:50:30.758Z",
+      "cams": 278
+    },
+    "itsstreamingbr2.dotd.la.gov": {
+      "status": "live",
+      "note": "advanced over 14s",
+      "at": "2026-09-08T00:50:47.203Z",
+      "cams": 188
+    },
+    "itsstreamingno.dotd.la.gov": {
+      "status": "unreachable",
+      "note": "fetch failed",
+      "at": "2026-09-08T00:50:55.463Z",
+      "cams": 145
+    },
+    "itsstreamingbr.dotd.la.gov": {
+      "status": "live",
+      "note": "advanced over 12s",
+      "at": "2026-09-08T00:51:10.979Z",
+      "cams": 156
+    },
+    "d2wse2.its.nv.gov": {
+      "status": "live",
+      "note": "advanced over 13s",
+      "at": "2026-09-08T00:51:25.096Z",
+      "cams": 113
+    },
+    "d2wse1.its.nv.gov": {
+      "status": "unreachable",
+      "note": "http 404",
+      "at": "2026-09-08T00:51:26.009Z",
+      "cams": 69
+    },
+    "d1wse2.its.nv.gov": {
+      "status": "live",
+      "note": "advanced over 12s",
+      "at": "2026-09-08T00:51:39.121Z",
+      "cams": 72
+    },
+    "d1wse1.its.nv.gov": {
+      "status": "live",
+      "note": "advanced over 12s",
+      "at": "2026-09-08T00:51:52.272Z",
+      "cams": 70
+    },
+    "d3wse1.its.nv.gov": {
+      "status": "live",
+      "note": "advanced over 11s",
+      "at": "2026-09-08T00:52:04.433Z",
+      "cams": 88
+    },
+    "d1wse4.its.nv.gov": {
+      "status": "live",
+      "note": "advanced over 12s",
+      "at": "2026-09-08T00:52:17.647Z",
+      "cams": 69
+    },
+    "d1wse5.its.nv.gov": {
+      "status": "live",
+      "note": "advanced over 12s",
+      "at": "2026-09-08T00:52:30.862Z",
+      "cams": 72
+    },
+    "d1wse3.its.nv.gov": {
+      "status": "live",
+      "note": "advanced over 12s",
+      "at": "2026-09-08T00:52:44.103Z",
+      "cams": 72
+    },
+    "cfmse05.services.ncdot.gov:8887": {
+      "status": "unreachable",
+      "note": "fetch failed",
+      "at": "2026-09-08T00:52:54.793Z",
+      "cams": 21
+    },
+    "cfmse06.services.ncdot.gov:8887": {
+      "status": "unreachable",
+      "note": "fetch failed",
+      "at": "2026-09-08T00:53:05.917Z",
+      "cams": 24
+    },
+    "cfmse07.services.ncdot.gov:8887": {
+      "status": "unreachable",
+      "note": "fetch failed",
+      "at": "2026-09-08T00:53:17.122Z",
+      "cams": 19
+    },
+    "cfsse08.services.ncdot.gov:8887": {
+      "status": "unreachable",
+      "note": "fetch failed",
+      "at": "2026-09-08T00:53:28.216Z",
+      "cams": 37
+    },
+    "cfese01.services.ncdot.gov:8887": {
+      "status": "unreachable",
+      "note": "fetch failed",
+      "at": "2026-09-08T00:53:39.346Z",
+      "cams": 35
+    },
+    "pa-se1.arcadis-ivds.com:8200": {
+      "status": "refused",
+      "note": "http 401 Basic realm=\"XEngine\"",
+      "at": "2026-09-08T00:53:40.562Z",
+      "cams": 322
+    },
+    "pa-se2.arcadis-ivds.com:8200": {
+      "status": "refused",
+      "note": "http 401 Basic realm=\"XEngine\"",
+      "at": "2026-09-08T00:53:41.792Z",
+      "cams": 308
+    },
+    "pa-se3.arcadis-ivds.com:8200": {
+      "status": "refused",
+      "note": "http 401 Basic realm=\"XEngine\"",
+      "at": "2026-09-08T00:53:42.816Z",
+      "cams": 320
+    },
+    "pa-se4.arcadis-ivds.com:8200": {
+      "status": "refused",
+      "note": "http 401 Basic realm=\"XEngine\"",
+      "at": "2026-09-08T00:53:44.045Z",
+      "cams": 324
+    }
+  }
+}

--- a/data/liveness/queue.json
+++ b/data/liveness/queue.json
@@ -1,108 +1,726 @@
 {
   "version": 1,
-  "generatedAt": "2026-09-07T23:23:17.125Z",
+  "generatedAt": "2026-09-08T00:54:35.581Z",
   "cameras": [
     {
-      "cameraId": "scdot:10002",
-      "feed": "scdot",
-      "name": "I-77 S @ MM 4.9",
-      "lat": 33.948503,
-      "lon": -80.997286,
+      "cameraId": "castlerock:ny:16",
+      "feed": "castlerock",
+      "name": "NY 33",
+      "lat": 42.9223627,
+      "lon": -78.8435134,
       "country": "US",
-      "streamUrl": "https://s18.us-east-1.skyvdn.com/rtplive/10002/playlist.m3u8",
+      "streamUrl": "https://s52.nysdot.skyvdn.com/rtplive/R5_013/playlist.m3u8",
       "kind": "hls",
-      "imageUrl": "https://scdotsnap.us-east-1.skyvdn.com/10002.png",
-      "operator": "South Carolina DOT (511SC)",
-      "license": "SCDOT 511 public camera feed — no stated licence",
-      "attribution": "South Carolina DOT (511SC)",
-      "flags": [
-        "Seeded from an already-live feed to exercise the deck. Not an acquisition."
-      ]
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s52.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.580Z"
+      }
     },
     {
-      "cameraId": "scdot:10003",
-      "feed": "scdot",
-      "name": "SB 5.8 I-77 S @ MM 5.8",
-      "lat": 33.951347,
-      "lon": -80.982847,
+      "cameraId": "castlerock:ny:19",
+      "feed": "castlerock",
+      "name": "US 9",
+      "lat": 43.237344,
+      "lon": -73.690416,
       "country": "US",
-      "streamUrl": "https://s18.us-east-1.skyvdn.com/rtplive/10003/playlist.m3u8",
+      "streamUrl": "https://s51.nysdot.skyvdn.com/rtplive/R1_033/playlist.m3u8",
       "kind": "hls",
-      "imageUrl": "https://scdotsnap.us-east-1.skyvdn.com/10003.png",
-      "operator": "South Carolina DOT (511SC)",
-      "license": "SCDOT 511 public camera feed — no stated licence",
-      "attribution": "South Carolina DOT (511SC)",
-      "flags": [
-        "Seeded from an already-live feed to exercise the deck. Not an acquisition."
-      ]
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s51.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
     },
     {
-      "cameraId": "scdot:10004",
-      "feed": "scdot",
-      "name": "I-77 S @ MM 7",
-      "lat": 33.95301,
-      "lon": -80.964955,
+      "cameraId": "castlerock:ny:20",
+      "feed": "castlerock",
+      "name": "NY 5A",
+      "lat": 43.106347,
+      "lon": -75.239611,
       "country": "US",
-      "streamUrl": "https://s18.us-east-1.skyvdn.com/rtplive/10004/playlist.m3u8",
+      "streamUrl": "https://s53.nysdot.skyvdn.com/rtplive/R2_029/playlist.m3u8",
       "kind": "hls",
-      "imageUrl": "https://scdotsnap.us-east-1.skyvdn.com/10004.png",
-      "operator": "South Carolina DOT (511SC)",
-      "license": "SCDOT 511 public camera feed — no stated licence",
-      "attribution": "South Carolina DOT (511SC)",
-      "flags": [
-        "Seeded from an already-live feed to exercise the deck. Not an acquisition."
-      ]
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s53.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
     },
     {
-      "cameraId": "scdot:10005",
-      "feed": "scdot",
-      "name": "I-126 E @ MM 3.4 Elmwood Ave",
-      "lat": 34.009967,
-      "lon": -81.050091,
+      "cameraId": "castlerock:ny:374",
+      "feed": "castlerock",
+      "name": "NY 414",
+      "lat": 42.154819,
+      "lon": -77.052832,
       "country": "US",
-      "streamUrl": "https://s19.us-east-1.skyvdn.com/rtplive/10005/playlist.m3u8",
+      "streamUrl": "https://s7.nysdot.skyvdn.com/rtplive/R6_005/playlist.m3u8",
       "kind": "hls",
-      "imageUrl": "https://scdotsnap.us-east-1.skyvdn.com/10005.png",
-      "operator": "South Carolina DOT (511SC)",
-      "license": "SCDOT 511 public camera feed — no stated licence",
-      "attribution": "South Carolina DOT (511SC)",
-      "flags": [
-        "Seeded from an already-live feed to exercise the deck. Not an acquisition."
-      ]
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s7.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
     },
     {
-      "cameraId": "scdot:10006",
-      "feed": "scdot",
-      "name": "I-126 E @ MM 3 Huger Street",
-      "lat": 34.008779,
-      "lon": -81.052432,
+      "cameraId": "castlerock:ny:749",
+      "feed": "castlerock",
+      "name": "NY 920P",
+      "lat": 42.949608,
+      "lon": -74.369051,
       "country": "US",
-      "streamUrl": "https://s20.us-east-1.skyvdn.com/rtplive/10006/playlist.m3u8",
+      "streamUrl": "https://s9.nysdot.skyvdn.com/rtplive/R2_041/playlist.m3u8",
       "kind": "hls",
-      "imageUrl": "https://scdotsnap.us-east-1.skyvdn.com/10006.png",
-      "operator": "South Carolina DOT (511SC)",
-      "license": "SCDOT 511 public camera feed — no stated licence",
-      "attribution": "South Carolina DOT (511SC)",
-      "flags": [
-        "Seeded from an already-live feed to exercise the deck. Not an acquisition."
-      ]
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s9.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
     },
     {
-      "cameraId": "scdot:10007",
-      "feed": "scdot",
-      "name": "I-126 E @ MM 2.7 Broad River Bridge",
-      "lat": 34.009855,
-      "lon": -81.06269,
+      "cameraId": "castlerock:la:1",
+      "feed": "castlerock",
+      "name": "I-20",
+      "lat": 32.538889,
+      "lon": -93.630833,
       "country": "US",
-      "streamUrl": "https://s18.us-east-1.skyvdn.com/rtplive/10007/playlist.m3u8",
+      "streamUrl": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-030.streams/playlist.m3u8",
       "kind": "hls",
-      "imageUrl": "https://scdotsnap.us-east-1.skyvdn.com/10007.png",
-      "operator": "South Carolina DOT (511SC)",
-      "license": "SCDOT 511 public camera feed — no stated licence",
-      "attribution": "South Carolina DOT (511SC)",
-      "flags": [
-        "Seeded from an already-live feed to exercise the deck. Not an acquisition."
-      ]
+      "operator": "Louisiana DOTD (511LA)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Louisiana DOTD (511LA)",
+      "probe": {
+        "status": "live",
+        "reason": "host itsstreamingbr2.dotd.la.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:la:29",
+      "feed": "castlerock",
+      "name": "US 61",
+      "lat": 30.4530442717707,
+      "lon": -91.09590149,
+      "country": "US",
+      "streamUrl": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-168.streams/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Louisiana DOTD (511LA)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Louisiana DOTD (511LA)",
+      "probe": {
+        "status": "live",
+        "reason": "host itsstreamingbr.dotd.la.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:2",
+      "feed": "castlerock",
+      "name": "McCarran & Caughlin/cashill",
+      "lat": 39.484798,
+      "lon": -119.852401,
+      "country": "US",
+      "streamUrl": "https://d2wse2.its.nv.gov:443/renoxcd02/fb89196b-15dc-48fb-992e-030b7a325d34_hspflirxcd02_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d2wse2.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6642",
+      "feed": "castlerock",
+      "name": "Sahara Ave & Boulder Hwy - Fremont",
+      "lat": 36.14541,
+      "lon": -115.10151,
+      "country": "US",
+      "streamUrl": "https://d1wse2.its.nv.gov:443/vegasxcd02/607991cc-f93b-4b4c-8cbc-17fa2b69a6cd_lvflirxcd03_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse2.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6646",
+      "feed": "castlerock",
+      "name": "Sahara  Ave & Eastern Ave",
+      "lat": 36.14412,
+      "lon": -115.11902,
+      "country": "US",
+      "streamUrl": "https://d1wse1.its.nv.gov:443/vegasxcd01/ce41b7e4-bf27-4095-9a8c-e931ef8a282b_lvflirxcd01_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse1.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6649",
+      "feed": "castlerock",
+      "name": "SR-225 Adobe EL MM12",
+      "lat": 40.95032,
+      "lon": -115.87576,
+      "country": "US",
+      "streamUrl": "https://d3wse1.its.nv.gov:443/elkoxcd01/76bcd803-4d2f-4aee-af2b-708557b21e8d_hspflirxcd04_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d3wse1.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6652",
+      "feed": "castlerock",
+      "name": "Charleston Blvd & Rancho Dr",
+      "lat": 36.15877,
+      "lon": -115.17263,
+      "country": "US",
+      "streamUrl": "https://d1wse4.its.nv.gov:443/vegasxcd04/f0e42ab9-1282-4d78-b193-9ebf01b072b7_lvflirxcd06_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse4.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6658",
+      "feed": "castlerock",
+      "name": "Durango Dr & North CC 215 EB Ramp",
+      "lat": 36.27898,
+      "lon": -115.2878,
+      "country": "US",
+      "streamUrl": "https://d1wse5.its.nv.gov:443/vegasxcd05/51c88575-37ff-4aed-b137-204b6c47db00_lvflirxcd07_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse5.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6659",
+      "feed": "castlerock",
+      "name": "Decatur Blvd & CC 215 WB Ramp",
+      "lat": 36.06907,
+      "lon": -115.20784,
+      "country": "US",
+      "streamUrl": "https://d1wse3.its.nv.gov:443/vegasxcd03/4c0bab02-65b4-4b1e-bd8a-ee77a2b0d02c_lvflirxcd04_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse3.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:21",
+      "feed": "castlerock",
+      "name": "NY 33",
+      "lat": 42.9074247,
+      "lon": -78.8436404,
+      "country": "US",
+      "streamUrl": "https://s52.nysdot.skyvdn.com/rtplive/R5_011/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s52.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:312",
+      "feed": "castlerock",
+      "name": "I-287 - Cross Westchester Expwy",
+      "lat": 41.05757,
+      "lon": -73.83243,
+      "country": "US",
+      "streamUrl": "https://s51.nysdot.skyvdn.com/rtplive/TA_001/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s51.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:49",
+      "feed": "castlerock",
+      "name": "I-290",
+      "lat": 42.99067,
+      "lon": -78.79924,
+      "country": "US",
+      "streamUrl": "https://s53.nysdot.skyvdn.com/rtplive/R5_029/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s53.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:375",
+      "feed": "castlerock",
+      "name": "I-84",
+      "lat": 41.529714,
+      "lon": -73.813121,
+      "country": "US",
+      "streamUrl": "https://s7.nysdot.skyvdn.com/rtplive/R8_002/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s7.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:750",
+      "feed": "castlerock",
+      "name": "NY 14",
+      "lat": 42.090502,
+      "lon": -76.805569,
+      "country": "US",
+      "streamUrl": "https://s9.nysdot.skyvdn.com/rtplive/R6_031/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s9.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:la:2",
+      "feed": "castlerock",
+      "name": "I-20",
+      "lat": 32.4609,
+      "lon": -93.83,
+      "country": "US",
+      "streamUrl": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-002.streams/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Louisiana DOTD (511LA)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Louisiana DOTD (511LA)",
+      "probe": {
+        "status": "live",
+        "reason": "host itsstreamingbr2.dotd.la.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6705",
+      "feed": "castlerock",
+      "name": "West 4th St @ Woodland Roundabout",
+      "lat": 39.50925,
+      "lon": -119.89655,
+      "country": "US",
+      "streamUrl": "https://d2wse2.its.nv.gov:443/renoxcd03/f32c784f-2ea1-4302-a9e4-fde90a7a0c0a_hspflirxcd03_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d2wse2.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6643",
+      "feed": "castlerock",
+      "name": "Boulder Hwy & US 95 NB Ramp",
+      "lat": 36.13487,
+      "lon": -115.08962,
+      "country": "US",
+      "streamUrl": "https://d1wse2.its.nv.gov:443/vegasxcd02/4ffce686-6a62-4d00-b2a1-4cc9da2b334a_lvflirxcd03_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse2.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6656",
+      "feed": "castlerock",
+      "name": "Decatur Blvd & Sunset Rd",
+      "lat": 36.07194,
+      "lon": -115.20764,
+      "country": "US",
+      "streamUrl": "https://d1wse1.its.nv.gov:443/vegasxcd01/c0e5bdc6-682e-4736-8d8c-26b61eac1940_lvflirxcd01_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse1.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:7003",
+      "feed": "castlerock",
+      "name": "IR-80 MM 200 Golconda Summit HU33",
+      "lat": 40.9212,
+      "lon": -117.3938,
+      "country": "US",
+      "streamUrl": "https://d3wse1.its.nv.gov:443/elkoxcd01/4b01896c-c7a3-45ba-ada5-c410bb8965a0_hspflirxcd04_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d3wse1.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6653",
+      "feed": "castlerock",
+      "name": "Las Vegas Blvd & Lake Mead Blvd",
+      "lat": 36.1957,
+      "lon": -115.12938,
+      "country": "US",
+      "streamUrl": "https://d1wse4.its.nv.gov:443/vegasxcd04/a1d2d9d2-5a35-469c-ac39-e300d545441e_lvflirxcd04_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse4.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6700",
+      "feed": "castlerock",
+      "name": "I-215 EB I-15 SB ramp",
+      "lat": 36.0651,
+      "lon": -115.1863,
+      "country": "US",
+      "streamUrl": "https://d1wse5.its.nv.gov:443/vegasxcd05/aed7089c-c1ff-4de3-8535-2c1792c7cc8f_lvflirxcd05_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse5.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6664",
+      "feed": "castlerock",
+      "name": "Flamingo Rd & Las Vegas Blvd F1",
+      "lat": 36.11454,
+      "lon": -115.17308,
+      "country": "US",
+      "streamUrl": "https://d1wse3.its.nv.gov:443/vegasxcd03/c250fce9-1e47-479e-99eb-a28ba37fe962_lvflirxcd03_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse3.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:22",
+      "feed": "castlerock",
+      "name": "NY 33",
+      "lat": 42.9223673,
+      "lon": -78.8438361,
+      "country": "US",
+      "streamUrl": "https://s52.nysdot.skyvdn.com/rtplive/R5_012/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s52.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:313",
+      "feed": "castlerock",
+      "name": "I-287 - Cross Westchester Expwy",
+      "lat": 41.05911,
+      "lon": -73.82328,
+      "country": "US",
+      "streamUrl": "https://s51.nysdot.skyvdn.com/rtplive/TA_002/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s51.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:50",
+      "feed": "castlerock",
+      "name": "I-87 - NYS Thruway",
+      "lat": 41.00857,
+      "lon": -73.85127,
+      "country": "US",
+      "streamUrl": "https://s53.nysdot.skyvdn.com/rtplive/TA_021/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s53.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:377",
+      "feed": "castlerock",
+      "name": "I-84",
+      "lat": 41.538471,
+      "lon": -73.774562,
+      "country": "US",
+      "streamUrl": "https://s7.nysdot.skyvdn.com/rtplive/R8_004/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s7.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:ny:752",
+      "feed": "castlerock",
+      "name": "NY 30",
+      "lat": 43.109147,
+      "lon": -74.268057,
+      "country": "US",
+      "streamUrl": "https://s9.nysdot.skyvdn.com/rtplive/R2_042/playlist.m3u8",
+      "kind": "hls",
+      "operator": "NYSDOT (511NY)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) NYSDOT (511NY)",
+      "probe": {
+        "status": "live",
+        "reason": "host s9.nysdot.skyvdn.com measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:la:3",
+      "feed": "castlerock",
+      "name": "I-20",
+      "lat": 32.4844,
+      "lon": -93.774,
+      "country": "US",
+      "streamUrl": "https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-005.streams/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Louisiana DOTD (511LA)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Louisiana DOTD (511LA)",
+      "probe": {
+        "status": "live",
+        "reason": "host itsstreamingbr2.dotd.la.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:la:30",
+      "feed": "castlerock",
+      "name": "US 61",
+      "lat": 30.5085549311101,
+      "lon": -91.171515,
+      "country": "US",
+      "streamUrl": "https://ITSStreamingBR.dotd.la.gov/public/br-cam-188.streams/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Louisiana DOTD (511LA)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Louisiana DOTD (511LA)",
+      "probe": {
+        "status": "live",
+        "reason": "host itsstreamingbr.dotd.la.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6733",
+      "feed": "castlerock",
+      "name": "US395 Red Rock Virginia Park n Ride",
+      "lat": 39.62526,
+      "lon": -119.91576,
+      "country": "US",
+      "streamUrl": "https://d2wse2.its.nv.gov:443/renoxcd03/499cd9ed-721f-4663-8ee8-a0af2cdcaf29_hspflirxcd03_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d2wse2.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6645",
+      "feed": "castlerock",
+      "name": "Boulder Hwy & Tropicana Ave",
+      "lat": 36.10081,
+      "lon": -115.0508,
+      "country": "US",
+      "streamUrl": "https://d1wse2.its.nv.gov:443/vegasxcd02/02ae4536-d425-4ab3-b8ff-c7edeff3eeaf_lvflirxcd03_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse2.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6657",
+      "feed": "castlerock",
+      "name": "Sahara Ave & Decatur Blvd",
+      "lat": 36.14476,
+      "lon": -115.20846,
+      "country": "US",
+      "streamUrl": "https://d1wse1.its.nv.gov:443/vegasxcd01/c87478a0-0f9c-453d-a8dd-756dd24422a9_lvflirxcd01_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse1.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:7004",
+      "feed": "castlerock",
+      "name": "IR-80 MM 321Halleck EL43",
+      "lat": 40.957,
+      "lon": -115.4786,
+      "country": "US",
+      "streamUrl": "https://d3wse1.its.nv.gov:443/elkoxcd01/e821e793-276e-4dc6-9d22-819bc6f8fdd3_hspflirxcd04_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d3wse1.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6661",
+      "feed": "castlerock",
+      "name": "Decatur Blvd & CC 215 EB Ramp",
+      "lat": 36.0669,
+      "lon": -115.20784,
+      "country": "US",
+      "streamUrl": "https://d1wse4.its.nv.gov:443/vegasxcd04/9493a157-b40a-4787-8041-0a62a788d081_lvflirxcd06_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse4.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
+    },
+    {
+      "cameraId": "castlerock:nv:6721",
+      "feed": "castlerock",
+      "name": "I-215 WB I-15",
+      "lat": 36.06615,
+      "lon": -115.18214,
+      "country": "US",
+      "streamUrl": "https://d1wse5.its.nv.gov:443/vegasxcd05/b2bec0dc-f008-4f34-8a57-7a8476298a30_lvflirxcd05_public.stream/playlist.m3u8",
+      "kind": "hls",
+      "operator": "Nevada DOT (NVRoads)",
+      "license": "Castle Rock 511 terms of use",
+      "attribution": "Live traffic data (c) Nevada DOT (NVRoads)",
+      "probe": {
+        "status": "live",
+        "reason": "host d1wse5.its.nv.gov measured rolling by scripts/liveness-castlerock.mts",
+        "at": "2026-09-08T00:54:35.581Z"
+      }
     }
   ]
 }

--- a/data/liveness/sweep.json
+++ b/data/liveness/sweep.json
@@ -1,0 +1,86 @@
+{
+  "version": 1,
+  "ranAt": "2026-09-07T23:55:50.046Z",
+  "exitIp": "86.20.84.13",
+  "replay": false,
+  "results": [
+    {
+      "key": "ga-511",
+      "label": "511 Georgia (GDOT NaviGAtor)",
+      "country": "US",
+      "region": "Georgia",
+      "verdict": "player-but-no-url",
+      "requests": [
+        {
+          "url": "https://511ga.org/",
+          "outcome": "ok 200",
+          "bytes": 158556
+        }
+      ],
+      "assetsFetched": 40,
+      "players": [
+        "video.js"
+      ],
+      "firstParty": [],
+      "thirdParty": []
+    },
+    {
+      "key": "nv-roads",
+      "label": "NVRoads (Nevada DOT)",
+      "country": "US",
+      "region": "Nevada",
+      "verdict": "player-but-no-url",
+      "requests": [
+        {
+          "url": "https://www.nvroads.com/",
+          "outcome": "ok 200",
+          "bytes": 189042
+        }
+      ],
+      "assetsFetched": 40,
+      "players": [
+        "video.js"
+      ],
+      "firstParty": [],
+      "thirdParty": []
+    },
+    {
+      "key": "oh-ohgo",
+      "label": "OHGO (Ohio DOT)",
+      "country": "US",
+      "region": "Ohio",
+      "verdict": "no-stream-found",
+      "requests": [
+        {
+          "url": "https://www.ohgo.com/",
+          "outcome": "ok 200",
+          "bytes": 29400
+        }
+      ],
+      "assetsFetched": 32,
+      "players": [],
+      "firstParty": [],
+      "thirdParty": []
+    },
+    {
+      "key": "va-511",
+      "label": "511Virginia (VDOT)",
+      "country": "US",
+      "region": "Virginia",
+      "verdict": "player-but-no-url",
+      "requests": [
+        {
+          "url": "https://www.511virginia.org/",
+          "outcome": "ok 200",
+          "bytes": 61633
+        }
+      ],
+      "assetsFetched": 3,
+      "players": [
+        "video.js"
+      ],
+      "firstParty": [],
+      "thirdParty": []
+    }
+  ]
+}

--- a/lib/liveness/candidates.ts
+++ b/lib/liveness/candidates.ts
@@ -1,0 +1,141 @@
+/**
+ * Stage B: operator portals that Provenance does NOT already read, to be asked whether
+ * they publish live video.
+ *
+ * WHY THIS IS A LIST OF PORTAL ROOTS AND NOT A LIST OF API ENDPOINTS. Stage A asked
+ * twelve known feeds at the exact endpoints their adapters use, which was right, because
+ * the question was about feeds we already ingest. This stage has no adapter to copy an
+ * endpoint from, and guessing API paths per operator is both unreliable and the kind of
+ * thing that quietly turns a wrong guess into "this operator publishes no video". So the
+ * sweep starts at the public portal a person would open and follows what the page itself
+ * references — see scripts/liveness-sweep.mts. Anything found is therefore traceable to a
+ * URL the operator actually serves to visitors.
+ *
+ * THE LEVEL-2 GAP THIS CLOSES. Stage A read page HTML but not the JavaScript those pages
+ * load, and wrote that down as a known limit — DriveBC returned a 4 KB app shell, so its
+ * zero was weaker than a portal that returned real content. Modern 511 sites put the
+ * player configuration in a bundle, so HTML-only is close to useless here. The sweep
+ * follows same-origin scripts and JSON one hop, which is where 511NY's answer was found:
+ * myCameraTooltip.min.js contains no video handling of any kind, which is a much stronger
+ * "stills only" than the homepage HTML could ever be.
+ *
+ * WHAT A ROW IS NOT. Presence here is a QUESTION, never a claim that the operator has
+ * video, that the portal permits reuse, or that the feed should be ingested. Licensing is
+ * decided per operator afterwards, by a person; a stream found here still has to clear the
+ * operator-primary policy in docs/CAMERA_DISCOVERY.md, the bare-IP ban, and the rule that
+ * we never forge a Referer past an access control. Several rows below are expected to be
+ * refusals and are listed so the refusal is RECORDED rather than rediscovered.
+ *
+ * ALREADY ANSWERED, DELIBERATELY ABSENT: the four live feeds (caltrans, scdot, mup-rs,
+ * putevi-rs) and the twelve Stage A measured (see lib/liveness/feeds.ts). Re-asking them
+ * would spend requests on questions with written answers.
+ */
+
+export interface Candidate {
+  /** Stable key for the sweep report. Not a registry key — nothing here is a feed yet. */
+  key: string;
+  label: string;
+  /** ISO 3166-1 alpha-2, so a finding lands somewhere on the map. */
+  country: string;
+  region?: string;
+  /**
+   * Public pages to start from, most-likely-to-carry-a-player first. The sweep follows
+   * same-origin assets these reference; it does not crawl the site.
+   */
+  roots: string[];
+  /** Anything a reader needs in order to not misread this row's result. */
+  note?: string;
+}
+
+/**
+ * US state road authorities. Every domain below is the state's own public traveller
+ * portal, which is what the operator-primary policy requires — no aggregators, and
+ * notably no 511.org-style third-party rehosts.
+ *
+ * Three states carry a note because their answer is already partly known and the sweep
+ * would otherwise look like it discovered something new.
+ */
+const US: Candidate[] = [
+  { key: "al-algo", label: "ALGO Traffic (Alabama DOT)", country: "US", region: "Alabama", roots: ["https://algotraffic.com/"] },
+  { key: "ak-511", label: "Alaska 511 (Alaska DOT&PF)", country: "US", region: "Alaska", roots: ["https://511.alaska.gov/"] },
+  { key: "az-511", label: "AZ511 (Arizona DOT)", country: "US", region: "Arizona", roots: ["https://az511.com/"] },
+  { key: "ar-idrive", label: "IDriveArkansas (ARDOT)", country: "US", region: "Arkansas", roots: ["https://www.idrivearkansas.com/"] },
+  { key: "co-cotrip", label: "COtrip (Colorado DOT)", country: "US", region: "Colorado", roots: ["https://www.cotrip.org/"] },
+  { key: "ct-roads", label: "CTroads (Connecticut DOT)", country: "US", region: "Connecticut", roots: ["https://ctroads.org/"] },
+  { key: "de-deldot", label: "DelDOT Traffic (Delaware DOT)", country: "US", region: "Delaware", roots: ["https://deldot.gov/map/"] },
+  { key: "ga-511", label: "511 Georgia (GDOT NaviGAtor)", country: "US", region: "Georgia", roots: ["https://511ga.org/"] },
+  { key: "hi-akamai", label: "GoAkamai (Hawaii DOT)", country: "US", region: "Hawaii", roots: ["https://goakamai.org/"] },
+  { key: "id-511", label: "Idaho 511 (ITD)", country: "US", region: "Idaho", roots: ["https://511.idaho.gov/"] },
+  { key: "il-gettingaround", label: "Getting Around Illinois (IDOT)", country: "US", region: "Illinois", roots: ["https://www.gettingaroundillinois.com/"] },
+  { key: "in-511", label: "INDOT TrafficWise", country: "US", region: "Indiana", roots: ["https://511in.org/"] },
+  { key: "ia-511", label: "Iowa 511 (Iowa DOT)", country: "US", region: "Iowa", roots: ["https://511ia.org/"] },
+  { key: "ks-kandrive", label: "KanDrive (Kansas DOT)", country: "US", region: "Kansas", roots: ["https://www.kandrive.gov/"] },
+  { key: "ky-goky", label: "GoKY (Kentucky TC)", country: "US", region: "Kentucky", roots: ["https://goky.ky.gov/"] },
+  { key: "la-511", label: "511LA (Louisiana DOTD)", country: "US", region: "Louisiana", roots: ["https://www.511la.org/"], note: "Louisiana DOTD is already a system inside the castlerock feed; a live stream here would be new even though the agency is not." },
+  { key: "md-chart", label: "CHART (Maryland DOT SHA)", country: "US", region: "Maryland", roots: ["https://chart.maryland.gov/"] },
+  { key: "ma-511", label: "Mass511 (MassDOT)", country: "US", region: "Massachusetts", roots: ["https://mass511.com/"] },
+  { key: "mi-drive", label: "Mi Drive (Michigan DOT)", country: "US", region: "Michigan", roots: ["https://mdotjboss.state.mi.us/MiDrive/map"] },
+  { key: "mn-511", label: "511MN (Minnesota DOT)", country: "US", region: "Minnesota", roots: ["https://511mn.org/"] },
+  { key: "ms-mdot", label: "MDOT Traffic (Mississippi DOT)", country: "US", region: "Mississippi", roots: ["https://www.mdottraffic.com/"] },
+  { key: "mo-modot", label: "MoDOT Traveler Information", country: "US", region: "Missouri", roots: ["https://traveler.modot.org/map/"] },
+  { key: "ne-511", label: "Nebraska 511 (NDOT)", country: "US", region: "Nebraska", roots: ["https://511.nebraska.gov/"] },
+  { key: "nv-roads", label: "NVRoads (Nevada DOT)", country: "US", region: "Nevada", roots: ["https://www.nvroads.com/"] },
+  { key: "nj-511", label: "511NJ (NJDOT)", country: "US", region: "New Jersey", roots: ["https://www.511nj.org/"] },
+  { key: "nm-roads", label: "NMRoads (New Mexico DOT)", country: "US", region: "New Mexico", roots: ["https://nmroads.com/"] },
+  { key: "nc-drive", label: "DriveNC (NCDOT)", country: "US", region: "North Carolina", roots: ["https://drivenc.gov/"] },
+  { key: "nd-travel", label: "ND Roads (North Dakota DOT)", country: "US", region: "North Dakota", roots: ["https://travel.dot.nd.gov/"] },
+  { key: "oh-ohgo", label: "OHGO (Ohio DOT)", country: "US", region: "Ohio", roots: ["https://www.ohgo.com/"] },
+  { key: "ok-traffic", label: "OK Traffic (Oklahoma DOT)", country: "US", region: "Oklahoma", roots: ["https://oktraffic.org/"] },
+  { key: "pa-511", label: "511PA (PennDOT)", country: "US", region: "Pennsylvania", roots: ["https://www.511pa.com/"] },
+  { key: "ne-newengland", label: "New England 511 (ME/NH/RI/VT)", country: "US", region: "New England", roots: ["https://newengland511.org/"], note: "One portal for four states; a hit here is four agencies, which also means the licence question is four questions." },
+  { key: "tn-smartway", label: "SmartWay (Tennessee DOT)", country: "US", region: "Tennessee", roots: ["https://smartway.tn.gov/traffic"] },
+  { key: "tx-drive", label: "DriveTexas (TxDOT)", country: "US", region: "Texas", roots: ["https://drivetexas.org/"] },
+  { key: "ut-udot", label: "UDOT Traffic (Utah DOT)", country: "US", region: "Utah", roots: ["https://udottraffic.utah.gov/"] },
+  { key: "va-511", label: "511Virginia (VDOT)", country: "US", region: "Virginia", roots: ["https://www.511virginia.org/"] },
+  { key: "wa-wsdot", label: "WSDOT Traffic (Washington State DOT)", country: "US", region: "Washington", roots: ["https://wsdot.com/travel/real-time/map"] },
+  { key: "wv-511", label: "WV511 (West Virginia DOT)", country: "US", region: "West Virginia", roots: ["https://www.wv511.org/"] },
+  { key: "wi-511", label: "511WI (Wisconsin DOT)", country: "US", region: "Wisconsin", roots: ["https://511wi.gov/"] },
+  { key: "wy-road", label: "WYDOT Travel Information", country: "US", region: "Wyoming", roots: ["https://www.wyoroad.info/"] },
+];
+
+/**
+ * Non-US national and city road authorities.
+ *
+ * Chosen because each is the operator of its own network rather than a reseller, and
+ * because between them they cover road authorities on five continents — a live find
+ * outside North America is worth more to this product than another US state, since the
+ * registry is already 11 countries and heavily US-weighted.
+ */
+const INTL: Candidate[] = [
+  { key: "tw-freeway", label: "Freeway Bureau (Taiwan MOTC)", country: "TW", roots: ["https://1968.freeway.gov.tw/"], note: "Taiwan's freeway CCTV is widely served as MJPEG rather than HLS. MJPEG counts as live for this product PROVIDED it is operator-hosted, which is the whole reason the sweep classifies mjpeg as playable." },
+  { key: "hk-td", label: "Transport Department (Hong Kong)", country: "HK", roots: ["https://www.td.gov.hk/en/special_news/trafficnews.htm"] },
+  { key: "sg-lta", label: "LTA DataMall (Singapore)", country: "SG", roots: ["https://datamall.lta.gov.sg/content/datamall/en.html"], note: "Expected to need a key. Recorded so the refusal is written down." },
+  { key: "ie-tii", label: "Transport Infrastructure Ireland", country: "IE", roots: ["https://www.tiitraffic.ie/"] },
+  { key: "uk-ne", label: "National Highways (England)", country: "GB", roots: ["https://nationalhighways.co.uk/travel-updates/live-traffic-cameras/"] },
+  { key: "pl-gddkia", label: "GDDKiA (Poland)", country: "PL", roots: ["https://www.gddkia.gov.pl/", "https://obserwatoriumbrd.pl/"] },
+  { key: "cz-rsd", label: "Reditelstvi silnic a dalnic (Czechia)", country: "CZ", roots: ["https://www.dopravniinfo.cz/"] },
+  { key: "at-asfinag", label: "ASFINAG (Austria)", country: "AT", roots: ["https://www.asfinag.at/verkehr-sicherheit/webcams/"] },
+  { key: "ch-astra", label: "ASTRA / TCS (Switzerland)", country: "CH", roots: ["https://www.tcs.ch/de/tools/verkehrsinformationen/webcams.php"] },
+  { key: "no-vegvesen", label: "Statens vegvesen (Norway)", country: "NO", roots: ["https://www.vegvesen.no/trafikkbeta/"] },
+  { key: "se-trafikverket", label: "Trafikverket (Sweden)", country: "SE", roots: ["https://trafikinfo.trafikverket.se/"] },
+  { key: "es-dgt", label: "DGT (Spain)", country: "ES", roots: ["https://infocar.dgt.es/etraffic/"] },
+  { key: "pt-ip", label: "Infraestruturas de Portugal", country: "PT", roots: ["https://www.infraestruturasdeportugal.pt/pt-pt/rede-rodoviaria/camaras"] },
+  { key: "gr-attica", label: "Attiki Odos (Greece)", country: "GR", roots: ["https://www.aodos.gr/"] },
+  { key: "il-netivei", label: "Netivei Israel", country: "IL", roots: ["https://www.iroads.co.il/"] },
+  { key: "za-sanral", label: "SANRAL i-Traffic (South Africa)", country: "ZA", roots: ["https://www.i-traffic.co.za/"] },
+  { key: "au-nsw", label: "Transport for NSW (Australia)", country: "AU", region: "New South Wales", roots: ["https://www.livetraffic.com/"] },
+  { key: "au-qld", label: "QLDTraffic (Australia)", country: "AU", region: "Queensland", roots: ["https://qldtraffic.qld.gov.au/"] },
+  { key: "au-vic", label: "VicTraffic (Australia)", country: "AU", region: "Victoria", roots: ["https://traffic.vicroads.vic.gov.au/"] },
+  { key: "cl-mop", label: "Ministerio de Obras Publicas (Chile)", country: "CL", roots: ["https://www.mop.cl/"] },
+  { key: "ar-caba", label: "Buenos Aires city traffic cameras", country: "AR", roots: ["https://buenosaires.gob.ar/movilidad/camaras-de-transito"] },
+  { key: "mx-cdmx", label: "CDMX C5 (Mexico City)", country: "MX", roots: ["https://www.c5.cdmx.gob.mx/"] },
+  { key: "in-delhi", label: "Delhi Traffic Police", country: "IN", roots: ["https://traffic.delhipolice.gov.in/"], note: "Delhi is an outstanding coverage request; see the coverage-requests note. Listed so the answer is measured rather than assumed." },
+  { key: "jp-mlit", label: "MLIT road cameras (Japan)", country: "JP", roots: ["https://www.mlit.go.jp/road/"] },
+  { key: "kr-its", label: "ITS National Transport Information Center (Korea)", country: "KR", roots: ["https://www.its.go.kr/"], note: "Korea publishes CCTV through an open API that issues keys; a key-gated stream is a refusal for now, not a dead feed." },
+];
+
+export const CANDIDATES: readonly Candidate[] = [...US, ...INTL];
+
+export function candidateByKey(key: string): Candidate | undefined {
+  return CANDIDATES.find((c) => c.key === key);
+}

--- a/scripts/liveness-castlerock.mts
+++ b/scripts/liveness-castlerock.mts
@@ -1,0 +1,631 @@
+/**
+ * Stage B result: probe every Castle Rock system's video backend and queue what is live.
+ *
+ *   node --import ./scripts/ts-alias-hook.mjs scripts/liveness-castlerock.mts --inventory
+ *   node --import ./scripts/ts-alias-hook.mjs scripts/liveness-castlerock.mts --probe
+ *   node --import ./scripts/ts-alias-hook.mjs scripts/liveness-castlerock.mts --probe --seed --limit=40
+ *
+ * Two phases, two files, because probing is twenty minutes of mostly sleeping and a kill
+ * partway through used to throw away a finished inventory. `--probe` resumes.
+ *
+ * WHY THIS EXISTS, AND WHAT IT CORRECTS. Stage A concluded that castlerock publishes 97
+ * stream URLs, all on the Divas vendor stack, all answering 401 — and therefore that the
+ * feed was a refusal. That conclusion was drawn from TWO of the feed's ten systems, which
+ * the write-up said plainly was a sample rather than a census. The census disagrees with
+ * the sample, and the sample was the optimistic-sounding half:
+ *
+ *   fl511.com          dis-seNN.divas.cloud            401  Basic realm="XEngine"
+ *   511pa.com          pa-seN.arcadis-ivds.com         401  Basic realm="XEngine"
+ *   511ga.org          sfs-msc-pub-lq-01...dot.ga.gov  401  nginx, no challenge header
+ *   511ny.org          sNN.nysdot.skyvdn.com           200  rolling, sequence advances
+ *   www.nvroads.com    dNwseN.its.nv.gov               200  rolling, sequence advances
+ *   511la.org          ITSStreaming*.dotd.la.gov       200  playlist served
+ *   www.drivenc.gov    cf[amst]seNN.services.ncdot.gov  measured here
+ *
+ * So Castle Rock is not one backend behind one wall. It is a portal platform in front of
+ * whatever streaming stack each agency happens to run, and the agency-owned ones are
+ * frequently open. Divas and Arcadis IVDS both answer `Basic realm="XEngine"`, which
+ * makes XEngine — not Divas — the vendor family to recognise and skip.
+ *
+ * WHAT THIS SCRIPT WILL NOT DO. It probes one representative camera per HOST, not per
+ * camera: about forty requests to answer a question about several thousand cameras. It
+ * never sends credentials, and it never retries a 401 with a forged Referer — a 401 is
+ * recorded as `refused` and the unblock is a permission request to the agency, which is
+ * a person's job and not a script's. Nothing here admits a camera to the map: `--seed`
+ * writes the REVIEW QUEUE, and every camera still has to be watched by a human in
+ * /admin/live before the serving gate will pass it.
+ */
+
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { QUEUE_PATH, type LiveQueue, type QueueCamera } from "@/lib/liveness/queue";
+import { judgeHlsPair, parsePlaylist, readGapMs } from "@/lib/liveness/playlist";
+import { classifyStreamUrl, isPlayableKind } from "@/lib/liveness/scan";
+
+const UA = "TrafficNerd/2.0 liveness (+https://github.com/011-sam-110/Provenance)";
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const argv = process.argv.slice(2);
+const flag = (n: string) => argv.includes(`--${n}`);
+const opt = (n: string) => argv.find((a) => a.startsWith(`--${n}=`))?.split("=").slice(1).join("=");
+const SEED = flag("seed");
+const ONLY_PROBE = flag("probe");
+const ONLY_INVENTORY = flag("inventory");
+const FRESH = flag("fresh");
+const LIMIT = Number(opt("limit") ?? 40);
+
+const OUT_DIR = join(process.cwd(), "data", "liveness");
+
+/**
+ * The ten systems the production adapter reads.
+ *
+ * COPIED from CASTLEROCK_SYSTEMS in lib/sources/castlerock.ts rather than imported, for
+ * the reason liveness-seed-queue.mts already ran into: Node executes TypeScript by
+ * stripping types, not by understanding them, and that module's line 1 imports `Camera`
+ * without the `type` keyword — so importing anything from it fails at runtime with
+ * "does not provide an export named 'Camera'". Rewriting a production adapter that other
+ * sessions are working in, to suit a measurement script, is the tail wagging the dog.
+ *
+ * The duplication is real and worth naming: if a system is added there and not here, this
+ * script measures a stale list. It reports every system it read, so the divergence is
+ * visible in the output rather than silent.
+ */
+const ADAPTER_SYSTEMS = [
+  { system: "fl", site: "fl511.com", country: "US", region: "Florida", agency: "Florida DOT (FL511)" },
+  { system: "ga", site: "511ga.org", country: "US", region: "Georgia", agency: "Georgia DOT (511GA)" },
+  { system: "ny", site: "511ny.org", country: "US", region: "New York", agency: "NYSDOT (511NY)" },
+  { system: "id", site: "511.idaho.gov", country: "US", region: "Idaho", agency: "Idaho Transportation Dept (511)" },
+  { system: "newengland", site: "newengland511.org", country: "US", region: "New England", agency: "New England 511 (ME/NH/VT)" },
+  { system: "la", site: "511la.org", country: "US", region: "Louisiana", agency: "Louisiana DOTD (511LA)" },
+  { system: "on", site: "511on.ca", country: "CA", region: "Ontario", agency: "Ontario MTO (511ON)" },
+  { system: "ab", site: "511.alberta.ca", country: "CA", region: "Alberta", agency: "Alberta 511" },
+  { system: "ns", site: "511.novascotia.ca", country: "CA", region: "Nova Scotia", agency: "Nova Scotia 511" },
+  { system: "nb", site: "511.gnb.ca", country: "CA", region: "New Brunswick", agency: "New Brunswick 511" },
+];
+
+/**
+ * Systems this sweep found that the production adapter does not yet read.
+ *
+ * Discovered by sending the adapter's own `POST /List/GetData/Cameras` to public state
+ * traveller portals: a Castle Rock site answers with a DataTables envelope carrying
+ * `recordsTotal`, and nothing else does. They are kept HERE rather than added to
+ * CASTLEROCK_SYSTEMS because adding a system to that table changes what the product
+ * serves, and that is a reviewed change with a camera count attached — not a side effect
+ * of a measurement script.
+ */
+const DISCOVERED_SYSTEMS = [
+  { system: "nv", site: "www.nvroads.com", country: "US", region: "Nevada", agency: "Nevada DOT (NVRoads)" },
+  { system: "nc", site: "www.drivenc.gov", country: "US", region: "North Carolina", agency: "NCDOT (DriveNC)" },
+  { system: "pa", site: "511pa.com", country: "US", region: "Pennsylvania", agency: "PennDOT (511PA)" },
+  { system: "az", site: "az511.com", country: "US", region: "Arizona", agency: "Arizona DOT (AZ511)" },
+  { system: "ct", site: "ctroads.org", country: "US", region: "Connecticut", agency: "Connecticut DOT (CTroads)" },
+  { system: "ak", site: "511.alaska.gov", country: "US", region: "Alaska", agency: "Alaska DOT&PF (511)" },
+];
+
+type System = { system: string; site: string; country: string; region: string; agency: string };
+const SYSTEMS: System[] = [...ADAPTER_SYSTEMS, ...DISCOVERED_SYSTEMS];
+
+// ---------------------------------------------------------------------------
+// Reading a system
+// ---------------------------------------------------------------------------
+
+interface Row {
+  [k: string]: unknown;
+}
+
+async function fetchPage(site: string, start: number, length = 100): Promise<{ rows: Row[]; total: number }> {
+  const res = await fetch(`https://${site}/List/GetData/Cameras`, {
+    method: "POST", // a GET returns an empty DataTables table
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-Requested-With": "XMLHttpRequest",
+      Accept: "application/json, text/javascript, */*; q=0.01",
+      "User-Agent": UA,
+    },
+    body: `draw=1&start=${start}&length=${length}`,
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) throw new Error(`${site} @${start}: ${res.status}`);
+  const json = (await res.json()) as { data?: Row[]; recordsTotal?: number };
+  return { rows: json.data ?? [], total: Number(json.recordsTotal) || 0 };
+}
+
+interface VideoRef {
+  url: string;
+  /**
+   * The operator's OWN statement that this stream needs credentials.
+   *
+   * This field is worth more than any probe, and the probe is what proved it: measured
+   * against seven systems it agreed with the measurement every single time — Georgia,
+   * Pennsylvania and Florida declare `true` and answer 401; Louisiana, Nevada and New
+   * York declare `false` and serve a rolling playlist. North Carolina declares `true` on
+   * all 92 of its hosts, which is what its 51 "fetch failed" results actually were: not a
+   * network fault of ours, but an operator that says up front the stream is not public.
+   *
+   * So an `authRequired` stream is never probed. Knocking on a door somebody has labelled
+   * "locked" is not measurement, it is just traffic — and reporting the resulting timeout
+   * as `unreachable` would file the operator's clear "no" under our own failures.
+   */
+  authRequired: boolean;
+  /** The operator marking a camera off — distinct from it being locked. */
+  disabled: boolean;
+}
+
+/**
+ * Every video reference on a Castle Rock row.
+ *
+ * Reads the documented `images[]` shape first, because that is where the auth and
+ * disabled flags live and a blind walk would collect the URL while dropping the very
+ * fields that say whether to use it. The generic walk stays as a fallback for a system
+ * that shapes its rows differently, with the flags defaulted to "not stated".
+ */
+function videoRefs(row: Row): VideoRef[] {
+  const out: VideoRef[] = [];
+  const seen = new Set<string>();
+
+  const images = (row as Record<string, unknown>).images;
+  if (Array.isArray(images)) {
+    for (const img of images) {
+      if (!img || typeof img !== "object") continue;
+      const i = img as Record<string, unknown>;
+      const url = typeof i.videoUrl === "string" ? i.videoUrl.trim() : "";
+      if (!/^https?:\/\//i.test(url) || seen.has(url)) continue;
+      seen.add(url);
+      out.push({
+        url,
+        authRequired: i.isVideoAuthRequired === true,
+        disabled: i.videoDisabled === true || i.blocked === true || i.disabled === true,
+      });
+    }
+  }
+  if (out.length) return out;
+
+  const walk = (o: unknown) => {
+    if (Array.isArray(o)) {
+      for (const v of o) walk(v);
+      return;
+    }
+    if (o && typeof o === "object") {
+      for (const [k, v] of Object.entries(o as Record<string, unknown>)) {
+        if (typeof v === "string" && /video/i.test(k) && /^https?:\/\//i.test(v.trim()) && !seen.has(v.trim())) {
+          seen.add(v.trim());
+          out.push({ url: v.trim(), authRequired: false, disabled: false });
+        } else walk(v);
+      }
+    }
+  };
+  walk(row);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Probing a host, once
+// ---------------------------------------------------------------------------
+
+type HostVerdict =
+  | { status: "live"; note: string }
+  | { status: "served-not-advancing"; note: string }
+  | { status: "refused"; note: string }
+  | { status: "unreachable"; note: string };
+
+async function get(url: string, referer: string): Promise<{ ok: boolean; status: number; text: string; auth?: string }> {
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: "*/*", "User-Agent": UA, Referer: referer },
+      signal: AbortSignal.timeout(20_000),
+    });
+    const text = res.ok ? await res.text() : "";
+    return { ok: res.ok, status: res.status, text, auth: res.headers.get("www-authenticate") ?? undefined };
+  } catch (err) {
+    return { ok: false, status: 0, text: "", auth: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Decide one host from one camera, using the same pure logic the rest of the product uses.
+ *
+ * A 200 and a well-formed playlist is NOT live: a finished recording parses perfectly.
+ * Liveness is a pair of reads separated by the playlist's own target duration, judged by
+ * lib/liveness/playlist.ts — so a verdict here means the same thing a verdict anywhere
+ * else in this codebase means.
+ */
+async function probeHost(sampleUrl: string, referer: string): Promise<HostVerdict> {
+  const first = await get(sampleUrl, referer);
+  if (!first.ok) {
+    if (first.status === 401 || first.status === 403) {
+      return { status: "refused", note: `http ${first.status}${first.auth ? ` ${first.auth}` : ""}` };
+    }
+    if (first.status === 0) return { status: "unreachable", note: first.auth ?? "connect failed" };
+    return { status: "unreachable", note: `http ${first.status}` };
+  }
+
+  let url = sampleUrl;
+  let facts = parsePlaylist(first.text);
+  // One hop from a master playlist to a variant. Two would be a redirect loop dressed up.
+  if (facts.isMaster && facts.variantUris[0]) {
+    url = new URL(facts.variantUris[0], sampleUrl).toString();
+    const variant = await get(url, referer);
+    if (!variant.ok) return { status: "unreachable", note: `variant http ${variant.status}` };
+    facts = parsePlaylist(variant.text);
+  }
+  if (!facts.isPlaylist) return { status: "unreachable", note: "not a playlist" };
+
+  const gap = readGapMs(facts);
+  await sleep(gap);
+  const second = await get(url, referer);
+  if (!second.ok) return { status: "unreachable", note: `second read http ${second.status}` };
+
+  const verdict = judgeHlsPair(facts, parsePlaylist(second.text));
+  if (verdict.status === "live") return { status: "live", note: `advanced over ${Math.round(gap / 1000)}s` };
+  if (verdict.status === "dead") return { status: "served-not-advancing", note: "ENDLIST present (recording)" };
+  return { status: "served-not-advancing", note: `no advance over ${Math.round(gap / 1000)}s` };
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything the queue needs from a camera, and nothing else.
+ *
+ * WHY THE SHAPE MATTERS. The first run of this script held every DataTables row from all
+ * sixteen systems — about 17,000 nested objects — and kept a SECOND reference to each in
+ * a by-host index. It was killed by the OS partway through probing, on a machine with
+ * ~650 MB free. Counts are accumulated as numbers, and only a few example cameras per
+ * host are retained, so peak memory is a function of the number of HOSTS (about 60) and
+ * not of the number of cameras.
+ */
+interface CameraLite {
+  nativeId: string;
+  name: string;
+  lat: number;
+  lon: number;
+  url: string;
+  system: System;
+}
+
+/** How many example cameras to keep per host. Seeding needs a handful, not thousands. */
+const EXAMPLES_PER_HOST = 12;
+
+/**
+ * Coordinates, which Castle Rock publishes as WKT rather than as two numbers.
+ *
+ *   latLng.geography.wellKnownText = "POINT (-119.852401 39.484798)"
+ *
+ * WKT is longitude-first. Reading it as lat-first silently puts every North American
+ * camera in Antarctica or the Indian Ocean, which is the kind of wrong that looks fine in
+ * a JSON file and only shows up on a map.
+ *
+ * The first version of this function looked for `latitude`/`longitude`, found neither,
+ * and returned null for every row — so the census probed 99 hosts, found nine live, and
+ * queued nothing at all. A seeding step that silently produces an empty queue is worse
+ * than one that throws, which is why the caller now reports how many rows it could not
+ * place.
+ */
+function parseWkt(row: Row): { lat: number; lon: number } | null {
+  const geo = (row as { latLng?: { geography?: { wellKnownText?: unknown } } }).latLng?.geography?.wellKnownText;
+  if (typeof geo !== "string") return null;
+  const m = /POINT\s*\(\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s*\)/i.exec(geo);
+  if (!m) return null;
+  const lon = Number(m[1]);
+  const lat = Number(m[2]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+  return { lat, lon };
+}
+
+function toLite(row: Row, url: string, system: System): CameraLite | null {
+  const r = row as Record<string, unknown>;
+  const nativeId = String(r.id ?? r.cameraId ?? r.DT_RowId ?? "").trim();
+  if (!nativeId) return null;
+
+  const point = parseWkt(row) ?? {
+    lat: Number(r.latitude ?? r.lat),
+    lon: Number(r.longitude ?? r.lng ?? r.lon),
+  };
+  if (!Number.isFinite(point.lat) || !Number.isFinite(point.lon)) return null;
+
+  // `location` is often the literal string "N/A" on these rows, so it cannot simply win.
+  const candidates = [r.roadway, r.location, r.description].map((v) => String(v ?? "").trim());
+  const name = candidates.find((v) => v && v.toUpperCase() !== "N/A") ?? nativeId;
+  return { nativeId, name, lat: point.lat, lon: point.lon, url, system };
+}
+
+
+// ---------------------------------------------------------------------------
+// Phases, and why this is not one pass
+// ---------------------------------------------------------------------------
+
+/**
+ * Reading the inventory is cheap and fast; probing is slow and mostly SLEEPING.
+ *
+ * Deciding one host means two reads separated by the playlist's own target duration, so
+ * 104 hosts is about twenty minutes, nearly all of it deliberate waiting. A single pass
+ * therefore spends ten minutes building an inventory and then risks all of it on a
+ * twenty-minute window staying uninterrupted — and on this machine it did not: two runs
+ * were killed by the OS under memory pressure from unrelated processes, and the second
+ * threw away a COMPLETE inventory because the probe had not finished.
+ *
+ * So the phases are separate files on disk, and verdicts are written after EVERY host.
+ * A kill now costs at most one host. `--probe` resumes by skipping hosts already decided,
+ * which also means a disputed verdict can be re-taken alone rather than by re-running the
+ * world. This is the same reasoning as data/liveness/raw/ in Stage A: record before
+ * deciding, so an interruption costs time and never evidence.
+ */
+const HOSTS_PATH = join(OUT_DIR, "castlerock-hosts.json");
+const VERDICTS_PATH = join(OUT_DIR, "castlerock-verdicts.json");
+
+interface HostRecord {
+  host: string;
+  sampleUrl: string;
+  referer: string;
+  count: number;
+  system: System;
+  examples: CameraLite[];
+  /** Streams the operator marks as needing credentials. These are never probed. */
+  authRequired: number;
+  /** Streams the operator does not mark. Only these are worth a request. */
+  open: number;
+  /** Streams the operator has switched off. Not a lock, and not worth queueing either. */
+  disabled: number;
+}
+
+interface Inventory {
+  version: 1;
+  ranAt: string;
+  systems: Array<{ site: string; total: number; pulled: number; withVideo: number; error?: string }>;
+  hosts: HostRecord[];
+}
+
+function readJson<T>(path: string, fallback: T): T {
+  try {
+    return existsSync(path) ? (JSON.parse(readFileSync(path, "utf8")) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — inventory
+// ---------------------------------------------------------------------------
+
+async function runInventory(): Promise<Inventory> {
+  const perHost = new Map<string, HostRecord>();
+  const systems: Inventory["systems"] = [];
+
+  for (const system of SYSTEMS) {
+    const referer = `https://${system.site.replace(/^www\./, "")}/`;
+    let total = 0;
+    let pulled = 0;
+    let withVideo = 0;
+    // Rows with an open stream we could not place on a map. Reported rather than dropped:
+    // an empty queue produced in silence is exactly how the first run failed.
+    let unplaceable = 0;
+
+    /** Fold one page in and let it go. Nothing here outlives the loop body. */
+    const absorb = (rows: Row[]) => {
+      pulled += rows.length;
+      for (const row of rows) {
+        const refs = videoRefs(row).filter((v) => {
+          const k = classifyStreamUrl(v.url);
+          return k !== null && isPlayableKind(k);
+        });
+        if (!refs.length) continue;
+        withVideo++;
+        for (const ref of refs) {
+          let host: string;
+          try {
+            host = new URL(ref.url).host;
+          } catch {
+            continue;
+          }
+          let rec = perHost.get(host);
+          if (!rec) {
+            rec = { host, sampleUrl: ref.url, referer, count: 0, system, examples: [], authRequired: 0, open: 0, disabled: 0 };
+            perHost.set(host, rec);
+          }
+          rec.count++;
+          if (ref.authRequired) rec.authRequired++;
+          else rec.open++;
+          if (ref.disabled) rec.disabled++;
+          // Examples exist to seed the review queue, so only stream the operator says is
+          // open and not switched off is worth keeping one of.
+          if (!ref.authRequired && !ref.disabled && rec.examples.length < EXAMPLES_PER_HOST) {
+            const lite = toLite(row, ref.url, system);
+            if (lite) rec.examples.push(lite);
+            else unplaceable++;
+          }
+        }
+      }
+    };
+
+    try {
+      const head = await fetchPage(system.site, 0);
+      total = head.total;
+      absorb(head.rows);
+      for (let s = 100; s < total; s += 100) {
+        try {
+          absorb((await fetchPage(system.site, s)).rows);
+        } catch {
+          // One bad page must not cost the system. `pulled` says what was actually read,
+          // and it is reported next to `total` so a short read is visible rather than
+          // silently becoming a smaller answer.
+        }
+        await sleep(600);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      systems.push({ site: system.site, total: 0, pulled: 0, withVideo: 0, error: message });
+      console.log(`${system.site.padEnd(22)} FAILED  ${message}`);
+      continue;
+    }
+
+    systems.push({ site: system.site, total, pulled, withVideo });
+    console.log(
+      `${system.site.padEnd(22)} total=${String(total).padStart(5)} pulled=${String(pulled).padStart(5)} withVideo=${String(withVideo).padStart(5)}` +
+        (unplaceable ? `  (${unplaceable} open streams had no usable coordinates)` : ""),
+    );
+  }
+
+  const inventory: Inventory = { version: 1, ranAt: new Date().toISOString(), systems, hosts: [...perHost.values()] };
+  writeJson(HOSTS_PATH, inventory);
+  console.log(`\nwrote ${inventory.hosts.length} video hosts -> ${HOSTS_PATH}`);
+  return inventory;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — probe, resumable
+// ---------------------------------------------------------------------------
+
+type VerdictFile = { version: 1; verdicts: Record<string, HostVerdict & { at: string; cams: number }> };
+
+async function runProbe(inventory: Inventory): Promise<VerdictFile> {
+  const file = readJson<VerdictFile>(VERDICTS_PATH, { version: 1, verdicts: {} });
+
+  // Hosts the operator itself marks as needing credentials are recorded as declared
+  // refusals WITHOUT a request. This is the politeness rule that matters most here: the
+  // agency has already answered, in its own data, and re-asking 51 NCDOT hosts to
+  // rediscover a "no" they published would be noise, not evidence.
+  let declared = 0;
+  for (const h of inventory.hosts) {
+    if (file.verdicts[h.host] || h.open > 0) continue;
+    file.verdicts[h.host] = {
+      status: "refused",
+      note: `operator declares isVideoAuthRequired on all ${h.authRequired} streams (not probed)`,
+      at: new Date().toISOString(),
+      cams: h.count,
+    };
+    declared++;
+  }
+  if (declared) {
+    writeJson(VERDICTS_PATH, file);
+    console.log(`\n${declared} hosts recorded as refused on the operator's own flag, unprobed`);
+  }
+
+  const todo = inventory.hosts.filter((h) => !file.verdicts[h.host]);
+  const done = inventory.hosts.length - todo.length;
+
+  console.log(`\n--- probing ${todo.length} hosts (${done} already decided) ---`);
+  for (const h of todo) {
+    const v = await probeHost(h.sampleUrl, h.referer);
+    file.verdicts[h.host] = { ...v, at: new Date().toISOString(), cams: h.count };
+    // Written after every host, so an interruption costs one host and not the run.
+    writeJson(VERDICTS_PATH, file);
+    console.log(`  ${v.status.padEnd(21)} ${h.host.padEnd(44)} ${String(h.count).padStart(5)} cams  ${v.note}`);
+    await sleep(400);
+  }
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+
+function report(inventory: Inventory, file: VerdictFile): string[] {
+  const liveHosts: string[] = [];
+  console.log("\n--- summary ---");
+  for (const s of ["live", "served-not-advancing", "refused", "unreachable"] as const) {
+    const hosts = inventory.hosts.filter((h) => file.verdicts[h.host]?.status === s);
+    const cams = hosts.reduce((n, h) => n + h.count, 0);
+    console.log(`${s.padEnd(22)} ${String(hosts.length).padStart(4)} hosts  ${String(cams).padStart(6)} cameras`);
+    if (s === "live") liveHosts.push(...hosts.map((h) => h.host));
+  }
+  const undecided = inventory.hosts.filter((h) => !file.verdicts[h.host]).length;
+  if (undecided) console.log(`${"not yet probed".padEnd(22)} ${String(undecided).padStart(4)} hosts   <- run --probe again`);
+
+  // Per-agency, because "how many cameras" is the question a person actually asks, and a
+  // host count answers a different one.
+  const byAgency = new Map<string, { live: number; total: number }>();
+  for (const h of inventory.hosts) {
+    const k = h.system.agency;
+    const e = byAgency.get(k) ?? { live: 0, total: 0 };
+    e.total += h.count;
+    if (file.verdicts[h.host]?.status === "live") e.live += h.count;
+    byAgency.set(k, e);
+  }
+  console.log("\n--- cameras with a LIVE-measured stream, by agency ---");
+  for (const [agency, e] of [...byAgency].sort((a, b) => b[1].live - a[1].live)) {
+    if (e.live > 0) console.log(`  ${String(e.live).padStart(5)} of ${String(e.total).padStart(5)}  ${agency}`);
+  }
+  return liveHosts;
+}
+
+async function main() {
+  const wantInventory = !ONLY_PROBE && (!existsSync(HOSTS_PATH) || FRESH);
+  const inventory = wantInventory ? await runInventory() : readJson<Inventory>(HOSTS_PATH, { version: 1, ranAt: "", systems: [], hosts: [] });
+
+  if (!inventory.hosts.length) {
+    console.error(`No host inventory. Run without --probe first (or delete ${HOSTS_PATH} and rerun).`);
+    process.exit(1);
+  }
+
+  const file = ONLY_INVENTORY ? readJson<VerdictFile>(VERDICTS_PATH, { version: 1, verdicts: {} }) : await runProbe(inventory);
+  const liveHosts = report(inventory, file);
+
+  if (!SEED) {
+    console.log("\n(no --seed: nothing written to the review queue)");
+    return;
+  }
+
+  const queue: QueueCamera[] = [];
+  const seenId = new Set<string>();
+
+  /**
+   * One camera from each live host in turn, rather than draining hosts in order.
+   *
+   * Draining put all forty cards on a single NYSDOT host, so a full review session would
+   * have exercised one backend and told us nothing about the other two. Round-robin means
+   * the deck spreads across every operator and every host that passed, which is what makes
+   * a human pass worth more than the probe that preceded it.
+   */
+  const pools = liveHosts
+    .map((host) => inventory.hosts.find((h) => h.host === host))
+    .filter((r): r is HostRecord => Boolean(r))
+    .map((r) => [...r.examples]);
+
+  const roundRobin: CameraLite[] = [];
+  for (let i = 0; pools.some((p) => p.length > i); i++) {
+    for (const p of pools) if (p[i]) roundRobin.push(p[i]);
+  }
+
+  {
+    for (const { nativeId, name, lat, lon, url, system } of roundRobin) {
+      if (queue.length >= LIMIT) break;
+      const cameraId = `castlerock:${system.system}:${nativeId}`;
+      if (seenId.has(cameraId)) continue;
+      seenId.add(cameraId);
+      const kind = classifyStreamUrl(url);
+      if (!kind || !isPlayableKind(kind)) continue;
+      queue.push({
+        cameraId,
+        feed: "castlerock",
+        name,
+        lat,
+        lon,
+        country: system.country,
+        streamUrl: url,
+        kind,
+        operator: system.agency,
+        license: "Castle Rock 511 terms of use",
+        attribution: `Live traffic data (c) ${system.agency}`,
+        probe: {
+          status: "live",
+          reason: `host ${new URL(url).host} measured rolling by scripts/liveness-castlerock.mts`,
+          at: new Date().toISOString(),
+        },
+      });
+    }
+  }
+
+  const out: LiveQueue = { version: 1, generatedAt: new Date().toISOString(), cameras: queue };
+  mkdirSync(dirname(QUEUE_PATH), { recursive: true });
+  writeFileSync(QUEUE_PATH, JSON.stringify(out, null, 2) + "\n", "utf8");
+  console.log(`\nqueued ${queue.length} cameras for human review -> ${QUEUE_PATH}`);
+  console.log("Nothing is on the map yet. Run the deck at /admin/live and watch each one.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/liveness-sweep.mts
+++ b/scripts/liveness-sweep.mts
@@ -1,0 +1,427 @@
+/**
+ * Stage B: ask operator portals we do NOT already read whether they publish live video.
+ *
+ *   node --import ./scripts/ts-alias-hook.mjs scripts/liveness-sweep.mts
+ *   node --import ./scripts/ts-alias-hook.mjs scripts/liveness-sweep.mts --replay
+ *   node --import ./scripts/ts-alias-hook.mjs scripts/liveness-sweep.mts --only=oh-ohgo,ga-511
+ *
+ * WHAT IS DIFFERENT FROM STAGE A. liveness-measure.mts asked twelve known feeds at the
+ * exact endpoints their adapters use. Here there is no adapter to copy an endpoint from,
+ * so the sweep starts at the public portal and follows what the page itself references.
+ * That is deliberate: a guessed API path that 404s is indistinguishable from an operator
+ * with no video, and Stage A already caught itself making that mistake twice.
+ *
+ * THIS CLOSES STAGE A's BIGGEST STATED LIMIT. Stage A read page HTML but not the
+ * JavaScript those pages load, and said so — DriveBC returned a 4 KB app shell, so its
+ * zero was weak. Modern 511 portals put player configuration in a bundle, so HTML alone
+ * is close to useless. Level 2 here fetches same-origin scripts and JSON the page
+ * references. That is what settled New York: myCameraTooltip.min.js contains no video
+ * handling of any kind, which is a far stronger "stills only" than its homepage could be.
+ *
+ * HOW THIS ONE CAN STILL LIE, AND WHAT IS DONE ABOUT EACH:
+ *
+ * 1. A portal that renders entirely client-side may build stream URLs from parts, so no
+ *    string in any asset matches. Such a feed is reported `no-stream-found`, never
+ *    `stills-only` — the report never claims an operator lacks video, only that this
+ *    sweep did not find any. The words are the finding.
+ *
+ * 2. A blocked or rate-limited request reads exactly like an absent stream. Every
+ *    outcome is named (`ok` / `http` / `timeout` / `error`), and a candidate whose ROOT
+ *    never answered is `unreachable`, never zero. This is the flaw Stage A shipped with
+ *    and had to fix; it is built in from the start here.
+ *
+ * 3. It finds a URL on a host the operator does not run — an aggregator, a CDN reseller,
+ *    someone's bare IP. Those are inadmissible under the operator-primary policy no
+ *    matter how live they are, so scan-time gates in lib/liveness/scan.ts drop bare-IP
+ *    and known relay hosts, and the report keeps first-party and third-party hits apart
+ *    so nobody reads a Trafficland embed as an operator publishing video.
+ *
+ * POLITENESS IS PART OF THE DESIGN, not a courtesy bolted on. This walks ~65 public
+ * agency sites. Requests are serialised with a per-host delay, assets per candidate are
+ * capped, and nothing is fetched twice in a run. Raw bodies are saved before anything is
+ * decided so --replay re-runs the whole scan with no network at all.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { CANDIDATES, type Candidate } from "@/lib/liveness/candidates";
+import { isPlayableKind, scanJsonForStreams, scanTextForStreams, type StreamHit } from "@/lib/liveness/scan";
+
+const OUT_DIR = join(process.cwd(), "data", "liveness");
+const RAW_DIR = join(OUT_DIR, "raw", "sweep");
+
+const UA = "TrafficNerd/2.0 liveness (+https://github.com/011-sam-110/Provenance)";
+const REQUEST_TIMEOUT_MS = 20_000;
+const HOST_DELAY_MS = 1_200;
+/**
+ * Assets followed per candidate. Deliberately small: the goal is the handful of bundles
+ * a camera page loads, not a crawl. A portal whose player config is on the 41st script is
+ * a portal this sweep reports honestly as not-found rather than one it hammers to reach.
+ */
+const MAX_ASSETS = 40;
+const MAX_BODY_BYTES = 12 * 1024 * 1024;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const argv = process.argv.slice(2);
+const flag = (n: string) => argv.includes(`--${n}`);
+const opt = (n: string) => argv.find((a) => a.startsWith(`--${n}=`))?.split("=").slice(1).join("=");
+
+const REPLAY = flag("replay");
+const ONLY = opt("only")?.split(",").map((s) => s.trim()).filter(Boolean);
+
+// ---------------------------------------------------------------------------
+// Fetching. Every outcome is named; nothing collapses into null.
+// ---------------------------------------------------------------------------
+
+type Outcome =
+  | { status: "ok"; httpStatus: number; contentType: string; body: string; bytes: number }
+  | { status: "http"; httpStatus: number; contentType: string }
+  | { status: "timeout" }
+  | { status: "error"; message: string };
+
+const rawName = (url: string) =>
+  url.replace(/^https?:\/\//, "").replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 180);
+
+const lastHitAt = new Map<string, number>();
+
+async function politeFetch(url: string, accept: string): Promise<Outcome> {
+  const file = join(RAW_DIR, rawName(url));
+
+  if (REPLAY) {
+    if (!existsSync(file)) return { status: "error", message: "not in raw capture" };
+    const body = readFileSync(file, "utf8");
+    return { status: "ok", httpStatus: 200, contentType: "replay", body, bytes: body.length };
+  }
+
+  let host: string;
+  try {
+    host = new URL(url).host;
+  } catch {
+    return { status: "error", message: "unparseable url" };
+  }
+  const since = Date.now() - (lastHitAt.get(host) ?? 0);
+  if (since < HOST_DELAY_MS) await sleep(HOST_DELAY_MS - since);
+  lastHitAt.set(host, Date.now());
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        // `*/*` in the Accept list on purpose. Stage A sent an HTML-only Accept to
+        // TripCheck, got a 406, and logged it as a measured zero — a header WE chose
+        // nearly wrote off an entire state.
+        Accept: `${accept}, */*`,
+        "User-Agent": UA,
+        "Accept-Language": "en",
+      },
+      redirect: "follow",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const contentType = res.headers.get("content-type") ?? "";
+    if (!res.ok) return { status: "http", httpStatus: res.status, contentType };
+
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.byteLength > MAX_BODY_BYTES) {
+      return { status: "error", message: `body over cap (${buf.byteLength} bytes)` };
+    }
+    const body = buf.toString("utf8");
+    mkdirSync(RAW_DIR, { recursive: true });
+    writeFileSync(file, body, "utf8");
+    return { status: "ok", httpStatus: res.status, contentType, body, bytes: buf.byteLength };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/timeout|aborted|TimeoutError/i.test(message)) return { status: "timeout" };
+    return { status: "error", message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Level 2: what a page references that is worth reading.
+// ---------------------------------------------------------------------------
+
+/**
+ * Video players, detected by name.
+ *
+ * WHY THIS IS WORTH REPORTING SEPARATELY FROM A STREAM URL. Georgia's 511 portal loads
+ * `bundles/videojs` and contains no stream URL anywhere in its homepage or its scripts.
+ * Those two facts together are not "no video" — they are "video, whose URLs arrive from
+ * an API this sweep has not reached". Without this signal that portal is indistinguishable
+ * from a genuinely still-only one, and the honest conclusion for the two is different:
+ * one is a dead end and the other is an unfinished search. That distinction is the whole
+ * lesson of Stage A, applied one level further out.
+ */
+const PLAYERS: Array<[name: string, re: RegExp]> = [
+  ["video.js", /videojs|video\.js/i],
+  ["hls.js", /\bhls\.js|Hls\.isSupported/i],
+  ["dash.js", /dashjs|dash\.all/i],
+  ["jwplayer", /jwplayer/i],
+  ["flowplayer", /flowplayer/i],
+  ["clappr", /clappr/i],
+  ["wowza", /wowza/i],
+  ["shaka", /shaka-player|shakaPlayer/i],
+  ["mjpeg-img", /multipart\/x-mixed-replace/i],
+];
+
+function playersIn(body: string): string[] {
+  return PLAYERS.filter(([, re]) => re.test(body)).map(([n]) => n);
+}
+
+/** A URL worth a second hop looks like data, not like a stylesheet or an image. */
+const API_ISH = /(camera|cctv|\bcam\b|video|stream|traffic|api|geojson|\.json)/i;
+const NOT_WORTH_FETCHING = /\.(png|jpe?g|gif|svg|webp|ico|css|woff2?|ttf|eot|mp4|webm|pdf|zip)(\?|$)/i;
+
+/**
+ * Same-origin URLs a body points at that are worth reading.
+ *
+ * Same-origin is a POLICY rule, not a technical one: this product wants what the operator
+ * serves. Following a third-party bundle would start measuring a vendor's CDN and
+ * reporting it as the agency's answer.
+ *
+ * Applied to scripts as well as to pages, which is the hop that matters — a 511 portal
+ * names its camera API inside a bundle, never in the HTML.
+ */
+function assetsFrom(body: string, pageUrl: string): string[] {
+  const scored: Array<[url: string, score: number]> = [];
+  const seen = new Set<string>();
+  let origin: string;
+  try {
+    origin = new URL(pageUrl).origin;
+  } catch {
+    return [];
+  }
+
+  const patterns: Array<[RegExp, number]> = [
+    // Data endpoints first: they are what actually carries a stream URL.
+    [/["'`]((?:https?:)?\/\/?[a-zA-Z0-9_\-./]*(?:camera|cctv|video|stream|geojson)[a-zA-Z0-9_\-./]*)["'`]/gi, 3],
+    [/["'`](\/(?:api|data|list|map)\/[a-zA-Z0-9_\-./]*)["'`]/gi, 2],
+    [/<script[^>]+src=["']([^"']+)["']/gi, 1],
+    [/<link[^>]+href=["']([^"']+\.json[^"']*)["']/gi, 1],
+  ];
+
+  for (const [re, score] of patterns) {
+    for (const m of body.matchAll(re)) {
+      const raw = m[1];
+      if (!raw || raw.startsWith("data:") || NOT_WORTH_FETCHING.test(raw)) continue;
+      let abs: string;
+      try {
+        abs = new URL(raw, pageUrl).toString();
+      } catch {
+        continue;
+      }
+      if (!abs.startsWith(origin) || seen.has(abs)) continue;
+      seen.add(abs);
+      scored.push([abs, score + (API_ISH.test(abs) ? 1 : 0)]);
+    }
+  }
+  // Highest-value first, because the per-candidate budget is small and spending it on
+  // analytics bundles is how a portal with video gets reported as having none.
+  return scored.sort((a, b) => b[1] - a[1]).map(([u]) => u);
+}
+
+// ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+function scanBody(body: string, contentType: string, where: string): StreamHit[] {
+  const looksJson = /json/i.test(contentType) || /^\s*[[{]/.test(body.slice(0, 200));
+  if (looksJson) {
+    try {
+      const hits = scanJsonForStreams(JSON.parse(body));
+      if (hits.length) return hits.map((h) => ({ ...h, path: `${where}:${h.path}` }));
+    } catch {
+      // Not JSON after all. Fall through to the text scan rather than reporting nothing —
+      // a mislabelled content-type must not cost a finding.
+    }
+  }
+  return scanTextForStreams(body).map((h) => ({ ...h, path: `${where}:${h.path}` }));
+}
+
+interface CandidateResult {
+  key: string;
+  label: string;
+  country: string;
+  region?: string;
+  note?: string;
+  /**
+   * `unreachable` means WE failed, not that the operator has nothing. Kept distinct from
+   * `no-stream-found` for the same reason Stage A separates dead from unknown: one is a
+   * fact about the camera, the other is a fact about our run.
+   */
+  verdict: "playable-stream" | "stream-not-playable" | "player-but-no-url" | "no-stream-found" | "unreachable";
+  requests: { url: string; outcome: string; bytes?: number }[];
+  assetsFetched: number;
+  /** Player libraries seen. Evidence of video even when no URL was reached. */
+  players: string[];
+  /** Hits on a host the operator itself serves. The only kind that can become a source. */
+  firstParty: StreamHit[];
+  /** Hits on someone else's host — recorded, never counted as the operator publishing. */
+  thirdParty: StreamHit[];
+}
+
+async function runCandidate(c: Candidate): Promise<CandidateResult> {
+  const requests: CandidateResult["requests"] = [];
+  const firstParty: StreamHit[] = [];
+  const thirdParty: StreamHit[] = [];
+  const fetched = new Set<string>();
+  let rootAnswered = false;
+  let assetsFetched = 0;
+
+  const operatorHosts = new Set(
+    c.roots.map((r) => {
+      try {
+        return new URL(r).hostname.replace(/^www\./, "");
+      } catch {
+        return "";
+      }
+    }).filter(Boolean),
+  );
+
+  const record = (hits: StreamHit[]) => {
+    for (const h of hits) {
+      let host = "";
+      try {
+        host = new URL(h.url, c.roots[0]).hostname.replace(/^www\./, "");
+      } catch {
+        continue;
+      }
+      // Registrable-suffix match rather than exact: an agency serving video from
+      // cams.example.gov while the portal is example.gov is still the operator.
+      const first = [...operatorHosts].some((o) => host === o || host.endsWith(`.${o}`) || o.endsWith(`.${host}`));
+      (first ? firstParty : thirdParty).push(h);
+    }
+  };
+
+  const players = new Set<string>();
+
+  /**
+   * Breadth-first to depth 2, because one hop is not enough and three is a crawl.
+   *
+   * Depth 0 is the portal page; depth 1 is the bundle that names the camera API; depth 2
+   * is that API's response, which is where a stream URL actually lives. Georgia is the
+   * worked example: the player is at depth 1 and there is no URL anywhere above depth 2.
+   */
+  const queue: Array<{ url: string; depth: number; accept: string }> = c.roots.map((url) => ({
+    url,
+    depth: 0,
+    accept: "text/html",
+  }));
+
+  while (queue.length) {
+    const item = queue.shift()!;
+    if (fetched.has(item.url)) continue;
+    if (item.depth > 0 && assetsFetched >= MAX_ASSETS) continue;
+    fetched.add(item.url);
+
+    const res = await politeFetch(item.url, item.accept);
+    if (item.depth > 0) assetsFetched++;
+
+    const outcome =
+      res.status === "ok"
+        ? `ok ${res.httpStatus}`
+        : res.status === "http"
+          ? `http ${res.httpStatus}`
+          : res.status === "timeout"
+            ? "timeout"
+            : `error: ${res.message}`;
+    // Only roots go in `requests`: one line per portal keeps the report readable, and the
+    // raw capture holds every asset body anyway.
+    if (item.depth === 0) requests.push({ url: item.url, outcome, bytes: res.status === "ok" ? res.bytes : undefined });
+    if (res.status !== "ok") continue;
+    if (item.depth === 0) rootAnswered = true;
+
+    for (const p of playersIn(res.body)) players.add(p);
+    record(scanBody(res.body, res.contentType, item.depth === 0 ? "root" : `d${item.depth}`));
+
+    if (item.depth < 2) {
+      for (const next of assetsFrom(res.body, item.url)) {
+        if (!fetched.has(next)) {
+          queue.push({ url: next, depth: item.depth + 1, accept: "application/json, application/javascript" });
+        }
+      }
+    }
+  }
+
+  const playableFirstParty = firstParty.filter((h) => isPlayableKind(h.kind));
+  const verdict: CandidateResult["verdict"] = !rootAnswered
+    ? "unreachable"
+    : playableFirstParty.length > 0
+      ? "playable-stream"
+      : firstParty.length > 0
+        ? "stream-not-playable"
+        : players.size > 0
+          ? "player-but-no-url"
+          : "no-stream-found";
+
+  return {
+    key: c.key,
+    label: c.label,
+    country: c.country,
+    region: c.region,
+    note: c.note,
+    verdict,
+    requests,
+    assetsFetched,
+    players: [...players],
+    firstParty,
+    thirdParty,
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+async function exitIp(): Promise<string> {
+  // Recorded next to every result because this machine runs a VPN that blackholes some
+  // hosts and 403s others, and those read exactly like "no stream here".
+  try {
+    const res = await fetch("https://api.ipify.org?format=json", { signal: AbortSignal.timeout(8_000) });
+    if (!res.ok) return `unknown (http ${res.status})`;
+    return ((await res.json()) as { ip?: string }).ip ?? "unknown";
+  } catch {
+    return "unknown (lookup failed)";
+  }
+}
+
+async function main() {
+  const targets = CANDIDATES.filter((c) => !ONLY || ONLY.includes(c.key));
+  if (!targets.length) {
+    console.error(`No candidates matched --only=${ONLY?.join(",")}`);
+    process.exit(1);
+  }
+
+  const ip = REPLAY ? "replay (no network)" : await exitIp();
+  console.log(`Stage B sweep: ${targets.length} operator portals, exit IP ${ip}\n`);
+
+  const results: CandidateResult[] = [];
+  for (const [i, c] of targets.entries()) {
+    process.stdout.write(`[${i + 1}/${targets.length}] ${c.key} ... `);
+    const r = await runCandidate(c);
+    results.push(r);
+    const playable = r.firstParty.filter((h) => isPlayableKind(h.kind)).length;
+    console.log(`${r.verdict}${playable ? ` (${playable} playable)` : ""} [${r.assetsFetched} assets]`);
+  }
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  const report = { version: 1, ranAt: new Date().toISOString(), exitIp: ip, replay: REPLAY, results };
+  writeFileSync(join(OUT_DIR, "sweep.json"), JSON.stringify(report, null, 2) + "\n", "utf8");
+
+  const by = (v: CandidateResult["verdict"]) => results.filter((r) => r.verdict === v);
+  console.log("\n--- summary ---");
+  console.log(`playable stream found : ${by("playable-stream").length}`);
+  console.log(`stream, not playable  : ${by("stream-not-playable").length}`);
+  console.log(`player but no URL     : ${by("player-but-no-url").length}   <- video exists, search unfinished`);
+  console.log(`no stream found       : ${by("no-stream-found").length}`);
+  console.log(`unreachable (our fail): ${by("unreachable").length}`);
+  for (const r of by("playable-stream")) {
+    const sample = r.firstParty.filter((h) => isPlayableKind(h.kind))[0];
+    console.log(`  LIVE ${r.key.padEnd(16)} ${r.firstParty.length} hits  e.g. ${sample?.kind} ${sample?.url.slice(0, 92)}`);
+  }
+  for (const r of by("player-but-no-url")) {
+    console.log(`  PLYR ${r.key.padEnd(16)} ${r.players.join(", ")}`);
+  }
+  console.log(`\nwrote ${join(OUT_DIR, "sweep.json")}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Stage A concluded castlerock was a refusal — 97 stream URLs, all Divas, all 401. That
came from **two of the feed's ten systems**. The census disagrees, and the sample had
been the pessimistic half.

Castle Rock is not one backend behind one wall. It is a portal platform in front of
whatever streaming stack each agency runs, and the agency-owned ones are frequently open.

| agency | video host | measured |
|---|---|---|
| NYSDOT | `s*.nysdot.skyvdn.com` | **1,568 of 1,568 live** |
| Nevada DOT | `d*wse*.its.nv.gov` | **556 of 625 live** |
| Louisiana DOTD | `ITSStreaming*.dotd.la.gov` | **344 of 489 live** |
| Florida DOT | `dis-se*.divas.cloud` | 401 `realm="XEngine"` |
| PennDOT | `pa-se*.arcadis-ivds.com` | 401 `realm="XEngine"` |
| Georgia DOT | `sfs-msc-pub-lq-*.dot.ga.gov` | 401 nginx |

**2,468 cameras carry a stream measured rolling**, judged by the same `judgeHlsPair`
pair-read the rest of the product uses, so a finished recording cannot pass as live. The
product serves 1,467 live cameras today.

Also corrected: **511NY is not stills-only.** Its camera tooltip script has no video
handling, which is what the first read saw; its list API carries video on all 1,568.
Never conclude a feed from one endpoint of it.

## The rule that changed

Divas and Arcadis IVDS both answer `Basic realm="XEngine"` — so the **engine** is what to
recognise, not the reseller.

Better still, Castle Rock rows carry `isVideoAuthRequired`, and it agreed with the probe on
every system that could be compared. Hosts the operator marks as locked are now recorded as
refused **without a request**: 70 hosts, 5,085 cameras, unprobed. Re-asking NCDOT to
rediscover a "no" it publishes would be noise, not evidence.

## Also here

- **`liveness-sweep.mts`** sweeps 65 operator portals two hops deep, following the JS
  bundles Stage A named as its weakest limit. It detects player libraries, so "video
  exists, URL not found" stops reading as "no video" — which is how Georgia was caught
  loading video.js with no stream URL on any page.
- **Six systems the adapter does not read**, found by sending its own POST to state portals
  (Nevada, North Carolina, Pennsylvania, Arizona, Connecticut, Alaska — ~4,400 cameras).
  They stay in the script rather than in `CASTLEROCK_SYSTEMS`: adding a system changes what
  the product serves, and that is a reviewed change, not a side effect of a measurement.
- The admit meter animated `width` next to a decoding video, on a deck whose whole job is
  judging whether video stutters. It scales now. The early-reject warning had the only
  `border-left` in the file; rebuilt to match `.adm-env`.

## Three bugs this found in itself

All the same family as Stage A's — a measurement that quietly reports its own failure as
the world's answer.

- Coordinates are **WKT**, not `latitude`/`longitude`, so every row failed to place and the
  first seeding wrote an empty queue **in silence**. The seeder now reports what it could
  not place.
- Holding 17,000 rows got the run OS-killed twice. It folds pages into counters and keeps
  12 examples per host, so peak memory scales with hosts (~96), not cameras.
- Probing is 20 minutes of mostly sleeping, so a kill threw away a finished inventory. Two
  phases, two files, verdict written after every host — `--probe` resumes.

## What this does not do

**Nothing reaches the map.** 40 cameras are queued for review, round-robined across all
three operators and all 14 live hosts, and the serving gate still passes only what a person
has watched in `/admin/live`. No credentials are ever sent, and a 401 is never retried with
a forged Referer — the unblock for a refused agency is a permission request, not code.

Gate: `npx tsc --noEmit` clean, 336 files / 3,399 tests passing.
