### PR TITLE
Give a drawn Streets board a way back to the question

### DIFF
--- a/components/console/WallWorkspace.tsx
+++ b/components/console/WallWorkspace.tsx
@@ -8,6 +8,7 @@ import { readingOrder, COLS, ROW_PX, GAP_PX } from "@/lib/terminal/layoutGrid";
 import { useGridDrag, gridArea, type ResizeDir } from "@/lib/terminal/useGridDrag";
 import { visibleShell } from "@/lib/terminal/rowBudget";
 import { SKIP_TARGET_ID } from "@/components/shell/SkipLink";
+import { clearMonitorArea } from "@/lib/console/widgets/camslot.apply";
 
 // The camera wall: ONE free twelve-column grid of tiles, and no map in it.
 //
@@ -45,6 +46,14 @@ import { SKIP_TARGET_ID } from "@/components/shell/SkipLink";
 
 /** The eight resize handles, in the order they are painted. */
 const HANDLES: ResizeDir[] = ["n", "s", "e", "w", "ne", "nw", "se", "sw"];
+
+/** Into ConsoleShell's single `.tn-toast` live region. Inlined because there is
+ *  no shared helper to import: every caller in the tree dispatches this event
+ *  directly, and CameraTray keeps a local `toast` of exactly this shape. A
+ *  module for it would be a change to all of them, not to this one. */
+function toast(message: string): void {
+  window.dispatchEvent(new CustomEvent("tn-toast", { detail: message }));
+}
 
 export default function WallWorkspace({
   style,
@@ -184,6 +193,38 @@ export default function WallWorkspace({
           state it matters in. The same goes for adding a tile — the map's "PICK
           CAMERAS" flow is the other door, and it is behind the same closed dock. */}
       <div className="tn-wall-bar">
+        {/* THE WAY BACK TO THE QUESTION. `StreetsPrompt` — the only thing that
+            explains the gesture and the only control that starts it — renders
+            over the map at zero tiles and unmounts the moment the first nine
+            land, so a drawn board had nothing on it offering another area.
+
+            IT IS NOT THE FIRST WAY BACK, and the difference is the reason this
+            exists rather than being a duplicate. `resetActiveBoard()` — the ⟲ in
+            TerminalHeader and ⌘K's "Reset … to its default layout" — already
+            emptied the board. But it restores the preset TEMPLATE, which for
+            Streets carries `STREETS_DEFAULT_AREA`: reset leaves you monitoring
+            the authored San Diego ring again, and drops the board's saved edits
+            on the way. This lets go of the area instead of swapping in a
+            different one, touches nothing but the open board, and is labelled
+            for the thing the user came to do.
+
+            It CLEARS rather than clearing-and-arming; camslot.apply.ts records
+            the measurement behind that. Emptying the board is what brings the
+            prompt back, and the prompt asks the question and carries the button
+            that starts the draw. */}
+        <button
+          type="button"
+          className="tn-wall-btn"
+          title="Clear the board and draw a different area to monitor"
+          onClick={() => {
+            // The toast names what happened, because clearing swaps nine tiles
+            // for a full-bleed map in one frame — a big enough change to read as
+            // something having gone wrong rather than as the board asking again.
+            if (clearMonitorArea()) toast("Board cleared — draw an area to fill it again.");
+          }}
+        >
+          New area
+        </button>
         <button
           type="button"
           className="tn-wall-btn"

--- a/lib/console/widgets/camslot.apply.ts
+++ b/lib/console/widgets/camslot.apply.ts
@@ -76,6 +76,39 @@ export function tilesToLayout(
   return arrangeBoard(next, rows);
 }
 
+/**
+ * The board's row budget, read from the window it is being drawn in.
+ *
+ * Shared by every path that re-arranges the wall, so a redraw and a first draw
+ * cannot disagree about how many rows exist. The SSR fallback is a number
+ * rather than a throw because this module is imported by code that is evaluated
+ * on the server; nothing calls into it there.
+ */
+function visibleRows(): number {
+  return Math.floor((typeof window === "undefined" ? 900 : window.innerHeight) / (ROW_PX + GAP_PX));
+}
+
+/**
+ * The board with its area let go: no tiles, no ring. PURE for the same reason
+ * `tilesToLayout` is — the arithmetic is testable without a store or a map.
+ *
+ * `watch` is DELETED, not set to `null` and not set to an empty ring, and that
+ * is the one subtle line here. `lib/console/types.ts` states the contract it
+ * rests on: the key's ABSENCE is the untouched state, because `layoutSignature()`
+ * runs the layout through `JSON.stringify`, which drops `undefined` and keeps
+ * `null`. A board that has just been emptied carrying `watch: null` would light
+ * the "customised" dot — the opposite of what clearing it says.
+ */
+export function clearedWall(l: ShellLayout, rows: number): ShellLayout {
+  let next = l;
+  for (const w of [...l.widgets]) next = removeWidget(next, w.id);
+  const arranged = arrangeBoard(next, rows);
+  if (!("watch" in arranged)) return arranged;
+  const cleared = { ...arranged };
+  delete cleared.watch;
+  return cleared;
+}
+
 export interface ApplyResult { ok: boolean; message: string; created: number }
 
 /** Put a planned wall onto the open board and remember the area that made it. */
@@ -95,7 +128,7 @@ export function applyMonitorPlan(plan: MonitorPlan, ring: readonly [number, numb
   if (shellLayoutStore.get().mode !== "wall") {
     return { ok: false, message: "That area needs a camera wall — switch to Streets and draw it again.", created: 0 };
   }
-  const rows = Math.floor((typeof window === "undefined" ? 900 : window.innerHeight) / (ROW_PX + GAP_PX));
+  const rows = visibleRows();
   shellLayoutStore.replace((l) => ({
     ...tilesToLayout(l, plan.tiles, rows, nextWidgetId),
     watch: { ring: [...ring] as [number, number][] },
@@ -129,6 +162,52 @@ export function startStreetsArea(): { ok: boolean; message?: string } {
   });
   return ok ? { ok: true } : { ok: false, message: "Could not start drawing." };
 }
+
+/**
+ * Empty the open wall and let go of its area — the way back to the prompt.
+ *
+ * Guarded on `mode === "wall"` for the reason `applyMonitorPlan` is: this
+ * removes EVERY widget on the open board, so reaching it from a rails board
+ * would delete an Infrastructure or Intel board rather than a camera wall.
+ *
+ * THE DOCK IS FORCED OPEN, because `dockSize` checks `collapsed` BEFORE the
+ * empty-wall exception (lib/terminal/rails.ts). Clearing a board whose dock is
+ * closed would otherwise leave a 0px map, so the prompt this hands back to would
+ * have no width to render into and the board would look simply broken. Same
+ * reasoning the wall bar's "Map" button carries.
+ */
+export function clearMonitorArea(): boolean {
+  if (shellLayoutStore.get().mode !== "wall") return false;
+  const rows = visibleRows();
+  shellLayoutStore.replace((l) => clearedWall(l, rows));
+  shellLayoutStore.collapseSegment("right", false);
+  return true;
+}
+
+// ── WHY THIS DOES NOT ALSO ARM THE GESTURE ───────────────────────────────────
+//
+// The obvious next step is a `redrawStreetsArea()` that clears the board and
+// then calls `startStreetsArea()`, saving the user a click. It was written and
+// it does not work, for a reason worth recording because the next person will
+// try it too.
+//
+// Clearing the board is what MOUNTS `StreetsPrompt` (ConsoleWorkspace renders it
+// on `widgets.length === 0`), and that component's whole contract is to cancel
+// any live gesture when it unmounts — an armed circle holds pointer capture and
+// `dragPan.disable()`, so one left behind makes the map silently refuse to pan.
+// Under React StrictMode, which Next turns on in development by default, an
+// effect is mounted, torn down and mounted again in one commit, so that cleanup
+// fires immediately and cancels the gesture armed a moment earlier.
+//
+// Measured on the dev server at 1440x900: arming while the prompt is ALREADY
+// mounted leaves it live ("Press on the map and drag out from the centre");
+// arming in the same tick the prompt mounts leaves it idle ("Every camera inside
+// it fills the board"). The gesture was gone before the user could press.
+//
+// A `requestAnimationFrame` would step around it, and that is exactly the shape
+// to avoid: it makes the gesture depend on winning a race against a commit. So
+// clearing hands back to the prompt, and the prompt's own button — the one path
+// that is already proven — arms the draw.
 
 function toast(message: string): void {
   if (typeof window === "undefined") return;

--- a/tests/unit/camslot-apply.test.ts
+++ b/tests/unit/camslot-apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyMonitorPlan, tilesToLayout } from "@/lib/console/widgets/camslot.apply";
+import { applyMonitorPlan, clearMonitorArea, clearedWall, tilesToLayout } from "@/lib/console/widgets/camslot.apply";
 import { shellLayoutStore } from "@/lib/console/store";
 import { createDefaultLayout } from "@/lib/console/types";
 import type { FanOutTile } from "@/lib/console/widgets/camslot.fanout";
@@ -105,5 +105,71 @@ describe("applyMonitorPlan only lands on the board that asked for it", () => {
     // The board it already drew survives — an empty result is not an instruction
     // to throw away the last one that worked.
     expect(shellLayoutStore.get().widgets).toHaveLength(2);
+  });
+});
+
+describe("clearing the area — the way back off a drawn board", () => {
+  const ring: [number, number][] = [[0, 0], [1, 0], [1, 1]];
+  const plan = (n: number) => ({
+    tiles: Array.from({ length: n }, (_, i) => tile(`t${i}`, 2)),
+    found: n * 2,
+    live: n,
+    message: `${n} tiles`,
+  });
+
+  it("removes every tile, which is what brings the prompt back", () => {
+    // The prompt renders on `layout.widgets.length === 0` and nothing else, so
+    // this assertion IS the assertion that the board becomes askable again.
+    const drawn = tilesToLayout(wall(), [tile("a", 1), tile("b", 1)], 28, minter());
+    expect(clearedWall(drawn, 28).widgets).toEqual([]);
+  });
+
+  it("DELETES the watch key rather than nulling it", () => {
+    // Not a style point. `lib/console/types.ts`: the key's absence is the
+    // untouched state, because `layoutSignature()` goes through JSON.stringify,
+    // which drops `undefined` and keeps `null`. Setting `watch: null` would light
+    // the "customised" dot on a board that was just emptied. `toBeUndefined()`
+    // would pass either way, so this asserts on the KEY.
+    const drawn = { ...tilesToLayout(wall(), [tile("a", 1)], 28, minter()), watch: { ring } };
+    expect("watch" in drawn).toBe(true);
+    expect("watch" in clearedWall(drawn, 28)).toBe(false);
+  });
+
+  it("is idempotent on a board that is already clear", () => {
+    const once = clearedWall(wall(), 28);
+    expect(clearedWall(once, 28)).toEqual(once);
+  });
+
+  it("clears the live board through the store", () => {
+    shellLayoutStore.replace(wall());
+    expect(applyMonitorPlan(plan(4), ring).ok).toBe(true);
+    expect(shellLayoutStore.get().widgets).toHaveLength(4);
+
+    expect(clearMonitorArea()).toBe(true);
+    expect(shellLayoutStore.get().widgets).toEqual([]);
+    expect(shellLayoutStore.get().watch).toBeUndefined();
+  });
+
+  it("opens the dock, because a closed one leaves the prompt no map to render into", () => {
+    // `dockSize` checks `collapsed` BEFORE its empty-wall exception, so clearing
+    // a board whose dock is closed would hand the prompt a 0px stage — the board
+    // would look broken rather than askable.
+    shellLayoutStore.replace(wall());
+    expect(applyMonitorPlan(plan(4), ring).ok).toBe(true);
+    shellLayoutStore.collapseSegment("right", true);
+    expect(shellLayoutStore.get().segments.right.collapsed).toBe(true);
+
+    expect(clearMonitorArea()).toBe(true);
+    expect(shellLayoutStore.get().segments.right.collapsed).toBe(false);
+  });
+
+  it("REFUSES a board that is not a wall, for the reason applyMonitorPlan does", () => {
+    // Same hazard, opposite direction: this removes every widget on the open
+    // board, so reaching it from a rails board would delete an Infrastructure or
+    // Intel board rather than a camera wall.
+    shellLayoutStore.replace({ ...createDefaultLayout(), mode: "rails" as const });
+    const before = shellLayoutStore.get();
+    expect(clearMonitorArea()).toBe(false);
+    expect(shellLayoutStore.get()).toBe(before);
   });
 });


### PR DESCRIPTION
Sampo, on the merged Streets board: *"theres no way to reset it. or do it again"*. He is right — the board was a one-way door.

`StreetsPrompt` is the only thing that explains the circle gesture and the only control that starts it, and it renders over the map **only while the wall holds zero tiles**. The moment the first nine land it unmounts, and nothing on the board offers another area.

## This is not the first way back, and that is the point

`resetActiveBoard()` — the ⟲ in `TerminalHeader` and ⌘K's *"Reset … to its default layout"* — already emptied the board. It is the wrong instrument for this:

| | `resetActiveBoard()` | **New area** |
|---|---|---|
| what it restores | the preset **template** — for Streets that is `STREETS_DEFAULT_AREA`, so you are monitoring the authored San Diego ring again | lets go of the area entirely |
| blast radius | also drops the board's saved edits (`forgetBoardLayout`) | the open board only |
| what it is called | "Reset Streets to its default layout" / a bare ⟲ glyph | what the user came to do |

## Shape

`clearedWall(layout, rows)` is pure, beside `tilesToLayout` and for the same reason. It **deletes** the `watch` key rather than nulling it: `lib/console/types.ts` states that the key's absence is the untouched state, because `layoutSignature()` goes through `JSON.stringify`, which drops `undefined` and keeps `null` — a just-emptied board carrying `watch: null` would light the "customised" dot.

`clearMonitorArea()` carries `applyMonitorPlan`'s **wall guard**, because it removes every widget on the open board and reaching it from a rails board would delete an Infrastructure or Intel board. It also **forces the dock open**, since `dockSize` checks `collapsed` *before* its empty-wall exception, so a closed dock would hand the prompt a 0px map.

## It clears rather than clearing-and-arming, and that was measured

The obvious version saves a click: clear, then `startStreetsArea()`. It does not work. Clearing is what **mounts** `StreetsPrompt`, whose contract is to cancel any live gesture on unmount; under StrictMode the mount/cleanup/mount cycle fires that cleanup immediately.

Measured on the dev server at 1440×900:

- armed while the prompt was **already mounted** → live: *"Press on the map and drag out from the centre"*
- armed **in the same tick the prompt mounts** → idle: *"Every camera inside it fills the board"*

A `requestAnimationFrame` steps around it by winning a race against a commit, so the button hands back to the prompt's own button instead. The rejected approach is recorded in `camslot.apply.ts` so the next reader does not re-derive it.

## Verification

Browser, 1440×900: draw → 9 tiles + the bar; **New area** → 0 tiles, prompt back, map full-bleed, toast; draw a *different* area → 9 tiles; second round trip clean.

Three new guards, each **watched go red** before being kept:

| mutation | test that failed |
|---|---|
| `delete cleared.watch` → `watch: undefined` | "DELETES the watch key rather than nulling it" |
| wall guard removed | "REFUSES a board that is not a wall" |
| dock left collapsed | "opens the dock, because a closed one leaves the prompt no map" |

Bar width at the narrowest possible wall (`WALL_MIN_PX` 360): four buttons need **272px of 358px**, `scrollWidth === clientWidth`, measured at the real `--tnx-fs-xs` of 11px.

`npx tsc --noEmit` clean. 17/17 in `camslot-apply.test.ts`.

## Known, and not caused by this branch

- **`scripts/verify-streets-area.mjs` is 8/9.** The one failure is *"video actually plays"* (0/36 at that point in the run) — the check this branch has always recorded as knife-edge (1/27, 0/36, 1/27 across earlier runs). In the **same run**, *rotation paint rate* measured **20 of 20 switches painting, avg 486 ms**, and *rotation churn* passed, so video is healthy; the binary check samples a moment when nothing had loaded. Independently corroborated at the proxy: 3 of 5 cameras inside the default Streets area answered `502 upstream error` while `mup-rs` and `putevi-rs` served manifests fine.
- **`tests/unit/inspector-routing.test.ts` → "a toggle inside an area is not captured as the variant's override" is flaky**, timing out at 5000ms around its `await import`. Measured failing at `HEAD` with these changes reverted — do not attribute it to this diff.
- The pre-existing reload hydration mismatch is unchanged.