### PR TITLE
Compress API responses at the edge, which Next was never doing

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -130,10 +130,49 @@ provenance-online.com {
 		lb_try_interval 200ms
 	}
 
-	# NOT adding `encode` on purpose: Next's standalone server already compresses
-	# (`compress` defaults to true), including the ~6.4 MB /api/cameras body it deflates
-	# to roughly a megabyte. A second encoder buys nothing and costs CPU on every
-	# response, on a box with two shared vCPUs.
+	# ENCODE. THE COMMENT THAT USED TO BE HERE WAS WRONG, AND IT WAS EXPENSIVE.
+	#
+	# It said `encode` was deliberately absent because "Next's standalone server already
+	# compresses (`compress` defaults to true), including the ~6.4 MB /api/cameras body
+	# it deflates to roughly a megabyte". That was an assumption about a default, not a
+	# measurement. Taken on this box on 2026-09-09, straight at Next and bypassing Caddy:
+	#
+	#   curl -H 'Accept-Encoding: gzip, br' http://127.0.0.1:3000/api/cameras
+	#     -> 6,747,810 bytes, and NO Content-Encoding header at all.
+	#     -> byte-identical with the header omitted entirely.
+	#
+	# Next does not compress these route handlers, with or without the request header,
+	# and /api/planes behaves the same way. So every byte of API JSON was leaving this
+	# box raw. Measured from the rollup for 2026-09-08: /api/cameras 29.83 GB over 5,049
+	# responses (6,195 KB each) and /api/planes 28.23 GB over 22,916 — 91 of the day's
+	# 93.49 GB, against a bundle allowance of 3 TB/month that the day was tracking at
+	# 2.74 TB.
+	#
+	# WHAT HID IT FOR SO LONG: Cloudflare compresses for the visitor, so the same body
+	# arrives at a browser as 547 KB of brotli. The client saw a small, fast response
+	# while the origin paid the full 6.7 MB on every miss — and every request is a miss,
+	# because Cloudflare caches by file extension by default and `/api/*` has none
+	# (`cf-cache-status: DYNAMIC` on cameras, planes and coverage, measured the same day).
+	#
+	# THE MATCHER IS NOT DECORATION. /api/hls is 21.81 GB/day of already-compressed video
+	# and /api/proxy serves JPEG frames; pushing either through gzip spends CPU on two
+	# shared vCPUs to make the bytes very slightly bigger. Only text-shaped types are
+	# compressed, which also leaves the segment path streaming unbuffered exactly as the
+	# reverse_proxy comment above requires.
+	encode {
+		zstd
+		gzip 5
+		minimum_length 1024
+		match {
+			header Content-Type text/*
+			header Content-Type application/json*
+			header Content-Type application/geo+json*
+			header Content-Type application/javascript*
+			header Content-Type application/xml*
+			header Content-Type application/vnd.apple.mpegurl*
+			header Content-Type image/svg+xml*
+		}
+	}
 
 	# THE ACCESS LOG IS IP-MASKED, AND app/(site)/privacy PROMISES THAT IN WRITING.
 	# Caddy's default JSON encoder writes request>remote_ip and request>client_ip in


### PR DESCRIPTION
The box pushed **93.49 GB out on 2026-09-08** — a 2.74 TB/month pace against the Lightsail bundle's 3 TB. 97% of it was `/api`. I went looking for why and found that we have never compressed a single API response.

## What I measured

The Caddyfile said `encode` was deliberately absent because *"Next's standalone server already compresses (`compress` defaults to true), including the ~6.4 MB /api/cameras body it deflates to roughly a megabyte"*. That was an assumption about a default, not a measurement. Straight at Next on the box, bypassing Caddy:

```
curl -H 'Accept-Encoding: gzip, br' http://127.0.0.1:3000/api/cameras
  -> 6,747,810 bytes, and no Content-Encoding header at all
  -> byte-identical with the header omitted entirely
```

It does not compress these route handlers either way. `/api/planes` behaves the same. So every byte of API JSON has been leaving the box raw.

From the rollup for 2026-09-08:

| route | responses | GB/day | per response |
|---|---|---|---|
| `/api/cameras` | 5,049 | 29.83 | 6,195 KB |
| `/api/planes` | 22,916 | 28.23 | 1,292 KB |

That is 58 GB from two routes, and 91 of the day's 93.49 GB from `/api` overall.

**What hid it:** Cloudflare compresses for the visitor, so a browser receives 547 KB of brotli and everything feels fine. The client saw a small fast response while the origin paid the full 6.7 MB on every single request — and every request is a miss, because Cloudflare caches by file extension by default and `/api/*` has none. `cf-cache-status: DYNAMIC` on cameras, planes and coverage, measured the same day.

## What I changed

An `encode` block with `zstd` and `gzip 5`, behind a content-type matcher.

Modelled on the real response bodies at gzip level 5:

| route | raw | gzip-5 | ratio | GB/day now | after |
|---|---|---|---|---|---|
| `/api/cameras` | 6,747,810 | 536,485 | **12.6x** | 29.83 | 2.37 |
| `/api/planes` | 1,323,708 | 196,125 | **6.7x** | 28.23 | 4.18 |

Those two routes go from **58.1 to 6.6 GB/day**, the whole day from **93.5 to about 42 GB**, and the monthly pace from **2.74 TB to roughly 1.23 TB**. That model only counts two routes — the other JSON routes compress too, so the real figure lands lower.

**The matcher is load-bearing, not decoration.** `/api/hls` is 21.81 GB/day of already-compressed video and `/api/proxy` serves JPEG frames; pushing either through gzip spends CPU on two shared vCPUs to make the bytes slightly *bigger*. Only text-shaped types are touched, which also leaves the segment path streaming unbuffered exactly as the `reverse_proxy` comment above it requires.

## This is not applied yet — it needs one command on the box

`deploy/deploy.sh` does not touch the Caddyfile; `provision.sh` only prints it as a manual step. So **merging this changes nothing on its own.** On the box:

```
sudo install -m 644 deploy/Caddyfile /etc/caddy/Caddyfile && sudo systemctl reload caddy
```

I verified the live `/etc/caddy/Caddyfile` is byte-identical to the repo copy before this change, so there is no drift to lose, and `caddy validate --adapter caddyfile` passes as root against the new file on the box. A backup is already sitting at `/etc/caddy/Caddyfile.bak-20260909-encode`. I did not run the install myself — a permission gate stopped me overwriting a live production config, which is the right call.

## The other half, for later

Compression fixes the bytes. It does not fix the fact that **Cloudflare is caching none of this** — 5,049 identical 6 MB camera responses a day is still 5,049 origin hits for a body with a 60s `s-maxage`. A Cache Rule making `/api/*` eligible would collapse that further. Related: `lib/http/cache.ts` still sends `Vercel-CDN-Cache-Control`, a header nothing reads now that we have left Vercel. Both are worth a follow-up; neither is in this PR.

Built with Claude Opus 5.
