### PR TITLE
Read EONET flood rings in the order NASA actually publishes them

### DIFF
--- a/lib/marketing/repo-facts.data.ts
+++ b/lib/marketing/repo-facts.data.ts
@@ -16,7 +16,7 @@
  * Measured 2026-09-12 with `npx vitest list` on a clean tree.
  */
 export const UNIT_TESTS = {
-  cases: 3814,
-  files: 374,
+  cases: 3817,
+  files: 375,
   measuredAt: "2026-09-12",
 } as const;

--- a/lib/signals/eonet.ts
+++ b/lib/signals/eonet.ts
@@ -74,6 +74,29 @@ export interface EonetCategoryMeta {
    */
   maxAgeDays?: number;
   /**
+   * The order the category's coordinate pairs actually arrive in.
+   *
+   * GeoJSON says [lon, lat] and EONET honours that for every category but FLOODS,
+   * whose rings arrive [lat, lon]. Measured 2026-09-12 against
+   * `categories/floods?status=all`: all 60 open events are GDACS-relayed Polygons and
+   * all 60 are transposed — Indonesia at [-1.03, 98.24], Peru at [-13.39, -75.81],
+   * Iran at [36.50, 54.17]. The ones whose second value falls outside +-90 PROVE it;
+   * none prove the reverse.
+   *
+   * It is NOT the relay and it is NOT the geometry type, so do not widen this by
+   * guessing at either: GDACS-sourced WILDFIRE points in the same feed are correct
+   * [lon, lat], and ReliefWeb drought POLYGONS are correct too. The property belongs
+   * to this one category, which is why it is declared per category rather than
+   * sniffed per feature.
+   *
+   * `readPair` still range-checks whatever this asks for and falls back to the other
+   * order when the declared one is impossible, so if EONET ever fixes the feed the
+   * events that prove it keep working while this flag is stale. The events that do
+   * NOT prove it would flip, so the audit script asserts the order against live data
+   * on every run — see `assertFloodOrder` in scripts/country-event-breakdown.mts.
+   */
+  coordOrder?: "lonlat" | "latlon";
+  /**
    * Read this category from its own `status=all` feed instead of the shared
    * `status=open` one.
    *
@@ -116,18 +139,43 @@ export const CATEGORIES: Record<string, EonetCategoryMeta> = {
     color: "#0ea5e9",
     maxAgeDays: 60,
     allStatuses: true,
+    // See `coordOrder` above. Measured, not assumed.
+    coordOrder: "latlon",
   },
 };
 
-/** Extract a representative [lon, lat] from a Point or (defensively) a Polygon. */
-export function representativePoint(geom: EonetGeometry | undefined): [number, number] | null {
+/**
+ * Read one coordinate pair in the order the category actually publishes.
+ *
+ * Returns [lon, lat] whatever went in. When the declared order yields a latitude that
+ * cannot exist, the other order is used instead: a pair proves its own ordering when one
+ * of its values is outside +-90, and a proof on the wire beats a flag in this file.
+ */
+function readPair(a: number, b: number, order: "lonlat" | "latlon"): [number, number] {
+  const [lon, lat] = order === "latlon" ? [b, a] : [a, b];
+  if (Math.abs(lat) > 90 && Math.abs(lon) <= 90) return [lat, lon];
+  return [lon, lat];
+}
+
+/**
+ * Extract a representative [lon, lat] from a Point or (defensively) a Polygon.
+ *
+ * `order` is the order the SOURCE uses; the return value is always [lon, lat]. It
+ * defaults to the GeoJSON order, so every caller that does not pass one is unaffected.
+ */
+export function representativePoint(
+  geom: EonetGeometry | undefined,
+  order: "lonlat" | "latlon" = "lonlat",
+): [number, number] | null {
   const c = geom?.coordinates;
   if (!Array.isArray(c)) return null;
-  // Point: [lon, lat]
+  // Point
   if (typeof c[0] === "number" && typeof c[1] === "number") {
-    return [c[0], c[1]];
+    return readPair(c[0], c[1], order);
   }
-  // Polygon: [[[lon,lat], …]] — average the outer ring so an areal event still pins.
+  // Polygon: [[[…], …]] — average the outer ring so an areal event still pins. The ring
+  // is normalised vertex by vertex BEFORE averaging, so a ring that straddles the guard
+  // cannot average into a different answer than its own vertices give.
   const ring = (c as unknown[])[0];
   if (Array.isArray(ring) && ring.length) {
     let sx = 0;
@@ -135,8 +183,9 @@ export function representativePoint(geom: EonetGeometry | undefined): [number, n
     let n = 0;
     for (const pt of ring as unknown[]) {
       if (Array.isArray(pt) && typeof pt[0] === "number" && typeof pt[1] === "number") {
-        sx += pt[0];
-        sy += pt[1];
+        const [lon, lat] = readPair(pt[0] as number, pt[1] as number, order);
+        sx += lon;
+        sy += lat;
         n++;
       }
     }
@@ -166,7 +215,7 @@ export function eonetToFeatures(
       const t = Date.parse(last.date);
       if (Number.isFinite(t) && now - t > meta.maxAgeDays * 86_400_000) continue;
     }
-    const pt = representativePoint(last);
+    const pt = representativePoint(last, meta.coordOrder ?? "lonlat");
     if (!pt) continue;
     const [lon, lat] = pt;
     if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;

--- a/scripts/country-event-breakdown.mts
+++ b/scripts/country-event-breakdown.mts
@@ -245,23 +245,40 @@ type How = "iso" | "name" | "polygon" | "snap" | "geometry" | "title";
 type Resolved = Rec & { how: How };
 
 /**
- * EONET publishes the FLOODS category with Polygon rings in [lat, lon] order while
- * every other category is Point in GeoJSON [lon, lat]. Measured 2026-09-08 against
- * eonet.gsfc.nasa.gov/api/v3/categories/floods: 122 of 400 open events are Polygons,
- * and of the 36 whose ordering is provable (second value outside +-90) all 36 prove
- * [lat, lon] and none prove [lon, lat]. lib/signals/eonet.ts averages the ring as
- * [lon, lat], so those pins ship transposed — "Flood in Austria" lands in the Gulf
- * of Aden. This correction exists so the country breakdown is not wrong too; it does
- * NOT fix the shipped layer.
+ * EONET publishes the FLOODS category with its rings in [lat, lon] order while every
+ * other category is GeoJSON [lon, lat]. Measured 2026-09-08 against
+ * eonet.gsfc.nasa.gov/api/v3/categories/floods: of the 36 events whose ordering is
+ * provable (second value outside +-90) all 36 prove [lat, lon] and none prove the
+ * reverse; re-measured 2026-09-12, when all 60 open events proved it.
+ *
+ * This script used to carry a PRIVATE correction for that, so the country breakdown
+ * would be right while the shipped layer stayed wrong. `lib/signals/eonet.ts` now owns
+ * the order (`coordOrder: "latlon"` on the floods category), so the correction is gone
+ * and this is a CHECK instead.
+ *
+ * It raises rather than repairing. A silent repair here is what let the shipped layer
+ * stay broken for four days without anything going red: the audit looked correct, so
+ * nothing pointed at the adapter. If EONET ever fixes the feed, the flag in eonet.ts
+ * becomes wrong in the other direction and these pins land in the sea — this is what
+ * says so, on the next run, in the one place that has the country polygons to prove it.
  */
-function unswapEonetFlood(f: SignalFeature): SignalFeature {
-  if (f.signalId !== "floods") return f;
-  const inLand = locate(f.lon, f.lat);
-  const swapped = locate(f.lat, f.lon);
-  // Only swap when the transposed reading lands in a country and the shipped one
-  // does not — never "correct" a pin that is already somewhere real.
-  if (!inLand && swapped && Math.abs(f.lon) <= 90) return { ...f, lat: f.lon, lon: f.lat };
-  return f;
+function assertFloodOrder(feats: SignalFeature[]): void {
+  const floods = feats.filter((f) => f.signalId === "floods");
+  if (!floods.length) return;
+  // A flood that lands in no country at all, whose transposition DOES land in one, is
+  // the signature of a pair read the wrong way round. One is noise (a genuine coastal
+  // event just offshore); a cluster is the feed having changed under us.
+  const wrong = floods.filter(
+    (f) => !locate(f.lon, f.lat) && locate(f.lat, f.lon) && Math.abs(f.lon) <= 90,
+  );
+  if (wrong.length > Math.max(2, floods.length * 0.1)) {
+    const sample = wrong.slice(0, 3).map((f) => `${f.title} @ ${f.lon},${f.lat}`);
+    throw new Error(
+      `EONET flood coordinate order looks wrong: ${wrong.length} of ${floods.length} ` +
+        `land nowhere but would land in a country if transposed. Re-measure the feed and ` +
+        `fix \`coordOrder\` on CATEGORIES.floods in lib/signals/eonet.ts. Sample: ${sample.join("; ")}`,
+    );
+  }
 }
 
 /** Every country a line/area geometry touches (containment, then a coastal snap). */
@@ -371,8 +388,6 @@ interface LayerReport {
   /** Features carrying a line/area geometry — these are counted in every country they touch. */
   geometryFeatures: number;
   spansCountries?: boolean;
-  /** EONET flood pins this run had to un-transpose before it could place them. */
-  transposedFixed?: number;
 }
 
 /** GET /api/signals/<id> from a deployment. Throws on anything but a JSON body. */
@@ -454,9 +469,8 @@ for (const src of SIGNALS) {
     rep.ok = true;
     rep.returned = feats.length;
     rep.geometryFeatures = feats.filter((f) => f.geometry).length;
-    for (const raw of feats) {
-      const f = unswapEonetFlood(raw);
-      if (f !== raw) rep.transposedFixed = (rep.transposedFixed ?? 0) + 1;
+    assertFloodOrder(feats);
+    for (const f of feats) {
       // A line/area feature belongs to EVERY country it crosses — a cable landing in
       // eight countries is a fact about all eight. Those layers are counted as
       // "features touching this country", flagged by `spansCountries` in the output.

--- a/tests/fixtures/eonet-floods.json
+++ b/tests/fixtures/eonet-floods.json
@@ -1,0 +1,338 @@
+{
+  "title": "EONET Event Series",
+  "events": [
+    {
+      "id": "EONET_24157",
+      "title": "Flood in Indonesia 1104146",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_24157",
+      "categories": [
+        {
+          "id": "floods",
+          "title": "Floods"
+        }
+      ],
+      "sources": [
+        {
+          "id": "GDACS",
+          "url": "https://www.gdacs.org/report.aspx?eventtype=FL&eventid=1104146"
+        }
+      ],
+      "geometry": [
+        {
+          "date": "2026-09-05T20:00:00Z",
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -1.0336,
+                98.2364
+              ],
+              [
+                0.7759,
+                99.845
+              ],
+              [
+                1.4549,
+                100.3193
+              ],
+              [
+                4.0132,
+                98.0607
+              ],
+              [
+                3.2734,
+                97.9561
+              ],
+              [
+                -1.0336,
+                98.2364
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EONET_24158",
+      "title": "Flood in Peru 1104145",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_24158",
+      "categories": [
+        {
+          "id": "floods",
+          "title": "Floods"
+        }
+      ],
+      "sources": [
+        {
+          "id": "GDACS",
+          "url": "https://www.gdacs.org/report.aspx?eventtype=FL&eventid=1104145"
+        }
+      ],
+      "geometry": [
+        {
+          "date": "2026-09-04T20:00:00Z",
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -13.3897,
+                -75.8097
+              ],
+              [
+                -14.0941,
+                -75.0353
+              ],
+              [
+                -13.1008,
+                -74.4112
+              ],
+              [
+                -12.1881,
+                -74.3877
+              ],
+              [
+                -12.3462,
+                -75.1385
+              ],
+              [
+                -13.3897,
+                -75.8097
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EONET_24193",
+      "title": "Flood in Islamic Republic of Iran 1104147",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_24193",
+      "categories": [
+        {
+          "id": "floods",
+          "title": "Floods"
+        }
+      ],
+      "sources": [
+        {
+          "id": "GDACS",
+          "url": "https://www.gdacs.org/report.aspx?eventtype=FL&eventid=1104147"
+        }
+      ],
+      "geometry": [
+        {
+          "date": "2026-09-06T20:00:00Z",
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                36.5048,
+                54.173
+              ],
+              [
+                37.9796,
+                55.2288
+              ],
+              [
+                37.8296,
+                54.9978
+              ],
+              [
+                37.6626,
+                54.8028
+              ],
+              [
+                37.4484,
+                54.5783
+              ],
+              [
+                36.5048,
+                54.173
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EONET_24244",
+      "title": "Flood in Slovenia 1104152",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_24244",
+      "categories": [
+        {
+          "id": "floods",
+          "title": "Floods"
+        }
+      ],
+      "sources": [
+        {
+          "id": "GDACS",
+          "url": "https://www.gdacs.org/report.aspx?eventtype=FL&eventid=1104152"
+        }
+      ],
+      "geometry": [
+        {
+          "date": "2026-09-09T20:00:00Z",
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                45.622,
+                13.5932
+              ],
+              [
+                45.4588,
+                13.7309
+              ],
+              [
+                45.4272,
+                13.8604
+              ],
+              [
+                45.4645,
+                13.9866
+              ],
+              [
+                45.5139,
+                13.9799
+              ],
+              [
+                45.622,
+                13.5932
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EONET_24101",
+      "title": "Flood in Poland 1104144",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_24101",
+      "categories": [
+        {
+          "id": "floods",
+          "title": "Floods"
+        }
+      ],
+      "sources": [
+        {
+          "id": "GDACS",
+          "url": "https://www.gdacs.org/report.aspx?eventtype=FL&eventid=1104144"
+        }
+      ],
+      "geometry": [
+        {
+          "date": "2026-09-04T20:00:00Z",
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                53.142,
+                17.8742
+              ],
+              [
+                53.0881,
+                18.0364
+              ],
+              [
+                53.1999,
+                18.1877
+              ],
+              [
+                53.1746,
+                18.0549
+              ],
+              [
+                53.1809,
+                17.9479
+              ],
+              [
+                53.142,
+                17.8742
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EONET_24245",
+      "title": "Wildfire in Australia 1031915",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_24245",
+      "categories": [
+        {
+          "id": "wildfires",
+          "title": "Wildfires"
+        }
+      ],
+      "sources": [
+        {
+          "id": "GDACS",
+          "url": "https://www.gdacs.org/report.aspx?eventtype=WF&eventid=1031915"
+        }
+      ],
+      "geometry": [
+        {
+          "date": "2026-09-09T19:00:00Z",
+          "type": "Point",
+          "coordinates": [
+            123.6974,
+            -20.5031
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EONET_3935",
+      "title": "Madagascar Drought",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_3935",
+      "categories": [
+        {
+          "id": "drought",
+          "title": "Drought"
+        }
+      ],
+      "sources": [
+        {
+          "id": "ReliefWeb",
+          "url": "https://reliefweb.int/disaster/dr-2018-000141-mdg"
+        }
+      ],
+      "geometry": [
+        {
+          "date": "2018-08-03T00:00:00Z",
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                42.832,
+                -25.6671
+              ],
+              [
+                42.832,
+                -12.7827
+              ],
+              [
+                50.5273,
+                -12.7827
+              ],
+              [
+                50.5273,
+                -25.6671
+              ],
+              [
+                42.832,
+                -25.6671
+              ],
+              [
+                42.832,
+                -25.6671
+              ]
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/signals-eonet-flood-order.test.ts
+++ b/tests/unit/signals-eonet-flood-order.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "vitest";
+import fixture from "@/tests/fixtures/eonet-floods.json";
+import { eonetToFeatures, CATEGORIES, type EonetEvent } from "@/lib/signals/eonet";
+
+/**
+ * EONET publishes the FLOODS category with its ring vertices in [lat, lon] order, which
+ * is the reverse of every other category and of GeoJSON itself. The floods category is
+ * relayed from GDACS, and the transposition comes through the relay unchanged.
+ *
+ * Captured live from eonet.gsfc.nasa.gov/api/v3/categories/floods?status=all on
+ * 2026-09-12 and trimmed to five vertices per ring. All five flood events in the fixture
+ * are GDACS-sourced Polygons; the wildfire Point and the ReliefWeb drought Polygon are
+ * there to hold the other half of the contract, which is that nothing else moves.
+ *
+ * `scripts/country-event-breakdown.mts` has carried a private correction for this since
+ * 2026-09-08 so the country audit would not be wrong. The shipped layer was left alone,
+ * so every flood pin on the globe and in the console has been drawn transposed —
+ * "Flood in Slovenia" rendered off the coast of Yemen.
+ */
+const events = (fixture as { events: EonetEvent[] }).events;
+const NOW = Date.parse("2026-09-12T00:00:00Z");
+
+/**
+ * Where each fixture event genuinely is: the centroid of its (trimmed) ring, checked to
+ * half a degree — about 55 km, far tighter than the thousands of kilometres a transposed
+ * pair moves a pin, and loose enough that trimming the ring cannot flip the result.
+ */
+const TRUTH: Record<string, { lon: number; lat: number }> = {
+  "eonet:EONET_24157": { lon: 98.8, lat: 1.2 }, // Flood in Indonesia — North Sumatra
+  "eonet:EONET_24158": { lon: -75.1, lat: -13.1 }, // Flood in Peru — Ayacucho
+  "eonet:EONET_24193": { lon: 54.7, lat: 37.3 }, // Flood in Iran — Golestan
+  "eonet:EONET_24244": { lon: 13.8, lat: 45.5 }, // Flood in Slovenia — the Koper coast
+  "eonet:EONET_24101": { lon: 18.0, lat: 53.2 }, // Flood in Poland — Kuyavia
+};
+
+test("flood rings are read as [lat, lon], so the pin lands in the country the title names", () => {
+  const floods = eonetToFeatures(events, CATEGORIES.floods, NOW);
+
+  // Every flood in the fixture must survive. Under the [lon, lat] reading, Indonesia's
+  // ring averages to a latitude of 98 and is DROPPED by the range guard — so the bug
+  // both misplaces pins and silently deletes the ones whose longitude exceeds 90.
+  expect(floods.map((f) => f.id).sort()).toEqual(Object.keys(TRUTH).sort());
+
+  for (const f of floods) {
+    const t = TRUTH[f.id];
+    expect(t, `${f.id} (${f.title}) is not in the truth table`).toBeTruthy();
+    expect(f.lon, `${f.title} longitude`).toBeCloseTo(t.lon, 0);
+    expect(f.lat, `${f.title} latitude`).toBeCloseTo(t.lat, 0);
+  }
+});
+
+test("no flood pin lands in the Gulf of Aden", () => {
+  // The signature of the transposition: European floods, whose real longitudes are small
+  // and whose latitudes are 40-55, land in the sea off Yemen and Somalia when the pair is
+  // read the wrong way round. Cheap, specific, and it fails loudly if the order flips back.
+  const floods = eonetToFeatures(events, CATEGORIES.floods, NOW);
+  const inGulfOfAden = floods.filter(
+    (f) => f.lon > 40 && f.lon < 55 && f.lat > 8 && f.lat < 16,
+  );
+  expect(inGulfOfAden.map((f) => f.title)).toEqual([]);
+});
+
+test("every other category keeps GeoJSON [lon, lat] — points and polygons alike", () => {
+  const fires = eonetToFeatures(events, CATEGORIES.wildfires, NOW);
+  expect(fires).toHaveLength(1);
+  // Wildfire in Australia: 123.7E, 20.5S. Read the other way round it would be an
+  // impossible latitude, which is precisely why the fix must not be applied globally.
+  expect(fires[0].lon).toBeCloseTo(123.7, 0);
+  expect(fires[0].lat).toBeCloseTo(-20.5, 0);
+});


### PR DESCRIPTION
## What it fixes

Every flood pin on the globe and in the console was drawn in the wrong place. NASA EONET publishes the **floods** category with its ring vertices in `[lat, lon]`, the reverse of GeoJSON and of every other category it serves, and `lib/signals/eonet.ts` averaged the ring as `[lon, lat]`. "Flood in Slovenia" landed off the coast of Yemen, "Flood in Germany" in Somaliland, "Flood in Poland" in Oman. Floods now land where the title says they are.

I measured it against `categories/floods?status=all`: all 60 open events are GDACS-relayed Polygons and all 60 are transposed. The ones whose second value falls outside ±90 prove it; none prove the reverse.

## What was touched

- `lib/signals/eonet.ts` — `coordOrder` on the category meta, `latlon` on floods only; `readPair` normalises each vertex and falls back to the other order when the declared one gives an impossible latitude
- `scripts/country-event-breakdown.mts` — replaced the private un-transpose with an assertion that raises
- `tests/unit/signals-eonet-flood-order.test.ts`, `tests/fixtures/eonet-floods.json` — new, recorded from the live feed
- `lib/marketing/repo-facts.data.ts` — the test-count guard, re-measured

## Notes

- I declared the order per category rather than sniffing it, because neither the relay nor the geometry type is safe to key on: GDACS-sourced wildfire **Points** in the same feed are correct, and ReliefWeb drought **Polygons** are correct too.
- 4 of 111 floods were being dropped, not just misplaced — where the real longitude exceeded 90 the transposed pair failed the latitude range check and the event vanished. Indonesia and Japan were among them.
- The audit was wrong too. `country-event-breakdown.mts` has carried a private correction since 2026-09-08 so the country figures would be right while the layer stayed wrong, but it only fired for pins landing in **no** country — 54 of 111 today. The other 55 landed in a real but wrong country and it left them alone. I removed it and made the script raise instead; a silent repair downstream is what let this stay broken with nothing going red.
- The three new tests fail on the pre-fix code; I ran them red first. `npx tsc --noEmit` clean, `npm test` 3817 passed, and on a local production build `/api/signals/floods` returns 111 features with the only remaining Gulf of Aden point being *Flood in Yemen*, which belongs there.
- Follow-up, not here: `lib/marketing/coverage-audit.data.ts` was generated on 2026-09-08 and still carries those 55 mis-attributions. It needs regenerating from a production run — a keyless local run would degrade the layers that do have keys in prod.
