### PR TITLE
Cache the fattest API bodies on the box, and address the CDN that is there

### DIFF
--- a/app/api/planes/route.ts
+++ b/app/api/planes/route.ts
@@ -1,5 +1,6 @@
 import { fetchAircraftSnapshot } from "@/lib/sources/opensky";
-import { describeCoverage } from "@/lib/signals/coverage";
+import { planesBody } from "@/lib/planes/body";
+import { cachedBody } from "@/lib/http/originCache";
 import { edgeCacheHeaders } from "@/lib/http/cache";
 
 export const dynamic = "force-dynamic";
@@ -75,15 +76,19 @@ export const maxDuration = 60;
  * Response: { count, source?, coverage?, staleness?, planes }
  */
 export async function GET() {
-  const { planes, coverage, staleness, source } = await fetchAircraftSnapshot();
-  return Response.json(
-    {
-      count: planes.length,
-      ...(source ? { source } : {}),
-      ...(coverage ? { coverage: describeCoverage(coverage) } : {}),
-      ...(staleness ? { staleness } : {}),
-      planes,
-    },
-    { headers: edgeCacheHeaders(PLANES_TTL_MS) },
-  );
+  const snapshot = await fetchAircraftSnapshot();
+  // Keyed on the snapshot's own fetch instant, so a new pull rebuilds immediately and
+  // an upstream that has stopped ticking is bounded by the TTL instead. Between the
+  // two, 33,181 requests over five days become at most one build per 20 s — see
+  // lib/http/originCache.ts for why the rebuild runs behind the request and not in
+  // front of it.
+  const body = await cachedBody({
+    key: "planes",
+    ttlMs: PLANES_TTL_MS,
+    version: snapshot.fetchedAt ?? null,
+    build: () => planesBody(snapshot),
+  });
+  return new Response(body, {
+    headers: { "Content-Type": "application/json", ...edgeCacheHeaders(PLANES_TTL_MS) },
+  });
 }

--- a/lib/cameras/body.ts
+++ b/lib/cameras/body.ts
@@ -1,5 +1,6 @@
 import type { Camera } from "@/lib/types";
 import { isLiveStreamUrl } from "@/lib/proxy/hls-allowlist";
+import { REGISTRY_TTL_MS } from "@/lib/sources/registry";
 import { edgeCacheHeaders } from "@/lib/http/cache";
 
 // The body of GET /api/cameras, and its edge-cache policy.
@@ -17,11 +18,19 @@ import { edgeCacheHeaders } from "@/lib/http/cache";
  * stale-while-revalidate server-side, so this is about not paying an invocation per
  * visitor, not about protecting the upstreams.
  *
- * 60 s is safe for this body specifically because every time it carries is ABSOLUTE
- * (`lastSampledAt`), so a cached copy cannot under-report a camera's age — the client
- * subtracts from its own clock. Positions and names move on the order of days.
+ * DERIVED FROM THE REGISTRY'S OWN CADENCE rather than typed, which is the rule at the
+ * top of `lib/http/cache.ts`: a TTL is the source's declared refresh interval, never a
+ * number chosen to cut a bill. This was a hand-written 60 s against a registry that
+ * refreshes every 5 minutes — five sixths of the cacheable window given away, and a
+ * second number to keep in step by hand. `REGISTRY_TTL_MS` is the one to follow: past
+ * it the registry itself would re-derive, so a copy held any longer could outlive data
+ * that had genuinely moved.
+ *
+ * Safe at this length for this body specifically because every time it carries is
+ * ABSOLUTE (`lastSampledAt`), so a cached copy cannot under-report a camera's age — the
+ * client subtracts from its own clock. Positions and names move on the order of days.
  */
-const CAMERAS_TTL_MS = 60_000;
+const CAMERAS_TTL_MS = REGISTRY_TTL_MS;
 
 /**
  * The serialised body, held until the registry replaces its array.

--- a/lib/http/cache.ts
+++ b/lib/http/cache.ts
@@ -76,9 +76,28 @@ export function toSeconds(ms: number): number {
 // THE TTLs ARE UNCHANGED BY THIS. Nothing here caches for longer than it already
 // claimed to — the freshness rule at the top of this file still holds, because every
 // value still comes from the source's own declared refresh interval.
+//
+// ---------------------------------------------------------------------------
+// AND THEN THE CDN CHANGED. `Vercel-CDN-Cache-Control` is a VENDOR header: it means
+// something to Vercel's edge and nothing to anyone else. This deployment left Vercel
+// on 2026-09-07 for a Lightsail box behind Cloudflare, so from that day the header
+// above was addressed to a CDN that is no longer in the path — sent on every read
+// response, read by nothing. The Vercel project still exists, but only to 308 two
+// spare domains at the live one; it serves no application traffic.
+//
+// `CDN-Cache-Control` is the standard-track name for the same idea and is the one
+// Cloudflare reads. Swapping it is the whole change — the value is byte-identical.
+//
+// WHAT THIS DOES NOT FIX, measured 2026-09-11 against the live site: Cloudflare still
+// answers `cf-cache-status: DYNAMIC` on `/api/cameras`, because its default cache is
+// keyed on FILE EXTENSION and an extensionless `/api/*` path is never a candidate no
+// matter what the origin asks for. A correct header is necessary and not sufficient;
+// a Cache Rule has to opt the path in before any of this takes effect. Until one
+// exists the real cache is `lib/http/originCache.ts`, which is on the box and needs
+// nobody's permission.
 
-/** The header name the Vercel CDN reads. Not rewritten by the framework. */
-export const CDN_HEADER = "Vercel-CDN-Cache-Control";
+/** The header name shared CDNs read. Standard-track, and the one Cloudflare honours. */
+export const CDN_HEADER = "CDN-Cache-Control";
 
 /**
  * Cache headers for a read-only JSON response: `edgeCacheControl`'s policy, sent

--- a/lib/http/originCache.ts
+++ b/lib/http/originCache.ts
@@ -1,0 +1,196 @@
+// A response-body cache that lives on the ORIGIN, in front of the work that builds
+// a body rather than in front of the bytes that leave.
+//
+// WHY THIS EXISTS, MEASURED. Five days of the Caddy access log (2026-09-07 to 09-11)
+// say the box answered 1,218,502 requests and sent 275.9 GB, 98.1% of it from
+// `/api/*`. Two routes are 73% of that, and they had opposite problems:
+//
+//   /api/cameras  113.9 GB over ~4,800 calls/day. `camerasBody` already memoises on
+//                 the registry array's identity, so the CPU was paid once — but the
+//                 body itself was rebuilt into a fresh Response every request and
+//                 nothing above it cached anything.
+//   /api/planes    86.5 GB over 33,181 calls. NO memo of any kind: every request ran
+//                 `JSON.stringify` over ~3,000 aircraft to produce 1.27 MB that was
+//                 byte-identical to the last one until the 240 s upstream tick.
+//
+// Nothing in front helps. Cloudflare answers `cf-cache-status: DYNAMIC` on every
+// `/api/*` path because its default cache is keyed on file extension and these have
+// none, so a shared-cache TTL on the response reaches no cache that will act on it.
+// The only cache this deployment actually controls is this one.
+//
+// THE SHAPE IS "SERVE, THEN REFRESH", NOT "REFRESH, THEN SERVE". A request that
+// arrives after the tick has elapsed is answered from the copy already in hand and
+// starts the rebuild behind itself. It does not wait for it. That is the whole point:
+// the refresh is paid by nobody, on a schedule that traffic sets, and a slow or
+// failing upstream cannot turn into a slow response. Only a COLD cache blocks, once,
+// because there is genuinely nothing else to send.
+//
+// WHAT THIS IS NOT. It is not a freshness story. `app/(site)/privacy` and the whole
+// signals contract turn on a reading's age being reported honestly, so:
+//
+//   * A cached body may only carry ABSOLUTE instants. A body carrying a RELATIVE age
+//     ("120000 ms old") freezes that number while the clock keeps moving, and every
+//     request served from cache under-reports staleness by however long the entry has
+//     been held. `/api/planes` carried exactly that and is why it ships `fetchedAt`
+//     now; see the route.
+//   * `ttlMs` is the SOURCE'S OWN CADENCE, never a number picked to cut a bill. A
+//     layer that refreshes every 60 s is not cacheable for five minutes at any price.
+//     `lib/http/cache.ts` states the same rule for the shared-cache headers and it is
+//     the same rule; this file just applies it one layer further in.
+//
+// `version` is the stronger of the two invalidations and should be preferred where
+// the data has a natural one. `/api/cameras` passes the registry array, which is only
+// ever REPLACED, so identity changes exactly when the contents do. `/api/planes`
+// passes the snapshot's `fetchedAt`. A TTL is then a ceiling rather than the
+// mechanism, which is what keeps a cached body from outliving its own cadence when an
+// upstream quietly stops ticking.
+
+interface Entry {
+  body: string;
+  builtAt: number;
+  version: unknown;
+  /**
+   * True while a rebuild is in flight, so a burst of requests triggers exactly one.
+   *
+   * A BOOLEAN SET BEFORE THE CALL, not the promise the call returns, and that
+   * ordering is the whole point. `build` may throw synchronously, in which case the
+   * async wrapper runs to completion — `finally` included — BEFORE the assignment of
+   * its own promise. Storing the promise therefore wrote a settled value back over
+   * the `null` that `finally` had just written, the flag never cleared, and every
+   * later refresh returned early: one failed upstream fetch froze the entry at its
+   * last good body forever. Caught by the retry test, not by reading the code.
+   */
+  refreshing: boolean;
+}
+
+const entries = new Map<string, Entry>();
+
+/**
+ * In-flight COLD builds, kept OUT of `entries` on purpose.
+ *
+ * The first draft put a placeholder Entry in `entries` while the cold build ran, and
+ * the second concurrent caller found it and was served its empty body as though it
+ * were an answer. Two separate maps make that unrepresentable: an entry in `entries`
+ * has always been built, so there is no state in which a caller can read a body that
+ * does not exist yet.
+ */
+const coldBuilds = new Map<string, Promise<string>>();
+
+export interface OriginCacheOptions {
+  /** Cache key. One per route; include any parameter the body varies on. */
+  key: string;
+  /**
+   * The source's own refresh cadence in milliseconds. A ceiling on how long a body
+   * may be served, NOT a bill-shaped number — see the header of this file.
+   */
+  ttlMs: number;
+  /**
+   * Optional invalidation stronger than the clock: any value whose change means the
+   * body is out of date. Compared with `Object.is`, so pass a reference that is
+   * replaced rather than mutated, or a scalar such as a fetch instant.
+   */
+  version?: unknown;
+  /** Builds the body. Called at most once per tick, never concurrently per key. */
+  build: () => string | Promise<string>;
+  /** Injectable clock, for the test. */
+  now?: () => number;
+}
+
+/**
+ * The body for this key: the cached one where it is still current, otherwise the
+ * cached one plus a rebuild started behind this request.
+ *
+ * Awaits only on a cold cache. A rebuild that throws leaves the previous body in
+ * place and is retried on the next request that finds the entry stale — a failing
+ * upstream degrades to "the last good answer, held longer", never to a 5xx, which is
+ * the same dormant-safe contract every adapter in this project already keeps.
+ */
+export async function cachedBody(opts: OriginCacheOptions): Promise<string> {
+  const now = opts.now ?? Date.now;
+  const existing = entries.get(opts.key);
+
+  if (!existing) return coldBuild(opts, now);
+
+  const versionChanged = "version" in opts && !Object.is(existing.version, opts.version);
+  const expired = now() - existing.builtAt >= opts.ttlMs;
+
+  if (versionChanged || expired) startRefresh(existing, opts, now);
+
+  return existing.body;
+}
+
+/**
+ * The first caller for a key builds and waits; everyone arriving during that build
+ * waits on the SAME promise rather than starting their own. Without this, a cold
+ * start under load runs one full build per concurrent request — the exact thundering
+ * herd the cache exists to prevent, at the one moment it is most expensive.
+ */
+async function coldBuild(opts: OriginCacheOptions, now: () => number): Promise<string> {
+  const pending = coldBuilds.get(opts.key);
+  if (pending) return pending;
+
+  const build = (async () => {
+    try {
+      const body = await opts.build();
+      entries.set(opts.key, {
+        body,
+        builtAt: now(),
+        version: opts.version,
+        refreshing: false,
+      });
+      return body;
+    } finally {
+      // Cleared whether it resolved or threw, so a failed cold start is retried by
+      // the next request rather than every later caller awaiting the same rejection.
+      coldBuilds.delete(opts.key);
+    }
+  })();
+
+  coldBuilds.set(opts.key, build);
+  return build;
+}
+
+/** Start a rebuild behind the caller, unless one is already running for this key. */
+function startRefresh(entry: Entry, opts: OriginCacheOptions, now: () => number): void {
+  if (entry.refreshing) return;
+  entry.refreshing = true;
+
+  void (async () => {
+    try {
+      const body = await opts.build();
+      entry.body = body;
+      entry.builtAt = now();
+      entry.version = opts.version;
+    } catch {
+      // Hold the previous body. Deliberately silent: a failed refresh is the
+      // upstream's problem and the adapters below already record it; logging here
+      // would duplicate that once per tick per layer.
+    } finally {
+      entry.refreshing = false;
+    }
+  })();
+}
+
+/**
+ * Drop one key, or everything. The test seam, matching the house pattern
+ * (`__resetCamerasBody`). Not used in the served path.
+ */
+export function __resetOriginCache(key?: string): void {
+  if (key === undefined) {
+    entries.clear();
+    coldBuilds.clear();
+  } else {
+    entries.delete(key);
+    coldBuilds.delete(key);
+  }
+}
+
+/** What the cache is holding, for `/admin/analytics`. Never part of a response body. */
+export function originCacheStats(): Array<{ key: string; bytes: number; ageMs: number }> {
+  const now = Date.now();
+  return [...entries.entries()].map(([key, e]) => ({
+    key,
+    bytes: e.body.length,
+    ageMs: now - e.builtAt,
+  }));
+}

--- a/lib/planes/body.ts
+++ b/lib/planes/body.ts
@@ -1,0 +1,43 @@
+import type { AircraftSnapshot } from "@/lib/sources/opensky";
+import { describeCoverage } from "@/lib/signals/coverage";
+
+// The body of GET /api/planes.
+//
+// WHY IT IS NOT IN THE ROUTE FILE: a Next route module may export ONLY the names Next
+// recognises, so anything with a test seam lives here. Same reason as
+// `lib/cameras/body.ts`; `tests/unit/route-export-contract.test.ts` enforces it.
+//
+// WHY IT EXISTS AT ALL: this is the most-rebuilt body the deployment serves. The Caddy
+// log for 2026-09-07..11 has 33,181 `/api/planes` requests at 1.27 MB each, and every
+// one of them ran `JSON.stringify` over ~3,000 aircraft to produce bytes identical to
+// the last request's until the 240 s upstream tick moved. `/api/cameras` had had a memo
+// since it was written; this route had none. Pulling the body out is what lets
+// `lib/http/originCache.ts` hold one.
+
+/**
+ * `fetchedAt` IS THE FIELD THAT MAKES THIS BODY CACHEABLE, and it is the point of the
+ * change that introduced it.
+ *
+ * The route already carried `staleness.ageMs`, which is a RELATIVE age: "this reading
+ * is 120 s old". Held in a cache for 20 s, that sentence is wrong by 20 s, and it is
+ * wrong in the direction that flatters us. The route's own comment said as much — "do
+ * not raise it to save invocations without also making the age absolute".
+ *
+ * `fetchedAt` is the absolute instant the positions were pulled, so a consumer
+ * subtracts it from its own clock and gets the true age no matter how long the body sat
+ * in a cache. It is additive: `staleness` is unchanged and still carries the server's
+ * own verdict, which is why the TTL stays at its documented 20 s rather than moving to
+ * the five minutes the cameras body can take. Absolute age is what a longer tick would
+ * need, and this field is the half of it that can ship without a client change.
+ */
+export function planesBody(snapshot: AircraftSnapshot): string {
+  const { planes, coverage, staleness, source, fetchedAt } = snapshot;
+  return JSON.stringify({
+    count: planes.length,
+    ...(source ? { source } : {}),
+    ...(fetchedAt ? { fetchedAt } : {}),
+    ...(coverage ? { coverage: describeCoverage(coverage) } : {}),
+    ...(staleness ? { staleness } : {}),
+    planes,
+  });
+}

--- a/tests/unit/http-cache.test.ts
+++ b/tests/unit/http-cache.test.ts
@@ -74,7 +74,7 @@ describe("edgeCacheControl", () => {
  * checked, every one of them `dynamic = "force-dynamic"`. So `X-Vercel-Cache: MISS`
  * on 100% of requests and every poll from every open tab was a cold invocation.
  *
- * The fix does not depend on pinning which layer strips them: `Vercel-CDN-Cache-Control`
+ * The fix does not depend on pinning which layer strips them: `CDN-Cache-Control`
  * is read by the Vercel CDN directly and is not rewritten, so the TTL sent under that
  * name arrives. These tests exist so the pair can never drift apart again.
  */
@@ -82,19 +82,19 @@ describe("edgeCacheHeaders", () => {
   it("sends the SAME policy twice — once for any CDN, once under the name Vercel reads", () => {
     const headers = edgeCacheHeaders(60_000);
     expect(headers["Cache-Control"]).toBe("public, s-maxage=60, stale-while-revalidate=60");
-    expect(headers["Vercel-CDN-Cache-Control"]).toBe(headers["Cache-Control"]);
+    expect(headers["CDN-Cache-Control"]).toBe(headers["Cache-Control"]);
   });
 
   it("carries an explicit stale window into both headers", () => {
     const headers = edgeCacheHeaders(20_000, 60_000);
-    expect(headers["Vercel-CDN-Cache-Control"]).toBe(
+    expect(headers["CDN-Cache-Control"]).toBe(
       "public, s-maxage=20, stale-while-revalidate=60",
     );
   });
 
   it("never invents a TTL — it is edgeCacheControl's value, unchanged", () => {
     for (const ttl of [1_000, 20_000, 300_000, 86_400_000]) {
-      expect(edgeCacheHeaders(ttl)["Vercel-CDN-Cache-Control"]).toBe(edgeCacheControl(ttl));
+      expect(edgeCacheHeaders(ttl)["CDN-Cache-Control"]).toBe(edgeCacheControl(ttl));
     }
   });
 });
@@ -103,7 +103,7 @@ describe("frameCacheHeaders", () => {
   it("keeps the browser max-age a camera frame needs AND reaches the CDN", () => {
     const headers = frameCacheHeaders(300);
     expect(headers["Cache-Control"]).toBe("public, max-age=300, s-maxage=300");
-    expect(headers["Vercel-CDN-Cache-Control"]).toBe("public, s-maxage=300");
+    expect(headers["CDN-Cache-Control"]).toBe("public, s-maxage=300");
   });
 
   it("floors a zero or fractional cadence rather than emitting max-age=0", () => {
@@ -116,7 +116,7 @@ describe("frameCacheHeaders", () => {
   it("lets the CDN hold a rasterised card longer than the visitor's own tab", () => {
     const headers = browserAndEdgeHeaders(86_400, 604_800);
     expect(headers["Cache-Control"]).toBe("public, max-age=86400, s-maxage=604800");
-    expect(headers["Vercel-CDN-Cache-Control"]).toBe("public, s-maxage=604800");
+    expect(headers["CDN-Cache-Control"]).toBe("public, s-maxage=604800");
   });
 });
 

--- a/tests/unit/origin-cache.test.ts
+++ b/tests/unit/origin-cache.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { cachedBody, originCacheStats, __resetOriginCache } from "@/lib/http/originCache";
+
+/**
+ * These assert the two properties the cache exists for, and they are the two that
+ * would be silently wrong if it were written the obvious way round:
+ *
+ *   1. a request that finds the entry stale is answered from the copy in hand and
+ *      does NOT await the rebuild, and
+ *   2. a burst of such requests runs ONE rebuild between them.
+ *
+ * Both are observable only through the build counter, because the body a caller sees
+ * is the same string either way until the tick lands. A test that only checked the
+ * returned strings would pass against an implementation that awaited every refresh
+ * and ran one per request.
+ */
+
+/** Let every already-queued microtask run. Cheaper to read than counting `await`s. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+}
+
+/** A build that counts its calls and resolves when told, so "did not await" is testable. */
+function deferredBuilder(bodies: string[]) {
+  let calls = 0;
+  let release: (() => void) | null = null;
+  return {
+    get calls() {
+      return calls;
+    },
+    /** Let the in-flight build finish, then yield the microtask queue. */
+    async finish() {
+      release?.();
+      release = null;
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    build: () => {
+      const body = bodies[Math.min(calls, bodies.length - 1)];
+      calls += 1;
+      return new Promise<string>((resolve) => {
+        release = () => resolve(body);
+      });
+    },
+  };
+}
+
+describe("originCache", () => {
+  beforeEach(() => __resetOriginCache());
+
+  it("builds once on a cold cache and serves that body to later callers", async () => {
+    let calls = 0;
+    const build = () => {
+      calls += 1;
+      return "first";
+    };
+    const opts = { key: "k", ttlMs: 1_000, build, now: () => 0 };
+
+    expect(await cachedBody(opts)).toBe("first");
+    expect(await cachedBody(opts)).toBe("first");
+    expect(calls).toBe(1);
+  });
+
+  it("shares one cold build between callers that arrive together", async () => {
+    const b = deferredBuilder(["cold"]);
+    const opts = { key: "k", ttlMs: 1_000, build: b.build, now: () => 0 };
+
+    const a = cachedBody(opts);
+    const c = cachedBody(opts);
+    await b.finish();
+
+    expect(await a).toBe("cold");
+    expect(await c).toBe("cold");
+    // One build for two concurrent cold callers — without the shared promise this is 2,
+    // which is the thundering herd at the one moment the build is most expensive.
+    expect(b.calls).toBe(1);
+  });
+
+  it("serves the held body immediately when the TTL has passed, without awaiting the rebuild", async () => {
+    const b = deferredBuilder(["old", "new"]);
+    let clock = 0;
+    const opts = { key: "k", ttlMs: 100, build: b.build, now: () => clock };
+
+    const cold = cachedBody(opts);
+    await b.finish();
+    expect(await cold).toBe("old");
+
+    clock = 500; // stale
+    // The rebuild is now in flight and deliberately NOT resolved. The caller must
+    // still get an answer — this await would hang if the cache waited for it.
+    expect(await cachedBody(opts)).toBe("old");
+    expect(b.calls).toBe(2);
+
+    await b.finish();
+    expect(await cachedBody(opts)).toBe("new");
+  });
+
+  it("runs one rebuild for a burst of stale requests", async () => {
+    const b = deferredBuilder(["old", "new"]);
+    let clock = 0;
+    const opts = { key: "k", ttlMs: 100, build: b.build, now: () => clock };
+
+    const cold = cachedBody(opts);
+    await b.finish();
+    await cold;
+
+    clock = 500;
+    await Promise.all([cachedBody(opts), cachedBody(opts), cachedBody(opts)]);
+    // Cold build + exactly one refresh, not one per caller.
+    expect(b.calls).toBe(2);
+  });
+
+  it("rebuilds when the version changes even though the TTL has not passed", async () => {
+    const b = deferredBuilder(["v1", "v2"]);
+    const opts = (version: unknown) => ({
+      key: "k",
+      ttlMs: 10_000,
+      version,
+      build: b.build,
+      now: () => 0,
+    });
+    const first = {};
+    const second = {};
+
+    const cold = cachedBody(opts(first));
+    await b.finish();
+    expect(await cold).toBe("v1");
+
+    expect(await cachedBody(opts(second))).toBe("v1"); // still serves the held copy
+    await b.finish();
+    expect(await cachedBody(opts(second))).toBe("v2");
+    expect(b.calls).toBe(2);
+  });
+
+  it("does not rebuild while the version is unchanged and the TTL holds", async () => {
+    const b = deferredBuilder(["only"]);
+    const version = { same: true };
+    const opts = { key: "k", ttlMs: 10_000, version, build: b.build, now: () => 0 };
+
+    const cold = cachedBody(opts);
+    await b.finish();
+    await cold;
+    await cachedBody(opts);
+    await cachedBody(opts);
+
+    expect(b.calls).toBe(1);
+  });
+
+  it("keeps the last good body when a refresh throws, and retries on the next request", async () => {
+    let calls = 0;
+    let clock = 0;
+    const build = () => {
+      calls += 1;
+      if (calls === 2) throw new Error("upstream down");
+      return calls === 1 ? "good" : "recovered";
+    };
+    const opts = { key: "k", ttlMs: 100, build, now: () => clock };
+
+    expect(await cachedBody(opts)).toBe("good");
+
+    clock = 500;
+    // The refresh this starts throws. The caller must not see it: a dead upstream
+    // degrades to "the last good answer, held longer", never to a rejected request.
+    expect(await cachedBody(opts)).toBe("good");
+    await flush();
+    expect(calls).toBe(2);
+
+    expect(await cachedBody(opts)).toBe("good"); // still last-good; starts the retry
+    await flush();
+    expect(await cachedBody(opts)).toBe("recovered");
+  });
+
+  it("leaves no entry behind when the COLD build throws", async () => {
+    const opts = {
+      key: "k",
+      ttlMs: 100,
+      build: () => {
+        throw new Error("cold failure");
+      },
+      now: () => 0,
+    };
+
+    await expect(cachedBody(opts)).rejects.toThrow("cold failure");
+    // A placeholder entry here would be served as an empty body forever after.
+    expect(originCacheStats().find((s) => s.key === "k")).toBeUndefined();
+  });
+
+  it("keeps keys apart", async () => {
+    const opts = (key: string, body: string) => ({
+      key,
+      ttlMs: 1_000,
+      build: () => body,
+      now: () => 0,
+    });
+    expect(await cachedBody(opts("a", "A"))).toBe("A");
+    expect(await cachedBody(opts("b", "B"))).toBe("B");
+    expect(await cachedBody(opts("a", "ignored"))).toBe("A");
+  });
+
+  it("reports only built entries in the stats", async () => {
+    await cachedBody({ key: "cameras", ttlMs: 1_000, build: () => "12345", now: () => 0 });
+    const stats = originCacheStats();
+    const cameras = stats.find((s) => s.key === "cameras");
+    expect(cameras?.bytes).toBe(5);
+    expect(cameras?.ageMs).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
You asked for the server to be a proxy that serves users from a cache and refreshes it on 5-minute user-triggered ticks. That is what `lib/http/originCache.ts` does, and this PR is honest about the one route where 5 minutes is not available yet.

## What was actually costing anything

Measured over the Caddy log for 2026-09-07..11:

| Route | Requests | Body | Memoised before this? |
|---|---|---|---|
| `/api/planes` | 33,181 | 1.27 MB | **No — none at all** |
| `/api/cameras` | — | ~6.4 MB | Yes, on registry identity |

Every one of those 33,181 requests ran `JSON.stringify` over ~3,000 aircraft to produce a body byte-identical to the last one until the upstream's 240 s tick. `/api/cameras` was already memoised, but its shared-cache TTL was a hand-typed `60_000` against a registry that refreshes every 5 minutes.

## The cache

`cachedBody({ key, ttlMs, version, build })` holds one body per key and, when it is stale, **returns the body it has and rebuilds behind the request**. So:

- a refresh is paid by nobody — the user who triggers the tick is served immediately from the previous body;
- a slow upstream can never become a slow response;
- only a genuinely cold cache blocks, once, per key;
- a failed rebuild holds the last good body rather than serving an error.

Refreshes are single-flight: a second request arriving mid-rebuild does not start a second one. The `version` key means a new upstream snapshot rebuilds at once rather than waiting out the TTL.

Two defects the tests caught rather than review, both worth naming because neither is visible by reading:

- A cold-build placeholder sitting in the entry map was handed to concurrent callers **as an empty body**. In-flight cold builds now live in a separate map, so anything in `entries` has always been built.
- `refreshing` held the in-flight promise. A synchronously-throwing `build` ran the whole async IIFE — `finally` included — *before* the assignment wrote the settled promise back over it, so the flag never cleared and **one failed fetch froze the entry at its last good body forever**. It is now a boolean set before the call and cleared in `finally`.

## The honest limit on `/api/planes`

Its TTL stays at the documented 20 s and **is not raised to 5 minutes**. The body carries `staleness.ageMs`, a *relative* age — a cache freezes that number while the clock keeps moving, so a 5-minute-old body would claim to be 20 seconds old. The route's own comment already said not to raise the TTL without making the age absolute.

So this ships the half that needs no client change: the route now also emits **`fetchedAt`**, the absolute instant the positions were pulled, and the cache is version-keyed on it. Nothing reads `staleness.ageMs` today (`lib/planes/usePlanes.ts` reads `count` and `planes` only), so once a client switches to `fetchedAt` the TTL can go to the upstream's real 240 s cadence in a one-line change.

`/api/cameras` gets the full tick: `REGISTRY_TTL_MS` is already exactly 5 minutes, and that body carries only absolute times (`lastSampledAt`), so the registry's own cadence is the honest ceiling. Its TTL is now *derived* from that constant instead of typed beside it. It keeps its existing identity memo rather than also going through `originCache` — that would be two caches on one body.

## The CDN header, and why it changes nothing on its own

`CDN_HEADER` was `Vercel-CDN-Cache-Control` — a vendor header for an edge this deployment left on 2026-09-07. It is now `CDN-Cache-Control`, which is the name Cloudflare reads.

**Correcting it is necessary and not sufficient.** Measured 2026-09-11: Cloudflare still answers `cf-cache-status: DYNAMIC` on `/api/cameras`, because its default cache is keyed on *file extension* and `/api/*` has none. A Cache Rule has to opt the path in before any origin header takes effect. That is a dashboard change, not a code one — and it is exactly why the cache that matters today is the one on the box, which is what this PR builds.

## Gate

`npx tsc --noEmit` clean. **3,806 passing across 371 files.** 10 new cases in `tests/unit/origin-cache.test.ts` cover serve-stale, single-flight, version invalidation, the cold-build race and the throwing-rebuild recovery; the deferred-builder helper is what makes "did not await the rebuild" testable rather than assumed. Rebased onto `main` after #217–#221 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HB3DFXcUZ7z2YZAtyhCrVh
