### PR TITLE
Stop reporting a rolled-off HLS segment as our gateway failing

### DIFF
--- a/app/api/hls/route.ts
+++ b/app/api/hls/route.ts
@@ -2,6 +2,16 @@ import type { NextRequest } from "next/server";
 import { getCameraById } from "@/lib/sources/registry";
 import { isHlsAllowed } from "@/lib/proxy/hls-allowlist";
 import { rewritePlaylist } from "@/lib/proxy/hls-rewrite";
+import {
+  PLAYLIST_CACHE_CONTROL,
+  SEGMENT_BROWSER_TTL_SECONDS,
+  SEGMENT_SHARED_TTL_SECONDS,
+  describeFetchError,
+  isPlaylistResponse,
+  isServableUpstream,
+  statusForUpstream,
+} from "@/lib/proxy/hls-response";
+import { browserAndEdgeHeaders } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -39,19 +49,32 @@ export async function GET(req: NextRequest) {
       redirect: "error",
       signal: AbortSignal.timeout(10_000),
     });
-  } catch {
+  } catch (err) {
+    // Logged rather than swallowed: a bare `catch {}` here meant every transport-level
+    // failure — DNS, TLS, connection reset, the 10 s abort — arrived as one
+    // indistinguishable 502 with nothing written down, so there was no way to tell
+    // which had happened without reproducing it by hand.
+    console.warn(`[hls] fetch failed for ${target.host}${target.pathname}: ${describeFetchError(err)}`);
     return new Response("upstream fetch failed", { status: 502 });
   }
-  if (!res.ok && res.status !== 206) return new Response("upstream error", { status: 502 });
+
+  // A non-2xx upstream is reported as itself where that is the honest answer — see
+  // lib/proxy/hls-response.ts. The case that matters in practice is 404 on a segment
+  // that has rolled out of the live window, which is normal and is not our failure.
+  if (!isServableUpstream(res.status)) {
+    return new Response("upstream error", { status: statusForUpstream(res.status) });
+  }
 
   const ct = res.headers.get("content-type");
-  const isPlaylist = (ct?.includes("mpegurl") ?? false) || target.pathname.toLowerCase().endsWith(".m3u8");
 
-  if (isPlaylist) {
+  if (isPlaylistResponse(ct, target.pathname)) {
     const body = await res.text();
     return new Response(rewritePlaylist(body, target.toString()), {
       status: 200,
-      headers: { "Content-Type": "application/vnd.apple.mpegurl", "Cache-Control": "no-store" },
+      headers: {
+        "Content-Type": "application/vnd.apple.mpegurl",
+        "Cache-Control": PLAYLIST_CACHE_CONTROL,
+      },
     });
   }
 
@@ -61,6 +84,10 @@ export async function GET(req: NextRequest) {
   const cr = res.headers.get("content-range"); if (cr) headers.set("Content-Range", cr);
   const cl = res.headers.get("content-length"); if (cl) headers.set("Content-Length", cl);
   headers.set("Accept-Ranges", "bytes");
-  headers.set("Cache-Control", "public, max-age=5");
+  for (const [k, v] of Object.entries(
+    browserAndEdgeHeaders(SEGMENT_BROWSER_TTL_SECONDS, SEGMENT_SHARED_TTL_SECONDS),
+  )) {
+    headers.set(k, v);
+  }
   return new Response(res.body, { status: res.status, headers });
 }

--- a/lib/proxy/hls-response.ts
+++ b/lib/proxy/hls-response.ts
@@ -1,0 +1,98 @@
+// How /api/hls answers when the upstream does not return the bytes we asked for.
+//
+// WHY THIS EXISTS. The route used to collapse every non-OK upstream response into a
+// single `502 upstream error`. Measured on prod over 80 minutes on 2026-09-09: 389
+// responses of 502, ALL of them /api/hls, and 376 of the 382 distinct upstream URLs
+// behind them were `.ts` SEGMENTS on wzmedia.dot.ca.gov. Fetching one of those from
+// the box returns 404 in ~0.35 s; a segment still inside the live window returns 200
+// in ~0.6 s. So the upstream was healthy and reachable the whole time.
+//
+// A live HLS stream keeps a rolling window of a few segments and drops the rest. A
+// player that stalls — a backgrounded phone tab, and this site's traffic is mostly
+// mobile — comes back and asks for a segment that has since rolled off. The upstream
+// says 404, which is the correct and expected answer. Reporting that as 502 claims
+// OUR gateway failed, which is false, and it buried the error budget: 100% of the
+// site's 502s were this, so a real one had nowhere to show up.
+//
+// WHAT THIS DOES NOT CLAIM. Passing the status through does not stop players asking
+// for expired segments — that is inherent to proxying live HLS to mobile clients, and
+// the request count is unchanged. What changes is that the answer is now true, and a
+// 502 in the log once again means a gateway actually failed.
+
+/**
+ * The status /api/hls should serve, given what the upstream returned.
+ *
+ * - 2xx passes through unchanged, which keeps `206 Partial Content` intact for range
+ *   requests. Collapsing that to 200 would break seeking.
+ * - 4xx passes through unchanged. The upstream is answering; it is telling us this
+ *   resource is not available to this request. 404 on a rolled-off segment is the
+ *   case that motivated this file, and 403 (hotlink protection refusing our Referer)
+ *   is a fault worth seeing as itself rather than as a generic gateway error.
+ * - Everything else — 5xx, and any 3xx that somehow arrives despite `redirect:
+ *   "error"` — is a genuine bad gateway.
+ */
+export function statusForUpstream(status: number): number {
+  if (status >= 200 && status < 300) return status;
+  if (status >= 400 && status < 500) return status;
+  return 502;
+}
+
+/** Whether `statusForUpstream` treats this upstream status as a body worth serving. */
+export function isServableUpstream(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+/**
+ * Cache policy for a SEGMENT (or any non-playlist body).
+ *
+ * A segment URL names immutable bytes: `media_w929062248_4042.ts` is one fixed piece
+ * of video and re-requesting it can never legitimately return anything else. The
+ * previous `max-age=5` was therefore far shorter than the content allows, and it made
+ * every viewer of the same camera pull every segment through this box again — 48,845
+ * requests and 21.81 GB of origin egress on 2026-09-08 alone.
+ *
+ * Freshness is not at risk, because the PLAYLIST is `no-store`: a player always learns
+ * the current segment list from the upstream, and only then asks for the segments in
+ * it. A cached segment cannot make a stream look newer than it is.
+ *
+ * The shared TTL is deliberately longer than the upstream's own retention. Once a
+ * segment rolls off, the upstream answers 404 — so a cached copy is the difference
+ * between a late player getting its bytes and getting nothing.
+ */
+export const SEGMENT_BROWSER_TTL_SECONDS = 60;
+export const SEGMENT_SHARED_TTL_SECONDS = 600;
+
+/**
+ * Cache policy for a PLAYLIST. Never cached, at any layer.
+ *
+ * A playlist IS the freshness statement of a live stream — it names which segments
+ * exist right now. Serving a stale one hands the player a window that has already
+ * moved, which produces exactly the expired-segment requests this file exists to stop
+ * misreporting.
+ */
+export const PLAYLIST_CACHE_CONTROL = "no-store";
+
+/**
+ * Whether the upstream response is an HLS playlist rather than a media segment.
+ *
+ * Content-Type is checked first because it is what the upstream actually asserts;
+ * the path suffix is the fallback for servers that answer `.m3u8` with a generic
+ * type. Both were in the original route and both are load-bearing.
+ */
+export function isPlaylistResponse(contentType: string | null, pathname: string): boolean {
+  if (contentType?.includes("mpegurl")) return true;
+  return pathname.toLowerCase().endsWith(".m3u8");
+}
+
+/** A short, non-throwing description of a failed fetch, for the log line. */
+export function describeFetchError(err: unknown): string {
+  if (err instanceof Error) {
+    const cause = (err as { cause?: unknown }).cause;
+    const causeCode =
+      cause && typeof cause === "object" && "code" in cause
+        ? ` (${String((cause as { code: unknown }).code)})`
+        : "";
+    return `${err.name}: ${err.message}${causeCode}`;
+  }
+  return String(err);
+}

--- a/tests/unit/hls-response.test.ts
+++ b/tests/unit/hls-response.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "vitest";
+import {
+  PLAYLIST_CACHE_CONTROL,
+  SEGMENT_BROWSER_TTL_SECONDS,
+  SEGMENT_SHARED_TTL_SECONDS,
+  describeFetchError,
+  isPlaylistResponse,
+  isServableUpstream,
+  statusForUpstream,
+} from "@/lib/proxy/hls-response";
+
+// The case this file exists for. Measured on prod 2026-09-09: every one of the site's
+// 502s was /api/hls, and 376 of the 382 distinct upstream URLs behind them were .ts
+// segments answering 404 because they had rolled out of the live window.
+test("a rolled-off segment is reported as 404, not as our gateway failing", () => {
+  expect(statusForUpstream(404)).toBe(404);
+  expect(statusForUpstream(404)).not.toBe(502);
+});
+
+test("410 Gone also passes through rather than becoming 502", () => {
+  expect(statusForUpstream(410)).toBe(410);
+});
+
+test("403 passes through, so hotlink protection is visible as itself", () => {
+  expect(statusForUpstream(403)).toBe(403);
+});
+
+test("206 survives, so range requests keep working", () => {
+  expect(statusForUpstream(206)).toBe(206);
+  expect(statusForUpstream(200)).toBe(200);
+});
+
+test("a broken upstream is still a bad gateway", () => {
+  for (const s of [500, 502, 503, 504]) expect(statusForUpstream(s)).toBe(502);
+});
+
+test("a redirect that escapes redirect:error is a bad gateway", () => {
+  for (const s of [301, 302, 307]) expect(statusForUpstream(s)).toBe(502);
+});
+
+test("only 2xx bodies are served", () => {
+  expect(isServableUpstream(200)).toBe(true);
+  expect(isServableUpstream(206)).toBe(true);
+  expect(isServableUpstream(404)).toBe(false);
+  expect(isServableUpstream(500)).toBe(false);
+});
+
+test("a playlist is detected by content-type or by suffix", () => {
+  expect(isPlaylistResponse("application/vnd.apple.mpegurl", "/D12/x.stream/seg.ts")).toBe(true);
+  expect(isPlaylistResponse("application/octet-stream", "/D12/x.stream/chunklist_w1.m3u8")).toBe(true);
+  expect(isPlaylistResponse("application/octet-stream", "/D12/x.stream/CHUNKLIST.M3U8")).toBe(true);
+  expect(isPlaylistResponse(null, "/D12/x.stream/media_w1_0.ts")).toBe(false);
+  expect(isPlaylistResponse("video/mp2t", "/D12/x.stream/media_w1_0.ts")).toBe(false);
+});
+
+// A playlist IS the freshness statement of a live stream. Caching one hands the player
+// a segment window that has already moved.
+test("playlists are never cached", () => {
+  expect(PLAYLIST_CACHE_CONTROL).toBe("no-store");
+});
+
+// Segments are immutable bytes under a unique name, so the previous max-age=5 was far
+// shorter than the content allows. The shared TTL is deliberately the longer of the two.
+test("segments get a shared TTL longer than the browser one", () => {
+  expect(SEGMENT_SHARED_TTL_SECONDS).toBeGreaterThan(SEGMENT_BROWSER_TTL_SECONDS);
+  expect(SEGMENT_BROWSER_TTL_SECONDS).toBeGreaterThan(5);
+});
+
+test("a fetch failure describes itself, including the transport cause code", () => {
+  const err = new TypeError("fetch failed");
+  (err as { cause?: unknown }).cause = { code: "ECONNRESET" };
+  expect(describeFetchError(err)).toBe("TypeError: fetch failed (ECONNRESET)");
+});
+
+test("a non-Error rejection still produces a usable line", () => {
+  expect(describeFetchError("boom")).toBe("boom");
+  expect(describeFetchError(new Error("timed out"))).toBe("Error: timed out");
+});


### PR DESCRIPTION
Every 502 the site serves is `/api/hls`. I went looking for why after the Instagram traffic, and the answer is that we were mislabelling normal live-video behaviour as our own failure.

## What I measured

Over 80 minutes of the box's access log on 2026-09-09: **389 responses of 502, all of them `/api/hls`**, and **376 of the 382 distinct upstream URLs behind them were `.ts` segments** on `wzmedia.dot.ca.gov`. From the box itself:

- an expired segment → **404 in ~0.35s**
- a segment still inside the live window → **200 in ~0.6s**
- the playlist → **200 in ~0.4s**

So the upstream was healthy and reachable the whole time.

A live HLS stream keeps a rolling window of a few segments and drops the rest. A player that stalls — a backgrounded phone, and this site is mostly mobile — comes back and asks for a segment that has since rolled off. The upstream says 404, which is correct. We turned that into `502 upstream error`, which claims *our* gateway failed. It also buried the error budget: since 100% of the site's 502s were this, a real gateway failure had nowhere to show up.

## What I changed

`statusForUpstream` passes 2xx and 4xx through, and keeps 502 for 5xx and for any redirect that escapes `redirect: "error"`. 206 survives, so range requests still work. 403 now shows as 403, which matters because that is what hotlink protection refusing our Referer would look like.

The bare `catch {}` on the fetch is now logged with the transport cause code. DNS failures, TLS errors, connection resets and the 10s abort all used to arrive as one indistinguishable 502 with nothing written down, so there was no way to tell them apart without reproducing by hand.

Segments now carry a real cache lifetime instead of `max-age=5`. A segment URL names immutable bytes, so this cannot make anything stale — the playlist stays `no-store`, which is what actually governs freshness. A shared copy that outlives the upstream's own window is the difference between a late player getting its bytes and getting nothing. It also takes a bite out of the 21.81 GB `/api/hls` pushed out of the box on 2026-09-08.

## What this does not claim

**This does not stop players asking for expired segments.** That is inherent to proxying live HLS to mobile clients and the request count is unchanged. What changes is that the answer is now true, and a 502 in the log means a gateway actually failed again.

I also nearly changed the wrong thing: I saw one 8.1s upstream fetch and was about to call the 10s timeout too tight, then measured three fresh segments at ~0.6s and dropped it. The timeout is untouched.

`/api/proxy` has the same masking defect on its own upstreams. I left it alone because nothing in the log says it is currently costing us anything — worth a follow-up, not a guess.

## Gate

`npx tsc --noEmit` clean. Full unit suite **370 files / 3,783 tests, all passing**. The three status-passthrough tests were watched go red against the old behaviour before being kept — they failed with `expected 502 to be 404 / 410 / 403` and the other nine stayed green.

Built with Claude Opus 5.
