### PR TITLE
Point the docs at the domain we ship on, and write middleware.ts into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,10 @@
 # CLAUDE.md — Provenance (repo `Provenance`)
 
 A Next.js 15 single-page global situational-awareness map. **Product name: Provenance.**
-**Prod domain: `provenance-online.vercel.app`** — that is the only domain we ship on.
+**Prod domain: `provenance-online.com`** — that is the only domain we ship on.
+`provenance-online.vercel.app` is the legacy host: `middleware.ts` 301s it here
+(`lib/brand.legacy.ts`), so never publish it as a link, and `curl` it without `-L` and
+you get "Redirecting..." rather than the site.
 Deployed product = `origin/main`.
 
 ## Licence — `AGPL-3.0-only`
@@ -110,7 +113,17 @@ obligations and are not satisfied by the licence.
 - `app/` — routes + API. `app/api/*` are internal Next handlers (no user auth):
   `cameras`, `camera`, `coverage`, `planes`, `flight`, `satellites`, `signals/[id]`,
   `webcams`, `webcam-image`, `markets`, `news`, `brief`, `advisory`, `recon`, `geocode`,
-  `near`, `geolocate`, `proxy`, `hls`, `discord`, `telegram`.
+  `near`, `geolocate`, `proxy`, `hls`, `discord`, `telegram`, `air-quality`, `point-weather`,
+  `status`, `presence`, `feedback`, `webcam-place`, `webcam-search`, `youtube-live`, and the two
+  doors `middleware.ts` opens, `gate` and `private`.
+- **`middleware.ts` runs before every route its `matcher` does not exempt, and does three
+  things in a fixed order.** (1) 301s the legacy `.vercel.app` host to the `.com`
+  (`lib/brand.legacy.ts`) — first, so it still fires while the curtain is down. (2) The
+  maintenance curtain, armed by `MAINTENANCE_MODE` (`lib/gate/armed.ts`) and unlocked through
+  `/api/gate`. (3) The private endpoint (`lib/gate/private.ts`), unlocked through `/api/private`,
+  which rewrites to `/app`. The `matcher` must be a string literal, so it cannot import
+  `gateMatcher()`; `tests/unit/gate.test.ts` fails if the two drift. It is **not** the `/admin`
+  guard — that is the 404-in-production check described under discovery below.
 - `components/WorldMap.tsx` — the single MapLibre globe→2D instance; all layers are data-driven.
 - `components/shell/*` — thin console chrome (StatusBar, CommandPalette, BreakingBanner, panels).
 - `components/console/*` — the widget workspace (segments + centre stage + resizable widget frames).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">A live map of the world's open data, where every dot says who published it and how it knows.</p>
 
 <p align="center">
-  <a href="https://provenance-online.vercel.app"><img src="https://img.shields.io/badge/live-provenance--online.vercel.app-2ea44f" alt="Live at provenance-online.vercel.app"></a>
+  <a href="https://provenance-online.com"><img src="https://img.shields.io/badge/live-provenance--online.com-2ea44f" alt="Live at provenance-online.com"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/licence-AGPL--3.0-blue" alt="Licensed AGPL-3.0-only"></a>
   <img src="https://img.shields.io/badge/Next.js-15-black?logo=next.js" alt="Next.js 15">
   <img src="https://img.shields.io/badge/TypeScript-5-3178c6?logo=typescript&logoColor=white" alt="TypeScript">
@@ -18,7 +18,7 @@ Governments, space agencies, seismologists and UN clusters publish an enormous a
 
 The repository used to be called `TrafficNerd-V2` and the product was briefly called OpenData. Both are now **Provenance**. It is the web rewrite of [TrafficNerd v1](https://github.com/011-sam-110/TrafficNerd), which was a London-only terminal app.
 
-_Status: live at [provenance-online.vercel.app](https://provenance-online.vercel.app) and runs locally with no keys. Coverage is real but partial and depends on public upstreams staying open, so here is what production actually returned on **2026-08-18**, against `6f60b4a`:_
+_Status: live at [provenance-online.com](https://provenance-online.com) and runs locally with no keys. Coverage is real but partial and depends on public upstreams staying open, so here is what production actually returned on **2026-08-18**, against `6f60b4a`:_
 
 | Check | Result |
 |---|---|

--- a/app/(console)/app/page.tsx
+++ b/app/(console)/app/page.tsx
@@ -61,7 +61,7 @@ export function generateMetadata(): Metadata {
 // The same rule is already applied twice elsewhere and written down both times:
 // CLAUDE.md states it for the hero globe ("read from SOURCE_CATALOG in the server
 // component and passed down as a prop — never imported into the client, or all ~39
-// adapters land in the browser bundle"), and components/console/SourceCatalog.tsx
+// adapters land in the browser bundle"), and components/shell/SourceCatalog.tsx
 // derives its own count from CAMERA_REGIONS for exactly this reason.
 //
 // It stays DERIVED. CAMERA_FEED_COUNT is SOURCES.length, and the two pinning tests

--- a/lib/signals/coverage.ts
+++ b/lib/signals/coverage.ts
@@ -26,10 +26,10 @@
 // back and publishes it; the pure card projection turns it into a count label a
 // capped number cannot hide inside ("1,500 of 41,203", not "1,500").
 //
-// The side channel is a WeakMap keyed on the returned array rather than a new
-// field on SignalSource.fetch(), so `fetch(): Promise<SignalFeature[]>` is
-// unchanged and all 35 registered adapters keep compiling — including the ones
-// that legitimately declare nothing.
+// The side channel is a global-registry Symbol on the returned array (COVERAGE_KEY
+// below says why it is not a WeakMap) rather than a new field on
+// SignalSource.fetch(), so `fetch(): Promise<SignalFeature[]>` is unchanged and
+// every registered adapter keeps compiling — including the ones that declare nothing.
 //
 // HONESTY NOTE: absence of a coverage record means "this adapter did not declare
 // one", NOT "nothing was truncated". Never render "complete" off a missing record.

--- a/lib/signals/registry.ts
+++ b/lib/signals/registry.ts
@@ -19,7 +19,8 @@
 //   • Render    components/WorldMap.tsx — ONE aggregated `signals` GeoJSON source
 //                 + one data-driven circle+label layer (colour/radius from props)
 //   • Dossier   components/SignalDetail.tsx via lib/overlay-content.tsx (kind:"signal")
-//   • Rail      components/shell/LayerRail.tsx — auto-grouped "Global signals" section
+//   • Rail      components/shell/SourceCatalog.tsx — the six-section Sources rail,
+//                 its rows from lib/console/sources/railSources.ts
 //
 // POINTS, LINES and POLYGONS are all supported. A source whose features carry a
 // `geometry` (SignalFeature.geometry: LineString/MultiLineString → line layer,

--- a/lib/sources/registry.ts
+++ b/lib/sources/registry.ts
@@ -155,8 +155,8 @@ const SOURCES: CameraFeed[] = [
   // would let one network's outage discard every other discovered network's
   // cameras in the same round. See lib/sources/discovered.ts.
   //
-  // This spreads to LENGTH ZERO until a feed is admitted, so CAMERA_FEED_COUNT is
-  // 16 today and the two documents pinned against it stay true. When it grows,
+  // This spread to length zero until the first feed was admitted, so CAMERA_FEED_COUNT
+  // moves with every admission rather than with an adapter. When it grows,
   // claude-md-counts and readme-counts go red on purpose: a new camera network is
   // exactly the kind of change that ought to force the docs to move.
   ...discoveredCameraFeeds(),


### PR DESCRIPTION
The docs half of what you said to sort. Docs and comments only: no behaviour changes.

## Changed

| where | was | now |
|---|---|---|
| `CLAUDE.md:4` | "Prod domain: `provenance-online.vercel.app`, the only domain we ship on" | `provenance-online.com`, plus a line that the old host 301s here via `lib/brand.legacy.ts` (and that `curl` without `-L` shows "Redirecting...", which is how it bit me) |
| `README.md:9,21` | badge and status link to `.vercel.app` | `.com` (the 2026-08-18 measurement it introduces is left as dated) |
| `CLAUDE.md`, routes | 21 listed | +10 that exist in `app/api`: `air-quality`, `point-weather`, `status`, `presence`, `feedback`, `webcam-place`, `webcam-search`, `youtube-live`, `gate`, `private` |
| `CLAUDE.md`, new bullet | `middleware.ts` not mentioned | its three jobs in order (legacy 301 → curtain → private endpoint), the matcher/`gate.test.ts` pin, and that it is **not** the `/admin` guard |
| `lib/signals/registry.ts:22` | Rail = `components/shell/LayerRail.tsx` (doesn't exist) | `components/shell/SourceCatalog.tsx`, rows from `railSources.ts` |
| `app/(console)/app/page.tsx:64` | `components/console/SourceCatalog.tsx` | `components/shell/SourceCatalog.tsx` |
| `lib/sources/registry.ts:158` | "CAMERA_FEED_COUNT is 16 today" | no number (it's 17, and a number there rots again on the next admission) |
| `lib/signals/coverage.ts:29` | "The side channel is a WeakMap… all 35 registered adapters" | global-registry Symbol, pointing at its own `COVERAGE_KEY` note on why the WeakMap went; no count |

## Deliberately NOT changed

- **Correct uses of `.vercel.app`:** `lib/brand.legacy.ts` and its test (that's the redirect), `docs/VERCEL_ANALYTICS_ARCHIVE.md` (history), and `coverage-audit.data.ts`'s `AUDIT_MEASURED_FROM` (generated, never hand-edited).
- **`lib/brand.ts:117`**: the fallback site URL is still `.vercel.app`. That's code, not a comment, and it feeds canonical/OG URLs when the env var is unset, so it's your call, not a docs fix.
- **Script defaults** (`probe-planes.mjs`, `gen-place-table.mjs`, the `*prof.mjs` family) still target `.vercel.app`. They work through the 301 if they follow redirects. Not checked one by one.
- **`SourceCatalog.tsx:6` "the 37 signal layers"**: I had this on my list as stale. It isn't. It's past tense ("used to"), and 33 + the four removed on 09-05 is 37.
- **`lib/signals/usgs.ts:95`** still sends `User-Agent: TrafficNerd/2.0 (+github.com/011-sam-110/TrafficNerd-V2)`. That's a request header, not a doc.

## Gate

`npx tsc --noEmit` clean. `npm test` **376 files passed**, including `claude-md-counts` and `readme-counts`.
