### PR TITLE
Stop a finalised day being merged with a copy of itself, once per run

### DIFF
--- a/scripts/rollup-access-log.mts
+++ b/scripts/rollup-access-log.mts
@@ -38,13 +38,12 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { createGunzip } from "node:zlib";
 import type { Readable } from "node:stream";
-import { capDay, dayKey, foldRow, mergeDay, topN, type AccessRow } from "../lib/analytics/rollup.ts";
+import { capDay, dayKey, foldRow, topN, type AccessRow } from "../lib/analytics/rollup.ts";
 import {
   DEFAULT_ROLLUP_DIR,
   finalisableDays,
   makeVisitorKey,
   openDay,
-  readDay,
   readState,
   statePath,
   writeDay,
@@ -298,10 +297,19 @@ async function main(): Promise<void> {
       const day = state.days[date];
       if (!day) continue;
       // A day already on disk means the job was stopped for longer than the finalise
-      // lag and late rows arrived for it. Merge rather than overwrite, which would
-      // throw away whichever half is smaller, silently.
-      const existing = readDay(OUT_DIR, date);
-      writeDay(OUT_DIR, existing ? mergeDay(existing, day) : day);
+      // lag and late rows arrived for it. `openDay` ALREADY pulled that file back into
+      // state.days before those rows were folded in (rollup-store.mts, and its own
+      // test pins that), so `day` is the old counters PLUS the late ones — a whole
+      // value, and the write below is a whole-value write.
+      //
+      // MERGING IT AGAIN HERE ADDED THE DAY FILE TO A COPY OF ITSELF. Measured before
+      // this line changed: 2 real rows reported 2, then 3 reported 5, 4 reported 11,
+      // 5 reported 23 — `n → 2n+1` per run, compounding for as long as late rows keep
+      // arriving, and silent, because nothing errors and the shape stays plausible.
+      // Two defences against the same loss — hydrate on open, merge on write — are
+      // each correct alone and fabricate traffic together. Exactly one may own the
+      // day file; `openDay` reads it, this writes it.
+      writeDay(OUT_DIR, day);
     }
     // Day files first, then state. Both orders can be interrupted, and this one merely
     // rewrites an identical day file on the next run. The reverse drops a finalised day.

--- a/tests/unit/rollup-store.test.ts
+++ b/tests/unit/rollup-store.test.ts
@@ -164,6 +164,38 @@ describe("the rollup job, end to end", () => {
     expect(day().byPath["/cameras"]).toBe(1);
   });
 
+  it("does not double a finalised day when late rows keep arriving", () => {
+    // THE DAY FILE HAS EXACTLY ONE OWNER. openDay() pulls a finalised day back into
+    // state.days, and the finalise step writes it out again; when that write ALSO
+    // merged the file it had just been hydrated from, the day was added to a copy of
+    // itself once per run — 2 real rows reported 2, then 3 reported 5, 4 reported 11,
+    // 5 reported 23. `n → 2n+1`, compounding, and silent: nothing errors, and the
+    // shape of the numbers stays plausible.
+    //
+    // THE DATE IS RELATIVE, NOT THE FIXTURE'S FIXED ONE. This scenario only exists
+    // once a day is past FINALISE_LAG_MS, so a hard-coded date decides whether the
+    // test exercises the bug based on the calendar the day it runs — which is how
+    // this file came to be green when written and red two days later. Three days
+    // back is always finalisable and never depends on today.
+    const old = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const at = (n: number) => Date.parse(`${old}T12:00:00Z`) / 1000 + n / 1e6;
+    const p = join(logs, "provenance.log");
+
+    writeFileSync(p, line({ ts: at(1) }) + line({ ts: at(2) }));
+    run();
+    expect(day(old).requests).toBe(2);
+
+    // Every later run folds in exactly one more row, so the total must track the rows
+    // actually written. Under the bug this reads 5, then 11, then 23.
+    for (let i = 3; i <= 5; i += 1) {
+      appendFileSync(p, line({ ts: at(i), uri: "/cameras" }));
+      run();
+      expect(day(old).requests).toBe(i);
+    }
+    // One visitor throughout — the doubling inflated this too.
+    expect(day(old).visitors).toBe(1);
+  });
+
   it("does not re-count a rolled file after the rename", () => {
     // The rename preserves the inode and changes the name. A name-keyed cursor doubles
     // everything here.


### PR DESCRIPTION
## The short version

`tests/unit/rollup-store.test.ts` is **red on `main` right now** — 6 of its 22 cases. It is not flaky, and it is not the tests being wrong. They are catching a real defect in the rollup job, and the reason they went red two days after they were written is a fixed date in the fixture, not a change in the code.

**The defect:** a day already finalised to disk has its counters multiplied every time the job runs while late rows are still arriving.

Measured through the real job (child process, real files) against a synthetic log:

| rows actually written | reported |
|---|---|
| 2 | 2 |
| 3 | **5** |
| 4 | **11** |
| 5 | **23** |

`n → 2n+1` per run, compounding, and silent — nothing throws and the shape stays plausible. `visitors` inflates with it.

**The timing:** this path only exists once a day is older than `FINALISE_LAG_MS` (36 h). The fixture hard-codes `2026-09-07`, so the suite first walked into it on **2026-09-09**. Green when written, red two days later, same code both times.

## Root cause

Two defences against the same loss, each correct alone:

1. `scripts/lib/rollup-store.mts` — `openDay()` pulls a finalised day back into `state.days` so late rows are not lost. Its own unit test pins this ("pulls a finished day back off disk so late rows are merged, not lost").
2. `scripts/rollup-access-log.mts` — the finalise step read that same day file again and `mergeDay()`'d it before writing.

By the time step 2 ran, `day` was **already** the file's contents plus the late rows. Merging added the file to a copy of itself.

## The fix

The day file gets exactly one owner: `openDay` reads it, the finalise step writes it whole — which is how `writeDay` is documented to behave ("a WHOLE-VALUE write rather than an increment"). Removing the second read is the smaller change and preserves the hydrate-on-open behaviour that has a test asserting it.

The now-unused `mergeDay` / `readDay` imports are dropped from the job. `mergeDay` itself is untouched and still exported.

## Regression test

`does not double a finalised day when late rows keep arriving` — writes rows for a finalisable day, appends one at a time, and asserts the total tracks the rows actually written. Fails on `main` (reads 5, 11, 23), passes here.

It dates its fixture **three days back from `Date.now()`** rather than hard-coding one. A fixed date decides whether this scenario is exercised based on the calendar the day it runs, which is exactly how this defect stayed invisible for two days. The other fixtures in the file still carry that rot — deliberately left alone, since fixing them is a different change and this PR is one hypothesis.

## Gate

`npx tsc --noEmit` clean. `npm test` — **369 files / 3,772 tests, all green**. On `main` today the same command is 6 red.

**Not measured:** whether the box has already inflated real days this way. It would need `FINALISE_LAG_MS` to elapse with the job stopped, or a rolled file processed late; the arithmetic says any day where that happened is wrong by a lot rather than a little, so it should be obvious in `days/` rather than subtle.