### PR TITLE
Match the port as strictly as the host, and pin Serbia to the 4443 it serves on

### DIFF
--- a/lib/proxy/allowlist.ts
+++ b/lib/proxy/allowlist.ts
@@ -1,7 +1,7 @@
 // Each rule is host + required path prefix (+ optional suffix). Adding a source
 // = adding a rule. SCDOT snapshots live at the host root as `/<id>.png`, so that
 // rule pins the suffix instead of a deep prefix to stay tight.
-const RULES: { host: string; prefix: string; suffix?: string }[] = [
+const RULES: { host: string; prefix: string; suffix?: string; port?: string }[] = [
   { host: "s3-eu-west-1.amazonaws.com", prefix: "/jamcams.tfl.gov.uk/" },
   { host: "cwwp2.dot.ca.gov", prefix: "/data/" },
   { host: "scdotsnap.us-east-1.skyvdn.com", prefix: "/", suffix: ".png" },
@@ -52,11 +52,27 @@ const RULES: { host: string; prefix: string; suffix?: string }[] = [
   { host: "imgproxy.windy.com", prefix: "/_/" },
 ];
 
+/**
+ * THE PORT IS PART OF THE ADDRESS, and matching only the hostname left it open.
+ * `new URL()` normalises a scheme's own port away — `https://host:443` and
+ * `http://host:80` both report `url.port === ""` — so an empty string here means
+ * "the default for this scheme", and anything else is a port somebody asked for
+ * explicitly. Every rule below wants the default, so `r.port ?? ""` is the whole
+ * expression; a rule that needs a real port declares one (see hls-allowlist.ts,
+ * where the Serbian MUP host genuinely serves on 4443).
+ *
+ * Without this, `https://fl511.com:22/map/Cctv/x` passed the gate. That reaches
+ * no cloud metadata and no internal address — the hostname match already stops
+ * that — but it does turn this deployment into a way to knock on arbitrary ports
+ * of the allowlisted hosts, which are mostly state transport agencies, from
+ * Vercel's IP rather than the caller's.
+ */
 export function isAllowed(url: URL): boolean {
   if (url.protocol !== "https:" && url.protocol !== "http:") return false;
   return RULES.some(
     (r) =>
       url.hostname === r.host &&
+      url.port === (r.port ?? "") &&
       url.pathname.startsWith(r.prefix) &&
       (!r.suffix || url.pathname.endsWith(r.suffix)),
   );

--- a/lib/proxy/hls-allowlist.ts
+++ b/lib/proxy/hls-allowlist.ts
@@ -3,14 +3,24 @@
 // `referer` is optional because not every host is hotlink-protected: MUP serves
 // its playlists and segments to a bare request, and sending an empty Referer
 // where none is wanted is a claim we do not need to make.
-type HlsRule = { match: (host: string) => boolean; prefix: string; referer?: string };
+// `port` is the port this host is allowed to be reached on, as `new URL()` reports
+// it: an empty string means the scheme's default (443 for https), because URL
+// normalises `:443` away. Omit it for the normal case; declare it where an operator
+// genuinely publishes on something else, as the Serbian MUP does.
+type HlsRule = { match: (host: string) => boolean; prefix: string; referer?: string; port?: string };
 
 const RULES: HlsRule[] = [
   { match: (h) => h === "wzmedia.dot.ca.gov", prefix: "/", referer: "https://cwwp2.dot.ca.gov/" },
   { match: (h) => h.endsWith(".us-east-1.skyvdn.com"), prefix: "/rtplive/", referer: "https://www.511sc.org/" },
   // Serbia — MUP border crossings. Playlists carry ABSOLUTE segment URLs on the
   // same host, and no Referer is required (measured).
-  { match: (h) => h === "kamere.mup.gov.rs", prefix: "/" },
+  // PORT 4443 IS NOT A TYPO and it is not optional: the portal publishes these
+  // streams as `https://kamere.mup.gov.rs:4443/{Crossing}/{name}.m3u8` (the shape
+  // serbia.data.ts documents on its join key). It is the one host in either
+  // allowlist that does not serve on its scheme's default port, so it is also the
+  // reason this file matches the port rather than rejecting every explicit one —
+  // that shortcut would have taken every Serbian border camera off the map.
+  { match: (h) => h === "kamere.mup.gov.rs", prefix: "/", port: "4443" },
   // Serbia — JP Putevi Srbije toll plazas. cam.bitinfo.co.rs 403s without a
   // Referer, and the TRAILING SLASH matters: "https://kamere.toll4all.com"
   // alone is refused. jpps.bitinfo.co.rs does NOT enforce it (measured: 200
@@ -29,7 +39,10 @@ const RULES: HlsRule[] = [
 export function isHlsAllowed(url: URL): { ok: boolean; referer?: string } {
   if (url.protocol !== "https:" && url.protocol !== "http:") return { ok: false };
   for (const r of RULES) {
-    if (r.match(url.hostname) && url.pathname.startsWith(r.prefix)) {
+    // The port is matched as strictly as the host. `u=` on /api/hls takes a URL
+    // from the caller, so without this the route would fetch any port of an
+    // allowlisted host on their behalf, from this deployment's IP.
+    if (r.match(url.hostname) && url.port === (r.port ?? "") && url.pathname.startsWith(r.prefix)) {
       return { ok: true, referer: r.referer };
     }
   }

--- a/tests/unit/allowlist.test.ts
+++ b/tests/unit/allowlist.test.ts
@@ -29,3 +29,18 @@ test("rejects those hosts outside their allowed prefix", () => {
   expect(isAllowed(new URL("https://cwwp2.dot.ca.gov/etc/secret.jpg"))).toBe(false);
   expect(isAllowed(new URL("https://scdotsnap.us-east-1.skyvdn.com/rtplive/x.ts"))).toBe(false);
 });
+
+// The port is part of the address. Matching only the hostname let a caller pick
+// which port of an allowlisted host this deployment would connect to.
+test("rejects an explicit non-default port on an allowlisted host", () => {
+  expect(isAllowed(new URL("https://fl511.com:22/map/Cctv/1"))).toBe(false);
+  expect(isAllowed(new URL("https://fl511.com:8443/map/Cctv/1"))).toBe(false);
+  expect(isAllowed(new URL("http://cwwp2.dot.ca.gov:8080/data/d11/cctv/image/c/c.jpg"))).toBe(false);
+});
+
+test("still allows the scheme's own port, which URL normalises away", () => {
+  // Written by hand as :443/:80, reported by URL as "". These are the same address
+  // as the bare form, so refusing them would be refusing ordinary traffic.
+  expect(isAllowed(new URL("https://fl511.com:443/map/Cctv/1"))).toBe(true);
+  expect(isAllowed(new URL("https://cwwp2.dot.ca.gov:443/data/d11/cctv/image/c/c.jpg"))).toBe(true);
+});

--- a/tests/unit/hls-allowlist.test.ts
+++ b/tests/unit/hls-allowlist.test.ts
@@ -19,3 +19,19 @@ test("rejects unknown hosts, look-alike suffixes, and non-http", () => {
   expect(isHlsAllowed(new URL("https://x.us-east-1.skyvdn.com.attacker.com/rtplive/x")).ok).toBe(false);
   expect(isHlsAllowed(new URL("file:///etc/passwd")).ok).toBe(false);
 });
+
+test("rejects an explicit non-default port on an allowlisted stream host", () => {
+  // /api/hls takes `u=` from the caller, so this is the reachable one.
+  expect(isHlsAllowed(new URL("https://wzmedia.dot.ca.gov:22/live/x.m3u8")).ok).toBe(false);
+  expect(isHlsAllowed(new URL("https://s19.us-east-1.skyvdn.com:8443/rtplive/50001/playlist.m3u8")).ok).toBe(false);
+});
+
+test("keeps the Serbian MUP host on 4443, which is where it actually serves", () => {
+  // The one host in either allowlist that does not use its scheme's default port.
+  // Rejecting every explicit port would have taken these cameras off the map.
+  expect(isHlsAllowed(new URL("https://kamere.mup.gov.rs:4443/MaliZvornik/malizvornik1.m3u8")).ok).toBe(true);
+  // ...and only 4443. Another port on the same host is still refused.
+  expect(isHlsAllowed(new URL("https://kamere.mup.gov.rs:22/MaliZvornik/malizvornik1.m3u8")).ok).toBe(false);
+  // The bare form is not what the portal publishes, and is no longer accepted.
+  expect(isHlsAllowed(new URL("https://kamere.mup.gov.rs/MaliZvornik/malizvornik1.m3u8")).ok).toBe(false);
+});


### PR DESCRIPTION
## What

Both proxy allowlists matched hostname + path and **ignored the port**.

`/api/hls` takes `u=` straight from the caller, so this cleared the gate:

```
https://wzmedia.dot.ca.gov:22/live/x.m3u8   →  ok
```

and the deployment opened that connection. It reaches no cloud metadata and no internal address — the exact-hostname match already stops that, and `tests/unit/allowlist.test.ts` has pinned it since it was written. What it does allow is using this box to knock on arbitrary ports of the allowlisted hosts, which are mostly state transport agencies, **from Vercel's IP rather than the caller's**.

`/api/proxy` is not reachable this way — it resolves a camera `id` and never takes a caller URL — but it shared the same gap, so both are fixed.

## The part that would have broken production

The obvious fix is "refuse any explicit port". That would have taken **every Serbian border camera off the map**.

`kamere.mup.gov.rs` genuinely serves on **4443**. The MUP portal publishes its streams as `https://kamere.mup.gov.rs:4443/{Crossing}/{name}.m3u8` — the shape `serbia.data.ts` already documents on its join key. It is the only host in either allowlist not on its scheme's default port, and a grep over `lib/sources` plus the committed data files is what turned it up before the change was written rather than after.

So instead: **a rule declares the port it expects, and the match is exact.**

`new URL()` normalises a scheme's own port away — `:443` on https and `:80` on http both report `url.port === ""` — so an omitted `port` means "the default for this scheme", which is what every rule but one wants. The ordinary bare form is untouched.

## Tests

Both directions, in both files:

- an explicit odd port is refused (`:22`, `:8443`, `:8080`)
- `:443` / `:80` still pass, because URL reports them as the same address as the bare form
- Serbia passes on `4443`, and is refused on any other port **and** on the bare form the portal never publishes

## Gate

`npx tsc --noEmit` clean. `npm test` 3,769 passed / 6 failed — all 6 are `tests/unit/rollup-store.test.ts`, which is red on `main` and is what #220 fixes. Nothing in proxy.

**Not measured:** whether the MUP portal ever emits a port other than 4443. It was unreachable when I tried to re-check it live (the `curl` recipe in `serbia-borders.ts`), so 4443 rests on the URL shape documented in the repo. If those cameras ever go quiet, this rule is the first place to look — which is a trade I'd rather make explicit than leave the port unchecked.