### PR TITLE
Guard the import pattern that put this suite red, and correct why it did

### DIFF
--- a/tests/unit/inspector-routing.test.ts
+++ b/tests/unit/inspector-routing.test.ts
@@ -2,12 +2,20 @@ import { beforeEach, expect, test } from "vitest";
 import { inspectorStore, sourceRegions } from "@/lib/shell/inspector";
 import { DEFAULT_STATE, layersStore } from "@/lib/layers";
 import { signalsStore } from "@/lib/signals/store";
-// Static, not `await import(...)` inside a test body. Loading the store pulls the
-// whole signal registry, and vitest bills that to whichever test triggers it — which
-// put these two within a few hundred ms of the 5s timeout and made them fail under
-// full-suite parallel load every time a signal was added. The module has no top-level
-// side effects (captureOverride subscribes in bootstrap()), so this is a move, not a
-// behaviour change; three other test files already import it this way.
+// Static, not `await import(...)` inside a test body. Loading this module pulls the whole
+// signal registry, and vitest bills that load to whichever TEST triggers it rather than to
+// collect — which left two tests here spending ~1.8s of a 5s budget doing nothing but
+// importing, and going red whenever the machine was busy.
+//
+// It was NOT caused by the registry growing, though that was the first and most convincing
+// explanation. A peer reproduced both failures on a branch whose registry is byte-identical
+// to main, which is what ruled it out. Registry size, an extra test file, and someone
+// else's build in another worktree are all just ways to spend the same headroom.
+//
+// The module has no top-level side effects (captureOverride subscribes in bootstrap()), so
+// hoisting is a move and not a behaviour change; three other test files already import it
+// this way. Guarded by no-registry-import-in-test-body.test.ts, which explains there why
+// the guard is structural rather than a timeout.
 import { variantStore } from "@/lib/variants/store";
 
 const RING: [number, number][] = [

--- a/tests/unit/no-registry-import-in-test-body.test.ts
+++ b/tests/unit/no-registry-import-in-test-body.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Guards the one import pattern that has actually put this suite red.
+ *
+ * THE DEFECT. `await import("...")` inside a test BODY makes vitest charge the whole
+ * module-graph load to that test's `testTimeout`. The same import at the top of the file
+ * is charged to `collect`, which is not on the budget. Same modules, same work — only the
+ * accounting moves. Two tests in inspector-routing.test.ts spent ~1.8s of a 5s budget
+ * doing nothing but importing; hoisting took them to 25ms.
+ *
+ * WHY IT WAS HARD TO SEE. It fails by machine LOAD, not by code, so every author blames
+ * their own diff. Three agents did exactly that in one afternoon before one of them
+ * reproduced both failures on a branch whose registry was byte-identical to main.
+ *
+ * WHY THIS IS NOT A TIMEOUT ASSERTION. A tighter timeout was tried first and does not
+ * work. With the hoist reverted, a 2s timeout PASSED at 1,345ms — green on the exact
+ * regression it existed to catch. The same import measured ~1.3s idle, ~2.6s busy, and
+ * over 5,021ms on a box also running a dev server and a Playwright gate. Correct-fast and
+ * broken-slow are one distribution three orders wide, so no threshold separates them. A
+ * runtime check is no better: it has to execute the import to observe it, inheriting the
+ * timing it is trying to escape. Structural, on the source, is the only stable form.
+ *
+ * WHY IT IS SCOPED TO THESE MODULES AND NOT TO EVERY DYNAMIC IMPORT. ~37 other in-body
+ * `await import(...)` calls exist across 8 test files, and banning all of them was the
+ * first instinct. Measured before acting: their slowest test is 534ms, because they pull
+ * console stores rather than the signal registry. Condemning 37 working call sites to
+ * prevent a half-second is not a trade worth making, and a guard that has to be argued
+ * with gets deleted. The registry graph is the one that is expensive, so it is the one
+ * that is guarded — with room to add a module here the day another proves costly.
+ */
+
+/** Prefixes whose graphs pull the signal registry — the expensive one. */
+const HEAVY = ["@/lib/signals", "@/lib/variants", "@/lib/layers"];
+
+const TEST_DIR = join(process.cwd(), "tests", "unit");
+
+function offendersIn(file: string): string[] {
+  const source = readFileSync(join(TEST_DIR, file), "utf8");
+  const found: string[] = [];
+  source.split("\n").forEach((raw, i) => {
+    const line = raw.trim();
+    // Prose about the pattern is not the pattern. This very file, and the explanatory
+    // comment in inspector-routing.test.ts, both describe it in words on purpose.
+    if (line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) return;
+    const m = /await\s+import\(\s*["'`]([^"'`]+)["'`]/.exec(line);
+    if (m && HEAVY.some((h) => m[1] === h || m[1].startsWith(`${h}/`))) {
+      found.push(`${file}:${i + 1} imports ${m[1]}`);
+    }
+  });
+  return found;
+}
+
+describe("the signal registry is never loaded inside a test body", () => {
+  test("no test file dynamically imports a registry-backed module", () => {
+    const files = readdirSync(TEST_DIR).filter((f) => f.endsWith(".test.ts"));
+    // A guard that silently stops reading files passes forever. Pin that it found the suite.
+    expect(files.length).toBeGreaterThan(50);
+    expect(files.flatMap(offendersIn)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-on to #204. Two changes, both about the same defect.

## The cause I gave in #204 was wrong

I said registering the 33rd signal tipped `inspector-routing`'s two tests over their 5s timeout. **It didn't.** A peer reproduced both failures on a branch whose registry is byte-identical to `main`.

The real cost is `await import(...)` inside a test **body**: vitest bills the whole module-graph load to that test's timeout, while the same import at the top of the file is billed to `collect` and is free. It fails by machine *load*, not by code — registry size, an extra test file, and someone else's build in another worktree are all just ways to spend the same headroom. Three of us each blamed our own diff before that ruled it out. The comment in the file now says so, including how it was ruled out.

## A guard, because a hoist nobody watches gets undone

**A tighter timeout was the obvious guard and it does not work — I tried it first.** With the hoist reverted, a 2s timeout **passed at 1,345ms**: green on the exact regression it existed to catch.

The reason no threshold works is the spread. Same import, measured across three machines' worth of load:

| Condition | Cost |
|---|---|
| Idle box | ~1.3s |
| Busy box | ~2.6s |
| Dev server + Playwright gate driving Chromium | **>5,021ms** |

Correct-fast and broken-slow aren't two distributions you can put a line between — they're one distribution three orders wide, and the tail is set by what else is on the machine. Any bound tight enough to always catch the regression is one correct code trips under contention. A runtime check fails the same way, since it has to execute the import to observe it.

So the assertion is structural, on the source, and runs in **121ms**.

## Why it's scoped, not a blanket ban

Banning every in-body dynamic import was my first instinct and two reviewers suggested it, so I measured before acting: **~37 other in-body `await import(...)` calls exist across 8 test files, and their slowest test is 534ms** — they pull console stores, not the signal registry.

Condemning 37 working call sites to prevent half a second isn't a trade worth making, and a guard you have to argue with gets deleted. So it's scoped to the registry-backed prefixes (`@/lib/signals`, `@/lib/variants`, `@/lib/layers`). Adding a module is one line the day another proves costly.

## Watched fail before I kept it

With the `await import` restored it reports `inspector-routing.test.ts:241 imports @/lib/variants/store`; with the hoist it passes. It also pins that it found the suite, so a guard that silently stops reading files can't pass forever.

## Files

- `tests/unit/no-registry-import-in-test-body.test.ts` — the guard
- `tests/unit/inspector-routing.test.ts` — corrected explanation of the cause

Gate: `tsc` clean, **3622/3622**. Written with Claude Code.
