### PR TITLE
Stop calling a layer that read nothing "live · none right now"

### DIFF
--- a/components/WorldMap.tsx
+++ b/components/WorldMap.tsx
@@ -113,7 +113,7 @@ import { ringBounds, toWatchRingFC } from "@/lib/map/circle";
 import { shellLayoutStore } from "@/lib/console/store";
 import { MAP_SIGNALS } from "@/lib/signals/registry";
 import { useSignals, signalCountsStore } from "@/lib/signals/store";
-import { signalFreshnessStore } from "@/lib/signals/freshness";
+import { signalFreshnessStore, signalFreshnessFromPayload } from "@/lib/signals/freshness";
 import type { SignalFeature, SignalSource } from "@/lib/signals/types";
 import { useTimeWindow, windowMsFor, withinWindow } from "@/lib/shell/timeWindow";
 import { viewModeStore } from "@/lib/shell/viewMode";
@@ -2700,7 +2700,7 @@ function SignalFeed({
           rawRef.current = objs;
           loadedOnceRef.current = true;
           publish(objs);
-          signalFreshnessStore.record(id, { ok: true, count: objs.length });
+          signalFreshnessStore.record(id, signalFreshnessFromPayload({ ok: d.ok, count: objs.length }));
         })
         .catch(() => {
           if (!alive) return;

--- a/lib/signals/freshness.ts
+++ b/lib/signals/freshness.ts
@@ -43,6 +43,23 @@ export function classifySignalFreshness(r: SignalFreshRecord, now: number): Sign
   return "live";
 }
 
+/**
+ * What to record for one /api/signals/<id> response.
+ *
+ * The route publishes the adapter's own `ok` (lib/signals/outcome.ts), but a 200
+ * used to be recorded as success regardless — so a layer answering
+ * `{ok:false, degradedReason:"no key", count:0}` classified as "empty" and the rail
+ * said "live · none right now" about a feed that never read anything.
+ *
+ * A failure that still carries rows is deliberately left as it was. Those rows can
+ * be fresh (gdacs "partial: VO failed" with 36 current events) or last-good
+ * (`degradedWith`), and "unavailable" is the wrong word for both. That case needs
+ * its own state, not this function.
+ */
+export function signalFreshnessFromPayload(d: { ok?: boolean; count: number }): { ok: boolean; count: number } {
+  return { ok: d.ok === true || d.count > 0, count: d.count };
+}
+
 /** Pure short label for a freshness state, given the age text. */
 export function signalFreshLabel(state: SignalFreshState, ageText: string): string {
   switch (state) {

--- a/tests/unit/signals-freshness.test.ts
+++ b/tests/unit/signals-freshness.test.ts
@@ -3,6 +3,7 @@ import {
   classifySignalFreshness,
   signalFreshAgeMs,
   signalFreshLabel,
+  signalFreshnessFromPayload,
   type SignalFreshRecord,
 } from "@/lib/signals/freshness";
 
@@ -47,4 +48,27 @@ test("age helper is null before first fetch, clamped non-negative otherwise", ()
   expect(signalFreshAgeMs(base({ lastUpdate: null }), 5)).toBeNull();
   expect(signalFreshAgeMs(base({ lastUpdate: 1_000 }), 4_000)).toBe(3_000);
   expect(signalFreshAgeMs(base({ lastUpdate: 5_000 }), 4_000)).toBe(0); // clock skew → clamped
+});
+
+// Payload shapes below are what production /api/signals/<id> returned on 2026-09-12.
+const classifyPayload = (d: { ok?: boolean; count: number }) =>
+  classifySignalFreshness({ ...signalFreshnessFromPayload(d), lastUpdate: 1_000_000, refreshMs: 60_000 }, 1_000_000 + 1_000);
+
+test("a declared failure with nothing to show is down, not 'live · none right now'", () => {
+  expect(classifyPayload({ ok: false, count: 0 })).toBe("down"); // reliefweb/grid-load "no key", fire-active "http 400"
+});
+
+test("an upstream that answered with nothing is still the honest empty state", () => {
+  expect(classifyPayload({ ok: true, count: 0 })).toBe("empty");
+  expect(classifyPayload({ ok: true, count: 12 })).toBe("live");
+});
+
+test("an undeclared outcome with nothing to show is not read as healthy", () => {
+  expect(classifyPayload({ count: 0 })).toBe("down");
+});
+
+test("a failure that still carries rows keeps its current reading until partial/last-good has a state", () => {
+  // gdacs: "partial: VO failed (http 404)" with 36 fresh rows. Calling that layer
+  // unavailable would swap one false label for another.
+  expect(classifyPayload({ ok: false, count: 36 })).toBe("live");
 });


### PR DESCRIPTION
The #27 you said to sort, part 1 of 2: the per-layer freshness store that `WorldMap` writes, which is what the Sources widget dots (`lib/sources/live.ts`) and the sitrep export (`lib/export/view.ts`) read. **Card headers are not this path**: they read `useSignalFeed` and are fixed in #230, together with `quiet` in `lib/notify`. Independent: either can merge first.

## What it was

`/api/signals/<id>` already publishes the adapter's own `ok`. `WorldMap.tsx:2703` recorded every 200 as `ok: true`, so a layer that read nothing classified as `empty`, and the Sources widget said **"live · none now"** about a feed that never answered.

Measured on production, 2026-09-12, every layer, only the ones not `ok:true`:

| layer | ok | reason | count | Sources dot before this PR |
|---|---|---|---|---|
| reliefweb | false | no key | 0 | live · none now |
| grid-load | false | no key | 0 | live · none now |
| fire-active | false | http 400 | 0 | live · none now |
| cyber-ransomware | false | http 404 | 0 | live · none now |
| gdacs | false | partial: VO failed (http 404) | 36 | updated Xs ago |

## What changed

A failure with no rows is now `down` ("unavailable"), which is the word `freshChip.ts` and `feedHealth.ts` already use for "the last attempt failed". A missing `ok` with no rows is treated the same way, per the absence rule in `outcome.ts`.

A failure that **still carries rows is deliberately left as it was.** gdacs is the live example: one sub-feed failed and the other 36 events are current. Last-good rows from `degradedWith` are the same shape on the wire. "Unavailable" is the wrong word for both, which is what I meant on Discord by "probably needs its own state". I did not invent one here. The regression test pins that case as unchanged so it is a visible decision, not an accident.

The mapping is a pure function, `signalFreshnessFromPayload`, tested against the payload shapes above. Before the fix, 4 tests fail. After it, 10 of 10 pass.

## Gate

`npx tsc --noEmit` clean. `npm test` **376 files / 3,824 passed**.

## Not verified

- **No screenshot, so `persona-shots/` is empty for this one.** The capture failed twice: the preview never settled with the globe animating, and Playwright couldn't find the Intel board button on prod. I'd rather say that than attach something that isn't this change. Happy to add one if you want it before merge.
- Two things the table turned up that are not this PR: **fire-active answers `http 400`** even though CLAUDE.md lists NASA FIRMS as "live with keys" (key expired or rejected?), and **cyber-ransomware answers `http 404`** (upstream moved?).
- **Inconsistency this leaves, your call:** the cards ask the capability state (`signals.tsx:170`) and say DORMANT for reliefweb/grid-load; `lib/sources/live.ts` does not, so after this PR the Sources dot for those two says "unavailable" (before: "live · none now"). Truer than before, but not the same word as the card. Wiring the capability into `live.ts` the way `signals.tsx` does would close it. Separate PR if you want it.
- The landing page was rebuilt in #224. I did not re-check whether its layer table reads `ok` correctly.
