### PR TITLE
Sink the globe's sea below its land, so a pin has a coastline to sit on

### DIFF
--- a/components/marketing/HeroGlobe.tsx
+++ b/components/marketing/HeroGlobe.tsx
@@ -160,6 +160,59 @@ export interface GlobeControls {
   rest(): void;
 }
 
+/**
+ * THE GLOBE'S GROUND, AND THE ONE RULE IT HAS TO OBEY: THE SEA IS DARKER THAN THE LAND.
+ *
+ * The basemap draws no land. Land is whatever `background` is showing through, and the
+ * only thing that gives a continent a shape is the coverage choropleth painted on top of
+ * it. So the reader's sense of "that is a country and that is ocean" comes entirely from
+ * these tones, and if the sea is the brighter of the two the globe inverts: the oceans
+ * read as landmasses and the countries read as holes.
+ *
+ * That is what shipped. OpenFreeMap's dark style paints `water` rgb(27,27,29) over a
+ * `background` of rgb(12,12,12), and an unmeasured country composited to rgb(16,22,27) —
+ * DARKER than the sea around it. Nothing was geometrically wrong: the pins were on their
+ * cities to within a kilometre. They just looked wrong, because there was no readable
+ * coastline to place them against, so a pin on Lahore read as a dot floating over a shape
+ * nobody could identify.
+ *
+ * `landReadsAboveSea()` states the invariant and `tests/unit/landing-globe-ground.test.ts`
+ * holds it, so a palette change cannot re-invert the globe without going red.
+ */
+export const GLOBE_SEA = "#05070c";
+export const COVERAGE_NO_DATA = "#141f27";
+export const COVERAGE_RAMP_LOW = "#1d3540";
+export const COVERAGE_RAMP_HIGH = "#3fb4ce";
+export const COVERAGE_OPACITY = 0.55;
+/** OpenFreeMap `dark`'s own background, which is what land is painted on. */
+export const BASEMAP_LAND = "#0c0c0c";
+
+const hex = (c: string): [number, number, number] => [
+  parseInt(c.slice(1, 3), 16),
+  parseInt(c.slice(3, 5), 16),
+  parseInt(c.slice(5, 7), 16),
+];
+/** Rec. 709 relative luminance, 0-255. Good enough to order two near-blacks. */
+const luma = ([r, g, b]: [number, number, number]): number => 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+/**
+ * Does the DARKEST land on the globe still read as brighter than the sea?
+ *
+ * The darkest land is an unmeasured country: `COVERAGE_NO_DATA` at `COVERAGE_OPACITY`
+ * over the basemap's background. Everything the ramp paints is brighter than that, so
+ * checking the floor checks the whole globe.
+ */
+export function landReadsAboveSea(sea = GLOBE_SEA, noData = COVERAGE_NO_DATA): boolean {
+  const base = hex(BASEMAP_LAND);
+  const top = hex(noData);
+  const composited = base.map((v, i) => v * (1 - COVERAGE_OPACITY) + top[i] * COVERAGE_OPACITY) as [
+    number,
+    number,
+    number,
+  ];
+  return luma(composited) > luma(hex(sea));
+}
+
 export default function HeroGlobe({
   layers,
   satColor,
@@ -374,6 +427,16 @@ export default function HeroGlobe({
         if (layer.type === "symbol") map.setLayoutProperty(layer.id, "visibility", "none");
       }
 
+      // SINK THE SEA BELOW THE LAND. See the GLOBE_SEA block above for why this is not a
+      // taste change: upstream's water is brighter than an unmeasured country, which
+      // inverts the globe. Written as a paint override rather than a forked style for the
+      // same reason the labels are hidden rather than deleted — the style document comes
+      // from a URL we do not own and is re-fetched whole. A basemap that renames its water
+      // layer loses the correction and keeps the globe; it does not throw.
+      if (map.getLayer("water")) {
+        map.setPaintProperty("water", "fill-color", GLOBE_SEA);
+      }
+
       /**
        * THE COVERAGE CHOROPLETH — the land, shaded by how many signal layers reach it.
        *
@@ -413,7 +476,7 @@ export default function HeroGlobe({
                 "fill-color": [
                   "case",
                   ["==", ["get", "pvLayers"], 0],
-                  "#141f27",
+                  COVERAGE_NO_DATA,
                   [
                     "interpolate",
                     ["linear"],
@@ -422,12 +485,12 @@ export default function HeroGlobe({
                     // whole map at the dark end. The same 0.6 exponent the legend is drawn to.
                     ["^", ["/", ["to-number", ["get", "pvLayers"]], max], 0.6],
                     0,
-                    "#1d3540",
+                    COVERAGE_RAMP_LOW,
                     1,
-                    "#3fb4ce",
+                    COVERAGE_RAMP_HIGH,
                   ],
                 ],
-                "fill-opacity": 0.55,
+                "fill-opacity": COVERAGE_OPACITY,
                 "fill-outline-color": "rgba(5,7,12,0.7)",
               },
             });

--- a/lib/marketing/repo-facts.data.ts
+++ b/lib/marketing/repo-facts.data.ts
@@ -16,7 +16,7 @@
  * Measured 2026-09-12 with `npx vitest list` on a clean tree.
  */
 export const UNIT_TESTS = {
-  cases: 3817,
-  files: 375,
+  cases: 3820,
+  files: 376,
   measuredAt: "2026-09-12",
 } as const;

--- a/tests/unit/landing-globe-ground.test.ts
+++ b/tests/unit/landing-globe-ground.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import {
+  landReadsAboveSea,
+  GLOBE_SEA,
+  COVERAGE_NO_DATA,
+  COVERAGE_RAMP_LOW,
+  COVERAGE_RAMP_HIGH,
+} from "@/components/marketing/HeroGlobe";
+
+/**
+ * The hero globe has no land layer: land is the basemap's background showing through, and
+ * the only thing that gives a continent a shape is the coverage choropleth over it. So the
+ * whole map reads correctly on one relationship — the sea must be darker than the darkest
+ * land — and it shipped inverted, with OpenFreeMap's water (rgb 27,27,29) brighter than an
+ * unmeasured country (rgb 16,22,27 composited). The pins were never wrong; there was just
+ * no coastline to read them against.
+ */
+test("the sea is darker than the darkest land", () => {
+  expect(landReadsAboveSea()).toBe(true);
+});
+
+test("upstream's own water colour is what broke it, and would break it again", () => {
+  // OpenFreeMap dark's `water`. Left in as the regression case: if the override is ever
+  // dropped, this is the value that comes back, and this test says what it costs.
+  expect(landReadsAboveSea("#1b1b1d")).toBe(false);
+});
+
+test("the no-data tone is distinct from the ramp, so 'nothing found' is not 'found one'", () => {
+  // The page's legend names those two states separately, so the colours may not collide.
+  expect(COVERAGE_NO_DATA).not.toBe(COVERAGE_RAMP_LOW);
+  expect(COVERAGE_RAMP_LOW).not.toBe(COVERAGE_RAMP_HIGH);
+  // …and every one of them is a 6-digit hex, because the compositing maths assumes it.
+  for (const c of [GLOBE_SEA, COVERAGE_NO_DATA, COVERAGE_RAMP_LOW, COVERAGE_RAMP_HIGH]) {
+    expect(c).toMatch(/^#[0-9a-f]{6}$/i);
+  }
+});


### PR DESCRIPTION
## What it fixes

The scroll pins on the landing page look wrong. I checked all ten and they are not: each one centres the camera on its city, and `queryRenderedFeatures` at the pin returns the right country — the Lahore pin is sitting on Lahore's airport. What is wrong is that there is nothing underneath them to read them against.

The basemap draws no land. Land is whatever `background` shows through, and the only thing giving a continent a shape is the coverage choropleth painted over it. So the globe rests on one relationship — the sea must be darker than the land — and it shipped inverted:

| | composited |
| --- | --- |
| unmeasured country (`#141f27` at 0.55 over `#0c0c0c`) | rgb(16, 22, 27) |
| OpenFreeMap's `water` | rgb(27, 27, 29) |

The ocean is the brighter of the two, so oceans read as landmasses and low-coverage countries read as holes. A pin on Lahore looked like a dot floating over a shape nobody could identify. I confirmed it by projecting Karachi, Delhi, Mumbai, Kabul and Colombo onto the live globe — they land exactly where they should, and the pin sits on my Lahore reference to the pixel.

The sea is now the stage's own black, below the darkest land instead of above it.

## What was touched

- `components/marketing/HeroGlobe.tsx` — named the ground palette, added `landReadsAboveSea()`, and set `water` on `style.load`
- `tests/unit/landing-globe-ground.test.ts` — new, holds the invariant
- `lib/marketing/repo-facts.data.ts` — the test-count guard, re-measured

## Notes

- I wrote it as a paint override rather than forking the style, for the same reason the labels are hidden rather than deleted: the style document comes from a URL we do not own and is re-fetched whole. A basemap that renames its water layer loses the correction and keeps the globe; it does not throw.
- The test carries upstream's own water value as the regression case, so dropping the override goes red with a message saying what it costs.
- I verified it on a local production build, not just in the unit test — screenshots before and after are in the thread. `npx tsc --noEmit` clean, `npm test` 3820 passed.
- This is the ground only. The globe is still a dark map, and whether the coverage ramp itself wants more contrast is a separate call I have not made.
