### PR TITLE
Stop the boot ticker printing over the hero strip

### DIFF
--- a/app/provenance.css
+++ b/app/provenance.css
@@ -53,6 +53,11 @@
   /* The column every section measures itself against. */
   --pv-col: min(74rem, calc(100% - 2.5rem));
 
+  /* The height of the hero's bottom strip, DECLARED rather than derived, because the boot
+     ticker has to clear it and the two are written in different files by different owners.
+     `.pv-hero-strip-inner` is sized from this; `.pv-stage-status` is offset by it. */
+  --pv-strip-h: 2.75rem;
+
   /* Type roles. TWO FACES NOW.
 
      Inter is NOT loaded here: this group nests inside app/layout.tsx, which
@@ -304,10 +309,24 @@
   }
 }
 
+/* The boot ticker.
+
+   It sits ABOVE the hero strip, not beside it. The lines it carries are all produced while
+   the layers are landing — which is exactly the window in which the hero, and so the strip
+   nailed to the hero's bottom edge, is the thing on screen. Fixed to the bottom-left of the
+   viewport it landed on top of the strip's first line, and the page opened on two sentences
+   printed over each other. Cleared by the strip's declared height instead, and aligned to
+   the same column as the strip's own text so the two read as one stack rather than as one
+   line in the margin and one in the grid.
+
+   Below 60rem it is not drawn at all (see the breakpoint under this rule): at phone width
+   there is no room for a second line of mono down there, and the strip's claim wins.
+
+   tests/e2e/landing.spec.ts asserts the two boxes do not intersect. */
 .pv-stage-status {
   position: fixed;
-  left: 1.25rem;
-  bottom: 0.9rem;
+  left: calc(50% - var(--pv-col) / 2);
+  bottom: calc(var(--pv-strip-h) + 0.6rem);
   z-index: 2;
   margin: 0;
   font-family: var(--pv-mono);
@@ -708,6 +727,9 @@
   animation: pv-fade 1s ease 1.5s both;
 }
 
+/* The height is taken from `--pv-strip-h` rather than from padding plus whatever the mono
+   line happens to measure, because the boot ticker above it is positioned off that number.
+   Both lines in here are nowrap, so the bar is always exactly one line tall. */
 .pv-hero-strip-inner {
   width: var(--pv-col);
   margin: 0 auto;
@@ -715,7 +737,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
-  padding: 0.8rem 0;
+  height: var(--pv-strip-h);
   font-family: var(--pv-mono);
   font-size: 0.7rem;
   letter-spacing: 0.08em;

--- a/tests/e2e/globe.spec.ts
+++ b/tests/e2e/globe.spec.ts
@@ -1,12 +1,18 @@
 import { expect, test } from "@playwright/test";
 
-test("homepage renders the globe and a non-zero camera count", async ({ page }) => {
+// This test used to read `stat-line` off `/`, from when `/` WAS the Globe.GL homepage.
+// `stat-line` now lives in the console shell at `/app`, so the assertion had been failing
+// against a page that no longer contains the element — and nothing ran the suite to notice,
+// because no workflow runs Playwright. Re-pointed at the contract the homepage actually has
+// now: a globe canvas, and a non-zero measured figure printed beside it.
+test("homepage renders the globe and a non-zero measured count", async ({ page }) => {
   await page.goto("/");
-  // Globe.GL renders into a <canvas>
-  await expect(page.locator("canvas")).toBeVisible({ timeout: 30_000 });
-  const stat = page.getByTestId("stat-line");
-  // Regex avoids the substring trap where e.g. "870 cameras" contains "0 cameras".
-  await expect(stat).toContainText(/[1-9]\d* cameras/, { timeout: 30_000 });
+  // MapLibre renders the stage globe into a <canvas>.
+  await expect(page.locator("canvas").first()).toBeVisible({ timeout: 30_000 });
+  const strip = page.locator(".pv-hero-strip-inner p").first();
+  // Regex avoids the substring trap where e.g. "34 layers" contains "4 layers".
+  await expect(strip).toContainText(/[1-9]\d* layers · [1-9]\d* live/, { timeout: 30_000 });
+  await expect(strip).toContainText(/features placed in [1-9]\d* countries/);
 });
 
 test("the Earth texture is served locally (guards the black-globe regression)", async ({

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The landing page's bottom band carries two separate lines that are written by two
+ * different owners:
+ *
+ *   - `.pv-hero-strip`, a bar absolutely positioned at the bottom of the hero, holding the
+ *     page's first factual claim (the measured layer/feature counts) and the attributions.
+ *   - `.pv-stage-status`, the boot ticker, which `GlobeStage` fixes to the viewport and
+ *     fills from the queue of lines the globe hands up as each layer lands.
+ *
+ * The ticker's whole life is spent during boot — which is exactly when the hero, and so
+ * the strip, is the thing on screen. Fixing it to the bottom-left of the viewport put it
+ * on top of the strip's first line, so the two read as one smear of overlapping text for
+ * the first seconds of every visit. Neither owner can see the other in review, so the
+ * geometry is asserted here instead.
+ */
+test("the boot ticker does not collide with the hero strip", async ({ page }) => {
+  await page.goto("/");
+
+  const status = page.locator(".pv-stage-status");
+  const strip = page.locator(".pv-hero-strip");
+
+  // The strip fades in on a 1.5s delay; the ticker carries a line from first paint.
+  await expect(strip).toBeVisible({ timeout: 30_000 });
+  await expect(status).toBeVisible({ timeout: 30_000 });
+  await expect(status).not.toBeEmpty();
+
+  const a = await status.boundingBox();
+  const b = await strip.boundingBox();
+  expect(a, "the ticker should have a box").not.toBeNull();
+  expect(b, "the hero strip should have a box").not.toBeNull();
+
+  const overlaps =
+    a!.x < b!.x + b!.width &&
+    b!.x < a!.x + a!.width &&
+    a!.y < b!.y + b!.height &&
+    b!.y < a!.y + a!.height;
+
+  expect(
+    overlaps,
+    `ticker ${JSON.stringify(a)} overlaps hero strip ${JSON.stringify(b)}`,
+  ).toBe(false);
+});
+
+/**
+ * The ticker is hidden below 60rem, where there is no room beside the strip for it. If the
+ * breakpoint is ever dropped, the collision comes back on phones only — where nobody runs
+ * a desktop review. Asserted rather than trusted.
+ */
+test("the boot ticker is not drawn at phone width", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await expect(page.locator(".pv-hero-strip")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator(".pv-stage-status")).toBeHidden();
+});


### PR DESCRIPTION
The landing page from #224 opens on two sentences drawn on top of each other. I only caught it by screenshotting production after the merge.

`GlobeStage` fixes its boot ticker to the bottom-left of the viewport; `.pv-hero-strip` is nailed to the bottom of a 100vh hero. At scroll 0 they occupy the same band, so `CONNECTING TO 34 LAYERS` printed straight across `34 layers · 29 live · 8,485 features placed in 235 countries`. It is on every visit, not a flash during load — the ticker's whole life is the boot, which is exactly the window in which the hero is the thing on screen.

**Before / after** (1440×900, local production build):

| shipped | this PR |
| --- | --- |
| `AIR QUALITY · 48` over `34 LAYERS · 29 LIVE · …` | `EARTHQUAKES · 343` sitting above the bar, on the same column |

## The fix

The two lines are written in different files by different owners, so neither can see the other in review. The clearance is now declared rather than derived:

- `--pv-strip-h` sizes `.pv-hero-strip-inner` (both its lines are `nowrap`, so the bar is always one line tall).
- `.pv-stage-status` is offset by that height and aligned to `--pv-col`, so the ticker reads as a line stacked above the bar instead of one in the margin and one in the grid.

Nothing changes below 60rem, where the ticker was already `display: none`.

## Tests

`tests/e2e/landing.spec.ts` asserts the two boxes do not intersect. I watched it fail on the shipped page and pass on this one:

```
✘ landing.spec.ts › the boot ticker does not collide with the hero strip   (before)
✓ landing.spec.ts › the boot ticker does not collide with the hero strip   (after)
```

A second case holds the phone-width breakpoint, so dropping it brings the collision back on phones only — where nobody runs a desktop review — and fails instead.

## One thing I found next door

`globe.spec.ts` read `stat-line` off `/`, from when `/` **was** the Globe.GL homepage. That element now lives in the console shell at `/app`, so the test had been failing against a page that cannot contain it. Nothing noticed because no workflow runs Playwright — `npm run e2e` is manual. I re-pointed it at the contract the homepage actually has now. Worth deciding separately whether the e2e suite should run in CI; right now a red spec is invisible.

`npm test` — 3814 passed. `npm run e2e` on these two specs — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Si9xYQW7MdotkTSyHEku9o
